### PR TITLE
feat(buddy): per-user session history and journal after shared sit (#119)

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,4 +1,36 @@
+import fs from "fs";
+import path from "path";
 import { defineConfig } from "drizzle-kit";
+
+/** Drizzle CLI does not load Next.js env files; mirror common local setup. */
+function loadEnvFile(relPath: string): void {
+  const full = path.join(process.cwd(), relPath);
+  if (!fs.existsSync(full)) return;
+  const text = fs.readFileSync(full, "utf8");
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    let key = trimmed.slice(0, eq).trim();
+    if (key.startsWith("export ")) {
+      key = key.slice(7).trim();
+    }
+    let val = trimmed.slice(eq + 1).trim();
+    if (
+      (val.startsWith('"') && val.endsWith('"')) ||
+      (val.startsWith("'") && val.endsWith("'"))
+    ) {
+      val = val.slice(1, -1);
+    }
+    if (process.env[key] === undefined) {
+      process.env[key] = val;
+    }
+  }
+}
+
+loadEnvFile(".env.local");
+loadEnvFile(".env");
 
 export default defineConfig({
   schema: "./src/db/schema.ts",

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -17,11 +17,13 @@ function loadEnvFile(relPath: string): void {
       key = key.slice(7).trim();
     }
     let val = trimmed.slice(eq + 1).trim();
-    if (
-      (val.startsWith('"') && val.endsWith('"')) ||
-      (val.startsWith("'") && val.endsWith("'"))
-    ) {
-      val = val.slice(1, -1);
+    const quote = val[0];
+    if (quote === '"' || quote === "'") {
+      const close = val.lastIndexOf(quote);
+      if (close <= 0) continue;
+      val = val.slice(1, close);
+    } else {
+      val = val.replace(/\s+#.*$/, "").trim();
     }
     if (process.env[key] === undefined) {
       process.env[key] = val;

--- a/drizzle/sessions_buddy_session_id_incremental.sql
+++ b/drizzle/sessions_buddy_session_id_incremental.sql
@@ -3,8 +3,18 @@
 -- This file is a reference for existing databases if you apply SQL manually.
 
 ALTER TABLE "sessions" ADD COLUMN IF NOT EXISTS "buddy_session_id" uuid;
-ALTER TABLE "sessions" ADD CONSTRAINT "sessions_buddy_session_id_buddy_sessions_id_fk"
-  FOREIGN KEY ("buddy_session_id") REFERENCES "public"."buddy_sessions"("id") ON DELETE set null ON UPDATE no action;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'sessions_buddy_session_id_buddy_sessions_id_fk'
+  ) THEN
+    ALTER TABLE "sessions" ADD CONSTRAINT "sessions_buddy_session_id_buddy_sessions_id_fk"
+      FOREIGN KEY ("buddy_session_id") REFERENCES "public"."buddy_sessions"("id") ON DELETE set null ON UPDATE no action;
+  END IF;
+END $$;
 
 CREATE INDEX IF NOT EXISTS "idx_sessions_buddy_session" ON "sessions" USING btree ("buddy_session_id");
 

--- a/drizzle/sessions_buddy_session_id_incremental.sql
+++ b/drizzle/sessions_buddy_session_id_incremental.sql
@@ -1,0 +1,12 @@
+-- Incremental DDL for per-user buddy session history (#119).
+-- Preferred: apply schema with `npx drizzle-kit push` (see README).
+-- This file is a reference for existing databases if you apply SQL manually.
+
+ALTER TABLE "sessions" ADD COLUMN IF NOT EXISTS "buddy_session_id" uuid;
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_buddy_session_id_buddy_sessions_id_fk"
+  FOREIGN KEY ("buddy_session_id") REFERENCES "public"."buddy_sessions"("id") ON DELETE set null ON UPDATE no action;
+
+CREATE INDEX IF NOT EXISTS "idx_sessions_buddy_session" ON "sessions" USING btree ("buddy_session_id");
+
+CREATE UNIQUE INDEX IF NOT EXISTS "sessions_user_buddy_session_unique" ON "sessions" USING btree ("user_id", "buddy_session_id")
+  WHERE ("buddy_session_id" IS NOT NULL);

--- a/src/app/api/buddy/sessions/[id]/record-personal-session/route.ts
+++ b/src/app/api/buddy/sessions/[id]/record-personal-session/route.ts
@@ -1,0 +1,247 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import {
+  buddySessionParticipants,
+  buddySessions,
+  sessions,
+  thoughts,
+  users,
+} from "@/db/schema";
+import { getCurrentUser } from "@/lib/auth";
+import { isUuid } from "@/lib/friends";
+import { reconcileBuddySession } from "@/lib/buddySession";
+import {
+  requireBuddyActiveParticipant,
+  requireBuddySessionCompletedForPersonalRecord,
+} from "@/lib/buddySessionControlsPolicy";
+import { and, eq, sql } from "drizzle-orm";
+
+type Params = { params: Promise<{ id: string }> };
+
+function isUniqueViolation(e: unknown): boolean {
+  if (!e || typeof e !== "object") return false;
+  const o = e as { code?: string; cause?: unknown };
+  if (o.code === "23505") return true;
+  if (o.cause) return isUniqueViolation(o.cause);
+  return false;
+}
+
+function parseMindStateLog(raw: unknown): Array<{ time: number; state: string }> {
+  if (!Array.isArray(raw)) return [];
+  const out: Array<{ time: number; state: string }> = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const t = (item as { time?: unknown }).time;
+    const s = (item as { state?: unknown }).state;
+    if (typeof t !== "number" || typeof s !== "string") continue;
+    out.push({ time: t, state: s });
+  }
+  return out;
+}
+
+function parseThoughts(
+  raw: unknown,
+): Array<{ timeInSession: number; text: string }> {
+  if (!Array.isArray(raw)) return [];
+  const out: Array<{ timeInSession: number; text: string }> = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const timeInSession = (item as { timeInSession?: unknown }).timeInSession;
+    const text = (item as { text?: unknown }).text;
+    if (typeof timeInSession !== "number" || typeof text !== "string") continue;
+    const trimmed = text.trim().slice(0, 1000);
+    if (!trimmed) continue;
+    out.push({ timeInSession, text: trimmed });
+  }
+  return out;
+}
+
+function sessionDateOk(s: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(s);
+}
+
+/**
+ * #119: After the shared sit completes, create this user’s own `sessions` row (idempotent)
+ * and optional in-sit `thoughts`. Journal completion notes use POST /api/thoughts/batch.
+ */
+export async function POST(request: NextRequest, context: Params) {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id: sessionId } = await context.params;
+    if (!isUuid(sessionId)) {
+      return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
+    }
+
+    await reconcileBuddySession(sessionId);
+
+    const [buddyRow] = await db
+      .select()
+      .from(buddySessions)
+      .where(eq(buddySessions.id, sessionId))
+      .limit(1);
+
+    const phaseErr = requireBuddySessionCompletedForPersonalRecord(buddyRow);
+    if (phaseErr) return phaseErr;
+
+    const [p] = await db
+      .select()
+      .from(buddySessionParticipants)
+      .where(
+        and(
+          eq(buddySessionParticipants.buddySessionId, sessionId),
+          eq(buddySessionParticipants.userId, auth.userId),
+        ),
+      )
+      .limit(1);
+
+    const memberErr = requireBuddyActiveParticipant(p);
+    if (memberErr) return memberErr;
+
+    const [existing] = await db
+      .select()
+      .from(sessions)
+      .where(
+        and(eq(sessions.userId, auth.userId), eq(sessions.buddySessionId, sessionId)),
+      )
+      .limit(1);
+
+    if (existing) {
+      return NextResponse.json({ session: existing, already: true });
+    }
+
+    let body: Record<string, unknown> = {};
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      body = {};
+    }
+
+    const sessionDateRaw = body.sessionDate;
+    if (typeof sessionDateRaw !== "string" || !sessionDateOk(sessionDateRaw)) {
+      return NextResponse.json({ error: "Invalid or missing sessionDate" }, { status: 400 });
+    }
+
+    const clearPercentRaw = body.clearPercent;
+    if (typeof clearPercentRaw !== "number" || Number.isNaN(clearPercentRaw)) {
+      return NextResponse.json({ error: "Invalid clearPercent" }, { status: 400 });
+    }
+    const clearPercent = Math.max(0, Math.min(100, Math.round(clearPercentRaw)));
+
+    const thoughtCountRaw = body.thoughtCount;
+    const thoughtCount =
+      typeof thoughtCountRaw === "number" && !Number.isNaN(thoughtCountRaw)
+        ? Math.max(0, Math.min(10_000, Math.floor(thoughtCountRaw)))
+        : 0;
+
+    const mindStateLog = parseMindStateLog(body.mindStateLog);
+    const thoughtItems = parseThoughts(body.thoughts);
+
+    const duration = buddyRow!.durationSeconds;
+    let actualTime = duration;
+    const at = body.actualTime;
+    if (typeof at === "number" && !Number.isNaN(at)) {
+      actualTime = Math.max(0, Math.min(duration * 2, Math.round(at)));
+    }
+
+    const now = new Date();
+    const participantCompletedAt = p!.participantCompletedAt ?? now;
+
+    try {
+      const row = await db.transaction(async (tx) => {
+        const [u] = await tx
+          .select({ currentDay: users.currentDay })
+          .from(users)
+          .where(eq(users.id, auth.userId))
+          .limit(1);
+        if (!u) {
+          throw new Error("USER_NOT_FOUND");
+        }
+        const dayNumber = u.currentDay;
+
+        const [created] = await tx
+          .insert(sessions)
+          .values({
+            userId: auth.userId,
+            buddySessionId: sessionId,
+            dayNumber,
+            duration,
+            completed: true,
+            actualTime,
+            clearPercent,
+            thoughtCount,
+            mindStateLog,
+            sessionDate: sessionDateRaw,
+          })
+          .returning();
+
+        if (!created) {
+          throw new Error("SESSION_INSERT_FAILED");
+        }
+
+        await tx
+          .update(users)
+          .set({
+            currentDay: sql`${users.currentDay} + 1`,
+            updatedAt: new Date(),
+          })
+          .where(eq(users.id, auth.userId));
+
+        await tx
+          .update(buddySessionParticipants)
+          .set({
+            participantCompletedAt,
+            lastSeenAt: now,
+          })
+          .where(eq(buddySessionParticipants.id, p!.id));
+
+        await tx
+          .update(buddySessions)
+          .set({
+            revision: sql`${buddySessions.revision} + 1`,
+            updatedAt: new Date(),
+          })
+          .where(eq(buddySessions.id, sessionId));
+
+        if (thoughtItems.length > 0) {
+          await tx.insert(thoughts).values(
+            thoughtItems.map((t) => ({
+              userId: auth.userId,
+              sessionId: created.id,
+              dayNumber,
+              timeInSession: t.timeInSession,
+              text: t.text,
+            })),
+          );
+        }
+
+        return created;
+      });
+
+      return NextResponse.json({ session: row });
+    } catch (err) {
+      if ((err as Error)?.message === "USER_NOT_FOUND") {
+        return NextResponse.json({ error: "User not found" }, { status: 404 });
+      }
+      if (isUniqueViolation(err)) {
+        const [again] = await db
+          .select()
+          .from(sessions)
+          .where(
+            and(eq(sessions.userId, auth.userId), eq(sessions.buddySessionId, sessionId)),
+          )
+          .limit(1);
+        if (again) {
+          return NextResponse.json({ session: again, already: true });
+        }
+      }
+      throw err;
+    }
+  } catch (error) {
+    console.error("Buddy record-personal-session error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/sessions/[dayNumber]/route.ts
+++ b/src/app/api/sessions/[dayNumber]/route.ts
@@ -39,7 +39,12 @@ export async function GET(
       text: thoughts.text,
     })
       .from(thoughts)
-      .where(eq(thoughts.sessionId, session.id))
+      .where(
+        and(
+          eq(thoughts.sessionId, session.id),
+          eq(thoughts.userId, auth.userId),
+        ),
+      )
       .orderBy(asc(thoughts.timeInSession));
 
     return NextResponse.json({ session, thoughts: sessionThoughts });

--- a/src/app/api/thoughts/batch/route.ts
+++ b/src/app/api/thoughts/batch/route.ts
@@ -53,37 +53,48 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ thoughts: [] });
     }
 
