### PR TITLE
Add ITSAppUsesNonExemptEncryption to skip export compliance prompt

### DIFF
--- a/ios/StillPoint.xcodeproj/project.pbxproj
+++ b/ios/StillPoint.xcodeproj/project.pbxproj
@@ -225,7 +225,7 @@
 				LastUpgradeCheck = 1500;
 				TargetAttributes = {
 					1EC3D1ED76F9038154716BEC = {
-						DevelopmentTeam = "";
+						DevelopmentTeam = T5UU4BP6AV;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -306,7 +306,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = T5UU4BP6AV;
 				INFOPLIST_FILE = StillPointApp/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -318,7 +318,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.stillpoint.app;
+				PRODUCT_BUNDLE_IDENTIFIER = com.brettonauerbach.stillpoint;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -333,7 +333,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = T5UU4BP6AV;
 				INFOPLIST_FILE = StillPointApp/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -345,7 +345,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.stillpoint.app;
+				PRODUCT_BUNDLE_IDENTIFIER = com.brettonauerbach.stillpoint;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -29,6 +29,7 @@ targets:
           - Fonts/Newsreader-Italic-Variable.ttf
           - Fonts/JetBrainsMono-Variable.ttf
         CFBundleIconName: AppIcon
+        ITSAppUsesNonExemptEncryption: false
         UILaunchScreen: {}
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait


### PR DESCRIPTION
## Summary
- Adds `ITSAppUsesNonExemptEncryption: false` to `info.properties` in `ios/project.yml`
- Regenerated Xcode project via `xcodegen generate`

Closes #58

## Test Plan
- [x] ITSAppUsesNonExemptEncryption: false added to info.properties in project.yml
- [x] xcodegen generate runs without errors
- [x] No other properties in project.yml were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS application signing configuration and bundle identifier settings.
  * Added encryption compliance declaration for app store submission requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->