### PR TITLE
Fix Journey progress bars in iOS HistoryView

### DIFF
--- a/ios/StillPointApp/ViewModels/HistoryViewModel.swift
+++ b/ios/StillPointApp/ViewModels/HistoryViewModel.swift
@@ -1,6 +1,20 @@
 import SwiftUI
 import StillPointShared
 
+/// A display-ready row in the Journey list (session or missed day).
+struct HistoryEntry: Identifiable {
+    let id: String
+    let sessionId: String?
+    let dayNumber: Int?
+    let duration: Int
+    let actualTime: Int
+    let completed: Bool
+    let date: String          // "YYYY-MM-DD"
+    let clearPercent: Int
+    let thoughtCount: Int
+    let missed: Bool
+}
+
 @MainActor
 @Observable
 final class HistoryViewModel {
@@ -10,6 +24,12 @@ final class HistoryViewModel {
     var errorMessage: String?
     var expandedDay: Int?
     var dayThoughts: [Int: [ThoughtDTO]] = [:]
+
+    /// Flattened journey entries including missed days.
+    var history: [HistoryEntry] = []
+
+    /// Longest actualTime across all real sessions (floor 60).
+    var maxDuration: Int = 60
 
     func load() async {
         guard !isLoading else { return }
@@ -21,6 +41,7 @@ final class HistoryViewModel {
             let result = try await APIClient.shared.getSessions()
             sessions = result.sessions.sorted { $0.dayNumber < $1.dayNumber }
             stats = result.stats
+            buildHistory()
         } catch {
             errorMessage = "Failed to load sessions. Check your connection."
             print("Failed to load sessions: \(error)")
@@ -41,5 +62,57 @@ final class HistoryViewModel {
                 }
             }
         }
+    }
+
+    // MARK: - Private
+
+    private func buildHistory() {
+        var entries: [HistoryEntry] = []
+        let cal = Calendar.current
+        let df = DateFormatter()
+        df.dateFormat = "yyyy-MM-dd"
+
+        for (i, session) in sessions.enumerated() {
+            // Detect missed days between consecutive sessions
+            if i > 0,
+               let prevDate = df.date(from: sessions[i - 1].sessionDate),
+               let currDate = df.date(from: session.sessionDate) {
+                let daysBetween = cal.dateComponents([.day], from: prevDate, to: currDate).day ?? 0
+                for gap in 1..<daysBetween {
+                    if let missedDate = cal.date(byAdding: .day, value: gap, to: prevDate) {
+                        entries.append(HistoryEntry(
+                            id: "missed-\(df.string(from: missedDate))",
+                            sessionId: nil,
+                            dayNumber: nil,
+                            duration: 0,
+                            actualTime: 0,
+                            completed: false,
+                            date: df.string(from: missedDate),
+                            clearPercent: 0,
+                            thoughtCount: 0,
+                            missed: true
+                        ))
+                    }
+                }
+            }
+
+            entries.append(HistoryEntry(
+                id: session.id,
+                sessionId: session.id,
+                dayNumber: session.dayNumber,
+                duration: session.duration,
+                actualTime: session.actualTime ?? session.duration,
+                completed: session.completed,
+                date: session.sessionDate,
+                clearPercent: session.clearPercent,
+                thoughtCount: session.thoughtCount,
+                missed: false
+            ))
+        }
+
+        history = entries
+
+        let sessionTimes = entries.filter { !$0.missed }.map(\.actualTime)
+        maxDuration = max(sessionTimes.max() ?? 60, 60)
     }
 }