-    const hasCompletionNote = normalized.some((t) => t.timeInSession === -1);
-    if (hasCompletionNote) {
-      await db
-        .delete(thoughts)
-        .where(
-          and(
-            eq(thoughts.sessionId, sessionId),
-            eq(thoughts.userId, auth.userId),
-            eq(thoughts.timeInSession, -1),
-          ),
-        );
-    }
+    const completionNote = normalized.filter((t) => t.timeInSession === -1).at(-1);
+    const rowsToInsert = [
+      ...normalized.filter((t) => t.timeInSession !== -1),
+      ...(completionNote ? [completionNote] : []),
+    ];
 
-    const inserted = await db
-      .insert(thoughts)
-      .values(
-        normalized.map((t) => ({
-          userId: auth.userId,
-          sessionId,
-          dayNumber,
-          timeInSession: t.timeInSession,
-          text: t.text,
-        })),
-      )
-      .returning({
-        id: thoughts.id,
-        sessionId: thoughts.sessionId,
-        dayNumber: thoughts.dayNumber,
-        timeInSession: thoughts.timeInSession,
-        text: thoughts.text,
-      });
+    const inserted = await db.transaction(async (tx) => {
+      if (completionNote) {
+        await tx
+          .delete(thoughts)
+          .where(
+            and(
+              eq(thoughts.sessionId, sessionId),
+              eq(thoughts.userId, auth.userId),
+              eq(thoughts.timeInSession, -1),
+            ),
+          );
+      }
+
+      if (rowsToInsert.length === 0) {
+        return [];
+      }
+
+      return tx
+        .insert(thoughts)
+        .values(
+          rowsToInsert.map((t) => ({
+            userId: auth.userId,
+            sessionId,
+            dayNumber,
+            timeInSession: t.timeInSession,
+            text: t.text,
+          })),
+        )
+        .returning({
+          id: thoughts.id,
+          sessionId: thoughts.sessionId,
+          dayNumber: thoughts.dayNumber,
+          timeInSession: thoughts.timeInSession,
+          text: thoughts.text,
+        });
+    });
 
     return NextResponse.json({ thoughts: inserted });
   } catch (error) {

--- a/src/app/api/thoughts/batch/route.ts
+++ b/src/app/api/thoughts/batch/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
-import { thoughts } from "@/db/schema";
+import { sessions, thoughts } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
+import { and, eq } from "drizzle-orm";
 
 export async function POST(request: NextRequest) {
   try {
@@ -20,21 +21,69 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ thoughts: [] });
     }
 
