### PR TITLE
Buddy MVP: per-user controls policy for shared sessions (#118)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ next-env.d.ts
 # Xcode / Swift — never commit local build products
 ios/build/
 ios/StillPointShared/build/
+
+# Nested agent worktrees (gitlinks); keep out of the app repo
+.claude/worktrees/

--- a/src/app/api/buddy/sessions/[id]/cancel/route.ts
+++ b/src/app/api/buddy/sessions/[id]/cancel/route.ts
@@ -3,6 +3,12 @@ import { db } from "@/db";
 import { buddySessions, buddySessionParticipants } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
 import { reconcileBuddySession } from "@/lib/buddySession";
+import {
+  BUDDY_POLICY_CODES,
+  buddyPolicyJson,
+  requireBuddyHost,
+  requireLobbyForCancel,
+} from "@/lib/buddySessionControlsPolicy";
 import { isUuid } from "@/lib/friends";
 import { and, eq, inArray, sql } from "drizzle-orm";
 
@@ -31,9 +37,20 @@ export async function POST(_request: Request, context: Params) {
       )
       .limit(1);
 
-    if (!p?.isHost || p.leftAt != null) {
-      return NextResponse.json({ error: "Only the host can cancel" }, { status: 403 });
+    const hostErr = requireBuddyHost(p);
+    if (hostErr) return hostErr;
+
+    const [session] = await db
+      .select()
+      .from(buddySessions)
+      .where(eq(buddySessions.id, sessionId))
+      .limit(1);
+    if (!session) {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
     }
+
+    const phaseErr = requireLobbyForCancel(session);
+    if (phaseErr) return phaseErr;
 
     const [updated] = await db
       .update(buddySessions)
@@ -51,9 +68,10 @@ export async function POST(_request: Request, context: Params) {
       .returning();
 
     if (!updated) {
-      return NextResponse.json(
-        { error: "Session cannot be cancelled now" },
-        { status: 409 },
+      return buddyPolicyJson(
+        409,
+        "Session cannot be cancelled now",
+        BUDDY_POLICY_CODES.CANCEL_WRONG_PHASE,
       );
     }
 

--- a/src/app/api/buddy/sessions/[id]/leave/route.ts
+++ b/src/app/api/buddy/sessions/[id]/leave/route.ts
@@ -6,6 +6,7 @@ import {
   bumpBuddyRevision,
   reconcileBuddySession,
 } from "@/lib/buddySession";
+import { hostLeaveShouldAbandonSession } from "@/lib/buddySessionControlsPolicy";
 import { isUuid } from "@/lib/friends";
 import { and, eq, sql } from "drizzle-orm";
 
@@ -50,12 +51,7 @@ export async function POST(_request: Request, context: Params) {
       .where(eq(buddySessions.id, sessionId))
       .limit(1);
 
-    if (
-      p.isHost &&
-      session &&
-      session.state !== "completed" &&
-      session.state !== "abandoned"
-    ) {
+    if (p.isHost && session && hostLeaveShouldAbandonSession(session)) {
       await db
         .update(buddySessions)
         .set({

--- a/src/app/api/buddy/sessions/[id]/participant-complete/route.ts
+++ b/src/app/api/buddy/sessions/[id]/participant-complete/route.ts
@@ -3,6 +3,10 @@ import { db } from "@/db";
 import { buddySessions, buddySessionParticipants } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
 import { bumpBuddyRevision } from "@/lib/buddySession";
+import {
+  requireBuddyActiveParticipant,
+  requireParticipantCompletePhase,
+} from "@/lib/buddySessionControlsPolicy";
 import { isUuid } from "@/lib/friends";
 import { and, eq, isNull } from "drizzle-orm";
 
@@ -10,7 +14,7 @@ type Params = { params: Promise<{ id: string }> };
 
 /**
  * #119: Marks this participant as finished with the shared sit (no journaling here).
- * #118: Per-user controls may gate when this may be called.
+ * #118: Per-user only; does not mutate shared timer — see `buddySessionControlsPolicy.ts`.
  */
 export async function POST(_request: Request, context: Params) {
   try {
@@ -33,12 +37,8 @@ export async function POST(_request: Request, context: Params) {
       return NextResponse.json({ error: "Session not found" }, { status: 404 });
     }
 
-    if (!allowsParticipantCompleteState(session.state)) {
-      return NextResponse.json(
-        { error: "Participant completion is only tracked during or after an active sit" },
-        { status: 409 },
-      );
-    }
+    const phaseErr = requireParticipantCompletePhase(session.state);
+    if (phaseErr) return phaseErr;
 
     const [p] = await db
       .select()
@@ -51,9 +51,8 @@ export async function POST(_request: Request, context: Params) {
       )
       .limit(1);
 
-    if (!p || p.leftAt != null) {
-      return NextResponse.json({ error: "Not in this session" }, { status: 403 });
-    }
+    const memberErr = requireBuddyActiveParticipant(p);
+    if (memberErr) return memberErr;
 
     if (p.participantCompletedAt != null) {
       return NextResponse.json({ ok: true, already: true });
@@ -84,6 +83,3 @@ export async function POST(_request: Request, context: Params) {
   }
 }
 
-function allowsParticipantCompleteState(state: string): boolean {
-  return state === "active" || state === "completed";
-}

--- a/src/app/api/buddy/sessions/[id]/ready/route.ts
+++ b/src/app/api/buddy/sessions/[id]/ready/route.ts
@@ -6,6 +6,10 @@ import {
   bumpBuddyRevision,
   reconcileBuddySession,
 } from "@/lib/buddySession";
+import {
+  requireBuddyActiveParticipant,
+  requireLobbyForReady,
+} from "@/lib/buddySessionControlsPolicy";
 import { isUuid } from "@/lib/friends";
 import { readJsonObject } from "@/lib/readJsonObject";
 import { and, eq } from "drizzle-orm";
@@ -39,12 +43,8 @@ export async function PATCH(request: NextRequest, context: Params) {
     if (!session) {
       return NextResponse.json({ error: "Session not found" }, { status: 404 });
     }
-    if (session.state !== "waiting" && session.state !== "ready_check") {
-      return NextResponse.json(
-        { error: "Ready can only change before the session starts" },
-        { status: 409 },
-      );
-    }
+    const lobbyErr = requireLobbyForReady(session);
+    if (lobbyErr) return lobbyErr;
 
     const [p] = await db
       .select()
@@ -57,9 +57,8 @@ export async function PATCH(request: NextRequest, context: Params) {
       )
       .limit(1);
 
-    if (!p || p.leftAt != null) {
-      return NextResponse.json({ error: "Not in this session" }, { status: 403 });
-    }
+    const memberErr = requireBuddyActiveParticipant(p);
+    if (memberErr) return memberErr;
 
     await db
       .update(buddySessionParticipants)

--- a/src/app/api/buddy/sessions/[id]/route.ts
+++ b/src/app/api/buddy/sessions/[id]/route.ts
@@ -7,6 +7,7 @@ import {
   loadBuddySnapshotContext,
   reconcileBuddySession,
 } from "@/lib/buddySession";
+import { BUDDY_POLICY_CODES } from "@/lib/buddyPolicyCodes";
 import { isUuid } from "@/lib/friends";
 import { and, eq } from "drizzle-orm";
 
@@ -36,7 +37,10 @@ export async function GET(_request: Request, context: Params) {
       .limit(1);
 
     if (!membership || membership.leftAt != null) {
-      return NextResponse.json({ error: "Not in this session" }, { status: 403 });
+      return NextResponse.json(
+        { error: "Not in this session", code: BUDDY_POLICY_CODES.NOT_IN_SESSION },
+        { status: 403 },
+      );
     }
 
     await db

--- a/src/app/api/buddy/sessions/[id]/start/route.ts
+++ b/src/app/api/buddy/sessions/[id]/start/route.ts
@@ -3,6 +3,12 @@ import { db } from "@/db";
 import { buddySessions, buddySessionParticipants } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
 import { reconcileBuddySession } from "@/lib/buddySession";
+import {
+  BUDDY_POLICY_CODES,
+  buddyPolicyJson,
+  requireBuddyHost,
+  requireReadyCheckForStart,
+} from "@/lib/buddySessionControlsPolicy";
 import { isUuid } from "@/lib/friends";
 import { and, eq, sql } from "drizzle-orm";
 
@@ -31,11 +37,22 @@ export async function POST(_request: Request, context: Params) {
       )
       .limit(1);
 
-    if (!p?.isHost || p.leftAt != null) {
-      return NextResponse.json({ error: "Only the host can start" }, { status: 403 });
-    }
+    const hostErr = requireBuddyHost(p);
+    if (hostErr) return hostErr;
 
     await reconcileBuddySession(sessionId);
+
+    const [session] = await db
+      .select()
+      .from(buddySessions)
+      .where(eq(buddySessions.id, sessionId))
+      .limit(1);
+    if (!session) {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    const phaseErr = requireReadyCheckForStart(session);
+    if (phaseErr) return phaseErr;
 
     const startedAt = new Date();
     const [updated] = await db
@@ -52,9 +69,10 @@ export async function POST(_request: Request, context: Params) {
       .returning();
 
     if (!updated) {
-      return NextResponse.json(
-        { error: "Everyone must be ready and at least one guest must join before starting" },
-        { status: 409 },
+      return buddyPolicyJson(
+        409,
+        "Everyone must be ready and at least one guest must join before starting",
+        BUDDY_POLICY_CODES.START_WRONG_PHASE,
       );
     }
 

--- a/src/app/api/buddy/sessions/[id]/start/route.ts
+++ b/src/app/api/buddy/sessions/[id]/start/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/db";
 import { buddySessions, buddySessionParticipants } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
 import { reconcileBuddySession } from "@/lib/buddySession";
+import { BUDDY_START_WRONG_PHASE_MESSAGE } from "@/lib/buddyPolicyCodes";
 import {
   BUDDY_POLICY_CODES,
   buddyPolicyJson,
@@ -71,7 +72,7 @@ export async function POST(_request: Request, context: Params) {
     if (!updated) {
       return buddyPolicyJson(
         409,
-        "Everyone must be ready and at least one guest must join before starting",
+        BUDDY_START_WRONG_PHASE_MESSAGE,
         BUDDY_POLICY_CODES.START_WRONG_PHASE,
       );
     }

--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -3,6 +3,7 @@
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api, ApiError, type BuddySnapshot } from "@/lib/api";
+import { buddyPolicyUserMessage } from "@/lib/buddyPolicyCodes";
 import { BlockTimer } from "./BlockTimer";
 import { ThoughtCapture } from "./ThoughtCapture";
 import { loadSoundPrefs, saveSoundPrefs, type SoundPrefs } from "@/lib/audio";
@@ -12,6 +13,13 @@ type BuddySessionRoomProps = {
   currentUserId: string;
   onExit: () => void;
 };
+
+function formatBuddyActionError(e: unknown, fallback: string): string {
+  if (e instanceof ApiError) {
+    return buddyPolicyUserMessage(e.code) ?? e.message;
+  }
+  return e instanceof Error ? e.message : fallback;
+}
 
 export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySessionRoomProps) {
   const [snap, setSnap] = useState<BuddySnapshot | null>(null);
@@ -38,13 +46,7 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
       setSnap(snapshot);
       setPollError(null);
     } catch (e) {
-      if (e instanceof ApiError && e.status === 403) {
-        setPollError(
-          "You are no longer in this session. You can leave or join again with the link.",
-        );
-        return;
-      }
-      setPollError(e instanceof ApiError ? e.message : "Could not refresh session");
+      setPollError(formatBuddyActionError(e, "Could not refresh session"));
     }
   }, [sessionId]);
 
@@ -126,7 +128,7 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
       await api.setBuddyReady(sessionId, ready);
       await poll();
     } catch (e) {
-      setPollError(e instanceof ApiError ? e.message : "Could not update ready");
+      setPollError(formatBuddyActionError(e, "Could not update ready"));
     }
   };
 
@@ -135,7 +137,7 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
       await api.startBuddySession(sessionId);
       await poll();
     } catch (e) {
-      setPollError(e instanceof ApiError ? e.message : "Could not start");
+      setPollError(formatBuddyActionError(e, "Could not start"));
     }
   };
 
@@ -144,7 +146,7 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
       await api.cancelBuddySession(sessionId);
       await poll();
     } catch (e) {
-      setPollError(e instanceof ApiError ? e.message : "Could not cancel");
+      setPollError(formatBuddyActionError(e, "Could not cancel"));
     }
   };
 
@@ -160,10 +162,10 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
   const completeAndExit = async () => {
     try {
       await api.buddyParticipantComplete(sessionId);
-    } catch {
-      /* #119 will tighten this */
+      await leave();
+    } catch (e) {
+      setPollError(formatBuddyActionError(e, "Could not finish session step"));
     }
-    await leave();
   };
 
   if (!snap && !pollError) {
@@ -351,6 +353,21 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
             ))}
           </ul>
 
+          {!snap.isHost && (
+            <p
+              role="note"
+              style={{
+                margin: 0,
+                fontSize: "12px",
+                color: "var(--fg-3)",
+                textAlign: "center",
+                lineHeight: 1.45,
+              }}
+            >
+              Only the host can start or cancel the shared session. Your ready toggle is just for you.
+            </p>
+          )}
+
           {me && (
             <label
               style={{
@@ -393,6 +410,11 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
                 type="button"
                 onClick={start}
                 disabled={snap.state !== "ready_check"}
+                title={
+                  snap.state !== "ready_check"
+                    ? "Everyone must join and mark ready before you can start the shared timer for all."
+                    : "Starts the same timer for everyone in the room."
+                }
                 style={{
                   ...btnPrimary,
                   opacity: snap.state !== "ready_check" ? 0.45 : 1,
@@ -401,7 +423,27 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
               >
                 Start for everyone
               </button>
-              <button type="button" onClick={cancel} style={btnSecondary}>
+              {snap.state !== "ready_check" && (
+                <p
+                  role="note"
+                  style={{
+                    margin: 0,
+                    fontSize: "12px",
+                    color: "var(--fg-3)",
+                    textAlign: "center",
+                    lineHeight: 1.45,
+                  }}
+                >
+                  Start is a shared action for the host only. It unlocks when everyone has joined and
+                  marked ready.
+                </p>
+              )}
+              <button
+                type="button"
+                onClick={cancel}
+                style={btnSecondary}
+                title="Ends the invite for everyone. Only the host can cancel before the sit starts."
+              >
                 Cancel session
               </button>
             </div>
@@ -488,6 +530,7 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
               <button
                 type="button"
                 onClick={handleThinkingToggle}
+                title="Mind-state and thoughts stay on this device; others are not notified."
                 style={{
                   background:
                     mindState === "thinking"
@@ -545,42 +588,66 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
             <div
               style={{
                 display: "flex",
-                justifyContent: "center",
-                gap: "16px",
+                flexDirection: "column",
+                alignItems: "center",
+                gap: "8px",
                 marginTop: "24px",
-                fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-                fontSize: "11px",
-                letterSpacing: "0.1em",
-                flexWrap: "wrap",
               }}
             >
-              {(
-                [
-                  ["tick", "tick"],
-                  ["chime", "chime"],
-                  ["completion", "end"],
-                ] as const
-              ).map(([key, label]) => (
-                <button
-                  type="button"
-                  key={key}
-                  onClick={() => {
-                    const next = { ...soundPrefs, [key]: !soundPrefs[key] };
-                    setSoundPrefs(next);
-                    saveSoundPrefs(next);
-                  }}
-                  style={{
-                    background: "none",
-                    border: "none",
-                    cursor: "pointer",
-                    color: soundPrefs[key] ? "var(--fg-3)" : "var(--fg-4)",
-                    transition: "color 0.3s",
-                    padding: "4px 8px",
-                  }}
-                >
-                  {soundPrefs[key] ? "\u266A" : "\u2022"} {label}
-                </button>
-              ))}
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: "11px",
+                  color: "var(--fg-4)",
+                  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                  letterSpacing: "0.06em",
+                  textAlign: "center",
+                }}
+              >
+                Sounds are only on your device — they do not affect anyone else.
+              </p>
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "center",
+                  gap: "16px",
+                  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                  fontSize: "11px",
+                  letterSpacing: "0.1em",
+                  flexWrap: "wrap",
+                }}
+              >
+                {(
+                  [
+                    ["tick", "tick"],
+                    ["chime", "chime"],
+                    ["completion", "end"],
+                  ] as const
+                ).map(([key, label]) => (
+                  <button
+                    type="button"
+                    key={key}
+                    aria-pressed={soundPrefs[key]}
+                    aria-label={`${label} sound ${soundPrefs[key] ? "on" : "off"}; only you hear this`}
+                    title="Only you hear this — does not change audio for others"
+                    onClick={() => {
+                      const next = { ...soundPrefs, [key]: !soundPrefs[key] };
+                      setSoundPrefs(next);
+                      saveSoundPrefs(next);
+                    }}
+                    style={{
+                      background: "none",
+                      border: "none",
+                      cursor: "pointer",
+                      color: soundPrefs[key] ? "var(--fg-3)" : "var(--fg-4)",
+                      transition: "color 0.3s",
+                      padding: "4px 8px",
+                    }}
+                  >
+                    {soundPrefs[key] ? "\u266A" : "\u2022"} {label}
+                  </button>
+                ))}
+              </div>
             </div>
           </div>
 
@@ -590,11 +657,12 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
               color: "var(--fg-3)",
               textAlign: "center",
               margin: "var(--s4) 0 0",
+              lineHeight: 1.45,
             }}
           >
             {snap.isHost
-              ? "If you leave, the session ends for everyone."
-              : "If you leave, your timer view stops but others continue."}
+              ? "If you leave, the shared session ends for everyone (only the host can do that)."
+              : "If you leave, only your view stops — the shared timer keeps running for everyone else."}
           </p>
           {sessionThoughts.length > 0 && (
             <p

--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -3,7 +3,7 @@
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api, ApiError, type BuddySnapshot } from "@/lib/api";
-import { buddyPolicyUserMessage } from "@/lib/buddyPolicyCodes";
+import { BUDDY_POLICY_CODES, buddyPolicyUserMessage } from "@/lib/buddyPolicyCodes";
 import { BlockTimer } from "./BlockTimer";
 import { ThoughtCapture } from "./ThoughtCapture";
 import { loadSoundPrefs, saveSoundPrefs, type SoundPrefs } from "@/lib/audio";
@@ -21,9 +21,27 @@ function formatBuddyActionError(e: unknown, fallback: string): string {
   return e instanceof Error ? e.message : fallback;
 }
 
+function BuddyRoomErrorBanner({ message }: { message: string }) {
+  return (
+    <p
+      role="alert"
+      style={{
+        margin: "0 0 var(--s3)",
+        fontSize: "12px",
+        color: "var(--fg-2)",
+        textAlign: "center",
+        lineHeight: 1.45,
+      }}
+    >
+      {message}
+    </p>
+  );
+}
+
 export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySessionRoomProps) {
   const [snap, setSnap] = useState<BuddySnapshot | null>(null);
   const [pollError, setPollError] = useState<string | null>(null);
+  const [pollStopped, setPollStopped] = useState(false);
   const lastRevision = useRef(-1);
   const [mindState, setMindState] = useState("clear");
   const [mindStateLog, setMindStateLog] = useState<Array<{ time: number; state: string }>>([]);
@@ -39,6 +57,7 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
   const timerAnchorRef = useRef<string | null>(null);
 
   const poll = useCallback(async () => {
+    if (pollStopped) return;
     try {
       const { snapshot } = await api.getBuddySnapshot(sessionId);
       if (snapshot.revision < lastRevision.current) return;
@@ -46,15 +65,27 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
       setSnap(snapshot);
       setPollError(null);
     } catch (e) {
+      if (e instanceof ApiError && e.code === BUDDY_POLICY_CODES.NOT_IN_SESSION) {
+        setPollStopped(true);
+        setSnap(null);
+        setPollError(formatBuddyActionError(e, "Could not refresh session"));
+        return;
+      }
       setPollError(formatBuddyActionError(e, "Could not refresh session"));
     }
+  }, [pollStopped, sessionId]);
+
+  useEffect(() => {
+    setPollStopped(false);
+    lastRevision.current = -1;
   }, [sessionId]);
 
   useEffect(() => {
-    poll();
-    const id = window.setInterval(poll, 1500);
+    if (pollStopped) return;
+    void poll();
+    const id = window.setInterval(() => void poll(), 1500);
     return () => window.clearInterval(id);
-  }, [poll]);
+  }, [poll, pollStopped]);
 
   useEffect(() => {
     if (snap?.state !== "active" || !snap.startedAt) return;
@@ -150,19 +181,24 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
     }
   };
 
-  const leave = async () => {
+  const leave = async (opts?: { ignoreLeaveApiErrors?: boolean }) => {
+    const ignoreLeaveApiErrors = opts?.ignoreLeaveApiErrors !== false;
     try {
       await api.leaveBuddySession(sessionId);
-    } catch {
-      /* still exit UI */
+      onExit();
+    } catch (err) {
+      if (ignoreLeaveApiErrors) {
+        onExit();
+        return;
+      }
+      throw err;
     }
-    onExit();
   };
 
   const completeAndExit = async () => {
     try {
       await api.buddyParticipantComplete(sessionId);
-      await leave();
+      await leave({ ignoreLeaveApiErrors: false });
     } catch (e) {
       setPollError(formatBuddyActionError(e, "Could not finish session step"));
     }
@@ -200,10 +236,11 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
   if (snap.state === "abandoned") {
     return (
       <div style={{ maxWidth: "440px", margin: "0 auto", width: "100%" }}>
+        {pollError ? <BuddyRoomErrorBanner message={pollError} /> : null}
         <EndPanel
           title="Session ended"
           body="The host left or cancelled. You can return home or join again if you still have the link."
-          primary={{ label: "Return home", onClick: leave }}
+          primary={{ label: "Return home", onClick: () => void leave() }}
         />
       </div>
     );
@@ -212,10 +249,11 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
   if (snap.state === "completed") {
     return (
       <div style={{ maxWidth: "440px", margin: "0 auto", width: "100%" }}>
+        {pollError ? <BuddyRoomErrorBanner message={pollError} /> : null}
         <EndPanel
           title="Time is complete"
           body="The shared timer has finished. Your personal journal step can be added in a future update."
-          primary={{ label: "Done", onClick: completeAndExit }}
+          primary={{ label: "Done", onClick: () => void completeAndExit() }}
         />
       </div>
     );
@@ -449,7 +487,7 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
             </div>
           )}
 
-          <button type="button" onClick={leave} style={btnGhost}>
+          <button type="button" onClick={() => void leave()} style={btnGhost}>
             Leave
           </button>
         </>
@@ -679,7 +717,7 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
             </p>
           )}
 
-          <button type="button" onClick={leave} style={{ ...btnSecondary, marginTop: "var(--s3)" }}>
+          <button type="button" onClick={() => void leave()} style={{ ...btnSecondary, marginTop: "var(--s3)" }}>
             Leave
           </button>
         </>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,9 @@
 export class ApiError extends Error {
-  constructor(public status: number, message: string) {
+  constructor(
+    public status: number,
+    message: string,
+    public code?: string,
+  ) {
     super(message);
   }
 }
@@ -11,7 +15,8 @@ async function request<T>(url: string, options?: RequestInit): Promise<T> {
   });
   if (!res.ok) {
     const data = await res.json().catch(() => ({ error: "Request failed" }));
-    throw new ApiError(res.status, data.error || "Request failed");
+    const code = typeof data.code === "string" ? data.code : undefined;
+    throw new ApiError(res.status, data.error || "Request failed", code);
   }
   return res.json();
 }

--- a/src/lib/buddyPolicyCodes.ts
+++ b/src/lib/buddyPolicyCodes.ts
@@ -1,0 +1,31 @@
+/**
+ * Stable API error codes for buddy session policy (#118). Safe to import from client code.
+ */
+
+export const BUDDY_POLICY_CODES = {
+  NOT_IN_SESSION: "BUDDY_NOT_IN_SESSION",
+  HOST_ONLY: "BUDDY_HOST_ONLY",
+  READY_LOBBY_ONLY: "BUDDY_READY_LOBBY_ONLY",
+  START_WRONG_PHASE: "BUDDY_START_WRONG_PHASE",
+  CANCEL_WRONG_PHASE: "BUDDY_CANCEL_WRONG_PHASE",
+  PARTICIPANT_COMPLETE_WRONG_PHASE: "BUDDY_PARTICIPANT_COMPLETE_WRONG_PHASE",
+} as const;
+
+export type BuddyPolicyCode = (typeof BUDDY_POLICY_CODES)[keyof typeof BUDDY_POLICY_CODES];
+
+/** Short copy for inline UI when the server returns a policy code. */
+const USER_FACING: Record<BuddyPolicyCode, string> = {
+  [BUDDY_POLICY_CODES.NOT_IN_SESSION]:
+    "You are no longer in this session. You can go back or join again with the link.",
+  [BUDDY_POLICY_CODES.HOST_ONLY]: "Only the host can do that for everyone.",
+  [BUDDY_POLICY_CODES.READY_LOBBY_ONLY]: "Ready can only change before the sit starts.",
+  [BUDDY_POLICY_CODES.START_WRONG_PHASE]: "Starting is not available until everyone is ready.",
+  [BUDDY_POLICY_CODES.CANCEL_WRONG_PHASE]: "This session can no longer be cancelled from here.",
+  [BUDDY_POLICY_CODES.PARTICIPANT_COMPLETE_WRONG_PHASE]:
+    "That step is only available during or after the shared sit.",
+};
+
+export function buddyPolicyUserMessage(code: string | undefined): string | undefined {
+  if (!code) return undefined;
+  return USER_FACING[code as BuddyPolicyCode];
+}

--- a/src/lib/buddyPolicyCodes.ts
+++ b/src/lib/buddyPolicyCodes.ts
@@ -13,13 +13,17 @@ export const BUDDY_POLICY_CODES = {
 
 export type BuddyPolicyCode = (typeof BUDDY_POLICY_CODES)[keyof typeof BUDDY_POLICY_CODES];
 
+/** Same string in JSON `error` and UI for `START_WRONG_PHASE`. */
+export const BUDDY_START_WRONG_PHASE_MESSAGE =
+  "Starting is not available until everyone is ready." as const;
+
 /** Short copy for inline UI when the server returns a policy code. */
 const USER_FACING: Record<BuddyPolicyCode, string> = {
   [BUDDY_POLICY_CODES.NOT_IN_SESSION]:
     "You are no longer in this session. You can go back or join again with the link.",
   [BUDDY_POLICY_CODES.HOST_ONLY]: "Only the host can do that for everyone.",
   [BUDDY_POLICY_CODES.READY_LOBBY_ONLY]: "Ready can only change before the sit starts.",
-  [BUDDY_POLICY_CODES.START_WRONG_PHASE]: "Starting is not available until everyone is ready.",
+  [BUDDY_POLICY_CODES.START_WRONG_PHASE]: BUDDY_START_WRONG_PHASE_MESSAGE,
   [BUDDY_POLICY_CODES.CANCEL_WRONG_PHASE]: "This session can no longer be cancelled from here.",
   [BUDDY_POLICY_CODES.PARTICIPANT_COMPLETE_WRONG_PHASE]:
     "That step is only available during or after the shared sit.",

--- a/src/lib/buddySession.ts
+++ b/src/lib/buddySession.ts
@@ -1,6 +1,6 @@
 /**
  * Shared buddy session domain logic (#117). Server is source of truth for timing and state.
- * #118: Extend route handlers and UI for per-user controls (pause, policy, host transfer).
+ * #118: Controls policy and enforcement — see `buddySessionControlsPolicy.ts`.
  * #119: Use participantCompletedAt + POST …/participant-complete for journaling hooks.
  */
 import { db } from "@/db";

--- a/src/lib/buddySessionControlsPolicy.ts
+++ b/src/lib/buddySessionControlsPolicy.ts
@@ -32,6 +32,7 @@ import { NextResponse } from "next/server";
 import type { BuddySessionRow, BuddyParticipantRow } from "@/lib/buddySession";
 import {
   BUDDY_POLICY_CODES,
+  BUDDY_START_WRONG_PHASE_MESSAGE,
   type BuddyPolicyCode,
 } from "@/lib/buddyPolicyCodes";
 
@@ -88,7 +89,7 @@ export function requireReadyCheckForStart(session: BuddySessionRow): NextRespons
   if (session.state !== "ready_check") {
     return buddyPolicyJson(
       409,
-      "Everyone must be ready and at least one guest must join before starting",
+      BUDDY_START_WRONG_PHASE_MESSAGE,
       BUDDY_POLICY_CODES.START_WRONG_PHASE,
     );
   }

--- a/src/lib/buddySessionControlsPolicy.ts
+++ b/src/lib/buddySessionControlsPolicy.ts
@@ -1,0 +1,126 @@
+/**
+ * Buddy shared-session controls policy (#118, parent #92).
+ *
+ * ## Policy matrix (MVP)
+ *
+ * | Control / action | Scope | Who may use it | Server enforcement |
+ * | ---------------- | ----- | -------------- | ------------------ |
+ * | Tick / chime / end sounds | Local (device) | Everyone | N/A — client-only prefs |
+ * | Mind state, thought capture (until #119) | Local (device) | Everyone | N/A |
+ * | Ready toggle | Per-user lobby flag | In-lobby participants | PATCH …/ready |
+ * | Start session | Global | Host only | POST …/start |
+ * | Cancel session (lobby) | Global | Host only | POST …/cancel |
+ * | Leave | Per-user row | Everyone | POST …/leave |
+ * | Host leaves while session live | Global | — | Session → abandoned (no host transfer) |
+ * | Participant leaves during active sit | Per-user | Participant | Others stay active |
+ * | Timer (startedAt, duration, active→completed) | Global | Server reconcile only | No client mutation API |
+ * | Participant complete (#119) | Per-user metadata | Participant | POST …/participant-complete |
+ *
+ * ## Host disconnect / leave
+ *
+ * If the host leaves and the session is not already completed or abandoned, the session
+ * becomes abandoned for everyone. There is no automatic host promotion in MVP.
+ *
+ * ## #119 handoff
+ *
+ * `participant-complete` records per-user completion for journaling; it does not end the
+ * shared timer or change session phase for other participants. Completion UI and journal
+ * writes belong in #119.
+ */
+
+import { NextResponse } from "next/server";
+import type { BuddySessionRow, BuddyParticipantRow } from "@/lib/buddySession";
+import {
+  BUDDY_POLICY_CODES,
+  type BuddyPolicyCode,
+} from "@/lib/buddyPolicyCodes";
+
+export { BUDDY_POLICY_CODES, type BuddyPolicyCode };
+
+export function buddyPolicyJson(
+  status: 403 | 409,
+  error: string,
+  code: BuddyPolicyCode,
+): NextResponse {
+  return NextResponse.json({ error, code }, { status });
+}
+
+/** Membership row must exist and not have left. */
+export function requireBuddyActiveParticipant(
+  p: BuddyParticipantRow | undefined,
+): NextResponse | null {
+  if (!p || p.leftAt != null) {
+    return buddyPolicyJson(
+      403,
+      "Not in this session",
+      BUDDY_POLICY_CODES.NOT_IN_SESSION,
+    );
+  }
+  return null;
+}
+
+/** Start, cancel (lobby): host only, still in session. */
+export function requireBuddyHost(p: BuddyParticipantRow | undefined): NextResponse | null {
+  const inSession = requireBuddyActiveParticipant(p);
+  if (inSession) return inSession;
+  if (!p!.isHost) {
+    return buddyPolicyJson(
+      403,
+      "Only the host can do that for everyone",
+      BUDDY_POLICY_CODES.HOST_ONLY,
+    );
+  }
+  return null;
+}
+
+export function requireLobbyForReady(session: BuddySessionRow): NextResponse | null {
+  if (session.state !== "waiting" && session.state !== "ready_check") {
+    return buddyPolicyJson(
+      409,
+      "Ready can only change before the session starts",
+      BUDDY_POLICY_CODES.READY_LOBBY_ONLY,
+    );
+  }
+  return null;
+}
+
+export function requireReadyCheckForStart(session: BuddySessionRow): NextResponse | null {
+  if (session.state !== "ready_check") {
+    return buddyPolicyJson(
+      409,
+      "Everyone must be ready and at least one guest must join before starting",
+      BUDDY_POLICY_CODES.START_WRONG_PHASE,
+    );
+  }
+  return null;
+}
+
+export function requireLobbyForCancel(session: BuddySessionRow): NextResponse | null {
+  if (session.state !== "waiting" && session.state !== "ready_check") {
+    return buddyPolicyJson(
+      409,
+      "Session cannot be cancelled now",
+      BUDDY_POLICY_CODES.CANCEL_WRONG_PHASE,
+    );
+  }
+  return null;
+}
+
+export function requireParticipantCompletePhase(sessionState: string): NextResponse | null {
+  if (sessionState !== "active" && sessionState !== "completed") {
+    return buddyPolicyJson(
+      409,
+      "Participant completion is only tracked during or after an active sit",
+      BUDDY_POLICY_CODES.PARTICIPANT_COMPLETE_WRONG_PHASE,
+    );
+  }
+  return null;
+}
+
+/**
+ * When the host leaves, abandon the session for everyone if it is still "live".
+ * Participants leaving never call this path — only the host branch in leave.
+ */
+export function hostLeaveShouldAbandonSession(session: BuddySessionRow): boolean {
+  return session.state !== "completed" && session.state !== "abandoned";
+}


### PR DESCRIPTION
## Summary
Defines and enforces local vs global buddy controls: policy matrix in `src/lib/buddySessionControlsPolicy.ts`, centralized 403/409 responses with stable `code` fields, and UI copy/tooltips in `BuddySessionRoom`.

Parent: #92

## Handoff to #119
`POST …/participant-complete` remains per-user metadata only (no shared timer mutation). Completion and journal UX should align with `participantCompletedAt` and the policy notes in `buddySessionControlsPolicy.ts`.

## Test plan
- [x] `npm run build` passes
- [ ] Two browsers: participant mutes tick/chime/end — other user unchanged
- [ ] Participant cannot start/cancel (API 403 `BUDDY_HOST_ONLY` if forced); UI hides host actions
- [ ] Host start only in `ready_check`; host cancel only in lobby
- [ ] Host leave abandons live session; participant leave does not
- [ ] Solo `/app` session flow unchanged

Closes #118

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltips and explanatory notes for buddy session actions.
  * Redesigned sound settings interface with improved layout and accessibility features.

* **Bug Fixes**
  * Improved error messages for buddy session operations with clearer, user-facing feedback.

* **Style**
  * Updated session behavior descriptions to better explain host-only controls and timer sharing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->