### PR TITLE
Simplify login to email + password only

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -6,13 +6,15 @@ import { eq } from "drizzle-orm";
 
 export async function POST(request: NextRequest) {
   try {
-    const { email, password } = await request.json();
+    const body = await request.json();
+    const email = typeof body?.email === "string" ? body.email.trim().toLowerCase() : "";
+    const password = typeof body?.password === "string" ? body.password : "";
 
     if (!email || !password) {
       return NextResponse.json({ error: "Email and password required" }, { status: 400 });
     }
 
-    const [user] = await db.select().from(users).where(eq(users.email, email.toLowerCase())).limit(1);
+    const [user] = await db.select().from(users).where(eq(users.email, email)).limit(1);
     if (!user) {
       return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
     }

--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -15,7 +15,9 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
   const [loading, setLoading] = useState(false);
 
   const handleSubmit = async () => {
-    if (!email || !password || (mode === "signup" && !username)) {
+    const trimmedEmail = email.trim().toLowerCase();
+    const trimmedUsername = username.trim();
+    if (!trimmedEmail || !password || (mode === "signup" && !trimmedUsername)) {
       setError(mode === "signup" ? "All fields required" : "Email and password required");
       return;
     }
@@ -27,7 +29,7 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
       const res = await fetch(endpoint, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(mode === "signup" ? { email, username, password } : { email, password }),
+        body: JSON.stringify(mode === "signup" ? { email: trimmedEmail, username: trimmedUsername, password } : { email: trimmedEmail, password }),
       });
       const data = await res.json();
 


### PR DESCRIPTION
## Summary
- Fixes #6
- Login form now shows only email + password (no username field)
- Username field only appears during signup
- Removed username-update-on-login logic from login API route (username editing will be handled by #7)

## Changes
- **`src/components/AuthScreen.tsx`**: Conditionally render username field only in signup mode, adjust validation and API payload per mode
- **`src/app/api/auth/login/route.ts`**: Remove username destructuring and the username-update block

## Test plan
- [ ] Login with existing account using email + password — works, no username field shown
- [ ] Switch to signup mode — username field appears
- [ ] Sign up with new account — username is set correctly
- [ ] Switch back to login — username field disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Login now requires only email and password; email input is normalized (trimmed and lowercased) for more reliable sign-in.
  * Validation messages clarified to indicate whether the user is signing up or logging in.
  * Removed username update during login to prevent unintended changes.

* **UI Updates**
  * Username field is shown only during signup, simplifying the login form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->