### PR TITLE
chore(ios): bump build to 4 for App Store resubmit

### DIFF
--- a/ios/RELEASING.md
+++ b/ios/RELEASING.md
@@ -53,7 +53,9 @@ Before your first TestFlight release, configure a tester group and handle encryp
 
 - `MARKETING_VERSION` — the user-facing version (e.g., `1.0.0`, `1.1.0`)
 - `CURRENT_PROJECT_VERSION` — the build number, must increment with every upload (e.g., `1`, `2`, `3`)
-- Tag format: `ios-v{MARKETING_VERSION}` (e.g., `ios-v1.0.0`)
+- **Git tag** must match `ios-v*` to trigger [`.github/workflows/ios-testflight.yml`](../.github/workflows/ios-testflight.yml). The tag string does **not** have to equal `MARKETING_VERSION` — **only** `ios/project.yml` sets what Xcode uploads.
+- **First upload** for a marketing version: `git tag ios-v1.0.0 && git push origin ios-v1.0.0` (example).
+- **Another upload with the same `MARKETING_VERSION`:** Git tags cannot be reused. Use a **new** tag that still matches `ios-v*`, e.g. `git tag ios-v1.0.0-build4 && git push origin ios-v1.0.0-build4` after bumping `CURRENT_PROJECT_VERSION` in `project.yml`.
 
 ## Submitting to the App Store
 

--- a/ios/StillPoint.xcodeproj/project.pbxproj
+++ b/ios/StillPoint.xcodeproj/project.pbxproj
@@ -222,7 +222,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1500;
+				LastUpgradeCheck = 2600;
 				TargetAttributes = {
 					1EC3D1ED76F9038154716BEC = {
 						DevelopmentTeam = T5UU4BP6AV;
@@ -305,7 +305,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = T5UU4BP6AV;
 				INFOPLIST_FILE = StillPointApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -327,7 +327,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = T5UU4BP6AV;
 				INFOPLIST_FILE = StillPointApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/ios/StillPointApp/Info.plist
+++ b/ios/StillPointApp/Info.plist
@@ -17,9 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Fonts/Newsreader-Variable.ttf</string>

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -24,6 +24,8 @@ targets:
     info:
       path: StillPointApp/Info.plist
       properties:
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         UIAppFonts:
           - Fonts/Newsreader-Variable.ttf
           - Fonts/Newsreader-Italic-Variable.ttf
@@ -45,7 +47,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: 1
+        CURRENT_PROJECT_VERSION: 4
         DEVELOPMENT_TEAM: T5UU4BP6AV
         CODE_SIGN_STYLE: Automatic
         SWIFT_VERSION: "5.9"


### PR DESCRIPTION
## Summary
- Set `CURRENT_PROJECT_VERSION` to **4** and keep `MARKETING_VERSION` **1.0.0** for the **1.0 (4)** App Store Connect target from #103.
- Bind `CFBundleShortVersionString` / `CFBundleVersion` via **XcodeGen** `info.properties` so the generated `Info.plist` tracks `project.yml` (fixes hardcoded `1.0` / `1` drift).
- **RELEASING.md:** document unique `ios-v*` tags when re-uploading the same marketing version (e.g. `ios-v1.0.0-build4`).

## After merge (ops)
1. `git checkout main && git pull`
2. `git tag ios-v1.0.0-build4 && git push origin ios-v1.0.0-build4` — triggers [TestFlight upload workflow](https://github.com/auerbachb/still-point/blob/main/.github/workflows/ios-testflight.yml) (`ios-v*`).

## Links
- #103

Made with [Cursor](https://cursor.com)