### PR TITLE
feat(buddy): web buddy flow — Daily room, video layout, join errors (#106)

### DIFF
--- a/drizzle/buddy_sessions_daily_room_incremental.sql
+++ b/drizzle/buddy_sessions_daily_room_incremental.sql
@@ -1,0 +1,6 @@
+-- Daily.co room fields for buddy video (#106).
+-- Preferred: apply schema with `npx drizzle-kit push` (see README).
+-- This file is a reference for existing databases if you apply SQL manually.
+
+ALTER TABLE "buddy_sessions" ADD COLUMN IF NOT EXISTS "daily_room_name" varchar(128);
+ALTER TABLE "buddy_sessions" ADD COLUMN IF NOT EXISTS "daily_room_url" text;

--- a/src/app/api/buddy/sessions/[id]/leave/route.ts
+++ b/src/app/api/buddy/sessions/[id]/leave/route.ts
@@ -5,6 +5,7 @@ import { getCurrentUser } from "@/lib/auth";
 import {
   bumpBuddyRevision,
   reconcileBuddySession,
+  teardownBuddyDailyRoomByName,
 } from "@/lib/buddySession";
 import { hostLeaveShouldAbandonSession } from "@/lib/buddySessionControlsPolicy";
 import { isUuid } from "@/lib/friends";
@@ -52,10 +53,13 @@ export async function POST(_request: Request, context: Params) {
       .limit(1);
 
     if (p.isHost && session && hostLeaveShouldAbandonSession(session)) {
+      await teardownBuddyDailyRoomByName(session.dailyRoomName);
       await db
         .update(buddySessions)
         .set({
           state: "abandoned",
+          dailyRoomName: null,
+          dailyRoomUrl: null,
           revision: sql`${buddySessions.revision} + 1`,
           updatedAt: now,
         })

--- a/src/app/api/buddy/sessions/[id]/meeting-token/route.ts
+++ b/src/app/api/buddy/sessions/[id]/meeting-token/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { buddySessions, buddySessionParticipants, users } from "@/db/schema";
+import { getCurrentUser } from "@/lib/auth";
+import { reconcileBuddySession } from "@/lib/buddySession";
+import { BUDDY_POLICY_CODES } from "@/lib/buddyPolicyCodes";
+import { DailyApiError, createMeetingToken } from "@/lib/daily";
+import { isUuid } from "@/lib/friends";
+import { and, eq } from "drizzle-orm";
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function POST(_request: Request, context: Params) {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id: sessionId } = await context.params;
+    if (!isUuid(sessionId)) {
+      return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
+    }
+
+    const [membership] = await db
+      .select()
+      .from(buddySessionParticipants)
+      .where(
+        and(
+          eq(buddySessionParticipants.buddySessionId, sessionId),
+          eq(buddySessionParticipants.userId, auth.userId),
+        ),
+      )
+      .limit(1);
+
+    if (!membership || membership.leftAt != null) {
+      return NextResponse.json(
+        { error: "Not in this session", code: BUDDY_POLICY_CODES.NOT_IN_SESSION },
+        { status: 403 },
+      );
+    }
+
+    await reconcileBuddySession(sessionId);
+
+    const [session] = await db
+      .select()
+      .from(buddySessions)
+      .where(eq(buddySessions.id, sessionId))
+      .limit(1);
+    if (!session) {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    if (session.state !== "active" || !session.dailyRoomName?.trim()) {
+      return NextResponse.json(
+        { error: "Video token is only available during an active buddy sit" },
+        { status: 403 },
+      );
+    }
+
+    const [u] = await db
+      .select({ username: users.username })
+      .from(users)
+      .where(eq(users.id, auth.userId))
+      .limit(1);
+
+    try {
+      const token = await createMeetingToken({
+        roomName: session.dailyRoomName,
+        userName: u?.username ?? "Participant",
+        userId: auth.userId,
+      });
+      return NextResponse.json({ token });
+    } catch (e) {
+      if (e instanceof DailyApiError) {
+        console.error("Buddy meeting token error:", e.status, e.message);
+        return NextResponse.json(
+          { error: "Could not issue a video token. Check Daily configuration." },
+          { status: 503 },
+        );
+      }
+      throw e;
+    }
+  } catch (error) {
+    console.error("Buddy meeting-token route error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/buddy/sessions/[id]/start/route.ts
+++ b/src/app/api/buddy/sessions/[id]/start/route.ts
@@ -3,7 +3,12 @@ import { db } from "@/db";
 import { buddySessions, buddySessionParticipants } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
 import { reconcileBuddySession } from "@/lib/buddySession";
-import { DailyApiError, createRoom, deleteRoom } from "@/lib/daily";
+import {
+  DailyApiError,
+  createRoom,
+  deleteRoom,
+  isDailyRoomNameConflict,
+} from "@/lib/daily";
 import { BUDDY_START_WRONG_PHASE_MESSAGE } from "@/lib/buddyPolicyCodes";
 import {
   BUDDY_POLICY_CODES,
@@ -61,13 +66,30 @@ export async function POST(_request: Request, context: Params) {
     try {
       dailyRoom = await createRoom({ name: roomName, privacy: "private" });
     } catch (e) {
-      if (e instanceof DailyApiError) {
+      if (e instanceof DailyApiError && isDailyRoomNameConflict(e)) {
+        await deleteRoom(roomName, { ignoreMissing: true });
+        try {
+          dailyRoom = await createRoom({ name: roomName, privacy: "private" });
+        } catch (e2) {
+          if (e2 instanceof DailyApiError) {
+            return NextResponse.json(
+              {
+                error:
+                  "Video room could not be created (name conflict after cleanup). Check Daily and try again.",
+              },
+              { status: 503 },
+            );
+          }
+          throw e2;
+        }
+      } else if (e instanceof DailyApiError) {
         return NextResponse.json(
           { error: "Video room could not be created. Check Daily configuration and try again." },
           { status: 503 },
         );
+      } else {
+        throw e;
       }
-      throw e;
     }
 
     const startedAt = new Date();

--- a/src/app/api/buddy/sessions/[id]/start/route.ts
+++ b/src/app/api/buddy/sessions/[id]/start/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/db";
 import { buddySessions, buddySessionParticipants } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
 import { reconcileBuddySession } from "@/lib/buddySession";
+import { DailyApiError, createRoom, deleteRoom } from "@/lib/daily";
 import { BUDDY_START_WRONG_PHASE_MESSAGE } from "@/lib/buddyPolicyCodes";
 import {
   BUDDY_POLICY_CODES,
@@ -55,12 +56,28 @@ export async function POST(_request: Request, context: Params) {
     const phaseErr = requireReadyCheckForStart(session);
     if (phaseErr) return phaseErr;
 
+    const roomName = `buddy-${sessionId}`;
+    let dailyRoom: { name: string; url: string };
+    try {
+      dailyRoom = await createRoom({ name: roomName, privacy: "private" });
+    } catch (e) {
+      if (e instanceof DailyApiError) {
+        return NextResponse.json(
+          { error: "Video room could not be created. Check Daily configuration and try again." },
+          { status: 503 },
+        );
+      }
+      throw e;
+    }
+
     const startedAt = new Date();
     const [updated] = await db
       .update(buddySessions)
       .set({
         state: "active",
         startedAt,
+        dailyRoomName: dailyRoom.name,
+        dailyRoomUrl: dailyRoom.url,
         revision: sql`${buddySessions.revision} + 1`,
         updatedAt: startedAt,
       })
@@ -70,6 +87,11 @@ export async function POST(_request: Request, context: Params) {
       .returning();
 
     if (!updated) {
+      try {
+        await deleteRoom(dailyRoom.name, { ignoreMissing: true });
+      } catch (cleanupErr) {
+        console.error("Buddy start race: Daily room cleanup failed:", cleanupErr);
+      }
       return buddyPolicyJson(
         409,
         BUDDY_START_WRONG_PHASE_MESSAGE,

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -14,7 +14,7 @@ import { FriendsView } from "@/components/FriendsView";
 import { BuddySessionHub } from "@/components/BuddySessionHub";
 import { BuddySessionRoom, type BuddyPersonalRecordPayload } from "@/components/BuddySessionRoom";
 import { useIsMobile } from "@/lib/useIsMobile";
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 
 type View =
   | "home"
@@ -52,6 +52,7 @@ export default function StillPoint() {
   const [authRetryKey, setAuthRetryKey] = useState(0);
   const [completionData, setCompletionData] = useState<CompletionData | null>(null);
   const [buddySessionId, setBuddySessionId] = useState<string | null>(null);
+  const [buddyInviteError, setBuddyInviteError] = useState<string | null>(null);
   const buddyInviteInFlight = useRef(false);
   const isMobile = useIsMobile();
 
@@ -115,11 +116,18 @@ export default function StillPoint() {
       try {
         const { sessionId } = await api.joinBuddySession(raw);
         if (cancelled) return;
+        setBuddyInviteError(null);
         setBuddySessionId(sessionId);
         setView("buddy");
         window.history.replaceState({}, "", "/app");
-      } catch {
-        buddyInviteInFlight.current = false;
+      } catch (e) {
+        if (!cancelled) {
+          buddyInviteInFlight.current = false;
+          setBuddyInviteError(
+            e instanceof ApiError ? e.message : "Could not open that buddy invite.",
+          );
+          window.history.replaceState({}, "", "/app");
+        }
       }
     })();
 
@@ -146,6 +154,7 @@ export default function StillPoint() {
 
   const handleBuddyExit = useCallback(() => {
     setBuddySessionId(null);
+    setBuddyInviteError(null);
     setView("home");
   }, []);
 
@@ -436,6 +445,48 @@ export default function StillPoint() {
         </div>
       )}
 
+      {buddyInviteError && view !== "session" && (
+        <div
+          role="alert"
+          style={{
+            maxWidth: "480px",
+            width: "100%",
+            margin: "0 auto var(--s3)",
+            padding: "12px 16px",
+            borderRadius: "10px",
+            border: "1px solid var(--border-2)",
+            background: "var(--surface-1)",
+            color: "var(--fg-2)",
+            fontSize: "14px",
+            lineHeight: 1.45,
+            display: "flex",
+            flexDirection: "column",
+            gap: "var(--s2)",
+            alignItems: "stretch",
+          }}
+        >
+          <span>{buddyInviteError}</span>
+          <button
+            type="button"
+            onClick={() => setBuddyInviteError(null)}
+            style={{
+              alignSelf: "flex-end",
+              border: "none",
+              background: "transparent",
+              color: "var(--fg-3)",
+              cursor: "pointer",
+              fontSize: "12px",
+              fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+              textDecoration: "underline",
+            }}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
       {/* Views */}
       {view === "home" && (
         <HomeView
@@ -443,6 +494,7 @@ export default function StillPoint() {
           onBegin={handleBegin}
           onBuddy={() => {
             setBuddySessionId(null);
+            setBuddyInviteError(null);
             setView("buddy");
           }}
         />

--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -4,7 +4,9 @@ import type { CSSProperties } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api, ApiError, type BuddySnapshot } from "@/lib/api";
 import { BUDDY_POLICY_CODES, buddyPolicyUserMessage } from "@/lib/buddyPolicyCodes";
+import { useIsMobile } from "@/lib/useIsMobile";
 import { BlockTimer } from "./BlockTimer";
+import { BuddyVideo } from "./BuddyVideo";
 import { ThoughtCapture } from "./ThoughtCapture";
 import { loadSoundPrefs, saveSoundPrefs, type SoundPrefs } from "@/lib/audio";
 
@@ -82,6 +84,7 @@ export function BuddySessionRoom({
   onExit,
   onPersonalRecordComplete,
 }: BuddySessionRoomProps) {
+  const isMobile = useIsMobile();
   const [snap, setSnap] = useState<BuddySnapshot | null>(null);
   const [pollError, setPollError] = useState<string | null>(null);
   const [pollStopped, setPollStopped] = useState(false);
@@ -401,11 +404,16 @@ export function BuddySessionRoom({
 
   const lobbyReady = snap.state === "ready_check";
 
+  const shellMaxWidth =
+    snap.state === "active" && !isMobile
+      ? "min(1120px, 100%)"
+      : "560px";
+
   return (
     <div
       style={{
         width: "100%",
-        maxWidth: "560px",
+        maxWidth: shellMaxWidth,
         margin: "0 auto",
         display: "flex",
         flexDirection: "column",
@@ -631,231 +639,309 @@ export function BuddySessionRoom({
 
       {snap.state === "active" && snap.startedAt && (
         <>
-          <BlockTimer
-            key={`${sessionId}-${snap.startedAt}`}
-            totalSeconds={snap.durationSeconds}
-            syncClock={{
-              startedAt: snap.startedAt,
-              serverNow: snap.serverNow,
-              durationSeconds: snap.durationSeconds,
-            }}
-            isActive
-            mindState={mindState}
-            mindStateLog={mindStateLog}
-            onElapsedChange={handleElapsedChange}
-            soundPrefs={soundPrefs}
-            onComplete={handleBuddyTimerComplete}
-          />
-
-          <p
-            style={{
-              textAlign: "center",
-              margin: "-12px 0 0",
-              fontSize: "11px",
-              color: "var(--fg-3)",
-              fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-              letterSpacing: "0.08em",
-            }}
-          >
-            {snap.durationSeconds}s sit · timer synced from server
-          </p>
-
-          <ul
-            style={{
-              listStyle: "none",
-              margin: "var(--s3) 0 0",
-              padding: 0,
-              display: "grid",
-              gap: "var(--s1)",
-            }}
-          >
-            {activeInRoom.map((p) => (
-              <li
-                key={p.userId}
-                style={{ fontSize: "13px", color: "var(--fg-2)", textAlign: "center" }}
-              >
-                {p.username}
-                {p.connected ? "" : " (away)"}
-              </li>
-            ))}
-          </ul>
-
           <div
-            style={{
-              opacity: controlsVisible ? 1 : 0,
-              transition: "opacity 0.5s ease",
-              pointerEvents: controlsVisible ? "auto" : "none",
-              width: "100%",
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-            }}
+            style={
+              isMobile
+                ? {
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "var(--s4)",
+                    width: "100%",
+                  }
+                : {
+                    display: "grid",
+                    gridTemplateColumns: "minmax(0, 1fr) minmax(260px, min(36vw, 380px))",
+                    gap: "var(--s4)",
+                    alignItems: "start",
+                    width: "100%",
+                  }
+            }
           >
             <div
               style={{
                 display: "flex",
-                alignItems: "center",
-                gap: "16px",
-                marginTop: "24px",
-                justifyContent: "center",
-                flexWrap: "wrap",
+                flexDirection: "column",
+                gap: "var(--s4)",
+                minWidth: 0,
+                order: isMobile ? 1 : undefined,
               }}
             >
-              <button
-                type="button"
-                onClick={handleThinkingToggle}
-                title="Mind-state and thoughts stay on this device; others are not notified."
+              <BlockTimer
+                key={`${sessionId}-${snap.startedAt}`}
+                totalSeconds={snap.durationSeconds}
+                syncClock={{
+                  startedAt: snap.startedAt,
+                  serverNow: snap.serverNow,
+                  durationSeconds: snap.durationSeconds,
+                }}
+                isActive
+                mindState={mindState}
+                mindStateLog={mindStateLog}
+                onElapsedChange={handleElapsedChange}
+                soundPrefs={soundPrefs}
+                onComplete={handleBuddyTimerComplete}
+              />
+
+              <p
                 style={{
-                  background:
-                    mindState === "thinking"
-                      ? "var(--accent-amber-bg)"
-                      : "var(--accent-green-bg-subtle)",
-                  border: `1px solid ${
-                    mindState === "thinking"
-                      ? "var(--accent-amber-border)"
-                      : "var(--accent-green-border)"
-                  }`,
-                  color:
-                    mindState === "thinking" ? "var(--accent-amber)" : "var(--accent-green)",
+                  textAlign: "center",
+                  margin: "-12px 0 0",
+                  fontSize: "11px",
+                  color: "var(--fg-3)",
                   fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-                  fontSize: "12px",
-                  letterSpacing: "0.15em",
-                  textTransform: "uppercase",
-                  padding: "12px 28px",
-                  borderRadius: "24px",
-                  cursor: "pointer",
-                  transition: "all 0.3s",
-                  minWidth: "160px",
+                  letterSpacing: "0.08em",
                 }}
               >
-                {mindState === "thinking" ? "\u25CB clear mind" : "\u2726 I'm thinking"}
-              </button>
-              {sessionThoughtCount > 0 && (
-                <div
-                  style={{
-                    fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-                    fontSize: "11px",
-                    color: "var(--accent-amber-border)",
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "4px",
-                  }}
-                >
-                  💭 {sessionThoughtCount}
-                </div>
-              )}
+                {snap.durationSeconds}s sit · timer synced from server
+              </p>
             </div>
 
-            {showThoughtInput && (
-              <div
-                style={{
-                  marginTop: "20px",
-                  width: "100%",
-                  display: "flex",
-                  justifyContent: "center",
-                }}
-              >
-                <ThoughtCapture onSave={handleSaveThought} onCancel={handleSkipThought} />
-              </div>
-            )}
+            <div
+              style={{
+                width: "100%",
+                order: isMobile ? 2 : undefined,
+                ...(isMobile
+                  ? {}
+                  : { position: "sticky", top: "var(--s4)", alignSelf: "start" }),
+              }}
+            >
+              {snap.dailyRoomUrl ? (
+                <BuddyVideo
+                  roomUrl={snap.dailyRoomUrl}
+                  displayName={me?.username ?? "Participant"}
+                />
+              ) : (
+                <p
+                  role="status"
+                  style={{
+                    margin: 0,
+                    padding: "var(--s4)",
+                    textAlign: "center",
+                    fontSize: "13px",
+                    color: "var(--fg-2)",
+                    lineHeight: 1.5,
+                    borderRadius: "12px",
+                    border: "1px solid var(--border-2)",
+                    background: "var(--surface-1)",
+                  }}
+                >
+                  Video is not available for this session (server did not return a room link).
+                </p>
+              )}
+            </div>
 
             <div
               style={{
                 display: "flex",
                 flexDirection: "column",
-                alignItems: "center",
-                gap: "8px",
-                marginTop: "24px",
+                gap: "var(--s4)",
+                minWidth: 0,
+                order: isMobile ? 3 : undefined,
+                gridColumn: isMobile ? undefined : "1 / -1",
               }}
             >
-              <p
+              <ul
                 style={{
+                  listStyle: "none",
                   margin: 0,
-                  fontSize: "11px",
-                  color: "var(--fg-4)",
-                  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-                  letterSpacing: "0.06em",
-                  textAlign: "center",
+                  padding: 0,
+                  display: "grid",
+                  gap: "var(--s1)",
                 }}
               >
-                Sounds are only on your device — they do not affect anyone else.
-              </p>
+                {activeInRoom.map((p) => (
+                  <li
+                    key={p.userId}
+                    style={{ fontSize: "13px", color: "var(--fg-2)", textAlign: "center" }}
+                  >
+                    {p.username}
+                    {p.connected ? "" : " (away)"}
+                  </li>
+                ))}
+              </ul>
+
               <div
                 style={{
+                  opacity: controlsVisible ? 1 : 0,
+                  transition: "opacity 0.5s ease",
+                  pointerEvents: controlsVisible ? "auto" : "none",
+                  width: "100%",
                   display: "flex",
-                  justifyContent: "center",
-                  gap: "16px",
-                  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-                  fontSize: "11px",
-                  letterSpacing: "0.1em",
-                  flexWrap: "wrap",
+                  flexDirection: "column",
+                  alignItems: "center",
                 }}
               >
-                {(
-                  [
-                    ["tick", "tick"],
-                    ["chime", "chime"],
-                    ["completion", "end"],
-                  ] as const
-                ).map(([key, label]) => (
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "16px",
+                    marginTop: "8px",
+                    justifyContent: "center",
+                    flexWrap: "wrap",
+                  }}
+                >
                   <button
                     type="button"
-                    key={key}
-                    aria-pressed={soundPrefs[key]}
-                    aria-label={`${label} sound ${soundPrefs[key] ? "on" : "off"}; only you hear this`}
-                    title="Only you hear this — does not change audio for others"
-                    onClick={() => {
-                      const next = { ...soundPrefs, [key]: !soundPrefs[key] };
-                      setSoundPrefs(next);
-                      saveSoundPrefs(next);
-                    }}
+                    onClick={handleThinkingToggle}
+                    title="Mind-state and thoughts stay on this device; others are not notified."
                     style={{
-                      background: "none",
-                      border: "none",
+                      background:
+                        mindState === "thinking"
+                          ? "var(--accent-amber-bg)"
+                          : "var(--accent-green-bg-subtle)",
+                      border: `1px solid ${
+                        mindState === "thinking"
+                          ? "var(--accent-amber-border)"
+                          : "var(--accent-green-border)"
+                      }`,
+                      color:
+                        mindState === "thinking" ? "var(--accent-amber)" : "var(--accent-green)",
+                      fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                      fontSize: "12px",
+                      letterSpacing: "0.15em",
+                      textTransform: "uppercase",
+                      padding: "12px 28px",
+                      borderRadius: "24px",
                       cursor: "pointer",
-                      color: soundPrefs[key] ? "var(--fg-3)" : "var(--fg-4)",
-                      transition: "color 0.3s",
-                      padding: "4px 8px",
+                      transition: "all 0.3s",
+                      minWidth: "160px",
                     }}
                   >
-                    {soundPrefs[key] ? "\u266A" : "\u2022"} {label}
+                    {mindState === "thinking" ? "\u25CB clear mind" : "\u2726 I'm thinking"}
                   </button>
-                ))}
+                  {sessionThoughtCount > 0 && (
+                    <div
+                      style={{
+                        fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                        fontSize: "11px",
+                        color: "var(--accent-amber-border)",
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "4px",
+                      }}
+                    >
+                      💭 {sessionThoughtCount}
+                    </div>
+                  )}
+                </div>
+
+                {showThoughtInput && (
+                  <div
+                    style={{
+                      marginTop: "20px",
+                      width: "100%",
+                      display: "flex",
+                      justifyContent: "center",
+                    }}
+                  >
+                    <ThoughtCapture onSave={handleSaveThought} onCancel={handleSkipThought} />
+                  </div>
+                )}
+
+                <div
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    gap: "8px",
+                    marginTop: "24px",
+                  }}
+                >
+                  <p
+                    style={{
+                      margin: 0,
+                      fontSize: "11px",
+                      color: "var(--fg-4)",
+                      fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                      letterSpacing: "0.06em",
+                      textAlign: "center",
+                    }}
+                  >
+                    Sounds are only on your device — they do not affect anyone else.
+                  </p>
+                  <div
+                    style={{
+                      display: "flex",
+                      justifyContent: "center",
+                      gap: "16px",
+                      fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                      fontSize: "11px",
+                      letterSpacing: "0.1em",
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    {(
+                      [
+                        ["tick", "tick"],
+                        ["chime", "chime"],
+                        ["completion", "end"],
+                      ] as const
+                    ).map(([key, label]) => (
+                      <button
+                        type="button"
+                        key={key}
+                        aria-pressed={soundPrefs[key]}
+                        aria-label={`${label} sound ${soundPrefs[key] ? "on" : "off"}; only you hear this`}
+                        title="Only you hear this — does not change audio for others"
+                        onClick={() => {
+                          const next = { ...soundPrefs, [key]: !soundPrefs[key] };
+                          setSoundPrefs(next);
+                          saveSoundPrefs(next);
+                        }}
+                        style={{
+                          background: "none",
+                          border: "none",
+                          cursor: "pointer",
+                          color: soundPrefs[key] ? "var(--fg-3)" : "var(--fg-4)",
+                          transition: "color 0.3s",
+                          padding: "4px 8px",
+                        }}
+                      >
+                        {soundPrefs[key] ? "\u266A" : "\u2022"} {label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
               </div>
+
+              <p
+                style={{
+                  fontSize: "12px",
+                  color: "var(--fg-3)",
+                  textAlign: "center",
+                  margin: 0,
+                  lineHeight: 1.45,
+                }}
+              >
+                {snap.isHost
+                  ? "If you leave, the shared session ends for everyone (only the host can do that)."
+                  : "If you leave, only your view stops — the shared timer keeps running for everyone else."}
+              </p>
+              {sessionThoughts.length > 0 && (
+                <p
+                  style={{
+                    fontSize: "11px",
+                    color: "var(--fg-4)",
+                    textAlign: "center",
+                    margin: 0,
+                    lineHeight: 1.45,
+                  }}
+                >
+                  {sessionThoughts.length} thought{sessionThoughts.length === 1 ? "" : "s"} captured on
+                  this device — they are saved to your journal when the shared timer ends.
+                </p>
+              )}
+
+              <button
+                type="button"
+                onClick={() => void leave()}
+                style={{ ...btnSecondary, marginTop: "var(--s1)" }}
+              >
+                Leave
+              </button>
             </div>
           </div>
-
-          <p
-            style={{
-              fontSize: "12px",
-              color: "var(--fg-3)",
-              textAlign: "center",
-              margin: "var(--s4) 0 0",
-              lineHeight: 1.45,
-            }}
-          >
-            {snap.isHost
-              ? "If you leave, the shared session ends for everyone (only the host can do that)."
-              : "If you leave, only your view stops — the shared timer keeps running for everyone else."}
-          </p>
-              {sessionThoughts.length > 0 && (
-            <p
-              style={{
-                fontSize: "11px",
-                color: "var(--fg-4)",
-                textAlign: "center",
-                margin: "var(--s2) 0 0",
-                lineHeight: 1.45,
-              }}
-            >
-              {sessionThoughts.length} thought{sessionThoughts.length === 1 ? "" : "s"} captured on
-              this device — they are saved to your journal when the shared timer ends.
-            </p>
-          )}
-
-          <button type="button" onClick={() => void leave()} style={{ ...btnSecondary, marginTop: "var(--s3)" }}>
-            Leave
-          </button>
         </>
       )}
     </div>

--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -102,6 +102,8 @@ export function BuddySessionRoom({
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const timerAnchorRef = useRef<string | null>(null);
   const [personalRecordError, setPersonalRecordError] = useState<string | null>(null);
+  const [dailyMeetingToken, setDailyMeetingToken] = useState<string | null>(null);
+  const [dailyTokenError, setDailyTokenError] = useState<string | null>(null);
   const autoFinalizeAttemptedRef = useRef(false);
   const snapRef = useRef(snap);
   const mindStateLogRef = useRef(mindStateLog);
@@ -137,7 +139,35 @@ export function BuddySessionRoom({
     lastRevision.current = -1;
     autoFinalizeAttemptedRef.current = false;
     setPersonalRecordError(null);
+    setDailyMeetingToken(null);
+    setDailyTokenError(null);
   }, [sessionId]);
+
+  useEffect(() => {
+    if (snap?.state !== "active" || !snap.dailyRoomUrl?.trim()) {
+      setDailyMeetingToken(null);
+      setDailyTokenError(null);
+      return;
+    }
+    let cancelled = false;
+    setDailyMeetingToken(null);
+    setDailyTokenError(null);
+    void api.getBuddyMeetingToken(sessionId).then(
+      (r) => {
+        if (!cancelled) setDailyMeetingToken(r.token);
+      },
+      (e) => {
+        if (!cancelled) {
+          setDailyTokenError(
+            e instanceof ApiError ? e.message : "Could not get video token",
+          );
+        }
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, snap?.state, snap?.dailyRoomUrl]);
 
   useEffect(() => {
     if (pollStopped) return;
@@ -706,10 +736,47 @@ export function BuddySessionRoom({
               }}
             >
               {snap.dailyRoomUrl ? (
-                <BuddyVideo
-                  roomUrl={snap.dailyRoomUrl}
-                  displayName={me?.username ?? "Participant"}
-                />
+                dailyTokenError ? (
+                  <p
+                    role="alert"
+                    style={{
+                      margin: 0,
+                      padding: "var(--s4)",
+                      textAlign: "center",
+                      fontSize: "13px",
+                      color: "var(--fg-2)",
+                      lineHeight: 1.5,
+                      borderRadius: "12px",
+                      border: "1px solid var(--border-2)",
+                      background: "var(--surface-1)",
+                    }}
+                  >
+                    {dailyTokenError}
+                  </p>
+                ) : dailyMeetingToken ? (
+                  <BuddyVideo
+                    roomUrl={snap.dailyRoomUrl}
+                    meetingToken={dailyMeetingToken}
+                    displayName={me?.username ?? "Participant"}
+                  />
+                ) : (
+                  <p
+                    role="status"
+                    style={{
+                      margin: 0,
+                      padding: "var(--s4)",
+                      textAlign: "center",
+                      fontSize: "13px",
+                      color: "var(--fg-2)",
+                      lineHeight: 1.5,
+                      borderRadius: "12px",
+                      border: "1px solid var(--border-2)",
+                      background: "var(--surface-1)",
+                    }}
+                  >
+                    Preparing video…
+                  </p>
+                )
               ) : (
                 <p
                   role="status"

--- a/src/components/BuddyVideo.tsx
+++ b/src/components/BuddyVideo.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 /**
- * Daily call-object embed for buddy sessions (#105). #106 can mount this when a `roomUrl` is
- * available (from server after `createRoom`), passing each participant's display name.
+ * Daily call-object embed for buddy sessions (#105). For private rooms (#106), pass
+ * `meetingToken` from `POST /api/buddy/sessions/:id/meeting-token` together with `roomUrl`.
  */
 
 import {
@@ -21,6 +21,8 @@ import { useEffect, useState } from "react";
 export type BuddyVideoProps = {
   /** Full Daily room URL from the REST API (`createRoom`). */
   roomUrl: string;
+  /** Required for private rooms: server minted via `POST …/meeting-token`. */
+  meetingToken?: string;
   /** Shown to other participants (Daily `userName`). */
   displayName: string;
   /** When true (default), joins on mount and leaves on unmount. */
@@ -83,6 +85,7 @@ function ParticipantTiles() {
 
 function BuddyVideoInner({
   roomUrl,
+  meetingToken,
   displayName,
   autoConnect = true,
   className,
@@ -107,7 +110,12 @@ function BuddyVideoInner({
     const run = async () => {
       if (!daily) return;
       try {
-        await daily.join({ url, userName: displayName });
+        const token = meetingToken?.trim();
+        await daily.join({
+          url,
+          userName: displayName,
+          ...(token ? { token } : {}),
+        });
       } catch (e) {
         if (!cancelled) {
           setJoinError(e instanceof Error ? e.message : "Could not join the video room");
@@ -123,7 +131,7 @@ function BuddyVideoInner({
         /* ignore teardown errors */
       });
     };
-  }, [autoConnect, roomUrl, displayName, daily]);
+  }, [autoConnect, roomUrl, meetingToken, displayName, daily]);
 
   if (!autoConnect) {
     return (

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -2,6 +2,7 @@ import {
   pgTable,
   uuid,
   varchar,
+  text,
   boolean,
   integer,
   jsonb,
@@ -35,6 +36,10 @@ export const buddySessions = pgTable("buddy_sessions", {
   state: varchar("state", { length: 20 }).notNull().default("waiting"),
   durationSeconds: integer("duration_seconds").notNull(),
   startedAt: timestamp("started_at", { withTimezone: true }),
+  /** Daily.co room name (for DELETE); set when the shared sit starts (#106). */
+  dailyRoomName: varchar("daily_room_name", { length: 128 }),
+  /** Daily.co meeting URL for participants while `state === 'active'`. */
+  dailyRoomUrl: text("daily_room_url"),
   revision: integer("revision").notNull().default(0),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -206,6 +206,12 @@ export const api = {
   getBuddySnapshot: (sessionId: string) =>
     request<{ snapshot: BuddySnapshot }>(`/api/buddy/sessions/${sessionId}`),
 
+  /** Server-issued Daily token for joining a private room while the buddy sit is active. */
+  getBuddyMeetingToken: (sessionId: string) =>
+    request<{ token: string }>(`/api/buddy/sessions/${sessionId}/meeting-token`, {
+      method: "POST",
+    }),
+
   setBuddyReady: (sessionId: string, ready: boolean) =>
     request<{ ok: boolean }>(`/api/buddy/sessions/${sessionId}/ready`, {
       method: "PATCH",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -110,6 +110,8 @@ export type BuddySnapshot = {
   endsAt: string | null;
   elapsedSeconds: number | null;
   remainingSeconds: number | null;
+  /** Daily.co room URL while the shared sit is active; null if video is unavailable. */
+  dailyRoomUrl: string | null;
   hostUserId: string;
   isHost: boolean;
   participants: BuddyParticipantSnap[];

--- a/src/lib/buddySession.ts
+++ b/src/lib/buddySession.ts
@@ -11,6 +11,7 @@ import {
   friendships,
 } from "@/db/schema";
 import { BASE_DURATION, INCREMENT } from "@/lib/constants";
+import { deleteRoom } from "@/lib/daily";
 import { orderedUserPair } from "@/lib/friends";
 import { and, eq, sql } from "drizzle-orm";
 
@@ -54,6 +55,22 @@ export async function bumpBuddyRevision(sessionId: string): Promise<void> {
     .where(eq(buddySessions.id, sessionId));
 }
 
+/**
+ * Best-effort Daily room teardown. Uses `ignoreMissing: true` by default; for strict admin
+ * surfacing of 404, call `deleteRoom` from `daily.ts` with `{ ignoreMissing: false }` instead.
+ */
+export async function teardownBuddyDailyRoomByName(
+  roomName: string | null | undefined,
+): Promise<void> {
+  const trimmed = roomName?.trim();
+  if (!trimmed) return;
+  try {
+    await deleteRoom(trimmed, { ignoreMissing: true });
+  } catch (e) {
+    console.error("Buddy Daily room teardown:", e);
+  }
+}
+
 /** Recompute active→completed and waiting↔ready_check. Call after reads/mutations that affect state. */
 export async function reconcileBuddySession(sessionId: string): Promise<void> {
   const [session] = await db
@@ -69,10 +86,13 @@ export async function reconcileBuddySession(sessionId: string): Promise<void> {
     const endMs =
       session.startedAt.getTime() + session.durationSeconds * 1000;
     if (Date.now() >= endMs) {
+      await teardownBuddyDailyRoomByName(session.dailyRoomName);
       await db
         .update(buddySessions)
         .set({
           state: "completed",
+          dailyRoomName: null,
+          dailyRoomUrl: null,
           revision: sql`${buddySessions.revision} + 1`,
           updatedAt: new Date(),
         })
@@ -139,6 +159,11 @@ export function buildBuddySnapshot(
     endsAt = new Date(startMs + session.durationSeconds * 1000).toISOString();
   }
 
+  const dailyRoomUrl =
+    session.state === "active" && session.dailyRoomUrl?.trim()
+      ? session.dailyRoomUrl.trim()
+      : null;
+
   return {
     id: session.id,
     state: session.state as BuddySessionState,
@@ -149,6 +174,7 @@ export function buildBuddySnapshot(
     endsAt,
     elapsedSeconds,
     remainingSeconds,
+    dailyRoomUrl,
     hostUserId: session.hostUserId,
     isHost: session.hostUserId === viewerUserId,
     participants: participants.map((p) => ({

--- a/src/lib/daily.ts
+++ b/src/lib/daily.ts
@@ -20,6 +20,19 @@ export class DailyApiError extends Error {
   }
 }
 
+/** True when Daily rejected creating a room because the name is already taken (orphan retry). */
+export function isDailyRoomNameConflict(error: DailyApiError): boolean {
+  if (error.status !== 400 && error.status !== 409) return false;
+  const raw = `${error.message}\n${JSON.stringify(error.body)}`.toLowerCase();
+  return (
+    raw.includes("already") ||
+    raw.includes("exists") ||
+    raw.includes("taken") ||
+    raw.includes("in use") ||
+    raw.includes("duplicate")
+  );
+}
+
 /** Normalized room payload from `POST /rooms` (fields we rely on for MVP). */
 export type DailyCreatedRoom = {
   name: string;
@@ -120,6 +133,54 @@ export async function createRoom(options: CreateDailyRoomOptions = {}): Promise<
       ? { config: data.config as Record<string, unknown> }
       : {}),
   };
+}
+
+export type CreateMeetingTokenOptions = {
+  roomName: string;
+  userName: string;
+  /** Daily `user_id` (max 36 chars); use your app user id when it is a UUID. */
+  userId: string;
+  /** Lifetime in seconds from now (default 4 hours). */
+  ttlSeconds?: number;
+};
+
+/**
+ * Creates a meeting token for joining a private Daily room. Server-only.
+ * https://docs.daily.co/reference/rest-api/meeting-tokens/create-meeting-token
+ */
+export async function createMeetingToken(
+  options: CreateMeetingTokenOptions,
+): Promise<string> {
+  const ttl = options.ttlSeconds ?? 4 * 3600;
+  const exp = Math.floor(Date.now() / 1000) + ttl;
+  const roomName = options.roomName.trim();
+  const userName = options.userName.trim().slice(0, 200) || "Participant";
+  const userId = options.userId.trim().slice(0, 36);
+
+  const res = await dailyFetch("/meeting-tokens", {
+    method: "POST",
+    body: JSON.stringify({
+      properties: {
+        room_name: roomName,
+        user_name: userName,
+        user_id: userId,
+        exp,
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    const errBody = await parseDailyErrorBody(res);
+    const message = errorMessageFromBody(errBody, `Daily meeting token failed (${res.status})`);
+    throw new DailyApiError(message, res.status, errBody);
+  }
+
+  const data = (await res.json()) as Record<string, unknown>;
+  const token = data.token;
+  if (typeof token !== "string" || !token.trim()) {
+    throw new DailyApiError("Daily meeting token response missing token", res.status, data);
+  }
+  return token.trim();
 }
 
 export type DeleteDailyRoomOptions = {


### PR DESCRIPTION
## Summary
Implements buddy MVP web flow pieces for #106: Daily room at session start, `BuddyVideo` with auto-connect, desktop timer-left / video-right layout, Daily teardown on complete/host abandon, and user-visible deep-link join failures.

Closes #106

## Test plan
- [ ] `npx drizzle-kit push` (or apply `drizzle/buddy_sessions_daily_room_incremental.sql`) so new columns exist
- [ ] `DAILY_API_KEY` set for start → active path
- [ ] Create/join buddy → waiting → ready → start: video connects without extra click; desktop shows video right of timer; narrow viewport stacks timer then video
- [ ] Complete sit → personal completion flow → home; solo session unchanged
- [ ] Invalid `?buddy=` shows dismissible alert and cleans URL
- [x] `npm run build`

## Notes
- Snapshot adds `dailyRoomUrl` while `state === "active"`.
- Polling unchanged: 1500ms in `BuddySessionRoom`.
- Admin strict delete: use `deleteRoom(name, { ignoreMissing: false })` from `daily.ts` when required (runtime teardown uses `true`).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic private video room provisioning for active buddy sessions with join tokens.
  * In-session video embedded in the session view, shown when available.

* **User Experience**
  * Responsive session layout refined for mobile and desktop.
  * Join flow now surfaces clearer invite and video-token errors with a dismissible alert.

* **Bug Fixes**
  * Video rooms and related data are cleaned up when sessions end or hosts leave, reducing orphaned rooms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->