### PR TITLE
Add global footer credit text across all pages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,7 +28,25 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${newsreader.variable} ${jetbrainsMono.variable}`}>
-        {children}
+        <div style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}>
+          <main style={{ flex: 1 }}>{children}</main>
+          <footer
+            style={{
+              padding: "14px 20px",
+              borderTop: "1px solid var(--border-1)",
+              color: "var(--fg-3)",
+              fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+              fontSize: "11px",
+              letterSpacing: "0.03em",
+              textAlign: "center",
+            }}
+          >
+            © Bretton Auerbach 2026 |{" "}
+            <a href="https://brettonauerbach.com" style={{ color: "inherit" }}>
+              brettonauerbach.com
+            </a>
+          </footer>
+        </div>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- add a global footer in the root layout so all pages show the credit line
- include clickable `brettonauerbach.com` link in the footer

## Test plan
- [x] Run `npm run build`
- [ ] Open `/` and `/app` to confirm footer renders at bottom

Closes #96

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced page layout to ensure footer remains positioned at the bottom of the page.
  * Pages now utilize full viewport height for optimal spacing and visual appearance on content-light pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->