--- a/ios/StillPointApp/ViewModels/HistoryViewModel.swift
+++ b/ios/StillPointApp/ViewModels/HistoryViewModel.swift
@@ -39,7 +39,7 @@ final class HistoryViewModel {
 
         do {
             let result = try await APIClient.shared.getSessions()
-            sessions = result.sessions.sorted { $0.dayNumber < $1.dayNumber }
+            sessions = result.sessions.sorted { $0.sessionDate < $1.sessionDate }
             stats = result.stats
             buildHistory()
         } catch {

--- a/ios/StillPointApp/Views/HistoryView.swift
+++ b/ios/StillPointApp/Views/HistoryView.swift
@@ -110,8 +110,8 @@ struct HistoryView: View {
 
     @ViewBuilder
     private func sessionRow(_ entry: HistoryEntry) -> some View {
-        let dayNumber = entry.dayNumber ?? 0
-        let isExpanded = vm.expandedDay == dayNumber
+        if let dayNumber = entry.dayNumber {
+            let isExpanded = vm.expandedDay == dayNumber
 
         VStack(spacing: 0) {
             Button {
@@ -201,6 +201,7 @@ struct HistoryView: View {
                 .padding(.vertical, 4)
             }
         }
+        } // if let dayNumber
     }
 
     // MARK: - Missed Row
@@ -262,7 +263,7 @@ struct HistoryView: View {
             GeometryReader { geo in
                 let barFraction = vm.maxDuration > 0
                     ? CGFloat(todayDuration) / CGFloat(vm.maxDuration)
-                    : 1.0
+                    : 0
                 let barWidth = geo.size.width * barFraction
 
                 ZStack(alignment: .leading) {
@@ -290,13 +291,23 @@ struct HistoryView: View {
 
     // MARK: - Helpers
 
-    /// Format "YYYY-MM-DD" → "Mon Mar 16" (short, fits mobile).
-    private func shortDateLabel(_ isoDate: String) -> String {
+    // MARK: - Cached Formatters
+
+    private static let isoDateFormatter: DateFormatter = {
         let df = DateFormatter()
         df.dateFormat = "yyyy-MM-dd"
-        guard let date = df.date(from: isoDate) else { return isoDate }
-        let out = DateFormatter()
-        out.dateFormat = "EEE MMM d"
-        return out.string(from: date)
+        return df
+    }()
+
+    private static let displayDateFormatter: DateFormatter = {
+        let df = DateFormatter()
+        df.dateFormat = "EEE MMM d"
+        return df
+    }()
+
+    /// Format "YYYY-MM-DD" → "Mon Mar 16" (short, fits mobile).
+    private func shortDateLabel(_ isoDate: String) -> String {
+        guard let date = Self.isoDateFormatter.date(from: isoDate) else { return isoDate }
+        return Self.displayDateFormatter.string(from: date)
     }
 }

--- a/ios/StillPointApp/Views/HistoryView.swift
+++ b/ios/StillPointApp/Views/HistoryView.swift
@@ -64,14 +64,19 @@ struct HistoryView: View {
                     }
 
                     // Journey
-                    VStack(alignment: .leading, spacing: SPSpacing.s2) {
+                    VStack(alignment: .leading, spacing: 4) {
                         Text("JOURNEY")
                             .font(SPFont.mono(11, weight: .medium))
                             .foregroundStyle(Color(SPColor.fg4))
                             .tracking(2)
+                            .padding(.bottom, 4)
 
-                        ForEach(vm.sessions, id: \.id) { session in
-                            sessionRow(session)
+                        ForEach(vm.history) { entry in
+                            if entry.missed {
+                                missedRow(entry)
+                            } else {
+                                sessionRow(entry)
+                            }
                         }
 
                         todayPreview
@@ -101,47 +106,83 @@ struct HistoryView: View {
         }
     }
 
+    // MARK: - Session Row
+
     @ViewBuilder
-    private func sessionRow(_ session: SessionDTO) -> some View {
-        let isExpanded = vm.expandedDay == session.dayNumber
+    private func sessionRow(_ entry: HistoryEntry) -> some View {
+        let dayNumber = entry.dayNumber ?? 0
+        let isExpanded = vm.expandedDay == dayNumber
 
         VStack(spacing: 0) {
             Button {
-                Task { await vm.toggleDay(session.dayNumber) }
+                Task { await vm.toggleDay(dayNumber) }
             } label: {
-                HStack(spacing: SPSpacing.s2) {
-                    Text("D\(session.dayNumber)")
-                        .font(SPFont.mono(12, weight: .medium))
+                HStack(spacing: 8) {
+                    // Date label
+                    Text(shortDateLabel(entry.date))
+                        .font(SPFont.mono(10))
+                        .foregroundStyle(Color(SPColor.fg4))
+                        .frame(width: 56, alignment: .trailing)
+                        .lineLimit(1)
+
+                    // Day number
+                    Text("D\(dayNumber)")
+                        .font(SPFont.mono(11, weight: .medium))
                         .foregroundStyle(Color(SPColor.fg3))
-                        .frame(width: 36, alignment: .leading)
+                        .frame(width: 28, alignment: .trailing)
 
-                    // Stacked bar
+                    // Proportional bar
                     GeometryReader { geo in
-                        let clearWidth = geo.size.width * Double(session.clearPercent) / 100.0
-                        let thinkWidth = geo.size.width - clearWidth
+                        let barFraction = vm.maxDuration > 0
+                            ? CGFloat(entry.actualTime) / CGFloat(vm.maxDuration)
+                            : 0
+                        let barWidth = geo.size.width * barFraction
+                        let clearWidth = barWidth * CGFloat(entry.clearPercent) / 100.0
+                        let thinkWidth = barWidth - clearWidth
 
-                        HStack(spacing: 0) {
-                            Rectangle()
-                                .fill(SPColor.green.opacity(0.6))
-                                .frame(width: max(0, clearWidth))
-                            Rectangle()
-                                .fill(SPColor.amber.opacity(0.5))
-                                .frame(width: max(0, thinkWidth))
+                        ZStack(alignment: .leading) {
+                            // Background track
+                            RoundedRectangle(cornerRadius: 3)
+                                .fill(Color(SPColor.surface1))
+                                .frame(width: geo.size.width, height: 16)
+
+                            // Proportional filled portion
+                            HStack(spacing: 0) {
+                                Rectangle()
+                                    .fill(SPColor.green.opacity(entry.completed ? 0.7 : 0.4))
+                                    .frame(width: max(0, clearWidth))
+                                Rectangle()
+                                    .fill(SPColor.amber.opacity(entry.completed ? 0.5 : 0.3))
+                                    .frame(width: max(0, thinkWidth))
+                            }
+                            .frame(height: 16)
+                            .clipShape(RoundedRectangle(cornerRadius: 3))
                         }
-                        .clipShape(RoundedRectangle(cornerRadius: 3))
                     }
                     .frame(height: 16)
 
-                    Text("\(session.clearPercent)%")
-                        .font(SPFont.mono(11))
-                        .foregroundStyle(SPColor.greenText)
-                        .frame(width: 36, alignment: .trailing)
+                    // Metadata: duration · clear% · thoughts
+                    HStack(spacing: 4) {
+                        Text("\(entry.actualTime)s")
+                            .foregroundStyle(Color(SPColor.fg3))
+                        Text("·")
+                            .foregroundStyle(Color(SPColor.fg4))
+                        Text("\(entry.clearPercent)%")
+                            .foregroundStyle(SPColor.greenText)
+                        Text("·")
+                            .foregroundStyle(Color(SPColor.fg4))
+                        Text("\(entry.thoughtCount)\u{1F4AD}")
+                            .foregroundStyle(SPColor.amberText)
+                    }
+                    .font(SPFont.mono(10))
+                    .frame(width: 100, alignment: .leading)
+                    .lineLimit(1)
                 }
-                .padding(.vertical, SPSpacing.s1)
+                .padding(.vertical, 2)
             }
 
             // Expanded thoughts
-            if isExpanded, let thoughts = vm.dayThoughts[session.dayNumber] {
+            if isExpanded, let thoughts = vm.dayThoughts[dayNumber] {
                 VStack(alignment: .leading, spacing: 4) {
                     ForEach(thoughts, id: \.id) { thought in
                         HStack(alignment: .top, spacing: SPSpacing.s2) {
@@ -157,27 +198,105 @@ struct HistoryView: View {
                     }
                 }
                 .padding(.leading, 44)
-                .padding(.vertical, SPSpacing.s1)
+                .padding(.vertical, 4)
             }
         }
     }
 
-    private var todayPreview: some View {
-        HStack(spacing: SPSpacing.s2) {
-            Text("D\(appVM.currentDay)")
-                .font(SPFont.mono(12, weight: .medium))
-                .foregroundStyle(Color(SPColor.fg4))
-                .frame(width: 36, alignment: .leading)
+    // MARK: - Missed Row
 
+    private func missedRow(_ entry: HistoryEntry) -> some View {
+        HStack(spacing: 8) {
+            // Date label
+            Text(shortDateLabel(entry.date))
+                .font(SPFont.mono(10))
+                .foregroundStyle(Color(SPColor.fg4))
+                .frame(width: 56, alignment: .trailing)
+                .lineLimit(1)
+
+            // Em-dash instead of day number
+            Text("\u{2014}")
+                .font(SPFont.mono(11, weight: .medium))
+                .foregroundStyle(Color(SPColor.fg3))
+                .frame(width: 28, alignment: .trailing)
+
+            // Dashed border container
             RoundedRectangle(cornerRadius: 3)
                 .stroke(SPColor.border2, style: StrokeStyle(lineWidth: 1, dash: [4]))
                 .frame(height: 16)
+                .overlay(alignment: .leading) {
+                    Text("missed")
+                        .font(SPFont.mono(10))
+                        .foregroundStyle(Color(SPColor.fg4))
+                        .italic()
+                        .padding(.leading, 8)
+                }
 
-            Text("\(appVM.todayDuration)s")
-                .font(SPFont.mono(11))
-                .foregroundStyle(Color(SPColor.fg4))
-                .frame(width: 36, alignment: .trailing)
+            // Empty metadata spacer
+            Color.clear
+                .frame(width: 100)
         }
-        .padding(.vertical, SPSpacing.s1)
+        .padding(.vertical, 2)
+        .opacity(0.35)
+    }
+
+    // MARK: - Today Preview
+
+    private var todayPreview: some View {
+        let todayDuration = appVM.todayDuration
+
+        return HStack(spacing: 8) {
+            // Date label
+            Text("today")
+                .font(SPFont.mono(10))
+                .foregroundStyle(Color(SPColor.fg4))
+                .frame(width: 56, alignment: .trailing)
+
+            // Day number
+            Text("D\(appVM.currentDay)")
+                .font(SPFont.mono(11, weight: .medium))
+                .foregroundStyle(Color(SPColor.fg4))
+                .frame(width: 28, alignment: .trailing)
+
+            // Proportional dashed bar
+            GeometryReader { geo in
+                let barFraction = vm.maxDuration > 0
+                    ? CGFloat(todayDuration) / CGFloat(vm.maxDuration)
+                    : 1.0
+                let barWidth = geo.size.width * barFraction
+
+                ZStack(alignment: .leading) {
+                    // Background track
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(Color(SPColor.surface1))
+                        .frame(width: geo.size.width, height: 16)
+
+                    // Dashed outline scaled to duration
+                    RoundedRectangle(cornerRadius: 3)
+                        .stroke(SPColor.border2, style: StrokeStyle(lineWidth: 1, dash: [4]))
+                        .frame(width: max(0, barWidth), height: 16)
+                }
+            }
+            .frame(height: 16)
+
+            // Duration label
+            Text("\(todayDuration)s")
+                .font(SPFont.mono(10))
+                .foregroundStyle(Color(SPColor.fg4))
+                .frame(width: 100, alignment: .leading)
+        }
+        .padding(.vertical, 2)
+    }
+
+    // MARK: - Helpers
+
+    /// Format "YYYY-MM-DD" → "Mon Mar 16" (short, fits mobile).
+    private func shortDateLabel(_ isoDate: String) -> String {
+        let df = DateFormatter()
+        df.dateFormat = "yyyy-MM-dd"
+        guard let date = df.date(from: isoDate) else { return isoDate }
+        let out = DateFormatter()
+        out.dateFormat = "EEE MMM d"
+        return out.string(from: date)
     }
 }

--- a/ios/StillPointApp/Views/HistoryView.swift
+++ b/ios/StillPointApp/Views/HistoryView.swift
@@ -296,6 +296,8 @@ struct HistoryView: View {
     private static let isoDateFormatter: DateFormatter = {
         let df = DateFormatter()
         df.dateFormat = "yyyy-MM-dd"
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.calendar = Calendar(identifier: .gregorian)
         return df
     }()
 


### PR DESCRIPTION
## Summary
- Scale bar widths proportional to session duration relative to the longest session (`actualTime / maxDuration`)
- Detect missed days (gaps between sessions) and render with dashed borders, "missed" text, reduced opacity
- Add date label (e.g., `Mon Mar 16`), duration label (e.g., `60s`), clear%, and thought count (💭) per row
- Reduce vertical spacing from `SPSpacing.s2` to `4px` for compact layout
- Scale today preview bar proportionally to maxDuration
- Sort sessions by `sessionDate` for correct chronological gap detection
- Cache DateFormatters with POSIX locale for locale safety

Closes #40

## Test plan
- [x] Bar widths are proportional to session duration relative to the longest session
- [x] Row vertical spacing is compact (4px gap)
- [x] Each session row shows date label (e.g., `Mon Mar 16`)
- [x] Each session row shows duration, clear%, and thought count with 💭
- [x] Missed days render with dashed border, "missed" text, and 0.35 opacity
- [x] Today preview bar scales proportionally to maxDuration
- [x] Builds and runs on iPhone 17 Pro simulator (iOS 26.4)
- [x] Expanded thoughts still work when tapping a session row

🤖 Generated with [Claude Code](https://claude.com/claude-code)