### PR TITLE
Add TestFlight CI/CD workflow and update signing config

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -100,8 +100,10 @@ jobs:
             --apiKey "$APPSTORE_API_KEY_ID" \
             --apiIssuer "$APPSTORE_API_ISSUER_ID"
 
-      - name: Clean up keychain and provisioning profile
+      - name: Clean up keychain, provisioning profile, and API key
         if: always()
         run: |
           security delete-keychain $RUNNER_TEMP/app-signing.keychain-db 2>/dev/null || true
-          rm -f ~/Library/MobileDevice/Provisioning\ Profiles/*.mobileprovision
+          rm -f $RUNNER_TEMP/build_pp.mobileprovision 2>/dev/null || true
+          rm -f ~/Library/MobileDevice/Provisioning\ Profiles/build_pp.mobileprovision 2>/dev/null || true
+          rm -rf ~/.private_keys 2>/dev/null || true

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           # Write API key to file for authentication
           mkdir -p ~/.private_keys
-          echo "$APPSTORE_API_PRIVATE_KEY" > ~/.private_keys/AuthKey_${APPSTORE_API_KEY_ID}.p8
+          printf '%s\n' "$APPSTORE_API_PRIVATE_KEY" > ~/.private_keys/AuthKey_${APPSTORE_API_KEY_ID}.p8
 
           # Export and upload in one step using xcodebuild
           # The ExportOptions.plist has destination=upload and method=app-store-connect

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -65,8 +65,6 @@ jobs:
             -configuration Release \
             -archivePath $RUNNER_TEMP/StillPoint.xcarchive \
             -destination 'generic/platform=iOS' \
-            DEVELOPMENT_TEAM=T5UU4BP6AV \
-            CODE_SIGN_STYLE=Automatic \
             -allowProvisioningUpdates
 
       - name: Upload to App Store Connect

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -1,0 +1,104 @@
+name: Build & Upload to TestFlight
+
+on:
+  push:
+    tags:
+      - 'ios-v*'
+
+concurrency:
+  group: ios-testflight
+  cancel-in-progress: false
+
+jobs:
+  build-and-upload:
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        working-directory: ios
+        run: xcodegen generate
+
+      - name: Install Apple certificate and provisioning profile
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
+        run: |
+          # Create variables
+          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -hex 16)
+
+          # Import certificate and provisioning profile from secrets
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+          echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
+
+          # Create temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          # Import certificate to keychain
+          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+
+          # Apply provisioning profile
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+
+      - name: Build archive
+        working-directory: ios
+        run: |
+          xcodebuild archive \
+            -project StillPoint.xcodeproj \
+            -scheme StillPoint \
+            -configuration Release \
+            -archivePath $RUNNER_TEMP/StillPoint.xcarchive \
+            -destination 'generic/platform=iOS' \
+            DEVELOPMENT_TEAM=T5UU4BP6AV \
+            CODE_SIGN_STYLE=Automatic \
+            -allowProvisioningUpdates
+
+      - name: Export IPA
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath $RUNNER_TEMP/StillPoint.xcarchive \
+            -exportOptionsPlist ios/ExportOptions.plist \
+            -exportPath $RUNNER_TEMP/export \
+            -allowProvisioningUpdates
+
+      - name: Upload to TestFlight
+        env:
+          APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+          APPSTORE_API_ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+          APPSTORE_API_PRIVATE_KEY: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
+        run: |
+          # Write API key to file
+          mkdir -p ~/.private_keys
+          echo "$APPSTORE_API_PRIVATE_KEY" > ~/.private_keys/AuthKey_${APPSTORE_API_KEY_ID}.p8
+
+          xcrun notarytool store-credentials "AC_PASSWORD" \
+            --apple-id "" \
+            --team-id T5UU4BP6AV \
+            --password "" 2>/dev/null || true
+
+          xcrun altool --upload-app \
+            --type ios \
+            --file "$(find $RUNNER_TEMP/export -name '*.ipa')" \
+            --apiKey "$APPSTORE_API_KEY_ID" \
+            --apiIssuer "$APPSTORE_API_ISSUER_ID"
+
+      - name: Clean up keychain and provisioning profile
+        if: always()
+        run: |
+          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db 2>/dev/null || true
+          rm -f ~/Library/MobileDevice/Provisioning\ Profiles/*.mobileprovision

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -36,6 +36,7 @@ jobs:
           PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
           KEYCHAIN_PASSWORD=$(openssl rand -hex 16)
+          PP_INSTALL_PATH=~/Library/MobileDevice/Provisioning\ Profiles/build_pp.mobileprovision
 
           # Import certificate and provisioning profile from secrets
           echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
@@ -53,7 +54,7 @@ jobs:
 
           # Apply provisioning profile
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+          cp "$PP_PATH" "$PP_INSTALL_PATH"
 
       - name: Build archive
         working-directory: ios
@@ -68,37 +69,27 @@ jobs:
             CODE_SIGN_STYLE=Automatic \
             -allowProvisioningUpdates
 
-      - name: Export IPA
-        run: |
-          xcodebuild -exportArchive \
-            -archivePath $RUNNER_TEMP/StillPoint.xcarchive \
-            -exportOptionsPlist ios/ExportOptions.plist \
-            -exportPath $RUNNER_TEMP/export \
-            -allowProvisioningUpdates
-
-      - name: Upload to TestFlight
+      - name: Upload to App Store Connect
         env:
           APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
           APPSTORE_API_ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
           APPSTORE_API_PRIVATE_KEY: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
         run: |
-          # Write API key to file
+          # Write API key to file for authentication
           mkdir -p ~/.private_keys
           echo "$APPSTORE_API_PRIVATE_KEY" > ~/.private_keys/AuthKey_${APPSTORE_API_KEY_ID}.p8
 
-          # Find the IPA
-          IPA_PATH=$(find $RUNNER_TEMP/export -name '*.ipa' | head -1)
-          if [ -z "$IPA_PATH" ]; then
-            echo "Error: No IPA file found in $RUNNER_TEMP/export"
-            exit 1
-          fi
-          echo "Uploading $IPA_PATH"
-
-          xcrun altool --upload-app \
-            --type ios \
-            --file "$IPA_PATH" \
-            --apiKey "$APPSTORE_API_KEY_ID" \
-            --apiIssuer "$APPSTORE_API_ISSUER_ID"
+          # Export and upload in one step using xcodebuild
+          # The ExportOptions.plist has destination=upload and method=app-store-connect
+          # which makes xcodebuild upload directly to App Store Connect / TestFlight
+          xcodebuild -exportArchive \
+            -archivePath $RUNNER_TEMP/StillPoint.xcarchive \
+            -exportOptionsPlist ios/ExportOptions.plist \
+            -exportPath $RUNNER_TEMP/export \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath ~/.private_keys/AuthKey_${APPSTORE_API_KEY_ID}.p8 \
+            -authenticationKeyID "$APPSTORE_API_KEY_ID" \
+            -authenticationKeyIssuerID "$APPSTORE_API_ISSUER_ID"
 
       - name: Clean up keychain, provisioning profile, and API key
         if: always()

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -50,7 +50,7 @@ jobs:
           # Import certificate to keychain
           security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH $(security list-keychains -d user | tr -d '"')
 
           # Apply provisioning profile
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
@@ -95,6 +95,7 @@ jobs:
         if: always()
         run: |
           security delete-keychain $RUNNER_TEMP/app-signing.keychain-db 2>/dev/null || true
+          rm -f $RUNNER_TEMP/build_certificate.p12 2>/dev/null || true
           rm -f $RUNNER_TEMP/build_pp.mobileprovision 2>/dev/null || true
           rm -f ~/Library/MobileDevice/Provisioning\ Profiles/build_pp.mobileprovision 2>/dev/null || true
           rm -rf ~/.private_keys 2>/dev/null || true

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -86,14 +86,17 @@ jobs:
           mkdir -p ~/.private_keys
           echo "$APPSTORE_API_PRIVATE_KEY" > ~/.private_keys/AuthKey_${APPSTORE_API_KEY_ID}.p8
 
-          xcrun notarytool store-credentials "AC_PASSWORD" \
-            --apple-id "" \
-            --team-id T5UU4BP6AV \
-            --password "" 2>/dev/null || true
+          # Find the IPA
+          IPA_PATH=$(find $RUNNER_TEMP/export -name '*.ipa' | head -1)
+          if [ -z "$IPA_PATH" ]; then
+            echo "Error: No IPA file found in $RUNNER_TEMP/export"
+            exit 1
+          fi
+          echo "Uploading $IPA_PATH"
 
           xcrun altool --upload-app \
             --type ios \
-            --file "$(find $RUNNER_TEMP/export -name '*.ipa')" \
+            --file "$IPA_PATH" \
             --apiKey "$APPSTORE_API_KEY_ID" \
             --apiIssuer "$APPSTORE_API_ISSUER_ID"
 

--- a/ios/ExportOptions.plist
+++ b/ios/ExportOptions.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>app-store-connect</string>
+	<key>signingStyle</key>
+	<string>automatic</string>
+	<key>teamID</key>
+	<string>T5UU4BP6AV</string>
+	<key>uploadSymbols</key>
+	<true/>
+	<key>destination</key>
+	<string>upload</string>
+</dict>
+</plist>

--- a/ios/RELEASING.md
+++ b/ios/RELEASING.md
@@ -1,0 +1,61 @@
+# Releasing Still Point for iOS
+
+## Prerequisites
+
+The following GitHub repository secrets must be configured (Settings → Secrets and variables → Actions):
+
+| Secret | Description | How to get it |
+|--------|-------------|---------------|
+| `BUILD_CERTIFICATE_BASE64` | Base64-encoded `.p12` distribution certificate | Export from Keychain Access, then `base64 -i cert.p12 \| pbcopy` |
+| `P12_PASSWORD` | Password used when exporting the `.p12` | The password you set during export |
+| `BUILD_PROVISION_PROFILE_BASE64` | Base64-encoded `.mobileprovision` file | Download from developer.apple.com, then `base64 -i profile.mobileprovision \| pbcopy` |
+| `APPSTORE_API_KEY_ID` | App Store Connect API Key ID | From appstoreconnect.apple.com → Users and Access → Integrations |
+| `APPSTORE_API_ISSUER_ID` | App Store Connect API Issuer ID | Same page as above |
+| `APPSTORE_API_PRIVATE_KEY` | Contents of the `.p8` API key file | Paste the full file contents including BEGIN/END lines |
+
+## Releasing to TestFlight
+
+1. Update the version in `ios/project.yml`:
+   ```yaml
+   MARKETING_VERSION: "1.1.0"
+   CURRENT_PROJECT_VERSION: 2
+   ```
+
+2. Commit the version bump:
+   ```bash
+   git add ios/project.yml
+   git commit -m "Bump iOS version to 1.1.0 (build 2)"
+   ```
+
+3. Tag and push:
+   ```bash
+   git tag ios-v1.1.0
+   git push origin main --tags
+   ```
+
+4. The GitHub Actions workflow builds and uploads to TestFlight automatically.
+
+5. After Apple processes the build (~15 minutes), it appears in the TestFlight app on your device.
+
+## Version numbering
+
+- `MARKETING_VERSION` — the user-facing version (e.g., `1.0.0`, `1.1.0`)
+- `CURRENT_PROJECT_VERSION` — the build number, must increment with every upload (e.g., `1`, `2`, `3`)
+- Tag format: `ios-v{MARKETING_VERSION}` (e.g., `ios-v1.0.0`)
+
+## Submitting to the App Store
+
+The same build uploaded to TestFlight can be submitted to the App Store:
+
+1. Go to [appstoreconnect.apple.com](https://appstoreconnect.apple.com) → your app
+2. Fill in the required metadata (screenshots, description, privacy policy URL)
+3. Select the TestFlight build under the version
+4. Click "Add for Review"
+
+## Troubleshooting
+
+**Build fails with signing error:** Verify the certificate hasn't expired and the provisioning profile includes the correct bundle ID (`com.brettonauerbach.stillpoint`).
+
+**Upload fails with authentication error:** Regenerate the App Store Connect API key and update the GitHub secrets.
+
+**Build number conflict:** `CURRENT_PROJECT_VERSION` must be unique per upload. Increment it even for re-uploads of the same marketing version.

--- a/ios/RELEASING.md
+++ b/ios/RELEASING.md
@@ -7,7 +7,7 @@ The following GitHub repository secrets must be configured (Settings → Secrets
 | Secret | Description | How to get it |
 |--------|-------------|---------------|
 | `BUILD_CERTIFICATE_BASE64` | Base64-encoded `.p12` distribution certificate | Export from Keychain Access, then `base64 -i cert.p12 \| pbcopy` |
-| `P12_PASSWORD` | Password used when exporting the `.p12` | The password you set during export |
+| `P12_PASSWORD` | Password used when exporting the `.p12` | Stored in the project root `.env` file as `P12_PASSWORD` |
 | `BUILD_PROVISION_PROFILE_BASE64` | Base64-encoded `.mobileprovision` file | Download from developer.apple.com, then `base64 -i profile.mobileprovision \| pbcopy` |
 | `APPSTORE_API_KEY_ID` | App Store Connect API Key ID | From appstoreconnect.apple.com → Users and Access → Integrations |
 | `APPSTORE_API_ISSUER_ID` | App Store Connect API Issuer ID | Same page as above |

--- a/ios/RELEASING.md
+++ b/ios/RELEASING.md
@@ -7,7 +7,7 @@ The following GitHub repository secrets must be configured (Settings → Secrets
 | Secret | Description | How to get it |
 |--------|-------------|---------------|
 | `BUILD_CERTIFICATE_BASE64` | Base64-encoded `.p12` distribution certificate | Export from Keychain Access, then `base64 -i cert.p12 \| pbcopy` |
-| `P12_PASSWORD` | Password used when exporting the `.p12` | Stored in the project root `.env` file as `P12_PASSWORD` |
+| `P12_PASSWORD` | Password used when exporting the `.p12` | The password you set during `.p12` export |
 | `BUILD_PROVISION_PROFILE_BASE64` | Base64-encoded `.mobileprovision` file | Download from developer.apple.com, then `base64 -i profile.mobileprovision \| pbcopy` |
 | `APPSTORE_API_KEY_ID` | App Store Connect API Key ID | From appstoreconnect.apple.com → Users and Access → Integrations |
 | `APPSTORE_API_ISSUER_ID` | App Store Connect API Issuer ID | Same page as above |
@@ -30,7 +30,7 @@ The following GitHub repository secrets must be configured (Settings → Secrets
 3. Tag and push:
    ```bash
    git tag ios-v1.1.0
-   git push origin main --tags
+   git push origin ios-v1.1.0
    ```
 
 4. The GitHub Actions workflow builds and uploads to TestFlight automatically.

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -1,6 +1,6 @@
 name: StillPoint
 options:
-  bundleIdPrefix: com.stillpoint
+  bundleIdPrefix: com.brettonauerbach.stillpoint
   deploymentTarget:
     iOS: "17.0"
   xcodeVersion: "15.0"

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -30,10 +30,10 @@ targets:
           - Fonts/JetBrainsMono-Variable.ttf
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.stillpoint.app
+        PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint
         MARKETING_VERSION: "1.0.0"
         CURRENT_PROJECT_VERSION: 1
-        DEVELOPMENT_TEAM: ""
+        DEVELOPMENT_TEAM: T5UU4BP6AV
         CODE_SIGN_STYLE: Automatic
         SWIFT_VERSION: "5.9"
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES"

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -1,6 +1,6 @@
 name: StillPoint
 options:
-  bundleIdPrefix: com.brettonauerbach.stillpoint
+  bundleIdPrefix: com.brettonauerbach
   deploymentTarget:
     iOS: "17.0"
   xcodeVersion: "15.0"


### PR DESCRIPTION
## Summary
- Updates bundle ID to `com.brettonauerbach.stillpoint` and sets Team ID `T5UU4BP6AV` in `ios/project.yml`
- Creates `ios/ExportOptions.plist` for App Store Connect distribution
- Adds GitHub Actions workflow (`.github/workflows/ios-testflight.yml`) triggered by `ios-v*` tags that builds, archives, and uploads to TestFlight
- Adds `ios/RELEASING.md` with setup instructions and release workflow documentation

Closes #51

## Test plan
- [x] Bundle ID in `ios/project.yml` matches registered App ID (`com.brettonauerbach.stillpoint`)
- [x] Team ID in `ios/project.yml` matches Apple Developer account (`T5UU4BP6AV`)
- [x] ExportOptions.plist uses `app-store-connect` method with automatic signing
- [x] GitHub Actions workflow triggers only on `ios-v*` tags
- [x] Workflow installs certificate and provisioning profile from secrets
- [x] Workflow generates Xcode project via XcodeGen before building
- [x] Workflow uses `xcodebuild -exportArchive` with authentication flags for upload
- [x] Cleanup step removes keychain, certificate, provisioning profile, and API key
- [x] RELEASING.md documents all required GitHub secrets
- [x] RELEASING.md documents tag-based release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated iOS TestFlight build & upload pipeline triggered by release tags for faster distribution.

* **Documentation**
  * Added comprehensive iOS release guide with versioning, tagging, TestFlight/App Store submission steps, required secrets, and troubleshooting.

* **Chores**
  * Updated iOS app bundle identifier and signing team configuration.

* **New Config**
  * Added export configuration for App Store Connect uploads (automatic signing, symbol upload).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->