### PR TITLE
feat(home): optional YouTube embed for landing (#166)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ DAILY_API_KEY=
 
 # Optional: set to exactly "true" to require friendship before buddy join (see README)
 # BUDDY_REQUIRE_FRIENDSHIP=
+
+# Optional: YouTube video id (11 characters) for homepage demo embed (#166). Unset or empty = no block shown.
+# STILLPOINT_HOMEPAGE_YOUTUBE_VIDEO_ID=

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Third-party keys in use today:
 | Service | Variable | Used for |
 |---------|----------|----------|
 | Daily.co | `DAILY_API_KEY` | Create/delete rooms, issue meeting tokens for buddy video (`src/lib/daily.ts`, `src/app/api/buddy/sessions/[id]/start`, `…/meeting-token`). |
+| YouTube (optional) | `STILLPOINT_HOMEPAGE_YOUTUBE_VIDEO_ID` | **Marketing only:** 11-character video id for the landing-page demo embed. Unset or empty → no embed (#166). |
 
 ### `vercel.json`
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { HomepageDemoVideo } from "@/components/HomepageDemoVideo";
 
 export default function LandingPage() {
   return (
@@ -77,6 +78,7 @@ export default function LandingPage() {
         >
           Still Point is a meditation timer for people struggling to get started and stay consistent: it begins at one minute, adds ten seconds per day, and shows time as boxes that fill up as you go to make sitting still easier.
         </p>
+        <HomepageDemoVideo />
         <div
           style={{
             display: "flex",

--- a/src/components/HomepageDemoVideo.tsx
+++ b/src/components/HomepageDemoVideo.tsx
@@ -1,0 +1,47 @@
+/**
+ * Optional homepage embed: set `STILLPOINT_HOMEPAGE_YOUTUBE_VIDEO_ID` to an
+ * 11-character YouTube video id. Unset, empty, or invalid id → renders nothing
+ * (scaffolding only until the asset exists).
+ */
+const YOUTUBE_VIDEO_ID = /^[a-zA-Z0-9_-]{11}$/;
+
+export function HomepageDemoVideo() {
+  const raw = process.env.STILLPOINT_HOMEPAGE_YOUTUBE_VIDEO_ID?.trim();
+  if (!raw || !YOUTUBE_VIDEO_ID.test(raw)) {
+    return null;
+  }
+
+  const src = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(raw)}?rel=0`;
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        maxWidth: "min(100%, 720px)",
+        margin: "0 auto",
+        borderRadius: "12px",
+        overflow: "hidden",
+        border: "1px solid var(--border-2)",
+        position: "relative",
+        aspectRatio: "16 / 9",
+        background: "var(--surface-1)",
+      }}
+    >
+      <iframe
+        title="How Still Point works"
+        src={src}
+        loading="lazy"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allowFullScreen
+        referrerPolicy="strict-origin-when-cross-origin"
+        style={{
+          position: "absolute",
+          inset: 0,
+          width: "100%",
+          height: "100%",
+          border: "none",
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Refs #166 (phase 1 scaffolding).

- `HomepageDemoVideo` server component: `youtube-nocookie` embed when `STILLPOINT_HOMEPAGE_YOUTUBE_VIDEO_ID` is a valid 11-char id; otherwise renders nothing.
- Wired into `src/app/page.tsx` between hero copy and CTAs.
- Documented in `.env.example` and README env matrix.

Issue #166 stays open until YouTube asset is set in Vercel and Phase 2 checklist is done (or we split a follow-up issue).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional YouTube demo video embed now available on the homepage below the introduction. Configurable via environment variable; leave unset to disable video display.

* **Documentation**
  * Added configuration documentation for the new YouTube video embed feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->