### PR TITLE
chore(git): ignore Apple private key files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ ios/StillPointShared/build/
 
 # Nested agent worktrees (gitlinks); keep out of the app repo
 .claude/worktrees/
+
+# Auth Keys
+*.p8


### PR DESCRIPTION
## Summary
- add a repo-level `.gitignore` rule for `*.p8`
- prevent accidental commits of local Apple auth/signing keys

## Test plan
- [x] Confirm `.gitignore` contains `*.p8`
- [x] Confirm branch diff vs `main` only changes `.gitignore`
- [ ] Verify locally that an `AuthKey_*.p8` file at repo root is not shown by `git status`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated repository configuration for file management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->