### PR TITLE
Fix iPad validation via XcodeGen info.properties

### DIFF
--- a/ios/project.yml
+++ b/ios/project.yml
@@ -28,6 +28,18 @@ targets:
           - Fonts/Newsreader-Variable.ttf
           - Fonts/Newsreader-Italic-Variable.ttf
           - Fonts/JetBrainsMono-Variable.ttf
+        CFBundleIconName: AppIcon
+        UILaunchScreen: {}
+        UISupportedInterfaceOrientations:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationPortraitUpsideDown
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
+        UISupportedInterfaceOrientations~ipad:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationPortraitUpsideDown
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint


### PR DESCRIPTION
## Summary
Adds missing Info.plist keys via XcodeGen's info.properties section, ensuring they're properly merged into the generated plist. Previous attempt added them to Info.plist directly but XcodeGen may override during project generation.

Related to #51

## Test plan
- [ ] TestFlight build uploads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * iOS app now explicitly configures app icon and launch screen settings
  * Added support for portrait and landscape device orientations on both iPhone and iPad

<!-- end of auto-generated comment: release notes by coderabbit.ai -->