### PR TITLE
Fix iPad validation: add missing Info.plist keys

### DIFF
--- a/ios/StillPointApp/Info.plist
+++ b/ios/StillPointApp/Info.plist
@@ -24,5 +24,16 @@
 		<string>Fonts/Newsreader-Italic-Variable.ttf</string>
 		<string>Fonts/JetBrainsMono-Variable.ttf</string>
 	</array>
+	<key>CFBundleIconName</key>
+	<string>AppIcon</string>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
 </dict>
 </plist>

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -43,6 +43,3 @@ targets:
         INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
-        INFOPLIST_KEY_CFBundleIconName: AppIcon
-        INFOPLIST_KEY_UILaunchStoryboardName: ""
-        INFOPLIST_KEY_UISupportedInterfaceOrientations: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"


### PR DESCRIPTION
## Summary
- Adds CFBundleIconName, UILaunchScreen, and UISupportedInterfaceOrientations directly to Info.plist
- Removes non-functional INFOPLIST_KEY_ build settings from project.yml (these only work with Xcode-generated plists, not pre-existing ones)
- Fixes the remaining App Store validation errors blocking TestFlight upload

Related to #51

## Test plan
- [ ] Info.plist contains CFBundleIconName, UILaunchScreen, and UISupportedInterfaceOrientations
- [ ] TestFlight build uploads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)