### PR TITLE
Add landing homepage and move app to /app

### DIFF
--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import type { User } from "@/lib/api";
 import { AuthScreen } from "@/components/AuthScreen";
 import { HomeView } from "@/components/HomeView";
 import { SessionView } from "@/components/SessionView";
@@ -13,14 +14,6 @@ import { useIsMobile } from "@/lib/useIsMobile";
 
 type View = "home" | "session" | "complete" | "history" | "journal" | "board" | "settings";
 
-type User = {
-  id: string;
-  email: string;
-  username: string;
-  isPublic: boolean;
-  currentDay: number;
-};
-
 type CompletionData = {
   sessionId: string | null;
   dayNumber: number;
@@ -30,24 +23,69 @@ type CompletionData = {
   thoughts: Array<{ timeInSession: number; text: string }>;
 };
 
+function getLocalIsoDate(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
 export default function StillPoint() {
   const [user, setUser] = useState<User | null>(null);
   const [view, setView] = useState<View>("home");
   const [authChecked, setAuthChecked] = useState(false);
+  const [authError, setAuthError] = useState<string | null>(null);
+  const [authRetryKey, setAuthRetryKey] = useState(0);
   const [completionData, setCompletionData] = useState<CompletionData | null>(null);
   const isMobile = useIsMobile();
 
   useEffect(() => {
-    fetch("/api/auth/me")
-      .then(res => res.ok ? res.json() : null)
-      .then(data => {
-        if (data?.user) {
-          setUser(data.user);
+    let cancelled = false;
+
+    async function checkAuth() {
+      try {
+        const res = await fetch("/api/auth/me");
+        if (cancelled) return;
+
+        if (res.ok) {
+          const data = await res.json();
+          setUser(data?.user ?? null);
+          setAuthError(null);
+          setAuthChecked(true);
+          return;
         }
+
+        if (res.status === 401 || res.status === 403) {
+          setUser(null);
+          setAuthError(null);
+          setAuthChecked(true);
+          return;
+        }
+
+        if (res.status >= 500) {
+          setAuthError("Unable to verify your sign-in due to a server issue. Please retry.");
+          setAuthChecked(true);
+          return;
+        }
+
+        setUser(null);
+        setAuthError(null);
         setAuthChecked(true);
-      })
-      .catch(() => setAuthChecked(true));
-  }, []);
+      } catch {
+        if (!cancelled) {
+          setAuthError("Unable to verify your sign-in due to a network issue. Please retry.");
+          setAuthChecked(true);
+        }
+      }
+    }
+
+    checkAuth();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authRetryKey]);
 
   const handleLogin = (userData: User) => {
     setUser(userData);
@@ -88,7 +126,7 @@ export default function StillPoint() {
           clearPercent: data.clearPercent,
           thoughtCount: data.thoughtCount,
           mindStateLog: data.mindStateLog,
-          sessionDate: new Date().toISOString().split("T")[0],
+          sessionDate: getLocalIsoDate(),
         }),
       });
 
@@ -154,7 +192,7 @@ export default function StillPoint() {
           clearPercent: data.clearPercent,
           thoughtCount: data.thoughtCount,
           mindStateLog: data.mindStateLog,
-          sessionDate: new Date().toISOString().split("T")[0],
+          sessionDate: getLocalIsoDate(),
         }),
       });
 
@@ -195,6 +233,48 @@ export default function StillPoint() {
         }}>
           Still Point
         </div>
