### PR TITLE
Enlarge mobile nav buttons and add welcome header

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -267,11 +267,11 @@ export default function StillPoint() {
         <div style={{
           fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
           fontSize: "11px", color: "rgba(232,228,222,0.25)",
-          letterSpacing: "2px", textTransform: "uppercase",
+          letterSpacing: "2px",
           textAlign: "center",
           marginBottom: "8px",
         }}>
-          Welcome, {user.username}
+          <span style={{ textTransform: "uppercase" }}>Welcome, </span>{user.username}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Increase mobile nav button font size from 11px to 13px with more padding for better tap targets
- Replace the old desktop-only absolute-positioned username badge with a centered "Welcome, <username>" header visible on both mobile and desktop
- Welcome header shown on all views except active sessions

Closes #10

## Test plan
- [x] Verify mobile nav buttons are visibly larger and easy to tap
- [x] Verify "Welcome, <username>" appears centered above content on mobile
- [x] Verify "Welcome, <username>" appears centered above content on desktop
- [x] Verify welcome header is hidden during active sessions
- [x] Verify desktop nav (top-right) remains unchanged in size

🤖 Generated with [Claude Code](https://claude.com/claude-code)