### PR TITLE
Fix iOS crash in buildHistory() due to invalid Swift range

### DIFF
--- a/ios/StillPointApp/ViewModels/HistoryViewModel.swift
+++ b/ios/StillPointApp/ViewModels/HistoryViewModel.swift
@@ -78,20 +78,22 @@ final class HistoryViewModel {
                let prevDate = df.date(from: sessions[i - 1].sessionDate),
                let currDate = df.date(from: session.sessionDate) {
                 let daysBetween = cal.dateComponents([.day], from: prevDate, to: currDate).day ?? 0
-                for gap in 1..<daysBetween {
-                    if let missedDate = cal.date(byAdding: .day, value: gap, to: prevDate) {
-                        entries.append(HistoryEntry(
-                            id: "missed-\(df.string(from: missedDate))",
-                            sessionId: nil,
-                            dayNumber: nil,
-                            duration: 0,
-                            actualTime: 0,
-                            completed: false,
-                            date: df.string(from: missedDate),
-                            clearPercent: 0,
-                            thoughtCount: 0,
-                            missed: true
-                        ))
+                if daysBetween > 1 {
+                    for gap in 1..<daysBetween {
+                        if let missedDate = cal.date(byAdding: .day, value: gap, to: prevDate) {
+                            entries.append(HistoryEntry(
+                                id: "missed-\(df.string(from: missedDate))",
+                                sessionId: nil,
+                                dayNumber: nil,
+                                duration: 0,
+                                actualTime: 0,
+                                completed: false,
+                                date: df.string(from: missedDate),
+                                clearPercent: 0,
+                                thoughtCount: 0,
+                                missed: true
+                            ))
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Guards the `1..<daysBetween` range in `HistoryViewModel.buildHistory()` with `if daysBetween > 1` to prevent a Swift fatal error when sessions are same-day, consecutive, or have negative date differences
- Fixes crash on History tab when any two sessions share the same date or are on consecutive days

Closes #59

## Test Plan
- [ ] History tab loads without crash when sessions have same-day entries (daysBetween=0)
- [ ] History tab loads without crash when sessions are consecutive days (daysBetween=1)
- [ ] History tab loads without crash with no sessions (empty history)
- [ ] Gap placeholders still appear correctly for multi-day gaps (daysBetween >= 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generation of missed day entries to only occur when there is an actual gap between sessions, preventing unnecessary or duplicate entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->