+      </div>
+    );
+  }
+
+  if (authError) {
+    return (
+      <div style={{
+        minHeight: "100vh", display: "flex", flexDirection: "column",
+        alignItems: "center", justifyContent: "center",
+        gap: "var(--s3)",
+        fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+        padding: "40px 20px",
+        textAlign: "center",
+      }}>
+        <div style={{ fontSize: "28px", fontStyle: "italic", color: "var(--fg)" }}>
+          Still Point
+        </div>
+        <p style={{ maxWidth: "44ch", color: "var(--fg-2)", lineHeight: 1.5 }}>
+          {authError}
+        </p>
+        <button
+          type="button"
+          onClick={() => {
+            setAuthChecked(false);
+            setAuthError(null);
+            setAuthRetryKey((prev) => prev + 1);
+          }}
+          style={{
+            border: "1px solid var(--border-2)",
+            background: "transparent",
+            color: "var(--fg)",
+            borderRadius: "999px",
+            padding: "10px 16px",
+            cursor: "pointer",
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+            fontSize: "12px",
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+          }}
+        >
+          Retry
+        </button>
       </div>
     );
   }

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { AuthScreen } from "@/components/AuthScreen";
+import { HomeView } from "@/components/HomeView";
+import { SessionView } from "@/components/SessionView";
+import { CompletionScreen } from "@/components/CompletionScreen";
+import { HistoryView } from "@/components/HistoryView";
+import { ThoughtJournal } from "@/components/ThoughtJournal";
+import { PublicBoard } from "@/components/PublicBoard";
+import { SettingsView } from "@/components/SettingsView";
+import { useIsMobile } from "@/lib/useIsMobile";
+
+type View = "home" | "session" | "complete" | "history" | "journal" | "board" | "settings";
+
+type User = {
+  id: string;
+  email: string;
+  username: string;
+  isPublic: boolean;
+  currentDay: number;
+};
+
+type CompletionData = {
+  sessionId: string | null;
+  dayNumber: number;
+  duration: number;
+  clearPercent: number;
+  thoughtCount: number;
+  thoughts: Array<{ timeInSession: number; text: string }>;
+};
+
+export default function StillPoint() {
+  const [user, setUser] = useState<User | null>(null);
+  const [view, setView] = useState<View>("home");
+  const [authChecked, setAuthChecked] = useState(false);
+  const [completionData, setCompletionData] = useState<CompletionData | null>(null);
+  const isMobile = useIsMobile();
+
+  useEffect(() => {
+    fetch("/api/auth/me")
+      .then(res => res.ok ? res.json() : null)
+      .then(data => {
+        if (data?.user) {
+          setUser(data.user);
+        }
+        setAuthChecked(true);
+      })
+      .catch(() => setAuthChecked(true));
+  }, []);
+
+  const handleLogin = (userData: User) => {
+    setUser(userData);
+    setView("home");
+  };
+
+  const handleLogout = () => {
+    setUser(null);
+    setView("home");
+  };
+
+  const handleBegin = () => {
+    setView("session");
+  };
+
+  const handleSessionComplete = useCallback(async (data: {
+    dayNumber: number;
+    duration: number;
+    completed: boolean;
+    actualTime: number;
+    clearPercent: number;
+    thoughtCount: number;
+    mindStateLog: Array<{ time: number; state: string }>;
+    thoughts: Array<{ timeInSession: number; text: string }>;
+  }) => {
+    let savedSessionId: string | null = null;
+
+    try {
+      // Save session
+      const sessionRes = await fetch("/api/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          dayNumber: data.dayNumber,
+          duration: data.duration,
+          completed: data.completed,
+          actualTime: data.actualTime,
+          clearPercent: data.clearPercent,
+          thoughtCount: data.thoughtCount,
+          mindStateLog: data.mindStateLog,
+          sessionDate: new Date().toISOString().split("T")[0],
+        }),
+      });
+
+      if (!sessionRes.ok) {
+        console.error("Failed to save session:", await sessionRes.text());
+      } else {
+        const sessionData = await sessionRes.json();
+        savedSessionId = sessionData.session?.id ?? null;
+
+        // Save thoughts if any
+        if (data.thoughts.length > 0 && savedSessionId) {
+          await fetch("/api/thoughts/batch", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              sessionId: savedSessionId,
+              dayNumber: data.dayNumber,
+              thoughts: data.thoughts,
+            }),
+          });
+        }
+
+        // Update local user state
+        if (data.completed && user) {
+          setUser({ ...user, currentDay: user.currentDay + 1 });
+        }
+      }
+    } catch (error) {
+      console.error("Failed to save session:", error);
+    }
+
+    setCompletionData({
+      sessionId: savedSessionId,
+      dayNumber: data.dayNumber,
+      duration: data.duration,
+      clearPercent: data.clearPercent,
+      thoughtCount: data.thoughtCount,
+      thoughts: data.thoughts,
+    });
+    setView("complete");
+  }, [user]);
+
+  const handleSessionAbandon = useCallback(async (data: {
+    dayNumber: number;
+    duration: number;
+    completed: boolean;
+    actualTime: number;
+    clearPercent: number;
+    thoughtCount: number;
+    mindStateLog: Array<{ time: number; state: string }>;
+    thoughts: Array<{ timeInSession: number; text: string }>;
+  }) => {
+    try {
+      // Save abandoned session
+      const sessionRes = await fetch("/api/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          dayNumber: data.dayNumber,
+          duration: data.duration,
+          completed: false,
+          actualTime: data.actualTime,
+          clearPercent: data.clearPercent,
+          thoughtCount: data.thoughtCount,
+          mindStateLog: data.mindStateLog,
+          sessionDate: new Date().toISOString().split("T")[0],
+        }),
+      });
+
+      if (sessionRes.ok) {
+        const sessionData = await sessionRes.json();
+
+        if (data.thoughts.length > 0 && sessionData.session?.id) {
+          await fetch("/api/thoughts/batch", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              sessionId: sessionData.session.id,
+              dayNumber: data.dayNumber,
+              thoughts: data.thoughts,
+            }),
+          });
+        }
+      }
+    } catch (error) {
+      console.error("Failed to save abandoned session:", error);
+    }
+
+    setView("home");
+  }, []);
+
+  const navItems: View[] = ["home", "history", "journal", "board", "settings"];
+
+  // Loading state
+  if (!authChecked) {
+    return (
+      <div style={{
+        minHeight: "100vh", display: "flex", alignItems: "center", justifyContent: "center",
+        fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+      }}>
+        <div style={{
+          fontSize: "42px", fontWeight: 300, fontStyle: "italic",
+          color: "var(--fg-4)", animation: "breathe 4s ease-in-out infinite",
+        }}>
+          Still Point
+        </div>
+      </div>
+    );
+  }
+
+  // Not logged in
+  if (!user) {
+    return (
+      <div style={{
+        minHeight: "100vh", display: "flex", flexDirection: "column",
+        alignItems: "center", justifyContent: "center",
+        fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+        padding: "40px 20px",
+      }}>
+        <AuthScreen onLogin={handleLogin} />
+      </div>
+    );
+  }
+
+  // Logged in
+  return (
+    <div style={{
+      minHeight: "100svh",
+      display: "grid",
+      gridTemplateRows: view === "session" ? "1fr" : "auto 1fr auto",
+      alignItems: "center",
+      fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+      padding: isMobile
+        ? "var(--s4) var(--s3) calc(var(--nav-h) + env(safe-area-inset-bottom, 0px))"
+        : "var(--s4) var(--s4)",
+    }}>
+      {/* Nav */}
+      {view !== "session" && (
+        <div style={isMobile ? {
+          position: "fixed", bottom: 0, left: 0, right: 0,
+          display: "flex", justifyContent: "space-around",
+          background: "rgba(var(--bg-rgb), 0.92)", backdropFilter: "blur(10px)",
+          borderTop: "1px solid var(--border-1)",
+          padding: "10px 0 env(safe-area-inset-bottom, 8px)",
+          zIndex: 100,
+        } : {
+          position: "fixed", top: "var(--s4)", right: "var(--s4)",
+          display: "flex", gap: "var(--s3)",
+          zIndex: 100,
+        }}>
+          {navItems.map(v => (
+            <button
+              type="button"
+              key={v}
+              onClick={() => setView(v)}
+              style={{
+                background: "none", border: "none",
+                color: view === v ? "var(--fg)" : "var(--fg-2)",
+                fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                fontSize: isMobile ? "13px" : "11px",
+                letterSpacing: "0.1em",
+                textTransform: "uppercase",
+                cursor: "pointer",
+                padding: isMobile ? "12px 14px" : "8px",
+                minWidth: isMobile ? "44px" : undefined,
+                minHeight: isMobile ? "44px" : undefined,
+                display: "inline-flex", alignItems: "center", justifyContent: "center",
+                transition: "color 0.3s",
+                position: "relative",
+              }}
+            >
+              {v}
+              {view === v && isMobile && (
+                <span style={{
+                  position: "absolute", bottom: "4px", left: "50%", transform: "translateX(-50%)",
+                  width: "16px", height: "2px", borderRadius: "1px",
+                  background: "var(--fg)",
+                }} />
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Welcome header */}
+      {view !== "session" && (
+        <div style={{
+          fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+          fontSize: "12px", color: "var(--fg-3)",
+          letterSpacing: "0.12em",
+          fontWeight: 400,
+          textAlign: "center",
+          paddingTop: isMobile ? "var(--s1)" : "var(--s5)",
+          marginBottom: "var(--s4)",
+        }}>
+          <span style={{ textTransform: "uppercase" }}>Welcome, </span>{user.username}
+        </div>
+      )}
+
+      {/* Views */}
+      {view === "home" && (
+        <HomeView currentDay={user.currentDay} onBegin={handleBegin} />
+      )}
+
+      {view === "session" && (
+        <SessionView
+          currentDay={user.currentDay}
+          onComplete={handleSessionComplete}
+          onAbandon={handleSessionAbandon}
+        />
+      )}
+
+      {view === "complete" && completionData && (
+        <CompletionScreen
+          dayNumber={completionData.dayNumber}
+          duration={completionData.duration}
+          clearPercent={completionData.clearPercent}
+          thoughtCount={completionData.thoughtCount}
+          thoughts={completionData.thoughts}
+          onReturn={() => setView("home")}
+          onSaveNote={completionData.sessionId ? async (text: string) => {
+            const res = await fetch("/api/thoughts/batch", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                sessionId: completionData.sessionId,
+                dayNumber: completionData.dayNumber,
+                thoughts: [{ timeInSession: -1, text }],
+              }),
+            });
+            if (!res.ok) {
+              throw new Error("Failed to save note");
+            }
+          } : undefined}
+        />
+      )}
+
+      {view === "history" && (
+        <HistoryView currentDay={user.currentDay} username={user.username} />
+      )}
+
+      {view === "journal" && (
+        <ThoughtJournal username={user.username} />
+      )}
+
+      {view === "board" && (
+        <PublicBoard currentUsername={user.username} />
+      )}
+
+      {view === "settings" && (
+        <SettingsView
+          user={user}
+          onTogglePublic={(isPublic) => setUser({ ...user, isPublic })}
+          onLogout={handleLogout}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,350 +1,109 @@
-"use client";
+import Link from "next/link";
 
-import { useState, useEffect, useCallback } from "react";
-import { AuthScreen } from "@/components/AuthScreen";
-import { HomeView } from "@/components/HomeView";
-import { SessionView } from "@/components/SessionView";
-import { CompletionScreen } from "@/components/CompletionScreen";
-import { HistoryView } from "@/components/HistoryView";
-import { ThoughtJournal } from "@/components/ThoughtJournal";
-import { PublicBoard } from "@/components/PublicBoard";
-import { SettingsView } from "@/components/SettingsView";
-import { useIsMobile } from "@/lib/useIsMobile";
-
-type View = "home" | "session" | "complete" | "history" | "journal" | "board" | "settings";
-
-type User = {
-  id: string;
-  email: string;
-  username: string;
-  isPublic: boolean;
-  currentDay: number;
-};
-
-type CompletionData = {
-  sessionId: string | null;
-  dayNumber: number;
-  duration: number;
-  clearPercent: number;
-  thoughtCount: number;
-  thoughts: Array<{ timeInSession: number; text: string }>;
-};
-
-export default function StillPoint() {
-  const [user, setUser] = useState<User | null>(null);
-  const [view, setView] = useState<View>("home");
-  const [authChecked, setAuthChecked] = useState(false);
-  const [completionData, setCompletionData] = useState<CompletionData | null>(null);
-  const isMobile = useIsMobile();
-
-  useEffect(() => {
-    fetch("/api/auth/me")
-      .then(res => res.ok ? res.json() : null)
-      .then(data => {
-        if (data?.user) {
-          setUser(data.user);
-        }
-        setAuthChecked(true);
-      })
-      .catch(() => setAuthChecked(true));
-  }, []);
-
-  const handleLogin = (userData: User) => {
-    setUser(userData);
-    setView("home");
-  };
-
-  const handleLogout = () => {
-    setUser(null);
-    setView("home");
-  };
-
-  const handleBegin = () => {
-    setView("session");
-  };
-
-  const handleSessionComplete = useCallback(async (data: {
-    dayNumber: number;
-    duration: number;
-    completed: boolean;
-    actualTime: number;
-    clearPercent: number;
-    thoughtCount: number;
-    mindStateLog: Array<{ time: number; state: string }>;
-    thoughts: Array<{ timeInSession: number; text: string }>;
-  }) => {
-    let savedSessionId: string | null = null;
-
-    try {
-      // Save session
-      const sessionRes = await fetch("/api/sessions", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          dayNumber: data.dayNumber,
-          duration: data.duration,
-          completed: data.completed,
-          actualTime: data.actualTime,
-          clearPercent: data.clearPercent,
-          thoughtCount: data.thoughtCount,
-          mindStateLog: data.mindStateLog,
-          sessionDate: new Date().toISOString().split("T")[0],
-        }),
-      });
-
-      if (!sessionRes.ok) {
-        console.error("Failed to save session:", await sessionRes.text());
-      } else {
-        const sessionData = await sessionRes.json();
-        savedSessionId = sessionData.session?.id ?? null;
-
-        // Save thoughts if any
-        if (data.thoughts.length > 0 && savedSessionId) {
-          await fetch("/api/thoughts/batch", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              sessionId: savedSessionId,
-              dayNumber: data.dayNumber,
-              thoughts: data.thoughts,
-            }),
-          });
-        }
-
-        // Update local user state
-        if (data.completed && user) {
-          setUser({ ...user, currentDay: user.currentDay + 1 });
-        }
-      }
-    } catch (error) {
-      console.error("Failed to save session:", error);
-    }
-
-    setCompletionData({
-      sessionId: savedSessionId,
-      dayNumber: data.dayNumber,
-      duration: data.duration,
-      clearPercent: data.clearPercent,
-      thoughtCount: data.thoughtCount,
-      thoughts: data.thoughts,
-    });
-    setView("complete");
-  }, [user]);
-
-  const handleSessionAbandon = useCallback(async (data: {
-    dayNumber: number;
-    duration: number;
-    completed: boolean;
-    actualTime: number;
-    clearPercent: number;
-    thoughtCount: number;
-    mindStateLog: Array<{ time: number; state: string }>;
-    thoughts: Array<{ timeInSession: number; text: string }>;
-  }) => {
-    try {
-      // Save abandoned session
-      const sessionRes = await fetch("/api/sessions", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          dayNumber: data.dayNumber,
-          duration: data.duration,
-          completed: false,
-          actualTime: data.actualTime,
-          clearPercent: data.clearPercent,
-          thoughtCount: data.thoughtCount,
-          mindStateLog: data.mindStateLog,
-          sessionDate: new Date().toISOString().split("T")[0],
-        }),
-      });
-
-      if (sessionRes.ok) {
-        const sessionData = await sessionRes.json();
-
-        if (data.thoughts.length > 0 && sessionData.session?.id) {
-          await fetch("/api/thoughts/batch", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              sessionId: sessionData.session.id,
-              dayNumber: data.dayNumber,
-              thoughts: data.thoughts,
-            }),
-          });
-        }
-      }
-    } catch (error) {
-      console.error("Failed to save abandoned session:", error);
-    }
-
-    setView("home");
-  }, []);
-
-  const navItems: View[] = ["home", "history", "journal", "board", "settings"];
-
-  // Loading state
-  if (!authChecked) {
-    return (
-      <div style={{
-        minHeight: "100vh", display: "flex", alignItems: "center", justifyContent: "center",
+export default function LandingPage() {
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
         fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
-      }}>
-        <div style={{
-          fontSize: "42px", fontWeight: 300, fontStyle: "italic",
-          color: "var(--fg-4)", animation: "breathe 4s ease-in-out infinite",
-        }}>
+        padding: "var(--s4)",
+      }}
+    >
+      <header
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: "var(--s6)",
+        }}
+      >
+        <div
+          style={{
+            fontSize: "22px",
+            fontStyle: "italic",
+            color: "var(--fg)",
+          }}
+        >
           Still Point
         </div>
