### PR TITLE
fix(db): Neon Pool for Drizzle transactions (friend accept 500)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,13 +18,15 @@
         "next": "15.5.12",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "server-only": "^0.0.1"
+        "server-only": "^0.0.1",
+        "ws": "^8.20.0"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/ws": "^8.18.1",
         "drizzle-kit": "^0.31.9",
         "typescript": "^5"
       }
@@ -1708,6 +1710,16 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@vercel/postgres": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@vercel/postgres/-/postgres-0.10.0.tgz",
@@ -2509,12 +2521,10 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -18,13 +18,15 @@
     "next": "15.5.12",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "server-only": "^0.0.1"
+    "server-only": "^0.0.1",
+    "ws": "^8.20.0"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/ws": "^8.18.1",
     "drizzle-kit": "^0.31.9",
     "typescript": "^5"
   }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -18,7 +18,12 @@ function getPool(): Pool {
     throw new Error("POSTGRES_URL is not set");
   }
   if (!globalForDb.__drizzlePool) {
-    globalForDb.__drizzlePool = new Pool({ connectionString: url });
+    globalForDb.__drizzlePool = new Pool({
+      connectionString: url,
+      max: 5,
+      idleTimeoutMillis: 30_000,
+      connectionTimeoutMillis: 10_000,
+    });
   }
   return globalForDb.__drizzlePool;
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,20 +1,38 @@
-import { neon } from "@neondatabase/serverless";
-import { drizzle, NeonHttpDatabase } from "drizzle-orm/neon-http";
+import { Pool, neonConfig } from "@neondatabase/serverless";
+import { drizzle, type NeonDatabase } from "drizzle-orm/neon-serverless";
+import ws from "ws";
 import * as schema from "./schema";
 
-let _db: NeonHttpDatabase<typeof schema> | null = null;
+neonConfig.webSocketConstructor = ws;
 
-export function getDb() {
-  if (!_db) {
-    const sql = neon(process.env.POSTGRES_URL!);
-    _db = drizzle(sql, { schema });
+type AppDb = NeonDatabase<typeof schema>;
+
+const globalForDb = globalThis as typeof globalThis & {
+  __drizzlePool?: Pool;
+  __drizzleDb?: AppDb;
+};
+
+function getPool(): Pool {
+  const url = process.env.POSTGRES_URL;
+  if (!url) {
+    throw new Error("POSTGRES_URL is not set");
   }
-  return _db;
+  if (!globalForDb.__drizzlePool) {
+    globalForDb.__drizzlePool = new Pool({ connectionString: url });
+  }
+  return globalForDb.__drizzlePool;
 }
 
-// For convenience, export as a getter
-export const db = new Proxy({} as NeonHttpDatabase<typeof schema>, {
+function getDb(): AppDb {
+  if (!globalForDb.__drizzleDb) {
+    globalForDb.__drizzleDb = drizzle(getPool(), { schema });
+  }
+  return globalForDb.__drizzleDb;
+}
+
+/** Neon serverless Pool (WebSocket) so `db.transaction()` works — not `neon-http`. */
+export const db = new Proxy({} as AppDb, {
   get(_, prop) {
-    return (getDb() as any)[prop];
+    return (getDb() as unknown as Record<string | symbol, unknown>)[prop as string];
   },
 });


### PR DESCRIPTION
## Problem
`drizzle-orm/neon-http` **cannot** run `db.transaction()` — it always throws `No transactions support in neon-http driver`. That surfaces as **500** on any route using transactions.

Affected routes include:
- `PATCH /api/friends/requests/:id` (accept)
- `POST /api/thoughts/batch` (transaction path)
- `POST /api/buddy/sessions/:id/record-personal-session`

This was **not** caused by missing migrations after schema was pushed.

## Fix
Use `drizzle-orm/neon-serverless` with Neon's `Pool` + `ws` WebSocket constructor (Vercel Node), cache pool on `globalThis` for warm invocations.

## Test plan
- [ ] Deploy preview / prod
- [ ] Accept a friend request → 200
- [ ] Save thoughts batch / buddy personal record if you use those flows

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added WebSocket runtime and corresponding TypeScript typings to project dependencies.

* **Refactor**
  * Migrated database connectivity to a WebSocket-backed pool with globally persisted connections and lazy initialization for more reliable, performant backend connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->