### PR TITLE
feat(timer): add MM:SS visibility toggle

### DIFF
--- a/src/components/BlockTimer.tsx
+++ b/src/components/BlockTimer.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import { BLOCK_DURATION } from "@/lib/constants";
 import { MindStateBar } from "./MindStateBar";
 import { playTick, playChime, playCompletion, type SoundPrefs } from "@/lib/audio";
+import { loadDisplayPrefs, saveDisplayPrefs } from "@/lib/displayPrefs";
 import { useIsMobile } from "@/lib/useIsMobile";
 
 type BlockTimerProps = {
@@ -65,6 +66,8 @@ export function BlockTimer({
   const isMobile = useIsMobile();
   const isBuddySync = Boolean(syncClock?.startedAt && syncClock?.serverNow);
   const isControlled = controlledElapsed !== undefined && !isBuddySync;
+  const [showTimer, setShowTimer] = useState(true);
+  const [hasLoadedDisplayPrefs, setHasLoadedDisplayPrefs] = useState(false);
   const blockSize = isMobile ? 56 : 75;
   const blockLabelSize = isMobile ? 13 : 17;
 
@@ -111,6 +114,17 @@ export function BlockTimer({
     if (!syncClock?.startedAt || !syncClock?.serverNow) return;
     skewRef.current = new Date(syncClock.serverNow).getTime() - Date.now();
   }, [syncClock?.startedAt, syncClock?.serverNow]);
+
+  useEffect(() => {
+    const prefs = loadDisplayPrefs();
+    setShowTimer(prefs.showTimer);
+    setHasLoadedDisplayPrefs(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hasLoadedDisplayPrefs) return;
+    saveDisplayPrefs({ showTimer });
+  }, [showTimer, hasLoadedDisplayPrefs]);
 
   useEffect(() => {
     if (isControlled || isBuddySync) return;
@@ -378,14 +392,58 @@ export function BlockTimer({
 
   return (
     <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "32px" }}>
-      <div style={{
-        fontFamily: "var(--font-jetbrains), 'JetBrains Mono', 'SF Mono', monospace",
-        fontSize: "min(120px, 18vw)", fontWeight: 200, letterSpacing: "0.05em",
-        color: elapsed >= totalSeconds ? "var(--accent-green)" : "var(--fg)",
-        textShadow: elapsed >= totalSeconds ? "0 0 40px var(--accent-green-glow)" : "none",
-        transition: "color 0.8s, text-shadow 0.8s",
-      }}>
-        {minutes}:{seconds.toString().padStart(2, "0")}
+      <div
+        style={{
+          width: "min(560px, calc(100vw - 24px))",
+          position: "relative",
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        <div
+          aria-hidden={!showTimer}
+          style={{
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', 'SF Mono', monospace",
+            fontSize: "min(120px, 18vw)",
+            fontWeight: 200,
+            letterSpacing: "0.05em",
+            color: elapsed >= totalSeconds ? "var(--accent-green)" : "var(--fg)",
+            textShadow: elapsed >= totalSeconds ? "0 0 40px var(--accent-green-glow)" : "none",
+            transition: "color 0.8s, text-shadow 0.8s, opacity 0.25s ease",
+            opacity: showTimer ? 1 : 0,
+            minHeight: "1em",
+            userSelect: "none",
+          }}
+        >
+          {minutes}:{seconds.toString().padStart(2, "0")}
+        </div>
+        <button
+          type="button"
+          aria-pressed={showTimer}
+          aria-label={showTimer ? "Hide numerical timer" : "Show numerical timer"}
+          onClick={() => setShowTimer(prev => !prev)}
+          style={{
+            position: "absolute",
+            right: 0,
+            top: "50%",
+            transform: "translateY(-50%)",
+            border: "1px solid var(--border-2)",
+            background: "var(--surface-1)",
+            color: "var(--fg-3)",
+            borderRadius: "999px",
+            cursor: "pointer",
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+            fontSize: "11px",
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            padding: "8px 12px",
+            transition: "opacity 0.2s, border-color 0.2s, color 0.2s",
+            opacity: showTimer ? 0.9 : 1,
+          }}
+        >
+          {showTimer ? "hide" : "show"}
+        </button>
       </div>
 
       {/* 60-second progress bar */}

--- a/src/components/BlockTimer.tsx
+++ b/src/components/BlockTimer.tsx
@@ -66,8 +66,7 @@ export function BlockTimer({
   const isMobile = useIsMobile();
   const isBuddySync = Boolean(syncClock?.startedAt && syncClock?.serverNow);
   const isControlled = controlledElapsed !== undefined && !isBuddySync;
-  const [showTimer, setShowTimer] = useState(true);
-  const [hasLoadedDisplayPrefs, setHasLoadedDisplayPrefs] = useState(false);
+  const [showTimer, setShowTimer] = useState(() => loadDisplayPrefs().showTimer);
   const blockSize = isMobile ? 56 : 75;
   const blockLabelSize = isMobile ? 13 : 17;
 
@@ -116,15 +115,8 @@ export function BlockTimer({
   }, [syncClock?.startedAt, syncClock?.serverNow]);
 
   useEffect(() => {
-    const prefs = loadDisplayPrefs();
-    setShowTimer(prefs.showTimer);
-    setHasLoadedDisplayPrefs(true);
-  }, []);
-
-  useEffect(() => {
-    if (!hasLoadedDisplayPrefs) return;
     saveDisplayPrefs({ showTimer });
-  }, [showTimer, hasLoadedDisplayPrefs]);
+  }, [showTimer]);
 
   useEffect(() => {
     if (isControlled || isBuddySync) return;

--- a/src/lib/displayPrefs.ts
+++ b/src/lib/displayPrefs.ts
@@ -1,0 +1,26 @@
+export type DisplayPrefs = {
+  showTimer: boolean;
+};
+
+const STORAGE_KEY = "stillpoint_display_prefs";
+
+const DEFAULTS: DisplayPrefs = {
+  showTimer: true,
+};
+
+export function loadDisplayPrefs(): DisplayPrefs {
+  if (typeof window === "undefined") return DEFAULTS;
+
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULTS;
+    return { ...DEFAULTS, ...JSON.parse(raw) };
+  } catch {
+    return DEFAULTS;
+  }
+}
+
+export function saveDisplayPrefs(prefs: DisplayPrefs) {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+}

--- a/src/lib/displayPrefs.ts
+++ b/src/lib/displayPrefs.ts
@@ -20,7 +20,11 @@ export function loadDisplayPrefs(): DisplayPrefs {
   }
 }
 
-export function saveDisplayPrefs(prefs: DisplayPrefs) {
+export function saveDisplayPrefs(prefs: DisplayPrefs): void {
   if (typeof window === "undefined") return;
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+  } catch {
+    // Best-effort persistence: ignore storage write failures.
+  }
 }


### PR DESCRIPTION
## Summary
- Add persisted display preferences via `src/lib/displayPrefs.ts` with SSR-safe `loadDisplayPrefs`/`saveDisplayPrefs` using `stillpoint_display_prefs`.
- Add a hide/show control in `BlockTimer` with `aria-pressed` and descriptive `aria-label` so users can toggle MM:SS visibility without stopping the sit.
- Keep timer layout stable while hidden by using opacity transitions instead of removing the element from layout.

Closes #135

## Test plan
- [x] `npm run build`
- [x] Start a solo session, toggle MM:SS hide/show, and confirm session continues uninterrupted
- [x] Reload the page and verify MM:SS visibility preference persists on this device
- [x] Join a buddy session and verify the same MM:SS toggle behavior works there too
- [x] Confirm toggling MM:SS does not cause awkward layout jump (only minimal fade)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a toggle button to show or hide the numerical timer in the UI.
  * Timer visibility preferences are saved and automatically restored between sessions.
  * The toggle updates accessibility attributes so screen readers reflect the timer state without changing existing timer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->