### PR TITLE
Fix note saving: add sessionId to batch thoughts API response

### DIFF
--- a/src/app/api/thoughts/batch/route.ts
+++ b/src/app/api/thoughts/batch/route.ts
@@ -30,6 +30,7 @@ export async function POST(request: NextRequest) {
 
     const inserted = await db.insert(thoughts).values(values).returning({
       id: thoughts.id,
+      sessionId: thoughts.sessionId,
       dayNumber: thoughts.dayNumber,
       timeInSession: thoughts.timeInSession,
       text: thoughts.text,


### PR DESCRIPTION
## Summary
- Adds `sessionId` to the `.returning()` clause in `src/app/api/thoughts/batch/route.ts`
- The batch insert was returning `id`, `dayNumber`, `timeInSession`, and `text` but omitting `sessionId`, causing iOS `ThoughtDTO` parsing to fail

Closes #60

## Test plan
- [x] The .returning() clause now includes sessionId alongside id, dayNumber, timeInSession, text
- [x] Response schema matches iOS ThoughtDTO expectations (sessionId is present in JSON response)
- [x] No other API routes or iOS files need changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)