### PR TITLE
fix(db): Neon HTTP driver for Vercel (signup/login/me 500)

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -2,7 +2,7 @@ import { loadEnvConfig } from "@next/env";
 import bcrypt from "bcryptjs";
 import { inArray } from "drizzle-orm";
 import type { NeonDatabase } from "drizzle-orm/neon-serverless";
-import { db } from "../src/db";
+import { poolDb } from "../src/db/pool";
 import * as schema from "../src/db/schema";
 import { friendships, sessions, thoughts, users } from "../src/db/schema";
 
@@ -68,7 +68,7 @@ async function main() {
 
   const seedEmails = seedUsers.map((user) => user.email);
 
-  await db.transaction(async (tx: AppDb) => {
+  await poolDb.transaction(async (tx: AppDb) => {
     const existing = await tx
       .select({ id: users.id })
       .from(users)

--- a/src/app/api/buddy/sessions/[id]/record-personal-session/route.ts
+++ b/src/app/api/buddy/sessions/[id]/record-personal-session/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
+import { poolDb } from "@/db/pool";
 import {
   buddySessionParticipants,
   buddySessions,
@@ -151,7 +152,7 @@ export async function POST(request: NextRequest, context: Params) {
     const participantCompletedAt = p!.participantCompletedAt ?? now;
 
     try {
-      const row = await db.transaction(async (tx) => {
+      const row = await poolDb.transaction(async (tx) => {
         const [u] = await tx
           .select({ currentDay: users.currentDay })
           .from(users)

--- a/src/app/api/friends/requests/[id]/route.ts
+++ b/src/app/api/friends/requests/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
+import { poolDb } from "@/db/pool";
 import { friendRequests, friendships } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
 import { orderedUserPair, isUuid } from "@/lib/friends";
@@ -94,7 +95,7 @@ export async function PATCH(request: NextRequest, context: Params) {
     // accept — single transaction so friendship is not orphaned if insert fails
     const [u1, u2] = orderedUserPair(row.fromUserId, row.toUserId);
 
-    const updated = await db.transaction(async (tx) => {
+    const updated = await poolDb.transaction(async (tx) => {
       const [u] = await tx
         .update(friendRequests)
         .set({ status: "accepted", updatedAt: new Date() })

--- a/src/app/api/thoughts/batch/route.ts
+++ b/src/app/api/thoughts/batch/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
+import { poolDb } from "@/db/pool";
 import { sessions, thoughts } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
 import { and, eq } from "drizzle-orm";
@@ -59,7 +60,7 @@ export async function POST(request: NextRequest) {
       ...(completionNote ? [completionNote] : []),
     ];
 
-    const inserted = await db.transaction(async (tx) => {
+    const inserted = await poolDb.transaction(async (tx) => {
       if (completionNote) {
         await tx
           .delete(thoughts)

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,41 +1,36 @@
-import { Pool, neonConfig } from "@neondatabase/serverless";
-import { drizzle, type NeonDatabase } from "drizzle-orm/neon-serverless";
-import ws from "ws";
+import { neon } from "@neondatabase/serverless";
+import { drizzle, type NeonHttpDatabase } from "drizzle-orm/neon-http";
 import * as schema from "./schema";
 
-neonConfig.webSocketConstructor = ws;
+type AppDb = NeonHttpDatabase<typeof schema>;
 
-type AppDb = NeonDatabase<typeof schema>;
-
-const globalForDb = globalThis as typeof globalThis & {
-  __drizzlePool?: Pool;
-  __drizzleDb?: AppDb;
+const globalForHttp = globalThis as typeof globalThis & {
+  __neonSql?: ReturnType<typeof neon>;
+  __httpDb?: AppDb;
 };
 
-function getPool(): Pool {
+function getSql() {
   const url = process.env.POSTGRES_URL;
   if (!url) {
     throw new Error("POSTGRES_URL is not set");
   }
-  if (!globalForDb.__drizzlePool) {
-    globalForDb.__drizzlePool = new Pool({
-      connectionString: url,
-      max: 5,
-      idleTimeoutMillis: 30_000,
-      connectionTimeoutMillis: 10_000,
-    });
+  if (!globalForHttp.__neonSql) {
+    globalForHttp.__neonSql = neon(url);
   }
-  return globalForDb.__drizzlePool;
+  return globalForHttp.__neonSql;
 }
 
 function getDb(): AppDb {
-  if (!globalForDb.__drizzleDb) {
-    globalForDb.__drizzleDb = drizzle(getPool(), { schema });
+  if (!globalForHttp.__httpDb) {
+    globalForHttp.__httpDb = drizzle(getSql(), { schema });
   }
-  return globalForDb.__drizzleDb;
+  return globalForHttp.__httpDb;
 }
 
-/** Neon serverless Pool (WebSocket) so `db.transaction()` works — not `neon-http`. */
+/**
+ * Neon **HTTP** driver — avoids WebSocket pool hangs on Vercel / Next.js 15 serverless.
+ * For `transaction()`, import `poolDb` from `@/db/pool` instead.
+ */
 export const db = new Proxy({} as AppDb, {
   get(_, prop) {
     return (getDb() as unknown as Record<string | symbol, unknown>)[prop as string];

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,0 +1,47 @@
+import { Pool, neonConfig } from "@neondatabase/serverless";
+import { drizzle, type NeonDatabase } from "drizzle-orm/neon-serverless";
+import ws from "ws";
+import * as schema from "./schema";
+
+neonConfig.webSocketConstructor = ws;
+
+export type PoolDb = NeonDatabase<typeof schema>;
+
+const globalForPool = globalThis as typeof globalThis & {
+  __drizzlePool?: Pool;
+  __poolDb?: PoolDb;
+};
+
+function getPool(): Pool {
+  const url = process.env.POSTGRES_URL;
+  if (!url) {
+    throw new Error("POSTGRES_URL is not set");
+  }
+  if (!globalForPool.__drizzlePool) {
+    globalForPool.__drizzlePool = new Pool({
+      connectionString: url,
+      max: 5,
+      idleTimeoutMillis: 30_000,
+      connectionTimeoutMillis: 10_000,
+    });
+  }
+  return globalForPool.__drizzlePool;
+}
+
+function getPoolDb(): PoolDb {
+  if (!globalForPool.__poolDb) {
+    globalForPool.__poolDb = drizzle(getPool(), { schema });
+  }
+  return globalForPool.__poolDb;
+}
+
+/**
+ * WebSocket-backed Drizzle client — use **only** for `db.transaction()` (Neon HTTP
+ * driver does not support interactive transactions). All other routes should use
+ * `@/db` (HTTP) for reliable connections on Vercel serverless.
+ */
+export const poolDb = new Proxy({} as PoolDb, {
+  get(_, prop) {
+    return (getPoolDb() as unknown as Record<string | symbol, unknown>)[prop as string];
+  },
+});

--- a/src/lib/accountDeletion.ts
+++ b/src/lib/accountDeletion.ts
@@ -18,9 +18,6 @@ import { users } from "@/db/schema";
  * `buddy_session_id` cleared.
  */
 export async function deleteUserAccount(userId: string): Promise<boolean> {
-  const removed = await db.transaction(async (tx) => {
-    const rows = await tx.delete(users).where(eq(users.id, userId)).returning({ id: users.id });
-    return rows.length > 0;
-  });
-  return removed;
+  const rows = await db.delete(users).where(eq(users.id, userId)).returning({ id: users.id });
+  return rows.length > 0;
 }


### PR DESCRIPTION
## Problem
Production `/api/auth/signup`, `/api/auth/login`, and authenticated `/api/auth/me` returned **500** after long hangs (~15s). Reproducible with `curl` against still-point.me.

## Cause
`@neondatabase/serverless` **WebSocket `Pool`** + Drizzle `neon-serverless` is unreliable on **Vercel serverless / Next.js 15** (known class of issues: WS connect stalls/timeouts).

## Fix
- Default **`db`** (`src/db/index.ts`): `neon(POSTGRES_URL)` + **`drizzle-orm/neon-http`** (stateless HTTP).
- **`poolDb`** (`src/db/pool.ts`): keep the existing Pool + `neon-serverless` **only** for code paths that call **`transaction()`**.
- **Account deletion**: single `DELETE` is already atomic with cascades — removed unnecessary transaction.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [ ] After deploy: `curl` signup + login smoke against production


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database connection strategy to enhance transaction reliability and system performance across multi-step operations.
  * Updated database infrastructure for improved consistency in critical operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->