### PR TITLE
Use still-point.me for iOS API and documentation URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Still Point
 
-**The app is live at [still-point.vercel.app](https://still-point.vercel.app)**
+**The app is live at [still-point.me](https://still-point.me)**
 
 Practice focus by watching the clock without thinking for fixed blocks of time.
 
@@ -78,7 +78,7 @@ echo "value" | npx vercel env add NAME production  # add var
 npx vercel env rm NAME production          # remove var
 ```
 
-The app is live at [still-point.vercel.app](https://still-point.vercel.app).
+The app is live at [still-point.me](https://still-point.me).
 
 ### Neon (database)
 

--- a/ios/RELEASING.md
+++ b/ios/RELEASING.md
@@ -60,7 +60,7 @@ Before your first TestFlight release, configure a tester group and handle encryp
 The same build uploaded to TestFlight can be submitted to the App Store:
 
 1. Go to [appstoreconnect.apple.com](https://appstoreconnect.apple.com) → your app
-2. Fill in the required metadata (screenshots, description, privacy policy URL)
+2. Fill in the required metadata (screenshots, description). Set **Privacy Policy URL** to `https://still-point.me/privacy` in App Store Connect.
 3. Select the TestFlight build under the version
 4. Click "Add for Review"
 

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -12,9 +12,9 @@ public actor APIClient {
 
     private init() {
         #if DEBUG
-        self.baseURL = URL(string: "https://still-point.vercel.app")!
+        self.baseURL = URL(string: "https://still-point.me")!
         #else
-        self.baseURL = URL(string: "https://still-point.vercel.app")!
+        self.baseURL = URL(string: "https://still-point.me")!
         #endif
 
         let config = URLSessionConfiguration.default


### PR DESCRIPTION
## Summary
Updates production URL references from `still-point.vercel.app` to the custom domain `still-point.me` per #76.

## Changes
- **iOS** `APIClient.swift`: default API base URL uses `https://still-point.me` (DEBUG and release).
- **README**: live site links point to `still-point.me`.
- **ios/RELEASING.md**: App Store Connect privacy policy URL documented as `https://still-point.me/privacy`.

## Already in `main` (no code change in this PR)
- Next.js `metadataBase` in `src/app/layout.tsx` is already `https://still-point.me`.
- Privacy page canonical and in-page links already use `still-point.me`.

## Test plan
- [ ] Merge after review
- [ ] Confirm iOS app hits production API after a clean build (optional smoke)

Closes #76

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated public app URL and deployment link to the new hosting domain.
  * Specified the concrete Privacy Policy URL for App Store submission.

* **Chores**
  * Pointed the app's network configuration to the new domain for all build types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->