### PR TITLE
Add in-app iOS account deletion flow in Settings

### DIFF
--- a/ios/RELEASING.md
+++ b/ios/RELEASING.md
@@ -64,6 +64,17 @@ The same build uploaded to TestFlight can be submitted to the App Store:
 3. Select the TestFlight build under the version
 4. Click "Add for Review"
 
+### App Review Notes (Account Deletion)
+
+Include this screen recording checklist in App Store review notes for Guideline 5.1.1(v):
+
+- Sign in with a test account in the iOS app.
+- Open `Settings`.
+- Tap `Delete Account`.
+- In the first prompt, tap `Continue`.
+- In the final confirmation alert, tap `Delete Account`.
+- Show the app returning to the signed-out/auth screen.
+
 ## Troubleshooting
 
 **Build fails with signing error:** Verify the certificate hasn't expired and the provisioning profile includes the correct bundle ID (`com.brettonauerbach.stillpoint`).

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -5,6 +5,11 @@ struct SettingsView: View {
     let appVM: AppViewModel
     @State private var isPublic: Bool = false
     @State private var isUpdating = false
+    @State private var showDeleteAccountDialog = false
+    @State private var showDeleteAccountConfirm = false
+    @State private var isDeletingAccount = false
+    @State private var deleteAccountError = ""
+    @State private var showDeleteAccountError = false
 
     var body: some View {
         ScrollView {
@@ -108,6 +113,55 @@ struct SettingsView: View {
                         .clipShape(Capsule())
                         .overlay(Capsule().stroke(SPColor.dangerBorderSubtle))
                 }
+                .disabled(isDeletingAccount)
+
+                Button {
+                    showDeleteAccountDialog = true
+                } label: {
+                    Group {
+                        if isDeletingAccount {
+                            ProgressView()
+                                .tint(SPColor.dangerMuted)
+                        } else {
+                            Text("Delete Account")
+                                .font(SPFont.mono(14, weight: .medium))
+                                .foregroundStyle(SPColor.dangerMuted)
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, SPSpacing.s2)
+                    .background(SPColor.surface1)
+                    .clipShape(Capsule())
+                    .overlay(Capsule().stroke(SPColor.dangerBorderSubtle))
+                }
+                .disabled(isDeletingAccount)
+                .confirmationDialog(
+                    "Delete your account?",
+                    isPresented: $showDeleteAccountDialog,
+                    titleVisibility: .visible
+                ) {
+                    Button("Continue", role: .destructive) {
+                        showDeleteAccountConfirm = true
+                    }
+                    Button("Cancel", role: .cancel) {}
+                } message: {
+                    Text("This permanently deletes your account and data.")
+                }
+                .alert("Final confirmation", isPresented: $showDeleteAccountConfirm) {
+                    Button("Delete Account", role: .destructive) {
+                        Task {
+                            await deleteAccount()
+                        }
+                    }
+                    Button("Cancel", role: .cancel) {}
+                } message: {
+                    Text("This action cannot be undone.")
+                }
+                .alert("Could not delete account", isPresented: $showDeleteAccountError) {
+                    Button("OK", role: .cancel) {}
+                } message: {
+                    Text(deleteAccountError)
+                }
 
                 Spacer().frame(height: SPSpacing.s6)
             }
@@ -116,6 +170,23 @@ struct SettingsView: View {
         .stillPointBackground()
         .onAppear {
             isPublic = appVM.currentUser?.isPublic ?? false
+        }
+    }
+
+    private func deleteAccount() async {
+        guard !isDeletingAccount else { return }
+        isDeletingAccount = true
+        defer { isDeletingAccount = false }
+
+        do {
+            try await APIClient.shared.deleteAccount()
+            appVM.didLogout()
+        } catch let error as APIError {
+            deleteAccountError = error.message
+            showDeleteAccountError = true
+        } catch {
+            deleteAccountError = "Please try again."
+            showDeleteAccountError = true
         }
     }
 }

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -47,6 +47,10 @@ public actor APIClient {
         let _: [String: Bool] = try await post("/api/auth/logout", body: Optional<String>.none)
     }
 
+    public func deleteAccount() async throws {
+        let _: [String: Bool] = try await delete("/api/account")
+    }
+
     public func me() async throws -> UserDTO? {
         do {
             let response: UserResponse = try await get("/api/auth/me")
@@ -127,6 +131,14 @@ public actor APIClient {
         request.httpMethod = "PATCH"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONEncoder().encode(body)
+        return try await execute(request)
+    }
+
+    private func delete<T: Decodable>(_ path: String) async throws -> T {
+        let url = baseURL.appendingPathComponent(path)
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         return try await execute(request)
     }
 

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -135,14 +135,6 @@ public actor APIClient {
         return try await execute(request)
     }
 
-    private func delete<T: Decodable>(_ path: String) async throws -> T {
-        let url = baseURL.appendingPathComponent(path)
-        var request = URLRequest(url: url)
-        request.httpMethod = "DELETE"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        return try await execute(request)
-    }
-
     private func delete(_ path: String) async throws {
         let url = baseURL.appendingPathComponent(path)
         var request = URLRequest(url: url)

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -48,7 +48,8 @@ public actor APIClient {
     }
 
     public func deleteAccount() async throws {
-        let _: [String: Bool] = try await delete("/api/account")
+        try await delete("/api/account")
+        clearLocalSessionArtifacts()
     }
 
     public func me() async throws -> UserDTO? {
@@ -142,7 +143,21 @@ public actor APIClient {
         return try await execute(request)
     }
 
+    private func delete(_ path: String) async throws {
+        let url = baseURL.appendingPathComponent(path)
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        _ = try await executeRaw(request)
+    }
+
     private func execute<T: Decodable>(_ request: URLRequest) async throws -> T {
+        let (data, _) = try await executeRaw(request)
+        let decoder = JSONDecoder()
+        return try decoder.decode(T.self, from: data)
+    }
+
+    private func executeRaw(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
         let (data, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw APIError(status: 0, message: "Invalid response")
@@ -154,8 +169,21 @@ public actor APIClient {
                 message: errorBody?.error ?? "Request failed"
             )
         }
-        let decoder = JSONDecoder()
-        return try decoder.decode(T.self, from: data)
+        return (data, httpResponse)
+    }
+
+    private func clearLocalSessionArtifacts() {
+        let cookieStorage = session.configuration.httpCookieStorage ?? .shared
+        for cookie in cookieStorage.cookies ?? [] {
+            cookieStorage.deleteCookie(cookie)
+        }
+
+        let credentialStorage = URLCredentialStorage.shared
+        for (protectionSpace, credentialsByUser) in credentialStorage.allCredentials {
+            for credential in credentialsByUser.values {
+                credentialStorage.remove(credential, for: protectionSpace)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add native iOS account deletion entry point in `Settings` with strong two-step confirmation (`confirmationDialog` + final destructive alert) so deletion is initiated inside the app for App Review.
- Extend `APIClient` with `deleteAccount()` using `DELETE /api/account` and existing authenticated cookie session behavior, then route success through `appVM.didLogout()` to match logout state handling.
- Add App Store review-notes checklist in `ios/RELEASING.md` for the requested recording path: sign in -> Settings -> delete -> confirm -> done.

Closes #158
Refs #103
Refs #37

## Test plan
- [x] Build compiles for simulator:
  - `xcodebuild -project ios/StillPoint.xcodeproj -scheme StillPoint -destination 'generic/platform=iOS Simulator' build`
- [x] Simulator manual flow:
  - Sign in with a fresh test account
  - Open `Settings`
  - Tap `Delete Account`
  - Confirm `Continue` in the confirmation dialog
  - Confirm `Delete Account` in the final alert
  - Verify app returns to signed-out/auth screen
- [x] Verify existing logout still works from `Settings`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added account deletion: users can remove their account from Settings via a two-step confirmation flow, see a progress indicator during deletion, receive error notifications, and are signed out/returned to the auth screen when deletion completes.

* **Documentation**
  * Added App Store review notes describing the step-by-step account deletion verification steps for reviewers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->