### PR TITLE
chore(git): ignore local .worktrees directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ ios/StillPointShared/build/
 
 # Nested agent worktrees (gitlinks); keep out of the app repo
 .claude/worktrees/
+.worktrees/
 
 # Auth Keys
 *.p8


### PR DESCRIPTION
## Summary
- add `.worktrees/` to `.gitignore`
- keep local nested worktree checkouts out of git status noise

## Test plan
- [x] Confirm `.gitignore` contains `.worktrees/`
- [x] Confirm PR diff only changes `.gitignore`
- [ ] Verify local root checkout no longer reports `.worktrees/` as untracked after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration files.

---

**Note:** This release contains no user-visible changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->