### PR TITLE
fix build reliability for turbopack flake (closes #124)

### DIFF
--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -1,0 +1,28 @@
+name: Web Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify repeatable clean builds
+        run: npm run build:verify -- 3

--- a/README.md
+++ b/README.md
@@ -55,6 +55,26 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000).
 
+## Building
+
+Production builds use the standard Next.js build path (without `--turbopack`) for stability:
+
+```bash
+npm run build
+```
+
+To verify clean build repeatability locally (same check used by CI):
+
+```bash
+npm run build:verify -- 3
+```
+
+Turbopack builds are kept as an explicit opt-in while Next 15.5 build support remains beta:
+
+```bash
+npm run build:turbo
+```
+
 ## Environment variables
 
 | Variable | Description | How to get it |

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "build": "next build",
+    "build:turbo": "next build --turbopack",
+    "build:verify": "bash ./scripts/verify-build.sh",
     "start": "next start",
     "db:seed": "tsx scripts/seed.ts"
   },

--- a/scripts/verify-build.sh
+++ b/scripts/verify-build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUNS="${1:-3}"
+
+for run in $(seq 1 "$RUNS"); do
+  echo "[build:verify] clean build ${run}/${RUNS}"
+  rm -rf .next
+  npm run build
+done
+
+echo "[build:verify] ${RUNS}/${RUNS} builds succeeded"

--- a/scripts/verify-build.sh
+++ b/scripts/verify-build.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 RUNS="${1:-3}"
 
+if ! [[ "$RUNS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "[build:verify] RUNS must be a positive integer, got: ${RUNS}" >&2
+  exit 1
+fi
+
 for run in $(seq 1 "$RUNS"); do
   echo "[build:verify] clean build ${run}/${RUNS}"
   rm -rf .next


### PR DESCRIPTION
## Summary
- switch default production build from `next build --turbopack` to `next build` to avoid intermittent Turbopack build flakes in Next 15.5 beta build mode
- keep Turbopack available as opt-in via `npm run build:turbo`
- add repeatability checks: `scripts/verify-build.sh`, `npm run build:verify -- <N>`, and a `web-build` workflow that runs 3 clean builds per PR/main push
- document supported build and verification commands in `README.md`

Closes #124.

## Test plan
- [x] `npm run build`
- [x] `npm run build:verify -- 3`
- [x] `npm run build:turbo`
- [x] `gh issue comment 124` with repro + recommendation details


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Building guide describing production builds, how to verify repeatable clean builds locally, and an opt-in Turbopack build option.

* **Chores**
  * Switched the default build to the standard non-Turbopack path and added an explicit Turbopack opt-in.
  * Added a repeatable build verification script and a CI workflow to run verification on PRs and main-branch pushes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->