### PR TITLE
feat(friends): search, requests, and friend list (#116)

### DIFF
--- a/drizzle/friend_graph_incremental.sql
+++ b/drizzle/friend_graph_incremental.sql
@@ -1,0 +1,33 @@
+-- Incremental DDL for friend graph (issue #116).
+-- Preferred: apply schema with `npx drizzle-kit push` (see README).
+-- This file is a reference for existing databases if you apply SQL manually.
+
+CREATE TABLE IF NOT EXISTS "friend_requests" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"from_user_id" uuid NOT NULL,
+	"to_user_id" uuid NOT NULL,
+	"status" varchar(20) DEFAULT 'pending' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "friend_requests_no_self" CHECK ("from_user_id" <> "to_user_id"),
+	CONSTRAINT "friend_requests_status_allowed" CHECK ("status" in ('pending', 'accepted', 'rejected', 'cancelled'))
+);
+
+CREATE TABLE IF NOT EXISTS "friendships" (
+	"user1_id" uuid NOT NULL,
+	"user2_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "friendships_user1_id_user2_id_pk" PRIMARY KEY("user1_id","user2_id"),
+	CONSTRAINT "friendships_user_order" CHECK ("user1_id" < "user2_id")
+);
+
+ALTER TABLE "friend_requests" ADD CONSTRAINT "friend_requests_from_user_id_users_id_fk" FOREIGN KEY ("from_user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "friend_requests" ADD CONSTRAINT "friend_requests_to_user_id_users_id_fk" FOREIGN KEY ("to_user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "friendships" ADD CONSTRAINT "friendships_user1_id_users_id_fk" FOREIGN KEY ("user1_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "friendships" ADD CONSTRAINT "friendships_user2_id_users_id_fk" FOREIGN KEY ("user2_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "friend_requests_pending_from_to" ON "friend_requests" USING btree ("from_user_id","to_user_id") WHERE "status" = 'pending';
+CREATE INDEX IF NOT EXISTS "idx_friend_requests_from" ON "friend_requests" USING btree ("from_user_id");
+CREATE INDEX IF NOT EXISTS "idx_friend_requests_to" ON "friend_requests" USING btree ("to_user_id");
+CREATE INDEX IF NOT EXISTS "idx_friendships_user1" ON "friendships" USING btree ("user1_id");
+CREATE INDEX IF NOT EXISTS "idx_friendships_user2" ON "friendships" USING btree ("user2_id");

--- a/drizzle/friend_graph_incremental.sql
+++ b/drizzle/friend_graph_incremental.sql
@@ -26,7 +26,12 @@ ALTER TABLE "friend_requests" ADD CONSTRAINT "friend_requests_to_user_id_users_i
 ALTER TABLE "friendships" ADD CONSTRAINT "friendships_user1_id_users_id_fk" FOREIGN KEY ("user1_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
 ALTER TABLE "friendships" ADD CONSTRAINT "friendships_user2_id_users_id_fk" FOREIGN KEY ("user2_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
 
-CREATE UNIQUE INDEX IF NOT EXISTS "friend_requests_pending_from_to" ON "friend_requests" USING btree ("from_user_id","to_user_id") WHERE "status" = 'pending';
+-- Replace legacy directional pending index with unordered pair (run once if upgrading from #116 initial schema).
+DROP INDEX IF EXISTS "friend_requests_pending_from_to";
+CREATE UNIQUE INDEX IF NOT EXISTS "friend_requests_pending_user_pair" ON "friend_requests" USING btree (
+  LEAST("from_user_id", "to_user_id"),
+  GREATEST("from_user_id", "to_user_id")
+) WHERE "status" = 'pending';
 CREATE INDEX IF NOT EXISTS "idx_friend_requests_from" ON "friend_requests" USING btree ("from_user_id");
 CREATE INDEX IF NOT EXISTS "idx_friend_requests_to" ON "friend_requests" USING btree ("to_user_id");
 CREATE INDEX IF NOT EXISTS "idx_friendships_user1" ON "friendships" USING btree ("user1_id");

--- a/src/app/api/friends/[friendUserId]/route.ts
+++ b/src/app/api/friends/[friendUserId]/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { friendships } from "@/db/schema";
+import { getCurrentUser } from "@/lib/auth";
+import { orderedUserPair, isUuid } from "@/lib/friends";
+import { and, eq } from "drizzle-orm";
+
+type Params = { params: Promise<{ friendUserId: string }> };
+
+export async function DELETE(_request: Request, context: Params) {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { friendUserId } = await context.params;
+
+    if (!isUuid(friendUserId)) {
+      return NextResponse.json({ error: "friendUserId must be a valid UUID" }, { status: 400 });
+    }
+    if (friendUserId === auth.userId) {
+      return NextResponse.json({ error: "Invalid friend user id" }, { status: 400 });
+    }
+
+    const [u1, u2] = orderedUserPair(auth.userId, friendUserId);
+
+    const removed = await db
+      .delete(friendships)
+      .where(and(eq(friendships.user1Id, u1), eq(friendships.user2Id, u2)))
+      .returning({ user1Id: friendships.user1Id, user2Id: friendships.user2Id });
+
+    if (removed.length === 0) {
+      return NextResponse.json({ error: "Not friends with this user" }, { status: 404 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("Unfriend error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/friends/requests/[id]/route.ts
+++ b/src/app/api/friends/requests/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { friendRequests, friendships } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
-import { orderedUserPair } from "@/lib/friends";
+import { orderedUserPair, isUuid } from "@/lib/friends";
 import { and, eq } from "drizzle-orm";
 
 type Params = { params: Promise<{ id: string }> };
@@ -15,6 +15,9 @@ export async function PATCH(request: NextRequest, context: Params) {
     }
 
     const { id } = await context.params;
+    if (!isUuid(id)) {
+      return NextResponse.json({ error: "Invalid request id" }, { status: 400 });
+    }
 
     let body: { action?: string };
     try {
@@ -54,6 +57,12 @@ export async function PATCH(request: NextRequest, context: Params) {
           status: friendRequests.status,
           updatedAt: friendRequests.updatedAt,
         });
+      if (!updated) {
+        return NextResponse.json(
+          { error: "Request changed concurrently; try again" },
+          { status: 409 },
+        );
+      }
       return NextResponse.json({ request: updated });
     }
 
@@ -71,35 +80,48 @@ export async function PATCH(request: NextRequest, context: Params) {
           status: friendRequests.status,
           updatedAt: friendRequests.updatedAt,
         });
+      if (!updated) {
+        return NextResponse.json(
+          { error: "Request changed concurrently; try again" },
+          { status: 409 },
+        );
+      }
       return NextResponse.json({ request: updated });
     }
 
-    // accept
+    // accept — single transaction so friendship is not orphaned if insert fails
     const [u1, u2] = orderedUserPair(row.fromUserId, row.toUserId);
 
-    const [updated] = await db
-      .update(friendRequests)
-      .set({ status: "accepted", updatedAt: new Date() })
-      .where(
-        and(
-          eq(friendRequests.id, id),
-          eq(friendRequests.status, "pending"),
-          eq(friendRequests.toUserId, auth.userId),
-        ),
-      )
-      .returning({
-        id: friendRequests.id,
-        fromUserId: friendRequests.fromUserId,
-        toUserId: friendRequests.toUserId,
-        status: friendRequests.status,
-        updatedAt: friendRequests.updatedAt,
-      });
+    const updated = await db.transaction(async (tx) => {
+      const [u] = await tx
+        .update(friendRequests)
+        .set({ status: "accepted", updatedAt: new Date() })
+        .where(
+          and(
+            eq(friendRequests.id, id),
+            eq(friendRequests.status, "pending"),
+            eq(friendRequests.toUserId, auth.userId),
+          ),
+        )
+        .returning({
+          id: friendRequests.id,
+          fromUserId: friendRequests.fromUserId,
+          toUserId: friendRequests.toUserId,
+          status: friendRequests.status,
+          updatedAt: friendRequests.updatedAt,
+        });
+
+      if (!u) {
+        return null;
+      }
+
+      await tx.insert(friendships).values({ user1Id: u1, user2Id: u2 }).onConflictDoNothing();
+      return u;
+    });
 
     if (!updated) {
       return NextResponse.json({ error: "Could not accept this request" }, { status: 409 });
     }
-
-    await db.insert(friendships).values({ user1Id: u1, user2Id: u2 }).onConflictDoNothing();
 
     return NextResponse.json({ request: updated });
   } catch (error) {

--- a/src/app/api/friends/requests/[id]/route.ts
+++ b/src/app/api/friends/requests/[id]/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { friendRequests, friendships } from "@/db/schema";
+import { getCurrentUser } from "@/lib/auth";
+import { orderedUserPair } from "@/lib/friends";
+import { and, eq } from "drizzle-orm";
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function PATCH(request: NextRequest, context: Params) {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id } = await context.params;
+
+    let body: { action?: string };
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const action = body.action;
+    if (action !== "accept" && action !== "reject" && action !== "cancel") {
+      return NextResponse.json(
+        { error: "action must be \"accept\", \"reject\", or \"cancel\"" },
+        { status: 400 },
+      );
+    }
+
+    const [row] = await db.select().from(friendRequests).where(eq(friendRequests.id, id)).limit(1);
+
+    if (!row) {
+      return NextResponse.json({ error: "Friend request not found" }, { status: 404 });
+    }
+
+    if (row.status !== "pending") {
+      return NextResponse.json({ error: "This friend request is no longer pending" }, { status: 409 });
+    }
+
+    if (action === "cancel") {
+      if (row.fromUserId !== auth.userId) {
+        return NextResponse.json({ error: "Only the sender can cancel this request" }, { status: 403 });
+      }
+      const [updated] = await db
+        .update(friendRequests)
+        .set({ status: "cancelled", updatedAt: new Date() })
+        .where(and(eq(friendRequests.id, id), eq(friendRequests.status, "pending")))
+        .returning({
+          id: friendRequests.id,
+          status: friendRequests.status,
+          updatedAt: friendRequests.updatedAt,
+        });
+      return NextResponse.json({ request: updated });
+    }
+
+    if (row.toUserId !== auth.userId) {
+      return NextResponse.json({ error: "Only the recipient can accept or reject this request" }, { status: 403 });
+    }
+
+    if (action === "reject") {
+      const [updated] = await db
+        .update(friendRequests)
+        .set({ status: "rejected", updatedAt: new Date() })
+        .where(and(eq(friendRequests.id, id), eq(friendRequests.status, "pending")))
+        .returning({
+          id: friendRequests.id,
+          status: friendRequests.status,
+          updatedAt: friendRequests.updatedAt,
+        });
+      return NextResponse.json({ request: updated });
+    }
+
+    // accept
+    const [u1, u2] = orderedUserPair(row.fromUserId, row.toUserId);
+
+    const [updated] = await db
+      .update(friendRequests)
+      .set({ status: "accepted", updatedAt: new Date() })
+      .where(
+        and(
+          eq(friendRequests.id, id),
+          eq(friendRequests.status, "pending"),
+          eq(friendRequests.toUserId, auth.userId),
+        ),
+      )
+      .returning({
+        id: friendRequests.id,
+        fromUserId: friendRequests.fromUserId,
+        toUserId: friendRequests.toUserId,
+        status: friendRequests.status,
+        updatedAt: friendRequests.updatedAt,
+      });
+
+    if (!updated) {
+      return NextResponse.json({ error: "Could not accept this request" }, { status: 409 });
+    }
+
+    await db.insert(friendships).values({ user1Id: u1, user2Id: u2 }).onConflictDoNothing();
+
+    return NextResponse.json({ request: updated });
+  } catch (error) {
+    console.error("Friend request patch error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/friends/requests/[id]/route.ts
+++ b/src/app/api/friends/requests/[id]/route.ts
@@ -3,7 +3,8 @@ import { db } from "@/db";
 import { friendRequests, friendships } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
 import { orderedUserPair, isUuid } from "@/lib/friends";
-import { and, eq } from "drizzle-orm";
+import { readJsonObject } from "@/lib/readJsonObject";
+import { and, eq, ne } from "drizzle-orm";
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -19,14 +20,15 @@ export async function PATCH(request: NextRequest, context: Params) {
       return NextResponse.json({ error: "Invalid request id" }, { status: 400 });
     }
 
-    let body: { action?: string };
-    try {
-      body = await request.json();
-    } catch {
-      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    const json = await readJsonObject(request);
+    if (!json.ok) {
+      return json.response;
     }
 
-    const action = body.action;
+    const action = json.body.action;
+    if (typeof action !== "string") {
+      return NextResponse.json({ error: "action is required" }, { status: 400 });
+    }
     if (action !== "accept" && action !== "reject" && action !== "cancel") {
       return NextResponse.json(
         { error: "action must be \"accept\", \"reject\", or \"cancel\"" },
@@ -116,6 +118,20 @@ export async function PATCH(request: NextRequest, context: Params) {
       }
 
       await tx.insert(friendships).values({ user1Id: u1, user2Id: u2 }).onConflictDoNothing();
+
+      // Clear any legacy reverse-direction pending row for the same pair (pre-LEAST/GREATEST index DBs).
+      await tx
+        .update(friendRequests)
+        .set({ status: "cancelled", updatedAt: new Date() })
+        .where(
+          and(
+            ne(friendRequests.id, id),
+            eq(friendRequests.fromUserId, row.toUserId),
+            eq(friendRequests.toUserId, row.fromUserId),
+            eq(friendRequests.status, "pending"),
+          ),
+        );
+
       return u;
     });
 

--- a/src/app/api/friends/requests/route.ts
+++ b/src/app/api/friends/requests/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/db";
 import { friendRequests, friendships, users } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
 import { orderedUserPair, isUuid } from "@/lib/friends";
+import { readJsonObject } from "@/lib/readJsonObject";
 import { and, eq, or } from "drizzle-orm";
 
 export async function GET() {
@@ -51,14 +52,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    let body: { toUserId?: string };
-    try {
-      body = await request.json();
-    } catch {
-      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    const json = await readJsonObject(request);
+    if (!json.ok) {
+      return json.response;
     }
 
-    const toUserId = body.toUserId;
+    const toUserId = json.body.toUserId;
     if (!toUserId || typeof toUserId !== "string") {
       return NextResponse.json({ error: "toUserId is required" }, { status: 400 });
     }

--- a/src/app/api/friends/requests/route.ts
+++ b/src/app/api/friends/requests/route.ts
@@ -1,0 +1,139 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { friendRequests, friendships, users } from "@/db/schema";
+import { getCurrentUser } from "@/lib/auth";
+import { orderedUserPair, isUuid } from "@/lib/friends";
+import { and, eq, or } from "drizzle-orm";
+
+export async function GET() {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const uid = auth.userId;
+
+    const incomingRows = await db
+      .select({
+        id: friendRequests.id,
+        createdAt: friendRequests.createdAt,
+        user: { id: users.id, username: users.username },
+      })
+      .from(friendRequests)
+      .innerJoin(users, eq(friendRequests.fromUserId, users.id))
+      .where(and(eq(friendRequests.toUserId, uid), eq(friendRequests.status, "pending")));
+
+    const outgoingRows = await db
+      .select({
+        id: friendRequests.id,
+        createdAt: friendRequests.createdAt,
+        user: { id: users.id, username: users.username },
+      })
+      .from(friendRequests)
+      .innerJoin(users, eq(friendRequests.toUserId, users.id))
+      .where(and(eq(friendRequests.fromUserId, uid), eq(friendRequests.status, "pending")));
+
+    return NextResponse.json({
+      incoming: incomingRows,
+      outgoing: outgoingRows,
+    });
+  } catch (error) {
+    console.error("Friend requests list error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    let body: { toUserId?: string };
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const toUserId = body.toUserId;
+    if (!toUserId || typeof toUserId !== "string") {
+      return NextResponse.json({ error: "toUserId is required" }, { status: 400 });
+    }
+    if (!isUuid(toUserId)) {
+      return NextResponse.json({ error: "toUserId must be a valid UUID" }, { status: 400 });
+    }
+    if (toUserId === auth.userId) {
+      return NextResponse.json({ error: "Cannot send a friend request to yourself" }, { status: 400 });
+    }
+
+    const [target] = await db.select({ id: users.id }).from(users).where(eq(users.id, toUserId)).limit(1);
+    if (!target) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const [u1, u2] = orderedUserPair(auth.userId, toUserId);
+    const [existingFriend] = await db
+      .select({ user1Id: friendships.user1Id })
+      .from(friendships)
+      .where(and(eq(friendships.user1Id, u1), eq(friendships.user2Id, u2)))
+      .limit(1);
+
+    if (existingFriend) {
+      return NextResponse.json({ error: "Already friends" }, { status: 409 });
+    }
+
+    const [pendingAny] = await db
+      .select({ id: friendRequests.id })
+      .from(friendRequests)
+      .where(
+        and(
+          eq(friendRequests.status, "pending"),
+          or(
+            and(eq(friendRequests.fromUserId, auth.userId), eq(friendRequests.toUserId, toUserId)),
+            and(eq(friendRequests.fromUserId, toUserId), eq(friendRequests.toUserId, auth.userId)),
+          ),
+        ),
+      )
+      .limit(1);
+
+    if (pendingAny) {
+      return NextResponse.json({ error: "A pending friend request already exists between these users" }, { status: 409 });
+    }
+
+    try {
+      const [created] = await db
+        .insert(friendRequests)
+        .values({
+          fromUserId: auth.userId,
+          toUserId,
+          status: "pending",
+          updatedAt: new Date(),
+        })
+        .returning({
+          id: friendRequests.id,
+          fromUserId: friendRequests.fromUserId,
+          toUserId: friendRequests.toUserId,
+          status: friendRequests.status,
+          createdAt: friendRequests.createdAt,
+          updatedAt: friendRequests.updatedAt,
+        });
+
+      return NextResponse.json({ request: created }, { status: 201 });
+    } catch (e: unknown) {
+      const code = typeof e === "object" && e !== null && "code" in e ? String((e as { code: unknown }).code) : "";
+      if (code === "23505") {
+        return NextResponse.json(
+          { error: "A pending friend request already exists between these users" },
+          { status: 409 },
+        );
+      }
+      throw e;
+    }
+  } catch (error) {
+    console.error("Friend request create error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/friends/route.ts
+++ b/src/app/api/friends/route.ts
@@ -13,19 +13,23 @@ export async function GET() {
 
     const uid = auth.userId;
 
-    const asUser1 = await db
-      .select({ id: users.id, username: users.username })
+    const friendSelect = { id: users.id, username: users.username };
+
+    const asUser1 = db
+      .select(friendSelect)
       .from(friendships)
       .innerJoin(users, eq(friendships.user2Id, users.id))
       .where(eq(friendships.user1Id, uid));
 
-    const asUser2 = await db
-      .select({ id: users.id, username: users.username })
+    const asUser2 = db
+      .select(friendSelect)
       .from(friendships)
       .innerJoin(users, eq(friendships.user1Id, users.id))
       .where(eq(friendships.user2Id, uid));
 
-    return NextResponse.json({ friends: [...asUser1, ...asUser2] });
+    const rows = await asUser1.union(asUser2);
+
+    return NextResponse.json({ friends: rows });
   } catch (error) {
     console.error("Friends list error:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/src/app/api/friends/route.ts
+++ b/src/app/api/friends/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { friendships, users } from "@/db/schema";
+import { getCurrentUser } from "@/lib/auth";
+import { eq } from "drizzle-orm";
+
+export async function GET() {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const uid = auth.userId;
+
+    const asUser1 = await db
+      .select({ id: users.id, username: users.username })
+      .from(friendships)
+      .innerJoin(users, eq(friendships.user2Id, users.id))
+      .where(eq(friendships.user1Id, uid));
+
+    const asUser2 = await db
+      .select({ id: users.id, username: users.username })
+      .from(friendships)
+      .innerJoin(users, eq(friendships.user1Id, users.id))
+      .where(eq(friendships.user2Id, uid));
+
+    return NextResponse.json({ friends: [...asUser1, ...asUser2] });
+  } catch (error) {
+    console.error("Friends list error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/friends/search/route.ts
+++ b/src/app/api/friends/search/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { users } from "@/db/schema";
+import { getCurrentUser } from "@/lib/auth";
+import { and, eq, ilike, ne } from "drizzle-orm";
+
+const MIN_LEN = 2;
+const LIMIT = 20;
+
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const q = (request.nextUrl.searchParams.get("q") ?? "").trim();
+    if (q.length < MIN_LEN) {
+      return NextResponse.json({ users: [] });
+    }
+
+    const escaped = q.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
+    const pattern = `%${escaped}%`;
+
+    const rows = await db
+      .select({
+        id: users.id,
+        username: users.username,
+      })
+      .from(users)
+      .where(
+        and(
+          eq(users.isPublic, true),
+          ne(users.id, auth.userId),
+          ilike(users.username, pattern),
+        ),
+      )
+      .limit(LIMIT);
+
+    return NextResponse.json({ users: rows });
+  } catch (error) {
+    console.error("Friends search error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -10,9 +10,10 @@ import { HistoryView } from "@/components/HistoryView";
 import { ThoughtJournal } from "@/components/ThoughtJournal";
 import { PublicBoard } from "@/components/PublicBoard";
 import { SettingsView } from "@/components/SettingsView";
+import { FriendsView } from "@/components/FriendsView";
 import { useIsMobile } from "@/lib/useIsMobile";
 
-type View = "home" | "session" | "complete" | "history" | "journal" | "board" | "settings";
+type View = "home" | "session" | "complete" | "history" | "journal" | "board" | "friends" | "settings";
 
 type CompletionData = {
   sessionId: string | null;
@@ -218,7 +219,7 @@ export default function StillPoint() {
     setView("home");
   }, []);
 
-  const navItems: View[] = ["home", "history", "journal", "board", "settings"];
+  const navItems: View[] = ["home", "history", "journal", "board", "friends", "settings"];
 
   // Loading state
   if (!authChecked) {
@@ -417,6 +418,8 @@ export default function StillPoint() {
       {view === "board" && (
         <PublicBoard currentUsername={user.username} />
       )}
+
+      {view === "friends" && <FriendsView />}
 
       {view === "settings" && (
         <SettingsView

--- a/src/components/FriendsView.tsx
+++ b/src/components/FriendsView.tsx
@@ -1,14 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-
-type PublicUser = { id: string; username: string };
-
-type RequestRow = {
-  id: string;
-  createdAt: string;
-  user: PublicUser;
-};
+import { api, ApiError, type FriendPublicUser, type FriendRequestRow } from "@/lib/api";
 
 const labelStyle: React.CSSProperties = {
   fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
@@ -41,22 +34,13 @@ const btnOutline: React.CSSProperties = {
   textTransform: "uppercase",
 };
 
-async function readError(res: Response): Promise<string> {
-  try {
-    const data = await res.json();
-    return typeof data?.error === "string" ? data.error : res.statusText;
-  } catch {
-    return res.statusText;
-  }
-}
-
 export function FriendsView() {
   const [q, setQ] = useState("");
-  const [searchResults, setSearchResults] = useState<PublicUser[]>([]);
+  const [searchResults, setSearchResults] = useState<FriendPublicUser[]>([]);
   const [searchLoading, setSearchLoading] = useState(false);
-  const [friends, setFriends] = useState<PublicUser[]>([]);
-  const [incoming, setIncoming] = useState<RequestRow[]>([]);
-  const [outgoing, setOutgoing] = useState<RequestRow[]>([]);
+  const [friends, setFriends] = useState<FriendPublicUser[]>([]);
+  const [incoming, setIncoming] = useState<FriendRequestRow[]>([]);
+  const [outgoing, setOutgoing] = useState<FriendRequestRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [actionId, setActionId] = useState<string | null>(null);
   const [banner, setBanner] = useState<string | null>(null);
@@ -64,18 +48,13 @@ export function FriendsView() {
   const loadLists = useCallback(async () => {
     setLoading(true);
     try {
-      const [frRes, reqRes] = await Promise.all([
-        fetch("/api/friends"),
-        fetch("/api/friends/requests"),
-      ]);
-      if (frRes.ok) {
-        const data = await frRes.json();
-        setFriends(data.friends ?? []);
-      }
-      if (reqRes.ok) {
-        const data = await reqRes.json();
-        setIncoming(data.incoming ?? []);
-        setOutgoing(data.outgoing ?? []);
+      const [fr, req] = await Promise.all([api.getFriends(), api.getFriendRequests()]);
+      setFriends(fr.friends);
+      setIncoming(req.incoming);
+      setOutgoing(req.outgoing);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setBanner(e.message);
       }
     } finally {
       setLoading(false);
@@ -95,14 +74,13 @@ export function FriendsView() {
     setSearchLoading(true);
     setBanner(null);
     try {
-      const res = await fetch(`/api/friends/search?q=${encodeURIComponent(trimmed)}`);
-      if (!res.ok) {
-        setBanner(await readError(res));
-        setSearchResults([]);
-        return;
+      const data = await api.searchFriends(trimmed);
+      setSearchResults(data.users);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setBanner(e.message);
       }
-      const data = await res.json();
-      setSearchResults(data.users ?? []);
+      setSearchResults([]);
     } finally {
       setSearchLoading(false);
     }
@@ -112,17 +90,13 @@ export function FriendsView() {
     setActionId(toUserId);
     setBanner(null);
     try {
-      const res = await fetch("/api/friends/requests", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ toUserId }),
-      });
-      if (!res.ok) {
-        setBanner(await readError(res));
-        return;
-      }
+      await api.sendFriendRequest(toUserId);
       setBanner("Request sent.");
       await loadLists();
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setBanner(e.message);
+      }
     } finally {
       setActionId(null);
     }
@@ -132,16 +106,12 @@ export function FriendsView() {
     setActionId(id);
     setBanner(null);
     try {
-      const res = await fetch(`/api/friends/requests/${id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ action }),
-      });
-      if (!res.ok) {
-        setBanner(await readError(res));
-        return;
-      }
+      await api.updateFriendRequest(id, action);
       await loadLists();
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setBanner(e.message);
+      }
     } finally {
       setActionId(null);
     }
@@ -151,12 +121,12 @@ export function FriendsView() {
     setActionId(friendUserId);
     setBanner(null);
     try {
-      const res = await fetch(`/api/friends/${friendUserId}`, { method: "DELETE" });
-      if (!res.ok) {
-        setBanner(await readError(res));
-        return;
-      }
+      await api.removeFriend(friendUserId);
       await loadLists();
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setBanner(e.message);
+      }
     } finally {
       setActionId(null);
     }
@@ -319,7 +289,9 @@ export function FriendsView() {
 
       <div style={{ ...cardStyle, gap: "16px" }}>
         <div style={labelStyle}>Your outgoing requests</div>
-        {!loading && outgoing.length === 0 ? (
+        {loading ? (
+          <span style={{ color: "var(--fg-3)", fontSize: "14px" }}>Loading…</span>
+        ) : outgoing.length === 0 ? (
           <span style={{ color: "var(--fg-3)", fontSize: "14px" }}>None.</span>
         ) : (
           <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: "12px" }}>
@@ -342,7 +314,9 @@ export function FriendsView() {
 
       <div style={{ ...cardStyle, gap: "16px" }}>
         <div style={labelStyle}>Your friends</div>
-        {!loading && friends.length === 0 ? (
+        {loading ? (
+          <span style={{ color: "var(--fg-3)", fontSize: "14px" }}>Loading…</span>
+        ) : friends.length === 0 ? (
           <span style={{ color: "var(--fg-3)", fontSize: "14px" }}>No friends yet.</span>
         ) : (
           <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: "12px" }}>

--- a/src/components/FriendsView.tsx
+++ b/src/components/FriendsView.tsx
@@ -1,0 +1,367 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+type PublicUser = { id: string; username: string };
+
+type RequestRow = {
+  id: string;
+  createdAt: string;
+  user: PublicUser;
+};
+
+const labelStyle: React.CSSProperties = {
+  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+  fontSize: "11px",
+  color: "var(--fg-4)",
+  letterSpacing: "0.12em",
+  textTransform: "uppercase",
+};
+
+const cardStyle: React.CSSProperties = {
+  padding: "16px 20px",
+  background: "var(--surface-1)",
+  borderRadius: "10px",
+  display: "flex",
+  flexDirection: "column",
+  gap: "12px",
+  width: "100%",
+};
+
+const btnOutline: React.CSSProperties = {
+  border: "1px solid var(--border-2)",
+  background: "transparent",
+  color: "var(--fg)",
+  borderRadius: "999px",
+  padding: "8px 14px",
+  cursor: "pointer",
+  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+  fontSize: "11px",
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+};
+
+async function readError(res: Response): Promise<string> {
+  try {
+    const data = await res.json();
+    return typeof data?.error === "string" ? data.error : res.statusText;
+  } catch {
+    return res.statusText;
+  }
+}
+
+export function FriendsView() {
+  const [q, setQ] = useState("");
+  const [searchResults, setSearchResults] = useState<PublicUser[]>([]);
+  const [searchLoading, setSearchLoading] = useState(false);
+  const [friends, setFriends] = useState<PublicUser[]>([]);
+  const [incoming, setIncoming] = useState<RequestRow[]>([]);
+  const [outgoing, setOutgoing] = useState<RequestRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [actionId, setActionId] = useState<string | null>(null);
+  const [banner, setBanner] = useState<string | null>(null);
+
+  const loadLists = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [frRes, reqRes] = await Promise.all([
+        fetch("/api/friends"),
+        fetch("/api/friends/requests"),
+      ]);
+      if (frRes.ok) {
+        const data = await frRes.json();
+        setFriends(data.friends ?? []);
+      }
+      if (reqRes.ok) {
+        const data = await reqRes.json();
+        setIncoming(data.incoming ?? []);
+        setOutgoing(data.outgoing ?? []);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadLists();
+  }, [loadLists]);
+
+  const runSearch = async () => {
+    const trimmed = q.trim();
+    if (trimmed.length < 2) {
+      setSearchResults([]);
+      return;
+    }
+    setSearchLoading(true);
+    setBanner(null);
+    try {
+      const res = await fetch(`/api/friends/search?q=${encodeURIComponent(trimmed)}`);
+      if (!res.ok) {
+        setBanner(await readError(res));
+        setSearchResults([]);
+        return;
+      }
+      const data = await res.json();
+      setSearchResults(data.users ?? []);
+    } finally {
+      setSearchLoading(false);
+    }
+  };
+
+  const sendRequest = async (toUserId: string) => {
+    setActionId(toUserId);
+    setBanner(null);
+    try {
+      const res = await fetch("/api/friends/requests", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ toUserId }),
+      });
+      if (!res.ok) {
+        setBanner(await readError(res));
+        return;
+      }
+      setBanner("Request sent.");
+      await loadLists();
+    } finally {
+      setActionId(null);
+    }
+  };
+
+  const patchRequest = async (id: string, action: "accept" | "reject" | "cancel") => {
+    setActionId(id);
+    setBanner(null);
+    try {
+      const res = await fetch(`/api/friends/requests/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action }),
+      });
+      if (!res.ok) {
+        setBanner(await readError(res));
+        return;
+      }
+      await loadLists();
+    } finally {
+      setActionId(null);
+    }
+  };
+
+  const unfriend = async (friendUserId: string) => {
+    setActionId(friendUserId);
+    setBanner(null);
+    try {
+      const res = await fetch(`/api/friends/${friendUserId}`, { method: "DELETE" });
+      if (!res.ok) {
+        setBanner(await readError(res));
+        return;
+      }
+      await loadLists();
+    } finally {
+      setActionId(null);
+    }
+  };
+
+  const friendIds = new Set(friends.map((f) => f.id));
+  const pendingWith = new Set([
+    ...incoming.map((r) => r.user.id),
+    ...outgoing.map((r) => r.user.id),
+  ]);
+
+  const containerStyle: React.CSSProperties = {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: "28px",
+    animation: "fadeIn 0.6s ease",
+    width: "100%",
+    maxWidth: "min(440px, calc(100vw - 40px))",
+  };
+
+  return (
+    <div style={containerStyle}>
+      <h2
+        style={{
+          fontSize: "28px",
+          fontWeight: 300,
+          fontStyle: "italic",
+          margin: 0,
+          fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+          color: "var(--fg)",
+        }}
+      >
+        Friends
+      </h2>
+
+      <p
+        style={{
+          fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+          fontSize: "11px",
+          color: "var(--fg-3)",
+          textAlign: "center",
+          margin: 0,
+          lineHeight: 1.5,
+        }}
+      >
+        Search finds public profiles only. Usernames never expose email.
+      </p>
+
+      {banner && (
+        <div
+          style={{
+            ...cardStyle,
+            border: "1px solid var(--border-2)",
+            color: "var(--fg-2)",
+            fontSize: "14px",
+          }}
+        >
+          {banner}
+        </div>
+      )}
+
+      <div style={cardStyle}>
+        <div style={labelStyle}>Find people</div>
+        <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+          <input
+            type="search"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && runSearch()}
+            placeholder="Username (min 2 chars)"
+            style={{
+              flex: "1 1 160px",
+              minWidth: 0,
+              padding: "10px 14px",
+              borderRadius: "8px",
+              border: "1px solid var(--border-2)",
+              background: "var(--bg)",
+              color: "var(--fg)",
+              fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+              fontSize: "16px",
+            }}
+          />
+          <button type="button" onClick={runSearch} style={btnOutline} disabled={searchLoading}>
+            {searchLoading ? "…" : "Search"}
+          </button>
+        </div>
+        {searchResults.length > 0 && (
+          <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: "8px" }}>
+            {searchResults.map((u) => {
+              const isFriend = friendIds.has(u.id);
+              const pending = pendingWith.has(u.id);
+              const busy = actionId === u.id;
+              return (
+                <li
+                  key={u.id}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: "12px",
+                    padding: "8px 0",
+                    borderBottom: "1px solid var(--border-1)",
+                  }}
+                >
+                  <span style={{ color: "var(--fg)", fontSize: "16px" }}>{u.username}</span>
+                  {isFriend ? (
+                    <span style={{ ...labelStyle, textTransform: "none", letterSpacing: "0.06em" }}>Friends</span>
+                  ) : pending ? (
+                    <span style={{ ...labelStyle, textTransform: "none", letterSpacing: "0.06em" }}>Pending</span>
+                  ) : (
+                    <button
+                      type="button"
+                      disabled={busy}
+                      onClick={() => sendRequest(u.id)}
+                      style={btnOutline}
+                    >
+                      {busy ? "…" : "Add"}
+                    </button>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <div style={{ ...cardStyle, gap: "16px" }}>
+        <div style={labelStyle}>Requests to you</div>
+        {loading ? (
+          <span style={{ color: "var(--fg-3)", fontSize: "14px" }}>Loading…</span>
+        ) : incoming.length === 0 ? (
+          <span style={{ color: "var(--fg-3)", fontSize: "14px" }}>No pending requests.</span>
+        ) : (
+          <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: "12px" }}>
+            {incoming.map((r) => (
+              <li key={r.id} style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: "10px" }}>
+                <span style={{ flex: "1 1 120px", color: "var(--fg)" }}>{r.user.username}</span>
+                <button
+                  type="button"
+                  disabled={actionId === r.id}
+                  onClick={() => patchRequest(r.id, "accept")}
+                  style={btnOutline}
+                >
+                  Accept
+                </button>
+                <button
+                  type="button"
+                  disabled={actionId === r.id}
+                  onClick={() => patchRequest(r.id, "reject")}
+                  style={{ ...btnOutline, opacity: 0.85 }}
+                >
+                  Reject
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div style={{ ...cardStyle, gap: "16px" }}>
+        <div style={labelStyle}>Your outgoing requests</div>
+        {!loading && outgoing.length === 0 ? (
+          <span style={{ color: "var(--fg-3)", fontSize: "14px" }}>None.</span>
+        ) : (
+          <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: "12px" }}>
+            {outgoing.map((r) => (
+              <li key={r.id} style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: "10px" }}>
+                <span style={{ flex: "1 1 120px", color: "var(--fg)" }}>{r.user.username}</span>
+                <button
+                  type="button"
+                  disabled={actionId === r.id}
+                  onClick={() => patchRequest(r.id, "cancel")}
+                  style={btnOutline}
+                >
+                  Cancel
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div style={{ ...cardStyle, gap: "16px" }}>
+        <div style={labelStyle}>Your friends</div>
+        {!loading && friends.length === 0 ? (
+          <span style={{ color: "var(--fg-3)", fontSize: "14px" }}>No friends yet.</span>
+        ) : (
+          <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: "12px" }}>
+            {friends.map((f) => (
+              <li key={f.id} style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "12px" }}>
+                <span style={{ color: "var(--fg)" }}>{f.username}</span>
+                <button
+                  type="button"
+                  disabled={actionId === f.id}
+                  onClick={() => unfriend(f.id)}
+                  style={{ ...btnOutline, fontSize: "10px" }}
+                >
+                  Remove
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/FriendsView.tsx
+++ b/src/components/FriendsView.tsx
@@ -198,6 +198,7 @@ export function FriendsView() {
             onChange={(e) => setQ(e.target.value)}
             onKeyDown={(e) => e.key === "Enter" && runSearch()}
             placeholder="Username (min 2 chars)"
+            aria-label="Search for users by username"
             style={{
               flex: "1 1 160px",
               minWidth: 0,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -12,7 +12,7 @@ import {
   check,
   primaryKey,
 } from "drizzle-orm/pg-core";
-import { relations, eq, sql } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
 
 export const users = pgTable("users", {
   id: uuid("id").primaryKey().defaultRandom(),
@@ -70,7 +70,7 @@ export const friendRequests = pgTable("friend_requests", {
     sql`${table.status} in ('pending', 'accepted', 'rejected', 'cancelled')`,
   ),
   pendingPairUnique: uniqueIndex("friend_requests_pending_from_to").on(table.fromUserId, table.toUserId).where(
-    eq(table.status, "pending"),
+    sql`${table.status} = 'pending'`,
   ),
   fromIdx: index("idx_friend_requests_from").on(table.fromUserId),
   toIdx: index("idx_friend_requests_to").on(table.toUserId),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -8,8 +8,11 @@ import {
   date,
   timestamp,
   index,
+  uniqueIndex,
+  check,
+  primaryKey,
 } from "drizzle-orm/pg-core";
-import { relations } from "drizzle-orm";
+import { relations, eq, sql } from "drizzle-orm";
 
 export const users = pgTable("users", {
   id: uuid("id").primaryKey().defaultRandom(),
@@ -52,6 +55,38 @@ export const thoughts = pgTable("thoughts", {
   userIdx: index("idx_thoughts_user").on(table.userId, table.dayNumber),
 }));
 
+/** pending | accepted | rejected | cancelled */
+export const friendRequests = pgTable("friend_requests", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  fromUserId: uuid("from_user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
+  toUserId: uuid("to_user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
+  status: varchar("status", { length: 20 }).notNull().default("pending"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+}, (table) => ({
+  noSelf: check("friend_requests_no_self", sql`${table.fromUserId} <> ${table.toUserId}`),
+  statusCheck: check(
+    "friend_requests_status_allowed",
+    sql`${table.status} in ('pending', 'accepted', 'rejected', 'cancelled')`,
+  ),
+  pendingPairUnique: uniqueIndex("friend_requests_pending_from_to").on(table.fromUserId, table.toUserId).where(
+    eq(table.status, "pending"),
+  ),
+  fromIdx: index("idx_friend_requests_from").on(table.fromUserId),
+  toIdx: index("idx_friend_requests_to").on(table.toUserId),
+}));
+
+export const friendships = pgTable("friendships", {
+  user1Id: uuid("user1_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
+  user2Id: uuid("user2_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+}, (table) => ({
+  pk: primaryKey({ columns: [table.user1Id, table.user2Id] }),
+  ordered: check("friendships_user_order", sql`${table.user1Id} < ${table.user2Id}`),
+  user1Idx: index("idx_friendships_user1").on(table.user1Id),
+  user2Idx: index("idx_friendships_user2").on(table.user2Id),
+}));
+
 export const usersRelations = relations(users, ({ many }) => ({
   sessions: many(sessions),
   thoughts: many(thoughts),
@@ -65,4 +100,14 @@ export const sessionsRelations = relations(sessions, ({ one, many }) => ({
 export const thoughtsRelations = relations(thoughts, ({ one }) => ({
   user: one(users, { fields: [thoughts.userId], references: [users.id] }),
   session: one(sessions, { fields: [thoughts.sessionId], references: [sessions.id] }),
+}));
+
+export const friendRequestsRelations = relations(friendRequests, ({ one }) => ({
+  fromUser: one(users, { fields: [friendRequests.fromUserId], references: [users.id] }),
+  toUser: one(users, { fields: [friendRequests.toUserId], references: [users.id] }),
+}));
+
+export const friendshipsRelations = relations(friendships, ({ one }) => ({
+  user1: one(users, { fields: [friendships.user1Id], references: [users.id] }),
+  user2: one(users, { fields: [friendships.user2Id], references: [users.id] }),
 }));

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -69,9 +69,11 @@ export const friendRequests = pgTable("friend_requests", {
     "friend_requests_status_allowed",
     sql`${table.status} in ('pending', 'accepted', 'rejected', 'cancelled')`,
   ),
-  pendingPairUnique: uniqueIndex("friend_requests_pending_from_to").on(table.fromUserId, table.toUserId).where(
-    sql`${table.status} = 'pending'`,
-  ),
+  /** At most one pending request per unordered pair (blocks A→B and B→A simultaneously). */
+  pendingUsersPairUnique: uniqueIndex("friend_requests_pending_user_pair").on(
+    sql`least(${table.fromUserId}, ${table.toUserId})`,
+    sql`greatest(${table.fromUserId}, ${table.toUserId})`,
+  ).where(sql`${table.status} = 'pending'`),
   fromIdx: index("idx_friend_requests_from").on(table.fromUserId),
   toIdx: index("idx_friend_requests_to").on(table.toUserId),
 }));

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -72,6 +72,16 @@ export type FriendRequestRecord = {
   updatedAt: string;
 };
 
+export type FriendRequestPatchResult = {
+  request: {
+    id: string;
+    status: string;
+    updatedAt: string;
+    fromUserId?: string;
+    toUserId?: string;
+  };
+};
+
 export const api = {
   signup: (data: { email: string; username: string; password: string }) =>
     request<{ user: User }>("/api/auth/signup", { method: "POST", body: JSON.stringify(data) }),
@@ -121,8 +131,13 @@ export const api = {
 
   getFriends: () => request<{ friends: FriendPublicUser[] }>("/api/friends"),
 
-  searchFriends: (q: string) =>
-    request<{ users: FriendPublicUser[] }>(`/api/friends/search?q=${encodeURIComponent(q)}`),
+  searchFriends: (q: string) => {
+    const t = q.trim();
+    if (t.length < 2) {
+      return Promise.resolve({ users: [] as FriendPublicUser[] });
+    }
+    return request<{ users: FriendPublicUser[] }>(`/api/friends/search?q=${encodeURIComponent(t)}`);
+  },
 
   getFriendRequests: () =>
     request<{ incoming: FriendRequestRow[]; outgoing: FriendRequestRow[] }>("/api/friends/requests"),
@@ -134,7 +149,7 @@ export const api = {
     }),
 
   updateFriendRequest: (id: string, action: "accept" | "reject" | "cancel") =>
-    request<{ request: Partial<FriendRequestRecord> }>(`/api/friends/requests/${id}`, {
+    request<FriendRequestPatchResult>(`/api/friends/requests/${id}`, {
       method: "PATCH",
       body: JSON.stringify({ action }),
     }),

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -52,6 +52,26 @@ export type BoardEntry = {
   totalSessions: number;
 };
 
+export type FriendPublicUser = {
+  id: string;
+  username: string;
+};
+
+export type FriendRequestRow = {
+  id: string;
+  createdAt: string;
+  user: FriendPublicUser;
+};
+
+export type FriendRequestRecord = {
+  id: string;
+  fromUserId: string;
+  toUserId: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export const api = {
   signup: (data: { email: string; username: string; password: string }) =>
     request<{ user: User }>("/api/auth/signup", { method: "POST", body: JSON.stringify(data) }),
@@ -98,4 +118,27 @@ export const api = {
 
   updateSettings: (data: { isPublic?: boolean }) =>
     request<{ user: User }>("/api/settings", { method: "PATCH", body: JSON.stringify(data) }),
+
+  getFriends: () => request<{ friends: FriendPublicUser[] }>("/api/friends"),
+
+  searchFriends: (q: string) =>
+    request<{ users: FriendPublicUser[] }>(`/api/friends/search?q=${encodeURIComponent(q)}`),
+
+  getFriendRequests: () =>
+    request<{ incoming: FriendRequestRow[]; outgoing: FriendRequestRow[] }>("/api/friends/requests"),
+
+  sendFriendRequest: (toUserId: string) =>
+    request<{ request: FriendRequestRecord }>("/api/friends/requests", {
+      method: "POST",
+      body: JSON.stringify({ toUserId }),
+    }),
+
+  updateFriendRequest: (id: string, action: "accept" | "reject" | "cancel") =>
+    request<{ request: Partial<FriendRequestRecord> }>(`/api/friends/requests/${id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ action }),
+    }),
+
+  removeFriend: (friendUserId: string) =>
+    request<{ ok: boolean }>(`/api/friends/${friendUserId}`, { method: "DELETE" }),
 };

--- a/src/lib/friends.ts
+++ b/src/lib/friends.ts
@@ -1,0 +1,11 @@
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function isUuid(value: string): boolean {
+  return UUID_RE.test(value);
+}
+
+/** Canonical undirected pair: user1Id < user2Id lexicographically. */
+export function orderedUserPair(userA: string, userB: string): [string, string] {
+  return userA < userB ? [userA, userB] : [userB, userA];
+}

--- a/src/lib/readJsonObject.ts
+++ b/src/lib/readJsonObject.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+
+export type ReadJsonObjectResult =
+  | { ok: true; body: Record<string, unknown> }
+  | { ok: false; response: NextResponse };
+
+/** Rejects invalid JSON, `null`, arrays, and non-objects with 400. */
+export async function readJsonObject(request: Request): Promise<ReadJsonObjectResult> {
+  let parsed: unknown;
+  try {
+    parsed = await request.json();
+  } catch {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Invalid JSON body" }, { status: 400 }),
+    };
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Invalid JSON body" }, { status: 400 }),
+    };
+  }
+  return { ok: true, body: parsed as Record<string, unknown> };
+}


### PR DESCRIPTION
## Summary
Implements the web friend graph for buddy meditation: Drizzle schema, authenticated REST API under `/api/friends`, and a minimal **Friends** screen in `/app`.

**Closes #116**

## Schema
- `friend_requests`: directed requests with `status` in `pending | accepted | rejected | cancelled`; CHECK `from_user_id <> to_user_id`; partial unique index on `(from_user_id, to_user_id)` WHERE `status = 'pending'`.
- `friendships`: undirected edge with `user1_id < user2_id` (CHECK + composite PK).

Apply to Neon: `npx drizzle-kit push` (see README). Optional one-shot reference DDL: `drizzle/friend_graph_incremental.sql`.

## API contract (authenticated; cookie JWT)

| Method | Path | Response / notes |
|--------|------|------------------|
| GET | `/api/friends` | `{ friends: { id, username }[] }` |
| GET | `/api/friends/requests` | `{ incoming, outgoing }` each `{ id, createdAt, user: { id, username } }[]` (pending only) |
| GET | `/api/friends/search?q=` | `{ users: { id, username }[] }`; `q` trimmed, min length 2; **public profiles only** (`is_public`); no email |
| POST | `/api/friends/requests` | Body `{ toUserId }`. `201` `{ request: { id, fromUserId, toUserId, status, createdAt, updatedAt } }`. `400` self/invalid; `404` unknown user; `409` already friends or pending (incl. race → unique violation) |
| PATCH | `/api/friends/requests/[id]` | Body `{ action: "accept" \| "reject" \| "cancel" }`. Recipient: accept/reject. Sender: cancel. `403` wrong actor; `404` missing; `409` not pending |
| DELETE | `/api/friends/[friendUserId]` | Unfriend. `{ ok: true }` or `404` |

## Test plan
- [ ] `npm run build`
- [ ] `npx drizzle-kit push` against a dev DB
- [ ] Two accounts: both set public; search by username substring; send request
- [ ] Recipient sees incoming; accept → both see friend in `GET /api/friends`
- [ ] Reject / cancel flows return expected errors when wrong user
- [ ] Remove friend; list updates

## Follow-ups for #117 / #118
- Buddy invites should use `GET /api/friends` for the invitee picker (ids + usernames only).
- Search is **public-only**; if product needs discoverability for private accounts, add explicit policy (e.g. exact username or invite links).
- Optional: rate limits on search and POST requests; notifications or polling for new requests.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added friend discovery with user search functionality
  * Added ability to send and manage friend requests (accept, reject, cancel)
  * Added friends list view displaying current friends and pending requests
  * Added in-app friend relationship management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->