### PR TITLE
Wire end-note persistence in CompletionView

### DIFF
--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -6,7 +6,7 @@ enum AppView: Equatable {
     case auth
     case home
     case session
-    case completion(clearPercent: Int, thoughtCount: Int, thoughts: [CapturedThought], dayNumber: Int, duration: Int)
+    case completion(sessionId: String, clearPercent: Int, thoughtCount: Int, thoughts: [CapturedThought], dayNumber: Int, duration: Int)
     case history
     case journal
     case board
@@ -87,6 +87,7 @@ final class AppViewModel {
     }
 
     func completeSession(
+        sessionId: String,
         clearPercent: Int,
         thoughtCount: Int,
         thoughts: [CapturedThought],
@@ -94,6 +95,7 @@ final class AppViewModel {
         duration: Int
     ) {
         currentView = .completion(
+            sessionId: sessionId,
             clearPercent: clearPercent,
             thoughtCount: thoughtCount,
             thoughts: thoughts,

--- a/ios/StillPointApp/Views/CompletionView.swift
+++ b/ios/StillPointApp/Views/CompletionView.swift
@@ -221,6 +221,7 @@ struct CompletionView: View {
                 isSaving = false
                 noteSaved = true
             } catch {
+                print("Failed to save end note: \(error)")
                 isSaving = false
                 saveError = "Failed to save note"
             }

--- a/ios/StillPointApp/Views/CompletionView.swift
+++ b/ios/StillPointApp/Views/CompletionView.swift
@@ -170,6 +170,9 @@ struct CompletionView: View {
             .padding(.horizontal, SPSpacing.s4)
         }
         .stillPointBackground()
+        .onChange(of: endNote) { _, _ in
+            saveError = nil
+        }
     }
 
     private func statCard(
@@ -202,7 +205,7 @@ struct CompletionView: View {
         guard !endNote.isEmpty, !sessionId.isEmpty else { return }
         isSaving = true
         saveError = nil
-        Task {
+        Task { @MainActor in
             do {
                 let request = BatchThoughtsRequest(
                     sessionId: sessionId,

--- a/ios/StillPointApp/Views/CompletionView.swift
+++ b/ios/StillPointApp/Views/CompletionView.swift
@@ -3,6 +3,7 @@ import StillPointShared
 
 struct CompletionView: View {
     let appVM: AppViewModel
+    let sessionId: String
     let clearPercent: Int
     let thoughtCount: Int
     let thoughts: [CapturedThought]
@@ -11,6 +12,8 @@ struct CompletionView: View {
 
     @State private var endNote = ""
     @State private var noteSaved = false
+    @State private var isSaving = false
+    @State private var saveError: String?
 
     private var nextDay: Int { dayNumber + 1 }
     private var nextDuration: Int { StillPoint.duration(forDay: nextDay) }
@@ -102,7 +105,7 @@ struct CompletionView: View {
                                 .stroke(SPColor.border2)
                         )
 
-                    if !endNote.isEmpty && !noteSaved {
+                    if !endNote.isEmpty && !noteSaved && !isSaving {
                         Button {
                             saveEndNote()
                         } label: {
@@ -110,12 +113,29 @@ struct CompletionView: View {
                                 .font(SPFont.mono(12, weight: .medium))
                                 .foregroundStyle(SPColor.green)
                         }
+                        .disabled(sessionId.isEmpty)
+                    }
+
+                    if isSaving {
+                        HStack(spacing: SPSpacing.s1) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("saving…")
+                                .font(SPFont.mono(11))
+                                .foregroundStyle(Color(SPColor.fg4))
+                        }
                     }
 
                     if noteSaved {
                         Text("saved")
                             .font(SPFont.mono(11))
                             .foregroundStyle(SPColor.greenDim)
+                    }
+
+                    if let saveError {
+                        Text(saveError)
+                            .font(SPFont.mono(11))
+                            .foregroundStyle(SPColor.dangerMuted)
                     }
                 }
 
@@ -179,10 +199,28 @@ struct CompletionView: View {
     }
 
     private func saveEndNote() {
-        guard !endNote.isEmpty else { return }
-        // TODO: Wire end-of-session note persistence once sessionId is passed into CompletionView.
-        // Requires calling APIClient.shared.batchThoughts with timeInSession = -1.
-        // For now, mark as saved — the note is captured locally but not synced.
-        noteSaved = true
+        guard !endNote.isEmpty, !sessionId.isEmpty else { return }
+        isSaving = true
+        saveError = nil
+        Task {
+            do {
+                let request = BatchThoughtsRequest(
+                    sessionId: sessionId,
+                    dayNumber: dayNumber,
+                    thoughts: [
+                        BatchThoughtsRequest.ThoughtInput(
+                            timeInSession: -1,
+                            text: endNote
+                        )
+                    ]
+                )
+                _ = try await APIClient.shared.batchThoughts(request)
+                isSaving = false
+                noteSaved = true
+            } catch {
+                isSaving = false
+                saveError = "Failed to save note"
+            }
+        }
     }
 }

--- a/ios/StillPointApp/Views/CompletionView.swift
+++ b/ios/StillPointApp/Views/CompletionView.swift
@@ -18,7 +18,7 @@ struct CompletionView: View {
     private var nextDay: Int { dayNumber + 1 }
     private var nextDuration: Int { StillPoint.duration(forDay: nextDay) }
     private var nextBlocks: Int { StillPoint.blockCount(forDuration: nextDuration) }
-    private var isSaveDisabled: Bool { endNote.isEmpty || noteSaved }
+    private var isSaveDisabled: Bool { endNote.isEmpty || noteSaved || isSaving || sessionId.isEmpty }
 
     var body: some View {
         ScrollView {
@@ -110,10 +110,22 @@ struct CompletionView: View {
                             if noteSaved { noteSaved = false }
                         }
 
-                    Button {
-                        saveEndNote()
-                    } label: {
-                        Text(noteSaved ? "Saved" : "Save note")
+                    if noteSaved {
+                        Text("Saved")
+                            .font(SPFont.mono(11, weight: .medium))
+                            .foregroundStyle(SPColor.green)
+                    } else {
+                        Button {
+                            saveEndNote()
+                        } label: {
+                            HStack(spacing: SPSpacing.s1) {
+                                if isSaving {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                        .tint(Color(SPColor.bg))
+                                }
+                                Text(isSaving ? "Saving…" : "Save note")
+                            }
                             .font(SPFont.serifItalic(18, weight: .light))
                             .foregroundStyle(isSaveDisabled ? Color(SPColor.fg3) : Color(SPColor.bg))
                             .frame(maxWidth: .infinity)
@@ -123,8 +135,9 @@ struct CompletionView: View {
                             .overlay(
                                 Capsule().stroke(isSaveDisabled ? SPColor.border2 : Color.clear)
                             )
+                        }
+                        .disabled(isSaveDisabled)
                     }
-                    .disabled(isSaveDisabled)
 
                     if let saveError {
                         Text(saveError)

--- a/ios/StillPointApp/Views/CompletionView.swift
+++ b/ios/StillPointApp/Views/CompletionView.swift
@@ -104,6 +104,7 @@ struct CompletionView: View {
                             RoundedRectangle(cornerRadius: 8)
                                 .stroke(SPColor.border2)
                         )
+                        .disabled(isSaving || noteSaved)
 
                     if !endNote.isEmpty && !noteSaved && !isSaving {
                         Button {
@@ -202,7 +203,8 @@ struct CompletionView: View {
     }
 
     private func saveEndNote() {
-        guard !endNote.isEmpty, !sessionId.isEmpty else { return }
+        let noteToSave = endNote
+        guard !noteToSave.isEmpty, !sessionId.isEmpty, !isSaving, !noteSaved else { return }
         isSaving = true
         saveError = nil
         Task { @MainActor in
@@ -213,7 +215,7 @@ struct CompletionView: View {
                     thoughts: [
                         BatchThoughtsRequest.ThoughtInput(
                             timeInSession: -1,
-                            text: endNote
+                            text: noteToSave
                         )
                     ]
                 )

--- a/ios/StillPointApp/Views/RootView.swift
+++ b/ios/StillPointApp/Views/RootView.swift
@@ -29,9 +29,10 @@ struct RootView: View {
                     SessionView(appVM: appVM)
                         .transition(.opacity)
 
-                case .completion(let clearPercent, let thoughtCount, let thoughts, let dayNumber, let duration):
+                case .completion(let sessionId, let clearPercent, let thoughtCount, let thoughts, let dayNumber, let duration):
                     CompletionView(
                         appVM: appVM,
+                        sessionId: sessionId,
                         clearPercent: clearPercent,
                         thoughtCount: thoughtCount,
                         thoughts: thoughts,

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -8,6 +8,7 @@ struct SessionView: View {
 
     let appVM: AppViewModel
     @State private var vm: SessionViewModel
+    @State private var showSaveError = false
 
     init(appVM: AppViewModel) {
         self.appVM = appVM
@@ -102,6 +103,21 @@ struct SessionView: View {
             if isComplete && !vm.isAbandoned {
                 handleCompletion()
             }
+        }
+        .alert("Session could not be saved", isPresented: $showSaveError) {
+            Button("Retry") { handleCompletion() }
+            Button("Continue without saving", role: .destructive) {
+                appVM.completeSession(
+                    sessionId: "",
+                    clearPercent: vm.clearPercent,
+                    thoughtCount: vm.thoughtCount,
+                    thoughts: vm.capturedThoughts,
+                    dayNumber: vm.dayNumber,
+                    duration: vm.totalSeconds
+                )
+            }
+        } message: {
+            Text("Your session data couldn't be saved. You can retry or continue without saving.")
         }
     }
 
@@ -267,9 +283,12 @@ struct SessionView: View {
     private func handleCompletion() {
         Task {
             // Persist session before navigating to completion screen
-            let session = await vm.saveSession(completed: vm.completedNaturally)
+            guard let session = await vm.saveSession(completed: vm.completedNaturally) else {
+                showSaveError = true
+                return
+            }
             appVM.completeSession(
-                sessionId: session?.id ?? "",
+                sessionId: session.id,
                 clearPercent: vm.clearPercent,
                 thoughtCount: vm.thoughtCount,
                 thoughts: vm.capturedThoughts,

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -257,8 +257,9 @@ struct SessionView: View {
     private func handleCompletion() {
         Task {
             // Persist session before navigating to completion screen
-            _ = await vm.saveSession(completed: vm.completedNaturally)
+            let session = await vm.saveSession(completed: vm.completedNaturally)
             appVM.completeSession(
+                sessionId: session?.id ?? "",
                 clearPercent: vm.clearPercent,
                 thoughtCount: vm.thoughtCount,
                 thoughts: vm.capturedThoughts,


### PR DESCRIPTION
## Summary
- Pass `sessionId` from `SessionViewModel.saveSession()` through `AppViewModel.completeSession()` into `CompletionView`
- Wire `saveEndNote()` to call `APIClient.shared.batchThoughts()` with `timeInSession: -1`
- Add loading spinner during save and error message on failure

Closes #39

## Test plan
- [x] Session completes and navigates to CompletionView with sessionId populated
- [x] Typing a note and tapping "Save note" triggers API call with loading spinner
- [x] After successful save, "saved" confirmation appears and button disappears
- [x] If API fails, error message "Failed to save note" is shown
- [x] Save button is disabled when sessionId is empty (graceful degradation)
- [x] Builds on iPhone 17 Pro simulator (iOS 26.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-of-session notes now persist to the server with guarded async saving, a "saving…" state, success confirmation, and error messaging.
  * Note editor and Save button disable while saving or after success; editing clears prior errors.
  * Completion screen now associates saved notes with a session identifier.

* **Bug Fixes**
  * Save outcome is respected before completing a session; on save failure users see an alert with Retry or Continue without saving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->