### PR TITLE
CompletionView: make Save Note button a full-width green capsule

### DIFF
--- a/ios/StillPointApp/Views/CompletionView.swift
+++ b/ios/StillPointApp/Views/CompletionView.swift
@@ -15,6 +15,7 @@ struct CompletionView: View {
     private var nextDay: Int { dayNumber + 1 }
     private var nextDuration: Int { StillPoint.duration(forDay: nextDay) }
     private var nextBlocks: Int { StillPoint.blockCount(forDuration: nextDuration) }
+    private var isSaveDisabled: Bool { endNote.isEmpty || noteSaved }
 
     var body: some View {
         ScrollView {
@@ -101,34 +102,25 @@ struct CompletionView: View {
                             RoundedRectangle(cornerRadius: 8)
                                 .stroke(SPColor.border2)
                         )
+                        .onChange(of: endNote) {
+                            if noteSaved { noteSaved = false }
+                        }
 
                     Button {
                         saveEndNote()
                     } label: {
                         Text(noteSaved ? "Saved" : "Save note")
                             .font(SPFont.serifItalic(18, weight: .light))
-                            .foregroundStyle(
-                                endNote.isEmpty || noteSaved
-                                    ? Color(SPColor.fg3)
-                                    : Color(SPColor.bg)
-                            )
+                            .foregroundStyle(isSaveDisabled ? Color(SPColor.fg3) : Color(SPColor.bg))
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, SPSpacing.s2)
-                            .background(
-                                endNote.isEmpty || noteSaved
-                                    ? SPColor.surface2
-                                    : SPColor.green
-                            )
+                            .background(isSaveDisabled ? SPColor.surface2 : SPColor.green)
                             .clipShape(Capsule())
                             .overlay(
-                                Capsule().stroke(
-                                    endNote.isEmpty || noteSaved
-                                        ? SPColor.border2
-                                        : Color.clear
-                                )
+                                Capsule().stroke(isSaveDisabled ? SPColor.border2 : Color.clear)
                             )
                     }
-                    .disabled(endNote.isEmpty || noteSaved)
+                    .disabled(isSaveDisabled)
                 }
 
                 // Tomorrow preview

--- a/ios/StillPointApp/Views/CompletionView.swift
+++ b/ios/StillPointApp/Views/CompletionView.swift
@@ -102,21 +102,33 @@ struct CompletionView: View {
                                 .stroke(SPColor.border2)
                         )
 
-                    if !endNote.isEmpty && !noteSaved {
-                        Button {
-                            saveEndNote()
-                        } label: {
-                            Text("Save note")
-                                .font(SPFont.mono(12, weight: .medium))
-                                .foregroundStyle(SPColor.green)
-                        }
+                    Button {
+                        saveEndNote()
+                    } label: {
+                        Text(noteSaved ? "Saved" : "Save note")
+                            .font(SPFont.serifItalic(18, weight: .light))
+                            .foregroundStyle(
+                                endNote.isEmpty || noteSaved
+                                    ? Color(SPColor.fg3)
+                                    : Color(SPColor.bg)
+                            )
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, SPSpacing.s2)
+                            .background(
+                                endNote.isEmpty || noteSaved
+                                    ? SPColor.surface2
+                                    : SPColor.green
+                            )
+                            .clipShape(Capsule())
+                            .overlay(
+                                Capsule().stroke(
+                                    endNote.isEmpty || noteSaved
+                                        ? SPColor.border2
+                                        : Color.clear
+                                )
+                            )
                     }
-
-                    if noteSaved {
-                        Text("saved")
-                            .font(SPFont.mono(11))
-                            .foregroundStyle(SPColor.greenDim)
-                    }
+                    .disabled(endNote.isEmpty || noteSaved)
                 }
 
                 // Tomorrow preview


### PR DESCRIPTION
## Summary
- Replace the small green text link "Save note" with a full-width green capsule button matching the app's design language
- Add `isSaveDisabled` computed property for clean conditional logic
- Add `.onChange(of: endNote)` to reset saved state when user edits text, enabling re-saving

## Button States
- **Empty text field:** Disabled, muted appearance (surface2 bg, fg3 text, subtle border)
- **Text entered:** Active green capsule (SPColor.green bg, dark SPColor.bg text)
- **After saving:** Shows "Saved", returns to disabled muted appearance
- **Edited after save:** Resets to active state, allowing re-save

## Test plan
- [x] Save Note button is full-width with green background when text is entered
- [x] Button has pill/capsule shape matching other CTAs in the app
- [x] Button is visually prominent and easy to tap
- [x] Disabled state when text field is empty (muted appearance)
- [x] After saving, button shows "Saved" in disabled state
- [x] Editing text after saving re-enables the button
- [x] Builds successfully on iPhone 17 Pro simulator (iOS 26.4)

Closes #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the note-saving experience with improved button feedback that clearly displays save status ("Save note" vs. "Saved")
  * The save button now provides better visual indication of when saving is available or disabled
  * Edited notes automatically reset their saved status, allowing users to save changes after initial completion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->