### PR TITLE
Add workflow to auto-trigger @coderabbitai plan on new issues

### DIFF
--- a/.github/workflows/cr-plan-on-issue.yml
+++ b/.github/workflows/cr-plan-on-issue.yml
@@ -1,0 +1,24 @@
+name: Trigger CodeRabbit Plan on New Issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  trigger-cr-plan:
+    runs-on: ubuntu-latest
+    if: "!endsWith(github.event.issue.user.login, '[bot]')"
+    steps:
+      - name: Comment @coderabbitai plan
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '@coderabbitai plan'
+            });


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to automatically comment `@coderabbitai plan` on every newly opened issue
- Skips bot-created issues (dependabot, renovate, etc.)
- Minimal permissions: issues write only

## Test plan
- [ ] Workflow triggers on new issue creation
- [ ] `@coderabbitai plan` comment appears on the issue
- [ ] Bot-created issues are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)