### PR TITLE
Improve welcome header contrast, weight, and spacing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -266,10 +266,11 @@ export default function StillPoint() {
       {view !== "session" && (
         <div style={{
           fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-          fontSize: "11px", color: "rgba(232,228,222,0.25)",
-          letterSpacing: "2px",
+          fontSize: "12px", color: "rgba(232,228,222,0.45)",
+          letterSpacing: "1.5px",
+          fontWeight: 500,
           textAlign: "center",
-          marginBottom: "8px",
+          marginBottom: "24px",
         }}>
           <span style={{ textTransform: "uppercase" }}>Welcome, </span>{user.username}
         </div>


### PR DESCRIPTION
## Summary
- Increase welcome header text opacity from 0.25 → 0.45 for better readability against dark background
- Bump font size from 11px → 12px and add font-weight 500 for more visual weight
- Tighten letter spacing from 2px → 1.5px for more natural reading
- Increase bottom margin from 8px → 24px for clear breathing room between welcome line and main content

Closes #12

## Test plan
- [x] Verify welcome text is noticeably more readable on mobile (higher contrast, bolder)
- [x] Verify clear visual spacing between "Welcome, username" and the content below
- [x] Verify the welcome header still feels subtle/secondary to the "Still Point" title (visual hierarchy preserved)
- [x] Verify no layout changes on desktop beyond the improved welcome header styling
- [ ] **Requires manual testing**: confirm visual appearance on actual mobile device after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)