-      </div>
-    );
-  }
+        <Link
+          href="/app"
+          style={{
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            fontSize: "12px",
+            color: "var(--fg)",
+            border: "1px solid var(--border-2)",
+            padding: "10px 14px",
+            borderRadius: "999px",
+            transition: "border-color 0.2s ease",
+          }}
+        >
+          Login
+        </Link>
+      </header>
 
-  // Not logged in
-  if (!user) {
-    return (
-      <div style={{
-        minHeight: "100vh", display: "flex", flexDirection: "column",
-        alignItems: "center", justifyContent: "center",
-        fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
-        padding: "40px 20px",
-      }}>
-        <AuthScreen onLogin={handleLogin} />
-      </div>
-    );
-  }
-
-  // Logged in
-  return (
-    <div style={{
-      minHeight: "100svh",
-      display: "grid",
-      gridTemplateRows: view === "session" ? "1fr" : "auto 1fr auto",
-      alignItems: "center",
-      fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
-      padding: isMobile
-        ? "var(--s4) var(--s3) calc(var(--nav-h) + env(safe-area-inset-bottom, 0px))"
-        : "var(--s4) var(--s4)",
-    }}>
-      {/* Nav */}
-      {view !== "session" && (
-        <div style={isMobile ? {
-          position: "fixed", bottom: 0, left: 0, right: 0,
-          display: "flex", justifyContent: "space-around",
-          background: "rgba(var(--bg-rgb), 0.92)", backdropFilter: "blur(10px)",
-          borderTop: "1px solid var(--border-1)",
-          padding: "10px 0 env(safe-area-inset-bottom, 8px)",
-          zIndex: 100,
-        } : {
-          position: "fixed", top: "var(--s4)", right: "var(--s4)",
-          display: "flex", gap: "var(--s3)",
-          zIndex: 100,
-        }}>
-          {navItems.map(v => (
-            <button
-              type="button"
-              key={v}
-              onClick={() => setView(v)}
-              style={{
-                background: "none", border: "none",
-                color: view === v ? "var(--fg)" : "var(--fg-2)",
-                fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-                fontSize: isMobile ? "13px" : "11px",
-                letterSpacing: "0.1em",
-                textTransform: "uppercase",
-                cursor: "pointer",
-                padding: isMobile ? "12px 14px" : "8px",
-                minWidth: isMobile ? "44px" : undefined,
-                minHeight: isMobile ? "44px" : undefined,
-                display: "inline-flex", alignItems: "center", justifyContent: "center",
-                transition: "color 0.3s",
-                position: "relative",
-              }}
-            >
-              {v}
-              {view === v && isMobile && (
-                <span style={{
-                  position: "absolute", bottom: "4px", left: "50%", transform: "translateX(-50%)",
-                  width: "16px", height: "2px", borderRadius: "1px",
-                  background: "var(--fg)",
-                }} />
-              )}
-            </button>
-          ))}
+      <section
+        style={{
+          maxWidth: "780px",
+          margin: "0 auto",
+          width: "100%",
+          display: "grid",
+          gap: "var(--s4)",
+        }}
+      >
+        <h1
+          style={{
+            fontSize: "clamp(36px, 8vw, 72px)",
+            fontWeight: 300,
+            lineHeight: 1.05,
+            color: "var(--fg)",
+          }}
+        >
+          Train attention.
+          <br />
+          Return to stillness.
+        </h1>
+        <p
+          style={{
+            maxWidth: "62ch",
+            fontSize: "clamp(17px, 2.5vw, 22px)",
+            color: "var(--fg-2)",
+            lineHeight: 1.55,
+          }}
+        >
+          Still Point is a meditation timer for people struggling to get started and stay consistent: it begins at one minute, adds ten seconds per day, and shows time as visual box blocks that fill like small progress bars so sitting still feels more tolerable.
+        </p>
+        <div
+          style={{
+            display: "flex",
+            gap: "var(--s3)",
+            flexWrap: "wrap",
+            marginTop: "var(--s2)",
+          }}
+        >
+          <Link
+            href="/app"
+            style={{
+              background: "linear-gradient(180deg, var(--accent-green), var(--accent-green-end))",
+              color: "rgb(var(--bg-rgb))",
+              border: "none",
+              borderRadius: "999px",
+              padding: "12px 20px",
+              fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+              fontSize: "12px",
+              fontWeight: 500,
+            }}
+          >
+            Open App
+          </Link>
         </div>
-      )}
-
-      {/* Welcome header */}
-      {view !== "session" && (
-        <div style={{
-          fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-          fontSize: "12px", color: "var(--fg-3)",
-          letterSpacing: "0.12em",
-          fontWeight: 400,
-          textAlign: "center",
-          paddingTop: isMobile ? "var(--s1)" : "var(--s5)",
-          marginBottom: "var(--s4)",
-        }}>
-          <span style={{ textTransform: "uppercase" }}>Welcome, </span>{user.username}
-        </div>
-      )}
-
-      {/* Views */}
-      {view === "home" && (
-        <HomeView currentDay={user.currentDay} onBegin={handleBegin} />
-      )}
-
-      {view === "session" && (
-        <SessionView
-          currentDay={user.currentDay}
-          onComplete={handleSessionComplete}
-          onAbandon={handleSessionAbandon}
-        />
-      )}
-
-      {view === "complete" && completionData && (
-        <CompletionScreen
-          dayNumber={completionData.dayNumber}
-          duration={completionData.duration}
-          clearPercent={completionData.clearPercent}
-          thoughtCount={completionData.thoughtCount}
-          thoughts={completionData.thoughts}
-          onReturn={() => setView("home")}
-          onSaveNote={completionData.sessionId ? async (text: string) => {
-            const res = await fetch("/api/thoughts/batch", {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                sessionId: completionData.sessionId,
-                dayNumber: completionData.dayNumber,
-                thoughts: [{ timeInSession: -1, text }],
-              }),
-            });
-            if (!res.ok) {
-              throw new Error("Failed to save note");
-            }
-          } : undefined}
-        />
-      )}
-
-      {view === "history" && (
-        <HistoryView currentDay={user.currentDay} username={user.username} />
-      )}
-
-      {view === "journal" && (
-        <ThoughtJournal username={user.username} />
-      )}
-
-      {view === "board" && (
-        <PublicBoard currentUsername={user.username} />
-      )}
-
-      {view === "settings" && (
-        <SettingsView
-          user={user}
-          onTogglePublic={(isPublic) => setUser({ ...user, isPublic })}
-          onLogout={handleLogout}
-        />
-      )}
-    </div>
+      </section>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary
- add a public homepage at `/` for still-point.me
- include a top-right `Login` button and `Open App` CTA routing into `/app`
- move the existing authenticated app experience to `/app`
- use a single paragraph explaining the product is for getting started/staying consistent with 1 minute + 10s/day progression and visual block-fill progress

## Test plan
- [x] Run `npm run build`
- [x] Confirm routes include both `/` and `/app`
- [ ] Verify homepage content and CTAs on production preview

Closes #94

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a marketing landing page with clear "Login" and "Open App" links.
  * Introduced an authenticated app at /app with gated sign-in, a loading screen, and persistent session handling.
  * In-app views for Home, Session, Complete, History, Journal, Board and Settings; session save/abandon and optional thought saving.

* **Refactor**
  * Reorganized top-level routing and page structure to separate landing and authenticated experiences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->