### PR TITLE
Fix block fill not reaching full height when completed

### DIFF
--- a/ios/StillPointApp/Components/BlockGridView.swift
+++ b/ios/StillPointApp/Components/BlockGridView.swift
@@ -87,13 +87,11 @@ struct BlockGridView: View {
 
             // Fill from bottom
             GeometryReader { geo in
-                VStack {
-                    Spacer()
-                    Rectangle()
-                        .fill(isFilled ? LinearGradient.greenFill : LinearGradient.amberFill)
-                        .frame(height: geo.size.height * progress)
-                        .opacity(isFilled ? 0.85 : 0.7)
-                }
+                Rectangle()
+                    .fill(isFilled ? LinearGradient.greenFill : LinearGradient.amberFill)
+                    .frame(height: geo.size.height * progress)
+                    .frame(maxHeight: .infinity, alignment: .bottom)
+                    .opacity(isFilled ? 0.85 : 0.7)
             }
             .clipShape(RoundedRectangle(cornerRadius: blockRadius))
 


### PR DESCRIPTION
## Summary
- Fixes visible gap at top of completed blocks in `BlockGridView` where the green fill gradient stopped short of 100% height
- Root cause: `VStack` default spacing between `Spacer()` and `Rectangle` consumed space even at full progress, preventing the fill from reaching the top
- Fix: Replace `VStack/Spacer` bottom-alignment pattern with `.frame(maxHeight: .infinity, alignment: .bottom)` which has no implicit spacing

Closes #31

## Test plan
- [x] Completed blocks are fully filled with green (no gap at top)
- [x] Fill animation is smooth from 0% to 100%
- [x] Block border radius clips the fill correctly at all corners
- [x] Build succeeds on iPhone 17 Pro simulator (iOS 26.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal rendering adjustment for block fill alignment; no visible changes to layout, appearance, or user interaction.
* **Chores**
  * Minor internal cleanup with no impact on functionality or user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->