### PR TITLE
Skip Vercel deploy when only ios/ files changed

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ':!ios' ':!.claude'"
+  "ignoreCommand": "git rev-parse HEAD^ >/dev/null 2>&1 && git diff --quiet HEAD^ HEAD -- . ':!ios' ':!.claude' || exit 1"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "ignoreCommand": "BASE=${VERCEL_GIT_PREVIOUS_SHA:-$(git rev-parse HEAD^ 2>/dev/null)} && git diff --quiet $BASE HEAD -- . ':!ios' ':!.claude' || exit 1"
+  "ignoreCommand": "BASE=${VERCEL_GIT_PREVIOUS_SHA:-$(git rev-parse HEAD^ 2>/dev/null || true)}; [ -n \"$BASE\" ] || exit 1; git diff --quiet \"$BASE\" HEAD -- . ':!ios' ':!.claude' || exit 1"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "ignoreCommand": "git rev-parse HEAD^ >/dev/null 2>&1 && git diff --quiet HEAD^ HEAD -- . ':!ios' ':!.claude' || exit 1"
+  "ignoreCommand": "BASE=${VERCEL_GIT_PREVIOUS_SHA:-$(git rev-parse HEAD^ 2>/dev/null)} && git diff --quiet $BASE HEAD -- . ':!ios' ':!.claude' || exit 1"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ':!ios' ':!.claude'"
+}


### PR DESCRIPTION
## Summary
- Adds `vercel.json` with `ignoreCommand` that skips Vercel builds when only `ios/` or `.claude/` files changed
- Uses `VERCEL_GIT_PREVIOUS_SHA` env var for reliable diff base across multi-commit pushes
- Falls back to `HEAD^` if env var is unset, and defaults to building if neither is available (shallow clone safety)

Closes #22

## Test plan
- [x] Pushes that only modify `ios/` files do NOT trigger a Vercel deploy
- [x] Pushes that modify `src/`, `package.json`, or other web files still trigger normally
- [x] Mixed pushes (both `ios/` and `src/`) still trigger a deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved deployment configuration to detect when a project has no relevant changes and skip unnecessary build/deploy steps, excluding specified platform/tooling directories from change detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->