### PR TITLE
fix(buddy): clearer errors for /start 500 (Daily key + DB schema)

### DIFF
--- a/src/app/api/buddy/sessions/[id]/start/route.ts
+++ b/src/app/api/buddy/sessions/[id]/start/route.ts
@@ -80,33 +80,72 @@ export async function POST(_request: Request, context: Params) {
               { status: 503 },
             );
           }
-          throw e2;
+          console.error("Buddy start Daily retry error:", e2);
+          return NextResponse.json(
+            { error: "Video room could not be created. Check Daily configuration and try again." },
+            { status: 503 },
+          );
         }
       } else if (e instanceof DailyApiError) {
         return NextResponse.json(
           { error: "Video room could not be created. Check Daily configuration and try again." },
           { status: 503 },
         );
+      } else if (e instanceof Error && e.message.includes("DAILY_API_KEY")) {
+        console.error("Buddy start: Daily API key missing on server");
+        return NextResponse.json(
+          {
+            error:
+              "Video is not configured on this server (DAILY_API_KEY). Add it in Vercel env and redeploy.",
+          },
+          { status: 503 },
+        );
       } else {
-        throw e;
+        console.error("Buddy start Daily unexpected error:", e);
+        return NextResponse.json(
+          { error: "Video room could not be created. Check Daily configuration and try again." },
+          { status: 503 },
+        );
       }
     }
 
     const startedAt = new Date();
-    const [updated] = await db
-      .update(buddySessions)
-      .set({
-        state: "active",
-        startedAt,
-        dailyRoomName: dailyRoom.name,
-        dailyRoomUrl: dailyRoom.url,
-        revision: sql`${buddySessions.revision} + 1`,
-        updatedAt: startedAt,
-      })
-      .where(
-        and(eq(buddySessions.id, sessionId), eq(buddySessions.state, "ready_check")),
-      )
-      .returning();
+    let updated: (typeof buddySessions.$inferSelect) | undefined;
+    try {
+      const rows = await db
+        .update(buddySessions)
+        .set({
+          state: "active",
+          startedAt,
+          dailyRoomName: dailyRoom.name,
+          dailyRoomUrl: dailyRoom.url,
+          revision: sql`${buddySessions.revision} + 1`,
+          updatedAt: startedAt,
+        })
+        .where(
+          and(eq(buddySessions.id, sessionId), eq(buddySessions.state, "ready_check")),
+        )
+        .returning();
+      updated = rows[0];
+    } catch (dbErr) {
+      console.error("Buddy start DB update error:", dbErr);
+      try {
+        await deleteRoom(dailyRoom.name, { ignoreMissing: true });
+      } catch (cleanupErr) {
+        console.error("Buddy start: Daily room cleanup after DB failure:", cleanupErr);
+      }
+      const msg = dbErr instanceof Error ? dbErr.message : "";
+      if (/daily_room|does not exist|42703/i.test(msg)) {
+        return NextResponse.json(
+          {
+            error:
+              "Database is missing buddy video columns. Run `npx drizzle-kit push` against production (see drizzle/buddy_sessions_daily_room_incremental.sql).",
+          },
+          { status: 503 },
+        );
+      }
+      return NextResponse.json({ error: "Could not start the shared session. Try again." }, { status: 503 });
+    }
 
     if (!updated) {
       try {


### PR DESCRIPTION
## Cause of `POST …/start` 500
Most likely one of:
1. **`DAILY_API_KEY` unset in Vercel** — `createRoom` threw a plain `Error`, which was rethrown and became **500**.
2. **Prod DB missing `daily_room_name` / `daily_room_url`** — `UPDATE buddy_sessions` fails → **500** (often if `drizzle-kit push` was only run against dev).

## Change
- Map those cases to **503** with a **specific `error` string** (and log server-side).
- On DB update failure after Daily room exists: **delete the orphan Daily room**, then return 503.
- Non-`DailyApiError` from Daily path: **503** instead of 500.

## What you should verify on prod
- Vercel **Production** env: `DAILY_API_KEY` set.
- Neon **production** DB has buddy daily room columns (`drizzle-kit push` with prod `POSTGRES_URL` or `drizzle/buddy_sessions_daily_room_incremental.sql`).

After deploy, retry **Start** — UI should show the API `error` message via existing `ApiError` handling.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling during shared session startup with clearer diagnostic messages
  * Improved system resilience by gracefully managing configuration and database-related issues during session initialization
  * Better error recovery with specific guidance when problems occur, preventing unhandled exceptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->