### PR TITLE
Add TestFlight tester group setup docs to RELEASING.md

### DIFF
--- a/ios/RELEASING.md
+++ b/ios/RELEASING.md
@@ -23,7 +23,7 @@ Before your first TestFlight release, configure a tester group and handle encryp
 4. Under the group's `Automatic Distribution` setting, enable it so new builds are distributed to the group automatically.
 5. On the first build upload, App Store Connect presents an encryption compliance questionnaire. Select **"None of the algorithms mentioned above"** — Still Point only uses standard HTTPS via `URLSession`, which is exempt.
 
-> **Note:** [#58](https://github.com/auerbachb/still-point/issues/58) has automated the encryption compliance step by setting `ITSAppUsesNonExemptEncryption` to `NO` in the `Info.plist`, so the questionnaire is no longer shown for subsequent uploads.
+> **Note:** [#58](https://github.com/auerbachb/still-point/issues/58) tracks automating this via `ITSAppUsesNonExemptEncryption` in `Info.plist`. Until that key is merged and present, expect the encryption questionnaire during upload.
 
 ## Releasing to TestFlight
 

--- a/ios/RELEASING.md
+++ b/ios/RELEASING.md
@@ -13,6 +13,18 @@ The following GitHub repository secrets must be configured (Settings → Secrets
 | `APPSTORE_API_ISSUER_ID` | App Store Connect API Issuer ID | Same page as above |
 | `APPSTORE_API_PRIVATE_KEY` | Contents of the `.p8` API key file | Paste the full file contents including BEGIN/END lines |
 
+## First-Time Setup
+
+Before your first TestFlight release, configure a tester group and handle encryption compliance:
+
+1. Open [App Store Connect](https://appstoreconnect.apple.com) and navigate to your app.
+2. Go to `TestFlight` → `Internal Testing` and click the `+` button to create a new group (e.g., "Internal Testers").
+3. Add testers to the group by clicking `Add Testers` and entering their Apple ID email addresses.
+4. Under the group's `Automatic Distribution` setting, enable it so new builds are distributed to the group automatically.
+5. On the first build upload, App Store Connect presents an encryption compliance questionnaire. Select **"None of the algorithms mentioned above"** — Still Point only uses standard HTTPS via `URLSession`, which is exempt.
+
+> **Note:** [#58](https://github.com/auerbachb/still-point/issues/58) has automated the encryption compliance step by setting `ITSAppUsesNonExemptEncryption` to `NO` in the `Info.plist`, so the questionnaire is no longer shown for subsequent uploads.
+
 ## Releasing to TestFlight
 
 1. Update the version in `ios/project.yml`:


### PR DESCRIPTION
## Summary
- Adds a new "First-Time Setup" section to `ios/RELEASING.md` between Prerequisites and Releasing to TestFlight
- Documents tester group creation, adding testers, automatic build distribution, and encryption compliance
- Links to [#58](https://github.com/auerbachb/still-point/issues/58) for encryption automation via `ITSAppUsesNonExemptEncryption`

Closes #64

## Test plan
- [x] New "First-Time Setup" section added between Prerequisites and Releasing to TestFlight
- [x] Covers tester group creation, adding testers, build assignment, and encryption compliance
- [x] References issue #58 for encryption automation
- [x] Follows existing doc conventions (numbered steps, imperative tone, inline code)
- [x] No other sections of RELEASING.md were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “First-Time Setup” section to the iOS release guide covering one-time App Store Connect steps: create an internal TestFlight tester group, add testers by Apple ID, enable Automatic Distribution for that group, and respond to the App Store encryption compliance questionnaire on the first build upload.
  * Noted that a forthcoming configuration change should automate compliance reporting; the questionnaire may persist until that change is applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->