### PR TITLE
feat(daily): Buddy Daily.co primitives (#105)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ POSTGRES_URL=postgresql://user:password@host/database?sslmode=require
 
 # JWT secret for auth tokens (generate with: openssl rand -base64 32)
 JWT_SECRET=your-secret-here
+
+# Daily.co — server-only REST API key for creating/deleting buddy video rooms (#105). Never expose to the client.
+DAILY_API_KEY=

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,13 @@
       "name": "still-point",
       "version": "0.1.0",
       "dependencies": {
+        "@daily-co/daily-js": "^0.89.1",
+        "@daily-co/daily-react": "^0.24.0",
         "@neondatabase/serverless": "^0.10.4",
         "bcryptjs": "^3.0.3",
         "drizzle-orm": "^0.45.1",
         "jose": "^6.1.3",
+        "jotai": "^2.19.1",
         "next": "15.5.12",
         "react": "19.1.0",
         "react-dom": "19.1.0"
@@ -23,6 +26,50 @@
         "@types/react-dom": "^19",
         "drizzle-kit": "^0.31.9",
         "typescript": "^5"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@daily-co/daily-js": {
+      "version": "0.89.1",
+      "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.89.1.tgz",
+      "integrity": "sha512-1RnXtzg8aeJYLhmMjRK9mnsWRljwsM2OUBJH5onpAOFIjHPSA7h03DSCd8D/YMyrpX8jQHcVMDSWOhcj+tZD/A==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@sentry/browser": "^8.33.1",
+        "bowser": "^2.8.1",
+        "dequal": "^2.0.3",
+        "events": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=22.14.0"
+      }
+    },
+    "node_modules/@daily-co/daily-react": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@daily-co/daily-react/-/daily-react-0.24.0.tgz",
+      "integrity": "sha512-eJH/EGicqtXcb33mua2kpZfowXL+zos2/s2lRMkENNZYBjlPNP2fNYqxx5FkK9grGc1gLfOUgULvONDOmfeFbg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash.throttle": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@daily-co/daily-js": ">=0.68.0 <1",
+        "jotai": "^2",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0"
       }
     },
     "node_modules/@drizzle-team/brocli": {
@@ -1529,6 +1576,81 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "8.55.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.55.1.tgz",
+      "integrity": "sha512-SipXiwVhJrxzy3/4kf+YIFmpYlLKtGSRD+er7SBCcuSBtv31Fee8IXMDvk+bq24gRXxyjOLUmT//GGXjy2LL6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.55.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "8.55.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.55.1.tgz",
+      "integrity": "sha512-9iFHaT/ijtzB0ffZhXMnt2rPNIXO/dDiCL1G1Bc55rQMPXgawR9AIaAWciyqQjYcbL1DDOhWbzdVqB+kVs5gXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.55.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "8.55.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.55.1.tgz",
+      "integrity": "sha512-XaX6r8pXeX47rfiQrSQUwkgxHsDkOKzIT++zfTwrmveVlYSqAhp3x+AKhxAXGmKG62wlmAKQz54GJKcG4cgyKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.55.1",
+        "@sentry/core": "8.55.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "8.55.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.55.1.tgz",
+      "integrity": "sha512-2sKRu96Qe70y6TiYdYbwkhg4um2prgzH/ZJRItuoSEAjPjoFYYlP+1qjE2CcBw4RPS8/PimV7SFheSaeZs2GCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "8.55.1",
+        "@sentry/core": "8.55.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "8.55.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.55.1.tgz",
+      "integrity": "sha512-OEn2eg8h3Mr7BmBGQ28BqbWehYA/NklZ0pAZB1FypPPl+kMd85AbaRdGTnaSjgmpc8bKbBO64edq4Y14sbCs5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.55.1",
+        "@sentry-internal/feedback": "8.55.1",
+        "@sentry-internal/replay": "8.55.1",
+        "@sentry-internal/replay-canvas": "8.55.1",
+        "@sentry/core": "8.55.1"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "8.55.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.1.tgz",
+      "integrity": "sha512-0ea+yDOgaijR3ba2al1QZxY0bZ9MBZq2a0G+2A0uCBpBkiXnpLFGVAo9UAlEikN1C4M8ROZYiuFU7yZCqacgLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1569,7 +1691,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1621,6 +1743,12 @@
       "bin": {
         "bcrypt": "bin/bcrypt"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -1674,7 +1802,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1693,6 +1821,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -1901,6 +2038,21 @@
         "esbuild": ">=0.12 <1"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
@@ -1922,6 +2074,41 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/jotai": {
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.19.1.tgz",
+      "integrity": "sha512-sqm9lVZiqBHZH8aSRk32DSiZDHY3yUIlulXYn9GQj7/LvoUdYXSMti7ZPJGo+6zjzKFt5a25k/I6iBCi43PJcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0",
+        "@babel/template": ">=7.0.0",
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@babel/template": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "jotai": "^2.19.1",
         "next": "15.5.12",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "server-only": "^0.0.1"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
@@ -2376,6 +2377,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.5",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,13 @@
     "start": "next start"
   },
   "dependencies": {
+    "@daily-co/daily-js": "^0.89.1",
+    "@daily-co/daily-react": "^0.24.0",
     "@neondatabase/serverless": "^0.10.4",
     "bcryptjs": "^3.0.3",
     "drizzle-orm": "^0.45.1",
     "jose": "^6.1.3",
+    "jotai": "^2.19.1",
     "next": "15.5.12",
     "react": "19.1.0",
     "react-dom": "19.1.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "jotai": "^2.19.1",
     "next": "15.5.12",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "server-only": "^0.0.1"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/src/components/BuddyVideo.tsx
+++ b/src/components/BuddyVideo.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+/**
+ * Daily call-object embed for buddy sessions (#105). #106 can mount this when a `roomUrl` is
+ * available (from server after `createRoom`), passing each participant's display name.
+ */
+
+import {
+  DailyAudio,
+  DailyProvider,
+  DailyVideo,
+  useDaily,
+  useDailyError,
+  useMeetingState,
+  useParticipantIds,
+} from "@daily-co/daily-react";
+import type { CSSProperties } from "react";
+import { useCallback, useEffect, useState } from "react";
+
+export type BuddyVideoProps = {
+  /** Full Daily room URL from the REST API (`createRoom`). */
+  roomUrl: string;
+  /** Shown to other participants (Daily `userName`). */
+  displayName: string;
+  /** When true (default), joins on mount and leaves on unmount. */
+  autoConnect?: boolean;
+  className?: string;
+  style?: CSSProperties;
+};
+
+const shell: CSSProperties = {
+  width: "100%",
+  borderRadius: "12px",
+  overflow: "hidden",
+  border: "1px solid var(--border-2)",
+  background: "var(--surface-1)",
+  minHeight: "200px",
+};
+
+const msg: CSSProperties = {
+  margin: 0,
+  padding: "var(--s4)",
+  textAlign: "center",
+  fontSize: "13px",
+  color: "var(--fg-2)",
+  lineHeight: 1.5,
+};
+
+const grid: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fill, minmax(140px, 1fr))",
+  gap: "var(--s2)",
+  padding: "var(--s3)",
+};
+
+function ParticipantTiles() {
+  const ids = useParticipantIds({ filter: useCallback(() => true, []) });
+  return (
+    <div style={grid}>
+      {ids.map((sessionId) => (
+        <div
+          key={sessionId}
+          style={{
+            aspectRatio: "4 / 3",
+            borderRadius: "8px",
+            overflow: "hidden",
+            background: "var(--surface-2)",
+          }}
+        >
+          <DailyVideo
+            sessionId={sessionId}
+            type="video"
+            automirror
+            fit="cover"
+            style={{ width: "100%", height: "100%", objectFit: "cover" }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function BuddyVideoInner({
+  roomUrl,
+  displayName,
+  autoConnect = true,
+  className,
+  style,
+}: BuddyVideoProps) {
+  const daily = useDaily();
+  const meetingState = useMeetingState();
+  const { meetingError } = useDailyError();
+  const [joinError, setJoinError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!autoConnect) return;
+    const url = roomUrl.trim();
+    if (!url) {
+      setJoinError("Missing room URL");
+      return;
+    }
+
+    let cancelled = false;
+    setJoinError(null);
+
+    const run = async () => {
+      if (!daily) return;
+      try {
+        await daily.join({ url, userName: displayName });
+      } catch (e) {
+        if (!cancelled) {
+          setJoinError(e instanceof Error ? e.message : "Could not join the video room");
+        }
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+      void daily?.leave().catch(() => {
+        /* ignore teardown errors */
+      });
+    };
+  }, [autoConnect, roomUrl, displayName, daily]);
+
+  if (!autoConnect) {
+    return (
+      <div className={className} style={{ ...shell, ...style }}>
+        <p style={msg}>Video is off (autoConnect is false).</p>
+      </div>
+    );
+  }
+
+  const trimmedUrl = roomUrl.trim();
+  if (!trimmedUrl) {
+    return (
+      <div className={className} style={{ ...shell, ...style }}>
+        <p role="alert" style={msg}>
+          A Daily room URL is required.
+        </p>
+      </div>
+    );
+  }
+
+  if (joinError) {
+    return (
+      <div className={className} style={{ ...shell, ...style }}>
+        <p role="alert" style={msg}>
+          {joinError}
+        </p>
+      </div>
+    );
+  }
+
+  if (meetingState === "error" && meetingError) {
+    const detail =
+      typeof meetingError.errorMsg === "string" && meetingError.errorMsg
+        ? meetingError.errorMsg
+        : "Video call error";
+    return (
+      <div className={className} style={{ ...shell, ...style }}>
+        <p role="alert" style={msg}>
+          {detail}
+        </p>
+      </div>
+    );
+  }
+
+  if (
+    meetingState === "new" ||
+    meetingState === "loading" ||
+    meetingState === "loaded" ||
+    meetingState === "joining-meeting" ||
+    meetingState === null
+  ) {
+    return (
+      <div className={className} style={{ ...shell, ...style }}>
+        <p style={msg}>Connecting to video…</p>
+      </div>
+    );
+  }
+
+  if (meetingState === "left-meeting") {
+    return (
+      <div className={className} style={{ ...shell, ...style }}>
+        <p style={msg}>Video disconnected.</p>
+      </div>
+    );
+  }
+
+  if (meetingState === "joined-meeting") {
+    return (
+      <div className={className} style={{ ...shell, ...style }}>
+        <DailyAudio />
+        <ParticipantTiles />
+      </div>
+    );
+  }
+
+  return (
+    <div className={className} style={{ ...shell, ...style }}>
+      <p style={msg}>Video unavailable.</p>
+    </div>
+  );
+}
+
+export function BuddyVideo(props: BuddyVideoProps) {
+  return (
+    <DailyProvider>
+      <BuddyVideoInner {...props} />
+    </DailyProvider>
+  );
+}

--- a/src/components/BuddyVideo.tsx
+++ b/src/components/BuddyVideo.tsx
@@ -9,13 +9,14 @@ import {
   DailyAudio,
   DailyProvider,
   DailyVideo,
+  useCallObject,
   useDaily,
   useDailyError,
   useMeetingState,
   useParticipantIds,
 } from "@daily-co/daily-react";
 import type { CSSProperties } from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 export type BuddyVideoProps = {
   /** Full Daily room URL from the REST API (`createRoom`). */
@@ -54,7 +55,7 @@ const grid: CSSProperties = {
 };
 
 function ParticipantTiles() {
-  const ids = useParticipantIds({ filter: useCallback(() => true, []) });
+  const ids = useParticipantIds();
   return (
     <div style={grid}>
       {ids.map((sessionId) => (
@@ -206,8 +207,9 @@ function BuddyVideoInner({
 }
 
 export function BuddyVideo(props: BuddyVideoProps) {
+  const callObject = useCallObject({});
   return (
-    <DailyProvider>
+    <DailyProvider callObject={callObject}>
       <BuddyVideoInner {...props} />
     </DailyProvider>
   );

--- a/src/lib/daily.ts
+++ b/src/lib/daily.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 /**
  * Daily.co REST helpers for buddy video rooms (#105). Server-only usage: call from API routes
  * or server actions so `DAILY_API_KEY` never reaches the client. See `.env.example`.
@@ -120,10 +122,22 @@ export async function createRoom(options: CreateDailyRoomOptions = {}): Promise<
   };
 }
 
+export type DeleteDailyRoomOptions = {
+  /**
+   * When true (default), HTTP 404 is treated as success so teardown is idempotent
+   * if the room was already deleted.
+   */
+  ignoreMissing?: boolean;
+};
+
 /**
  * Deletes a Daily room by name. Uses `DAILY_API_KEY` from the environment only.
  */
-export async function deleteRoom(roomName: string): Promise<void> {
+export async function deleteRoom(
+  roomName: string,
+  options: DeleteDailyRoomOptions = {},
+): Promise<void> {
+  const { ignoreMissing = true } = options;
   const trimmed = roomName.trim();
   if (!trimmed) {
     throw new Error("deleteRoom: room name is required");
@@ -133,6 +147,9 @@ export async function deleteRoom(roomName: string): Promise<void> {
   const res = await dailyFetch(path, { method: "DELETE" });
 
   if (!res.ok) {
+    if (ignoreMissing && res.status === 404) {
+      return;
+    }
     const errBody = await parseDailyErrorBody(res);
     const message = errorMessageFromBody(errBody, `Daily delete room failed (${res.status})`);
     throw new DailyApiError(message, res.status, errBody);

--- a/src/lib/daily.ts
+++ b/src/lib/daily.ts
@@ -1,0 +1,140 @@
+/**
+ * Daily.co REST helpers for buddy video rooms (#105). Server-only usage: call from API routes
+ * or server actions so `DAILY_API_KEY` never reaches the client. See `.env.example`.
+ * https://docs.daily.co/reference/rest-api/rooms
+ */
+
+const DAILY_API_BASE = "https://api.daily.co/v1";
+
+export class DailyApiError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = "DailyApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/** Normalized room payload from `POST /rooms` (fields we rely on for MVP). */
+export type DailyCreatedRoom = {
+  name: string;
+  url: string;
+  id?: string;
+  created_at?: string;
+  config?: Record<string, unknown>;
+};
+
+export type CreateDailyRoomOptions = {
+  /** Room name; omit for a Daily-generated name. */
+  name?: string;
+  privacy?: "public" | "private";
+  /** Merged into the request `properties` object (e.g. `exp`, `max_participants`). */
+  properties?: Record<string, unknown>;
+};
+
+function requireDailyApiKey(): string {
+  const key = process.env.DAILY_API_KEY?.trim();
+  if (!key) {
+    throw new Error(
+      "DAILY_API_KEY is not set. Add it to your environment for Daily room management (see .env.example).",
+    );
+  }
+  return key;
+}
+
+async function parseDailyErrorBody(res: Response): Promise<unknown> {
+  const text = await res.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function errorMessageFromBody(body: unknown, fallback: string): string {
+  if (body && typeof body === "object") {
+    const o = body as Record<string, unknown>;
+    const info = o.info;
+    if (typeof info === "string" && info.trim()) return info;
+    const err = o.error;
+    if (typeof err === "string" && err.trim()) return err;
+    const msg = o.message;
+    if (typeof msg === "string" && msg.trim()) return msg;
+  }
+  if (typeof body === "string" && body.trim()) return body;
+  return fallback;
+}
+
+async function dailyFetch(path: string, init: RequestInit): Promise<Response> {
+  const key = requireDailyApiKey();
+  const url = `${DAILY_API_BASE}${path}`;
+  const headers = new Headers(init.headers);
+  headers.set("Authorization", `Bearer ${key}`);
+  if (init.body != null && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+  return fetch(url, { ...init, headers });
+}
+
+/**
+ * Creates a Daily room. Uses `DAILY_API_KEY` from the environment only.
+ */
+export async function createRoom(options: CreateDailyRoomOptions = {}): Promise<DailyCreatedRoom> {
+  const body: Record<string, unknown> = {};
+  if (options.name !== undefined) body.name = options.name;
+  if (options.privacy !== undefined) body.privacy = options.privacy;
+  if (options.properties !== undefined && Object.keys(options.properties).length > 0) {
+    body.properties = options.properties;
+  }
+
+  const res = await dailyFetch("/rooms", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const errBody = await parseDailyErrorBody(res);
+    const message = errorMessageFromBody(errBody, `Daily create room failed (${res.status})`);
+    throw new DailyApiError(message, res.status, errBody);
+  }
+
+  const data = (await res.json()) as Record<string, unknown>;
+  const name = data.name;
+  const url = data.url;
+  if (typeof name !== "string" || typeof url !== "string") {
+    throw new DailyApiError("Daily create room response missing name or url", res.status, data);
+  }
+
+  return {
+    name,
+    url,
+    ...(typeof data.id === "string" ? { id: data.id } : {}),
+    ...(typeof data.created_at === "string" ? { created_at: data.created_at } : {}),
+    ...(data.config !== undefined && typeof data.config === "object" && data.config !== null
+      ? { config: data.config as Record<string, unknown> }
+      : {}),
+  };
+}
+
+/**
+ * Deletes a Daily room by name. Uses `DAILY_API_KEY` from the environment only.
+ */
+export async function deleteRoom(roomName: string): Promise<void> {
+  const trimmed = roomName.trim();
+  if (!trimmed) {
+    throw new Error("deleteRoom: room name is required");
+  }
+
+  const path = `/rooms/${encodeURIComponent(trimmed)}`;
+  const res = await dailyFetch(path, { method: "DELETE" });
+
+  if (!res.ok) {
+    const errBody = await parseDailyErrorBody(res);
+    const message = errorMessageFromBody(errBody, `Daily delete room failed (${res.status})`);
+    throw new DailyApiError(message, res.status, errBody);
+  }
+}


### PR DESCRIPTION
## Summary
Adds Daily.co integration primitives for buddy video: server REST helpers for room lifecycle and a reusable client `BuddyVideo` wrapper with auto-connect. Parent context: #92.

## Changes
- Dependencies: `@daily-co/daily-js`, `@daily-co/daily-react`, `jotai`
- `.env.example`: `DAILY_API_KEY` (server-only, no values)
- `src/lib/daily.ts`: `createRoom`, `deleteRoom`, `DailyApiError`; clear error if key missing; no key logging
- `src/components/BuddyVideo.tsx`: scoped `DailyProvider`, join on mount when `autoConnect`, `DailyVideo` grid + `DailyAudio`, loading/error/left states

## Out of scope (#106)
No buddy orchestration or wiring into `BuddySessionRoom` / start routes.

## Test plan
- [x] `npm run build` passes
- [ ] With `DAILY_API_KEY` and a valid `roomUrl` from `createRoom`, `BuddyVideo` joins (manual when #106 mounts it)
- [ ] Room create/delete callable from a server route or script (not added in this PR)

Closes #105

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added buddy video calling capability, enabling users to join video sessions with display name support and automatic connection options.
  * Integrated Daily.co video service for real-time peer-to-peer communication with participant management and audio/video handling.

* **Chores**
  * Added required dependencies to support video functionality and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->