### PR TITLE
Keep footer visible on / and /app without scrolling

### DIFF
--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -224,7 +224,7 @@ export default function StillPoint() {
   if (!authChecked) {
     return (
       <div style={{
-        minHeight: "100vh", display: "flex", alignItems: "center", justifyContent: "center",
+        minHeight: "100%", display: "flex", alignItems: "center", justifyContent: "center",
         fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
       }}>
         <div style={{
@@ -240,7 +240,7 @@ export default function StillPoint() {
   if (authError) {
     return (
       <div style={{
-        minHeight: "100vh", display: "flex", flexDirection: "column",
+        minHeight: "100%", display: "flex", flexDirection: "column",
         alignItems: "center", justifyContent: "center",
         gap: "var(--s3)",
         fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
@@ -283,7 +283,7 @@ export default function StillPoint() {
   if (!user) {
     return (
       <div style={{
-        minHeight: "100vh", display: "flex", flexDirection: "column",
+        minHeight: "100%", display: "flex", flexDirection: "column",
         alignItems: "center", justifyContent: "center",
         fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
         padding: "40px 20px",
@@ -296,7 +296,7 @@ export default function StillPoint() {
   // Logged in
   return (
     <div style={{
-      minHeight: "100svh",
+      minHeight: "100%",
       display: "grid",
       gridTemplateRows: view === "session" ? "1fr" : "auto 1fr auto",
       alignItems: "center",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ export default function LandingPage() {
   return (
     <main
       style={{
-        minHeight: "100vh",
+        minHeight: "100%",
         display: "flex",
         flexDirection: "column",
         fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",


### PR DESCRIPTION
## Summary
- change page wrapper min-height values from viewport-based heights to `100%`
- keep global footer visible without extra scrolling on `/` and `/app`

## Test plan
- [x] Run `npm run build`
- [ ] Open `/` and `/app` and confirm footer is visible without scrolling

Closes #100

Made with [Cursor](https://cursor.com)