-    const values = thoughtItems.map((t: { timeInSession: number; text: string }) => ({
-      userId: auth.userId,
-      sessionId,
-      dayNumber,
-      timeInSession: t.timeInSession,
-      text: t.text,
-    }));
+    const [session] = await db
+      .select()
+      .from(sessions)
+      .where(and(eq(sessions.id, sessionId), eq(sessions.userId, auth.userId)))
+      .limit(1);
 
-    const inserted = await db.insert(thoughts).values(values).returning({
-      id: thoughts.id,
-      sessionId: thoughts.sessionId,
-      dayNumber: thoughts.dayNumber,
-      timeInSession: thoughts.timeInSession,
-      text: thoughts.text,
-    });
+    if (!session) {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    if (session.dayNumber !== dayNumber) {
+      return NextResponse.json({ error: "Day number mismatch" }, { status: 400 });
+    }
+
+    const normalized = thoughtItems
+      .map((t: { timeInSession: unknown; text: unknown }) => {
+        if (typeof t.timeInSession !== "number" || typeof t.text !== "string") {
+          return null;
+        }
+        const text = t.text.trim().slice(0, 1000);
+        if (!text) return null;
+        return {
+          timeInSession: t.timeInSession,
+          text,
+        };
+      })
+      .filter((t): t is { timeInSession: number; text: string } => t != null);
+
+    if (normalized.length === 0) {
+      return NextResponse.json({ thoughts: [] });
+    }
+
+    const hasCompletionNote = normalized.some((t) => t.timeInSession === -1);
+    if (hasCompletionNote) {
+      await db
+        .delete(thoughts)
+        .where(
+          and(
+            eq(thoughts.sessionId, sessionId),
+            eq(thoughts.userId, auth.userId),
+            eq(thoughts.timeInSession, -1),
+          ),
+        );
+    }
+
+    const inserted = await db
+      .insert(thoughts)
+      .values(
+        normalized.map((t) => ({
+          userId: auth.userId,
+          sessionId,
+          dayNumber,
+          timeInSession: t.timeInSession,
+          text: t.text,
+        })),
+      )
+      .returning({
+        id: thoughts.id,
+        sessionId: thoughts.sessionId,
+        dayNumber: thoughts.dayNumber,
+        timeInSession: thoughts.timeInSession,
+        text: thoughts.text,
+      });
 
     return NextResponse.json({ thoughts: inserted });
   } catch (error) {

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -12,7 +12,7 @@ import { PublicBoard } from "@/components/PublicBoard";
 import { SettingsView } from "@/components/SettingsView";
 import { FriendsView } from "@/components/FriendsView";
 import { BuddySessionHub } from "@/components/BuddySessionHub";
-import { BuddySessionRoom } from "@/components/BuddySessionRoom";
+import { BuddySessionRoom, type BuddyPersonalRecordPayload } from "@/components/BuddySessionRoom";
 import { useIsMobile } from "@/lib/useIsMobile";
 import { api } from "@/lib/api";
 
@@ -147,6 +147,23 @@ export default function StillPoint() {
   const handleBuddyExit = useCallback(() => {
     setBuddySessionId(null);
     setView("home");
+  }, []);
+
+  const handleBuddyPersonalRecordComplete = useCallback((data: BuddyPersonalRecordPayload) => {
+    setBuddySessionId(null);
+    setCompletionData({
+      sessionId: data.sessionId,
+      dayNumber: data.dayNumber,
+      duration: data.duration,
+      clearPercent: data.clearPercent,
+      thoughtCount: data.thoughtCount,
+      thoughts: data.thoughts,
+    });
+    setView("complete");
+    void api
+      .me()
+      .then(({ user: u }) => setUser(u))
+      .catch(() => {});
   }, []);
 
   const handleSessionComplete = useCallback(async (data: {
@@ -443,6 +460,7 @@ export default function StillPoint() {
           sessionId={buddySessionId}
           currentUserId={user.id}
           onExit={handleBuddyExit}
+          onPersonalRecordComplete={handleBuddyPersonalRecordComplete}
         />
       )}
 
@@ -461,7 +479,13 @@ export default function StillPoint() {
           clearPercent={completionData.clearPercent}
           thoughtCount={completionData.thoughtCount}
           thoughts={completionData.thoughts}
-          onReturn={() => setView("home")}
+          onReturn={() => {
+            setView("home");
+            void api
+              .me()
+              .then(({ user: u }) => setUser(u))
+              .catch(() => {});
+          }}
           onSaveNote={completionData.sessionId ? async (text: string) => {
             const res = await fetch("/api/thoughts/batch", {
               method: "POST",

--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -8,11 +8,49 @@ import { BlockTimer } from "./BlockTimer";
 import { ThoughtCapture } from "./ThoughtCapture";
 import { loadSoundPrefs, saveSoundPrefs, type SoundPrefs } from "@/lib/audio";
 
+/** Payload for the shared `/app` completion screen after a buddy sit (#119). */
+export type BuddyPersonalRecordPayload = {
+  sessionId: string;
+  dayNumber: number;
+  duration: number;
+  clearPercent: number;
+  thoughtCount: number;
+  thoughts: Array<{ timeInSession: number; text: string }>;
+};
+
 type BuddySessionRoomProps = {
   sessionId: string;
   currentUserId: string;
   onExit: () => void;
+  /** When set, a finished shared timer saves a personal session row then opens the normal completion flow. */
+  onPersonalRecordComplete?: (data: BuddyPersonalRecordPayload) => void;
 };
+
+function getLocalIsoDate(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function calcBuddyClearPercent(
+  mindStateLog: Array<{ time: number; state: string }>,
+  totalSeconds: number,
+): number {
+  if (mindStateLog.length === 0) return 100;
+  let clearTime = 0;
+  let lastTime = 0;
+  let lastState = "clear";
+  const endTime = totalSeconds;
+  const log = [...mindStateLog, { time: endTime, state: "clear" }];
+  for (const entry of log) {
+    if (lastState === "clear") clearTime += entry.time - lastTime;
+    lastTime = entry.time;
+    lastState = entry.state;
+  }
+  return Math.round((clearTime / endTime) * 100);
+}
 
 function formatBuddyActionError(e: unknown, fallback: string): string {
   if (e instanceof ApiError) {
@@ -38,7 +76,12 @@ function BuddyRoomErrorBanner({ message }: { message: string }) {
   );
 }
 
-export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySessionRoomProps) {
+export function BuddySessionRoom({
+  sessionId,
+  currentUserId,
+  onExit,
+  onPersonalRecordComplete,
+}: BuddySessionRoomProps) {
   const [snap, setSnap] = useState<BuddySnapshot | null>(null);
   const [pollError, setPollError] = useState<string | null>(null);
   const [pollStopped, setPollStopped] = useState(false);
@@ -55,6 +98,17 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
   const elapsedRef = useRef(0);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const timerAnchorRef = useRef<string | null>(null);
+  const [personalRecordError, setPersonalRecordError] = useState<string | null>(null);
+  const autoFinalizeAttemptedRef = useRef(false);
+  const snapRef = useRef(snap);
+  const mindStateLogRef = useRef(mindStateLog);
+  const sessionThoughtsRef = useRef(sessionThoughts);
+  const sessionThoughtCountRef = useRef(sessionThoughtCount);
+
+  snapRef.current = snap;
+  mindStateLogRef.current = mindStateLog;
+  sessionThoughtsRef.current = sessionThoughts;
+  sessionThoughtCountRef.current = sessionThoughtCount;
 
   const poll = useCallback(async () => {
     if (pollStopped) return;
@@ -78,6 +132,8 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
   useEffect(() => {
     setPollStopped(false);
     lastRevision.current = -1;
+    autoFinalizeAttemptedRef.current = false;
+    setPersonalRecordError(null);
   }, [sessionId]);
 
   useEffect(() => {
@@ -195,7 +251,50 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
     }
   };
 
-  const completeAndExit = async () => {
+  const finalizePersonalSession = useCallback(async () => {
+    if (!onPersonalRecordComplete) return;
+    const snapNow = snapRef.current;
+    if (!snapNow || snapNow.state !== "completed") return;
+
+    setPersonalRecordError(null);
+    try {
+      const durationSeconds = snapNow.durationSeconds;
+      const clearPercent = calcBuddyClearPercent(mindStateLogRef.current, durationSeconds);
+      const thoughtsSnapshot = sessionThoughtsRef.current;
+      const { session } = await api.recordBuddyPersonalSession(sessionId, {
+        clearPercent,
+        thoughtCount: sessionThoughtCountRef.current,
+        mindStateLog: mindStateLogRef.current,
+        actualTime: durationSeconds,
+        sessionDate: getLocalIsoDate(),
+        thoughts: thoughtsSnapshot,
+      });
+      try {
+        await api.leaveBuddySession(sessionId);
+      } catch (leaveErr) {
+        console.error("Buddy leave after personal record:", leaveErr);
+      }
+      onPersonalRecordComplete({
+        sessionId: session.id,
+        dayNumber: session.dayNumber,
+        duration: session.duration,
+        clearPercent: session.clearPercent,
+        thoughtCount: session.thoughtCount,
+        thoughts: thoughtsSnapshot,
+      });
+    } catch (e) {
+      setPersonalRecordError(formatBuddyActionError(e, "Could not save your session"));
+    }
+  }, [sessionId, onPersonalRecordComplete]);
+
+  useEffect(() => {
+    if (snap?.state !== "completed" || !onPersonalRecordComplete) return;
+    if (autoFinalizeAttemptedRef.current) return;
+    autoFinalizeAttemptedRef.current = true;
+    void finalizePersonalSession();
+  }, [snap?.state, sessionId, onPersonalRecordComplete, finalizePersonalSession]);
+
+  const completeAndExitLegacy = async () => {
     try {
       await api.buddyParticipantComplete(sessionId);
       await leave({ ignoreLeaveApiErrors: false });
@@ -247,14 +346,51 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
   }
 
   if (snap.state === "completed") {
+    if (!onPersonalRecordComplete) {
+      return (
+        <div style={{ maxWidth: "440px", margin: "0 auto", width: "100%" }}>
+          {pollError ? <BuddyRoomErrorBanner message={pollError} /> : null}
+          <EndPanel
+            title="Time is complete"
+            body="The shared timer has finished. Sign in on the latest app to save this sit to your personal history."
+            primary={{ label: "Done", onClick: () => void completeAndExitLegacy() }}
+          />
+        </div>
+      );
+    }
+
     return (
       <div style={{ maxWidth: "440px", margin: "0 auto", width: "100%" }}>
         {pollError ? <BuddyRoomErrorBanner message={pollError} /> : null}
-        <EndPanel
-          title="Time is complete"
-          body="The shared timer has finished. Your personal journal step can be added in a future update."
-          primary={{ label: "Done", onClick: () => void completeAndExit() }}
-        />
+        <div
+          style={{
+            textAlign: "center",
+            display: "grid",
+            gap: "var(--s3)",
+            padding: "var(--s4) 0",
+          }}
+        >
+          <h3 style={{ margin: 0, fontWeight: 400, fontSize: "20px", color: "var(--fg)" }}>
+            Time is complete
+          </h3>
+          {personalRecordError ? (
+            <>
+              <BuddyRoomErrorBanner message={personalRecordError} />
+              <div style={{ display: "flex", flexDirection: "column", gap: "var(--s2)" }}>
+                <button type="button" onClick={() => void finalizePersonalSession()} style={btnPrimary}>
+                  Try again
+                </button>
+                <button type="button" onClick={() => void leave()} style={btnSecondary}>
+                  Return home without saving
+                </button>
+              </div>
+            </>
+          ) : (
+            <p style={{ margin: 0, color: "var(--fg-2)", lineHeight: 1.5, fontSize: "14px" }}>
+              Saving your personal session…
+            </p>
+          )}
+        </div>
       </div>
     );
   }
@@ -702,7 +838,7 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
               ? "If you leave, the shared session ends for everyone (only the host can do that)."
               : "If you leave, only your view stops — the shared timer keeps running for everyone else."}
           </p>
-          {sessionThoughts.length > 0 && (
+              {sessionThoughts.length > 0 && (
             <p
               style={{
                 fontSize: "11px",
@@ -713,7 +849,7 @@ export function BuddySessionRoom({ sessionId, currentUserId, onExit }: BuddySess
               }}
             >
               {sessionThoughts.length} thought{sessionThoughts.length === 1 ? "" : "s"} captured on
-              this device (#119 will sync to your journal).
+              this device — they are saved to your journal when the shared timer ends.
             </p>
           )}
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -27,9 +27,48 @@ export const users = pgTable("users", {
   publicIdx: index("idx_users_public").on(table.isPublic),
 }));
 
+/** waiting | ready_check | active | completed | abandoned */
+export const buddySessions = pgTable("buddy_sessions", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  shareToken: varchar("share_token", { length: 48 }).unique().notNull(),
+  hostUserId: uuid("host_user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
+  state: varchar("state", { length: 20 }).notNull().default("waiting"),
+  durationSeconds: integer("duration_seconds").notNull(),
+  startedAt: timestamp("started_at", { withTimezone: true }),
+  revision: integer("revision").notNull().default(0),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  stateCheck: check(
+    "buddy_sessions_state_allowed",
+    sql`${table.state} in ('waiting', 'ready_check', 'active', 'completed', 'abandoned')`,
+  ),
+  hostIdx: index("idx_buddy_sessions_host").on(table.hostUserId),
+}));
+
+export const buddySessionParticipants = pgTable("buddy_session_participants", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  buddySessionId: uuid("buddy_session_id").references(() => buddySessions.id, { onDelete: "cascade" }).notNull(),
+  userId: uuid("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
+  isHost: boolean("is_host").notNull().default(false),
+  ready: boolean("ready").notNull().default(false),
+  joinedAt: timestamp("joined_at", { withTimezone: true }).defaultNow().notNull(),
+  lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).defaultNow().notNull(),
+  leftAt: timestamp("left_at", { withTimezone: true }),
+  /** #119: participant finished their sit; journaling attaches here. */
+  participantCompletedAt: timestamp("participant_completed_at", { withTimezone: true }),
+}, (table) => ({
+  sessionUserUnique: uniqueIndex("buddy_session_participants_session_user").on(
+    table.buddySessionId,
+    table.userId,
+  ),
+}));
+
 export const sessions = pgTable("sessions", {
   id: uuid("id").primaryKey().defaultRandom(),
   userId: uuid("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
+  /** #119: provenance when this row was created from a completed buddy sit (personal copy per user). */
+  buddySessionId: uuid("buddy_session_id").references(() => buddySessions.id, { onDelete: "set null" }),
   dayNumber: integer("day_number").notNull(),
   duration: integer("duration").notNull(),
   completed: boolean("completed").notNull(),
@@ -41,6 +80,12 @@ export const sessions = pgTable("sessions", {
   createdAt: timestamp("created_at").defaultNow().notNull(),
 }, (table) => ({
   userIdx: index("idx_sessions_user").on(table.userId, table.dayNumber),
+  buddyIdx: index("idx_sessions_buddy_session").on(table.buddySessionId),
+  /** At most one personal session row per user per shared buddy sit. */
+  userBuddyUnique: uniqueIndex("sessions_user_buddy_session_unique").on(
+    table.userId,
+    table.buddySessionId,
+  ).where(sql`${table.buddySessionId} is not null`),
 }));
 
 export const thoughts = pgTable("thoughts", {
@@ -94,8 +139,26 @@ export const usersRelations = relations(users, ({ many }) => ({
   thoughts: many(thoughts),
 }));
 
+export const buddySessionsRelations = relations(buddySessions, ({ one, many }) => ({
+  host: one(users, { fields: [buddySessions.hostUserId], references: [users.id] }),
+  participants: many(buddySessionParticipants),
+  personalSessions: many(sessions),
+}));
+
+export const buddySessionParticipantsRelations = relations(buddySessionParticipants, ({ one }) => ({
+  session: one(buddySessions, {
+    fields: [buddySessionParticipants.buddySessionId],
+    references: [buddySessions.id],
+  }),
+  user: one(users, { fields: [buddySessionParticipants.userId], references: [users.id] }),
+}));
+
 export const sessionsRelations = relations(sessions, ({ one, many }) => ({
   user: one(users, { fields: [sessions.userId], references: [users.id] }),
+  buddySession: one(buddySessions, {
+    fields: [sessions.buddySessionId],
+    references: [buddySessions.id],
+  }),
   thoughts: many(thoughts),
 }));
 
@@ -112,54 +175,4 @@ export const friendRequestsRelations = relations(friendRequests, ({ one }) => ({
 export const friendshipsRelations = relations(friendships, ({ one }) => ({
   user1: one(users, { fields: [friendships.user1Id], references: [users.id] }),
   user2: one(users, { fields: [friendships.user2Id], references: [users.id] }),
-}));
-
-/** waiting | ready_check | active | completed | abandoned */
-export const buddySessions = pgTable("buddy_sessions", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  shareToken: varchar("share_token", { length: 48 }).unique().notNull(),
-  hostUserId: uuid("host_user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
-  state: varchar("state", { length: 20 }).notNull().default("waiting"),
-  durationSeconds: integer("duration_seconds").notNull(),
-  startedAt: timestamp("started_at", { withTimezone: true }),
-  revision: integer("revision").notNull().default(0),
-  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
-  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
-}, (table) => ({
-  stateCheck: check(
-    "buddy_sessions_state_allowed",
-    sql`${table.state} in ('waiting', 'ready_check', 'active', 'completed', 'abandoned')`,
-  ),
-  hostIdx: index("idx_buddy_sessions_host").on(table.hostUserId),
-}));
-
-export const buddySessionParticipants = pgTable("buddy_session_participants", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  buddySessionId: uuid("buddy_session_id").references(() => buddySessions.id, { onDelete: "cascade" }).notNull(),
-  userId: uuid("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
-  isHost: boolean("is_host").notNull().default(false),
-  ready: boolean("ready").notNull().default(false),
-  joinedAt: timestamp("joined_at", { withTimezone: true }).defaultNow().notNull(),
-  lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).defaultNow().notNull(),
-  leftAt: timestamp("left_at", { withTimezone: true }),
-  /** #119: participant finished their sit; journaling attaches here. */
-  participantCompletedAt: timestamp("participant_completed_at", { withTimezone: true }),
-}, (table) => ({
-  sessionUserUnique: uniqueIndex("buddy_session_participants_session_user").on(
-    table.buddySessionId,
-    table.userId,
-  ),
-}));
-
-export const buddySessionsRelations = relations(buddySessions, ({ one, many }) => ({
-  host: one(users, { fields: [buddySessions.hostUserId], references: [users.id] }),
-  participants: many(buddySessionParticipants),
-}));
-
-export const buddySessionParticipantsRelations = relations(buddySessionParticipants, ({ one }) => ({
-  session: one(buddySessions, {
-    fields: [buddySessionParticipants.buddySessionId],
-    references: [buddySessions.id],
-  }),
-  user: one(users, { fields: [buddySessionParticipants.userId], references: [users.id] }),
 }));

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -39,6 +39,8 @@ export type Session = {
   thoughtCount: number;
   mindStateLog: Array<{ time: number; state: string }> | null;
   sessionDate: string;
+  /** Present when this row was created from a completed buddy sit (#119). */
+  buddySessionId?: string | null;
 };
 
 export type Thought = {
@@ -228,5 +230,22 @@ export const api = {
     request<{ ok: boolean; already?: boolean; participantCompletedAt?: string }>(
       `/api/buddy/sessions/${sessionId}/participant-complete`,
       { method: "POST" },
+    ),
+
+  /** #119: Create this user’s personal `sessions` row after the shared timer has finished (idempotent). */
+  recordBuddyPersonalSession: (
+    sessionId: string,
+    body: {
+      clearPercent: number;
+      thoughtCount: number;
+      mindStateLog: Array<{ time: number; state: string }>;
+      actualTime: number;
+      sessionDate: string;
+      thoughts?: Array<{ timeInSession: number; text: string }>;
+    },
+  ) =>
+    request<{ session: Session; already?: boolean }>(
+      `/api/buddy/sessions/${sessionId}/record-personal-session`,
+      { method: "POST", body: JSON.stringify(body) },
     ),
 };

--- a/src/lib/buddyPolicyCodes.ts
+++ b/src/lib/buddyPolicyCodes.ts
@@ -9,6 +9,8 @@ export const BUDDY_POLICY_CODES = {
   START_WRONG_PHASE: "BUDDY_START_WRONG_PHASE",
   CANCEL_WRONG_PHASE: "BUDDY_CANCEL_WRONG_PHASE",
   PARTICIPANT_COMPLETE_WRONG_PHASE: "BUDDY_PARTICIPANT_COMPLETE_WRONG_PHASE",
+  /** Shared sit must be server-completed before recording a personal history row (#119). */
+  RECORD_PERSONAL_WRONG_PHASE: "BUDDY_RECORD_PERSONAL_WRONG_PHASE",
 } as const;
 
 export type BuddyPolicyCode = (typeof BUDDY_POLICY_CODES)[keyof typeof BUDDY_POLICY_CODES];
@@ -27,6 +29,8 @@ const USER_FACING: Record<BuddyPolicyCode, string> = {
   [BUDDY_POLICY_CODES.CANCEL_WRONG_PHASE]: "This session can no longer be cancelled from here.",
   [BUDDY_POLICY_CODES.PARTICIPANT_COMPLETE_WRONG_PHASE]:
     "That step is only available during or after the shared sit.",
+  [BUDDY_POLICY_CODES.RECORD_PERSONAL_WRONG_PHASE]:
+    "Your personal session is saved only after the shared timer has finished.",
 };
 
 export function buddyPolicyUserMessage(code: string | undefined): string | undefined {

--- a/src/lib/buddySession.ts
+++ b/src/lib/buddySession.ts
@@ -1,7 +1,7 @@
 /**
  * Shared buddy session domain logic (#117). Server is source of truth for timing and state.
  * #118: Controls policy and enforcement — see `buddySessionControlsPolicy.ts`.
- * #119: Use participantCompletedAt + POST …/participant-complete for journaling hooks.
+ * #119: POST …/record-personal-session creates each participant’s own `sessions` row; notes use `thoughts`.
  */
 import { db } from "@/db";
 import {

--- a/src/lib/buddySessionControlsPolicy.ts
+++ b/src/lib/buddySessionControlsPolicy.ts
@@ -23,9 +23,11 @@
  *
  * ## #119 handoff
  *
- * `participant-complete` records per-user completion for journaling; it does not end the
- * shared timer or change session phase for other participants. Completion UI and journal
- * writes belong in #119.
+ * `participant-complete` records per-user completion metadata; it does not end the
+ * shared timer or change session phase for other participants.
+ *
+ * `record-personal-session` (#119) creates the user-owned `sessions` row after the shared
+ * sit is completed and handles journaling via existing `thoughts` APIs.
  */
 
 import { NextResponse } from "next/server";
@@ -113,6 +115,23 @@ export function requireParticipantCompletePhase(sessionState: string): NextRespo
       409,
       "Participant completion is only tracked during or after an active sit",
       BUDDY_POLICY_CODES.PARTICIPANT_COMPLETE_WRONG_PHASE,
+    );
+  }
+  return null;
+}
+
+/** Personal history row is only created after the shared timer has ended (server state). */
+export function requireBuddySessionCompletedForPersonalRecord(
+  session: BuddySessionRow | undefined,
+): NextResponse | null {
+  if (!session) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+  if (session.state !== "completed") {
+    return buddyPolicyJson(
+      409,
+      "The shared sit is not finished yet",
+      BUDDY_POLICY_CODES.RECORD_PERSONAL_WRONG_PHASE,
     );
   }
   return null;


### PR DESCRIPTION
## Summary
Implements per-user persistence after a completed buddy session: each participant gets their own `sessions` row linked to the shared `buddy_sessions` id, optional in-sit thoughts persisted with that row, and the existing solo `CompletionScreen` for a personal completion note. `POST /api/thoughts/batch` now verifies session ownership and replaces prior completion notes (`time_in_session = -1`) to avoid duplicate journal entries.

## Schema
- `sessions.buddy_session_id` → `buddy_sessions.id`, `ON DELETE SET NULL`
- Partial unique index on `(user_id, buddy_session_id)` where `buddy_session_id IS NOT NULL` (idempotency)
- Reference SQL: `drizzle/sessions_buddy_session_id_incremental.sql`; prefer `npx drizzle-kit push` for dev DBs

## Deferred / follow-ups
- Analytics labels (solo vs buddy source, funnel by `buddy_session_id`) — not in this PR

Closes #119

## Test plan
- [x] `npm run build` passes
- [ ] Two accounts: complete same buddy sit; each sees own History day; each saves own completion note; other account cannot read/write that note (batch + session APIs)
- [ ] Repeat `record-personal-session` returns `already: true` without double day increment
- [ ] Solo session complete + note unchanged

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Record a personal meditation session immediately after a buddy session finishes; the app can auto-save your personal record when the shared timer ends.

* **Behavior & Validation**
  * Personal session inputs are validated, normalized, trimmed, and truncated; duplicate submissions return the existing record.
  * Thought uploads are validated, scoped to your user/session, and handled transactionally (including special “completion” notes).

* **UX**
  * New “Saving…” state with retry and an option to return home without saving; user data refreshes after completion.

* **Messages**
  * Added message: personal records save only after the shared timer finishes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->