### PR TITLE
ci: audit merge gates and harden TestFlight workflow

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'ios-v*'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ios-testflight
   cancel-in-progress: false
@@ -26,8 +29,23 @@ jobs:
           echo "iPhoneOS SDK: ${SDK_VERSION}"
           [[ "${SDK_VERSION%%.*}" -ge 26 ]]
 
-      - name: Install XcodeGen
-        run: brew install xcodegen
+      - name: Install XcodeGen (retry on transient Homebrew failures)
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if brew install xcodegen; then
+              exit 0
+            fi
+
+            if [[ "$attempt" -lt 3 ]]; then
+              sleep $((attempt * 10))
+            fi
+          done
+
+          echo "Failed to install xcodegen after 3 attempts."
+          exit 1
 
       - name: Generate Xcode project
         working-directory: ios

--- a/README.md
+++ b/README.md
@@ -106,6 +106,22 @@ gh pr create --title "..."       # create pull request
 
 Automated code review on pull requests via [CodeRabbit](https://coderabbit.ai). Reviews are posted as PR comments — no local setup needed.
 
+## Merge gates (current)
+
+As of this audit, GitHub branch protection and rulesets are not configured with required status checks on `main`. In practice, the team uses Vercel + PR review signals as the merge gate.
+
+What should be green before merge:
+
+- `Vercel` — preview deployment completed successfully
+- `Vercel Agent Review` — Vercel's automated review completed
+- `Vercel Preview Comments` — preview comment bot completed
+- `CodeRabbit` — review completed with no blocking findings
+
+Notes:
+
+- The GitHub Actions workflow `Build & Upload to TestFlight` is **release-only** (tag trigger `ios-v*`) and is not a pull-request merge gate.
+- For strict enforcement, add these check names under GitHub branch protection required checks for `main`.
+
 ## Project structure
 
 ```


### PR DESCRIPTION
## Summary
- audit GitHub Actions and repository gate configuration against the current Vercel-based shipping path
- document the current merge gate checks in `README.md`, including the exact check names observed on active PRs
- harden the TestFlight workflow by reducing token permissions and adding retry logic for transient Homebrew install failures

Closes #144

## Test plan
- [x] `ruby -e \"require 'yaml'; YAML.load_file('.github/workflows/ios-testflight.yml'); YAML.load_file('.github/workflows/cr-plan-on-issue.yml'); puts 'workflow yaml parse ok'\"`
- [x] `gh api repos/auerbachb/still-point/branches/main/protection` (returns `Branch not protected`)
- [x] `gh api repos/auerbachb/still-point/rulesets` (returns `[]`)
- [x] `gh pr checks 130` (captured active check names: `Vercel`, `Vercel Agent Review`, `Vercel Preview Comments`, `CodeRabbit`)

Made with [Cursor](https://cursor.com)