### PR TITLE
Fix CI signing: use manual code signing for CI builds

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -52,20 +52,31 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           security list-keychain -d user -s $KEYCHAIN_PATH $(security list-keychains -d user | tr -d '"')
 
-          # Apply provisioning profile
+          # Apply provisioning profile and extract UUID for manual signing
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          cp "$PP_PATH" "$PP_INSTALL_PATH"
+          PP_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< "$(/usr/bin/security cms -D -i $PP_PATH)")
+          cp "$PP_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/${PP_UUID}.mobileprovision
 
       - name: Build archive
         working-directory: ios
+        env:
+          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
         run: |
+          # Extract provisioning profile UUID for manual signing
+          PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
+          echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
+          PP_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< "$(/usr/bin/security cms -D -i $PP_PATH)")
+
           xcodebuild archive \
             -project StillPoint.xcodeproj \
             -scheme StillPoint \
             -configuration Release \
             -archivePath $RUNNER_TEMP/StillPoint.xcarchive \
             -destination 'generic/platform=iOS' \
-            -allowProvisioningUpdates
+            CODE_SIGN_STYLE=Manual \
+            DEVELOPMENT_TEAM=T5UU4BP6AV \
+            PROVISIONING_PROFILE_SPECIFIER="$PP_UUID" \
+            CODE_SIGN_IDENTITY="Apple Distribution"
 
       - name: Upload to App Store Connect
         env:

--- a/ios/ExportOptions.plist
+++ b/ios/ExportOptions.plist
@@ -5,9 +5,16 @@
 	<key>method</key>
 	<string>app-store-connect</string>
 	<key>signingStyle</key>
-	<string>automatic</string>
+	<string>manual</string>
 	<key>teamID</key>
 	<string>T5UU4BP6AV</string>
+	<key>signingCertificate</key>
+	<string>Apple Distribution</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>com.brettonauerbach.stillpoint</key>
+		<string>StillPoint App Store</string>
+	</dict>
 	<key>uploadSymbols</key>
 	<true/>
 	<key>destination</key>


### PR DESCRIPTION
## Summary
- Switches from automatic to manual code signing in the GitHub Actions workflow
- Extracts provisioning profile UUID and installs with correct filename
- Sets explicit `CODE_SIGN_STYLE=Manual`, `PROVISIONING_PROFILE_SPECIFIER`, and `CODE_SIGN_IDENTITY` for xcodebuild
- Updates ExportOptions.plist with manual signing style and profile mapping

Fixes the `No Accounts: Add a new account in Accounts settings` error from the first TestFlight build attempt.

Related to #51

## Test plan
- [x] Workflow uses manual signing with explicit provisioning profile UUID
- [x] ExportOptions.plist specifies manual signing style with profile name mapping
- [x] Build archive step sets CODE_SIGN_IDENTITY to "Apple Distribution"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS build and signing configuration to improve deployment reliability for TestFlight releases.
  * Refined the build pipeline provisioning process for more consistent distribution handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->