### PR TITLE
feat(api): DELETE /api/account for permanent account removal (#126)

### DIFF
--- a/src/app/api/account/route.ts
+++ b/src/app/api/account/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { deleteUserAccount } from "@/lib/accountDeletion";
+import { clearAuthCookie, getCurrentUser } from "@/lib/auth";
+
+/**
+ * `DELETE /api/account` — permanently delete the authenticated user's account.
+ * JWT-only session: clearing the auth cookie invalidates the client (same as logout).
+ */
+export async function DELETE() {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const deleted = await deleteUserAccount(auth.userId);
+
+    await clearAuthCookie();
+
+    if (!deleted) {
+      return NextResponse.json({ error: "Account not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("Account deletion error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/account/route.ts
+++ b/src/app/api/account/route.ts
@@ -7,6 +7,14 @@ import { clearAuthCookie, getCurrentUser } from "@/lib/auth";
  * JWT-only session: clearing the auth cookie invalidates the client (same as logout).
  */
 export async function DELETE() {
+  const clearCookieBestEffort = async () => {
+    try {
+      await clearAuthCookie();
+    } catch (cookieError) {
+      console.error("Account deletion cookie clear failed:", cookieError);
+    }
+  };
+
   try {
     const auth = await getCurrentUser();
     if (!auth) {
@@ -15,12 +23,12 @@ export async function DELETE() {
 
     const deleted = await deleteUserAccount(auth.userId);
 
-    await clearAuthCookie();
-
     if (!deleted) {
+      await clearCookieBestEffort();
       return NextResponse.json({ error: "Account not found" }, { status: 404 });
     }
 
+    await clearCookieBestEffort();
     return NextResponse.json({ ok: true });
   } catch (error) {
     console.error("Account deletion error:", error);

--- a/src/lib/accountDeletion.ts
+++ b/src/lib/accountDeletion.ts
@@ -1,0 +1,26 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { users } from "@/db/schema";
+
+/**
+ * Hard-deletes the `users` row for `userId`. All direct FKs from `users.id` use
+ * `ON DELETE CASCADE` in `schema.ts`, so Postgres removes (in dependency order):
+ *
+ * - `buddy_sessions` (host)
+ * - `buddy_session_participants` (participant `user_id`, and rows under deleted buddy sessions)
+ * - `sessions` (owner `user_id`; `thoughts` cascade via `session_id`)
+ * - `thoughts` (owner `user_id`)
+ * - `friend_requests` (from/to)
+ * - `friendships` (either side)
+ *
+ * `sessions.buddy_session_id` → `buddy_sessions` is `ON DELETE SET NULL`, so when a
+ * deleted user was the host, other participants keep their personal `sessions` rows with
+ * `buddy_session_id` cleared.
+ */
+export async function deleteUserAccount(userId: string): Promise<boolean> {
+  const removed = await db.transaction(async (tx) => {
+    const rows = await tx.delete(users).where(eq(users.id, userId)).returning({ id: users.id });
+    return rows.length > 0;
+  });
+  return removed;
+}


### PR DESCRIPTION
## Summary
Part of #126 (App Store Guideline 5.1.1(v)). Adds a **server-side** endpoint so an authenticated user can permanently delete their account and associated personal data.

## Why `DELETE /api/account`
REST maps the authenticated user’s account to a single resource URI. `DELETE` is idempotent at the HTTP level (repeat calls after deletion are handled safely) and matches common “delete my account” semantics without a JSON body.

## Auth
- `getCurrentUser()` from the `sp_token` cookie; **401** if missing/invalid (middleware + handler).
- Only the signed-in user’s row is targeted (`WHERE id = auth.userId`).

## Data / transaction
All FKs **from** `users.id` in `src/db/schema.ts` use `onDelete: "cascade"`:
`buddy_sessions` (host), `buddy_session_participants` (participant), `sessions` (owner), `thoughts` (owner), `friend_requests` (from/to), `friendships` (either side).

The implementation runs `DELETE FROM users WHERE id = …` inside a **single Drizzle transaction**. Postgres applies cascades in a valid order; no orphaned rows for this user’s owned data.

**Co-participants:** `sessions.buddy_session_id` → `buddy_sessions` is `onDelete: "set null"`. If the deleted user was a buddy **host**, their `buddy_sessions` row goes away and other users’ personal `sessions` rows that pointed at that buddy sit get `buddy_session_id` nulled (they are not deleted).

## Session
JWT is stateless; after a successful delete (or missing user with a stale token), we call `clearAuthCookie()` (same as `/api/auth/logout`) so the cookie cannot be reused.

## Response
- **200** `{ "ok": true }` after a row was deleted.
- **401** unauthenticated.
- **404** `{ "error": "Account not found" }` if the token user id has no row (cookie still cleared).
- **500** on unexpected errors (no stack/details in JSON).

## Tests
This repo has **no** `npm test` / test runner in `package.json`. Verification for this PR:
- `npm run build` (passes).

## Manual verification (`curl`)
1. Sign up or log in via the app (or `POST /api/auth/login`) so the browser/client has `sp_token`.
2. With the cookie:
   ```bash
   curl -i -X DELETE "http://localhost:3000/api/account" \
     -H "Cookie: sp_token=<paste token value>"
   ```
3. Expect **200** and `{"ok":true}`, then `GET /api/auth/me` with the same cookie should yield **401** (cookie cleared on delete response — re-send cookie only if you captured it before the delete response strips it).

Do **not** commit tokens or `.env` contents.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account deletion endpoint: authenticated users can delete their accounts; successful deletion clears the session and returns success.
  * Clear responses for failure states: returns 401 when unauthenticated, 404 if account not found, and 500 for unexpected server errors.
  * Server logs errors; session clearing is best-effort and won’t block the response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->