### PR TITLE
Fix timer countdown display and audio tick timing

### DIFF
--- a/ios/StillPointApp/ViewModels/SessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/SessionViewModel.swift
@@ -33,7 +33,7 @@ final class SessionViewModel {
     private var startDate: Date?
     private var pausedElapsed: Double = 0
     private var timer: AnyCancellable?
-    private var lastTickSec = -1
+    private var lastTickSec = 0
     private var lastChimeMinutesLeft: Int
     private var controlHideTimer: AnyCancellable?
 
@@ -41,12 +41,16 @@ final class SessionViewModel {
         max(0, Double(totalSeconds) - elapsed)
     }
 
+    private var displaySeconds: Int {
+        remaining == 0 ? 0 : Int(ceil(remaining))
+    }
+
     var minutes: Int {
-        Int(remaining) / 60
+        displaySeconds / 60
     }
 
     var seconds: Int {
-        Int(remaining) % 60
+        displaySeconds % 60
     }
 
     var clearPercent: Int {


### PR DESCRIPTION
## Summary
- Fixes spurious first audio tick firing immediately at session start by initializing `lastTickSec` to `0` instead of `-1`
- Fixes timer display off-by-one by using ceiling rounding (`Int(ceil(remaining))`) so remaining=10.0 shows "0:10" not "0:09"
- Extracts shared `displaySeconds` computed property to DRY up minutes/seconds logic

Closes #61

## Test plan
- [x] lastTickSec initialized to 0 instead of -1
- [x] First audio tick fires at ~1 second, not immediately at session start
- [x] Timer display uses ceiling rounding (Int(ceil(remaining)))
- [x] Display shows "0:10" when remaining=10.0 (not "0:09")
- [x] Display shows "0:00" at session completion (remaining=0.0)
- [x] Only SessionViewModel.swift was modified — no changes to AudioEngine, BlockGridView, or SessionLogic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved countdown display to round up remaining time (prevents showing a lower second prematurely).
  * Adjusted per-second audio cue timing so the first tick aligns correctly with the displayed time, reducing mismatched or missing initial cues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->