### PR TITLE
fix(auth): restore iOS note save/reload reliability

### DIFF
--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -33,8 +33,10 @@ public actor APIClient {
     public func signup(email: String, username: String, password: String) async throws -> UserDTO {
         let body: [String: String] = ["email": email, "username": username, "password": password]
         let response: UserResponse = try await post("/api/auth/signup", body: body)
-        if let token = response.token {
+        if let token = response.token, !token.isEmpty {
             AuthTokenStore.save(token)
+        } else {
+            AuthTokenStore.clear()
         }
         return response.user
     }
@@ -43,15 +45,17 @@ public actor APIClient {
         // Web app sends username too but only uses email+password for login
         let body: [String: String] = ["email": email, "username": "", "password": password]
         let response: UserResponse = try await post("/api/auth/login", body: body)
-        if let token = response.token {
+        if let token = response.token, !token.isEmpty {
             AuthTokenStore.save(token)
+        } else {
+            AuthTokenStore.clear()
         }
         return response.user
     }
 
     public func logout() async throws {
+        defer { clearLocalSessionArtifacts() }
         let _: [String: Bool] = try await post("/api/auth/logout", body: Optional<String>.none)
-        AuthTokenStore.clear()
     }
 
     public func deleteAccount() async throws {
@@ -119,6 +123,7 @@ public actor APIClient {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("ios", forHTTPHeaderField: "X-Still-Point-Client")
         applyAuthorizationHeader(to: &request)
         return try await execute(request)
     }
@@ -128,6 +133,7 @@ public actor APIClient {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("ios", forHTTPHeaderField: "X-Still-Point-Client")
         applyAuthorizationHeader(to: &request)
         if let body {
             request.httpBody = try JSONEncoder().encode(body)
@@ -140,6 +146,7 @@ public actor APIClient {
         var request = URLRequest(url: url)
         request.httpMethod = "PATCH"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("ios", forHTTPHeaderField: "X-Still-Point-Client")
         applyAuthorizationHeader(to: &request)
         request.httpBody = try JSONEncoder().encode(body)
         return try await execute(request)
@@ -150,6 +157,7 @@ public actor APIClient {
         var request = URLRequest(url: url)
         request.httpMethod = "DELETE"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("ios", forHTTPHeaderField: "X-Still-Point-Client")
         applyAuthorizationHeader(to: &request)
         _ = try await executeRaw(request)
     }

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -34,9 +34,11 @@ public actor APIClient {
         let body: [String: String] = ["email": email, "username": username, "password": password]
         let response: UserResponse = try await post("/api/auth/signup", body: body)
         if let token = response.token, !token.isEmpty {
-            AuthTokenStore.save(token)
+            guard AuthTokenStore.save(token) else {
+                throw APIError(status: 0, message: "Unable to securely save auth token")
+            }
         } else {
-            AuthTokenStore.clear()
+            _ = AuthTokenStore.clear()
         }
         return response.user
     }
@@ -46,9 +48,11 @@ public actor APIClient {
         let body: [String: String] = ["email": email, "username": "", "password": password]
         let response: UserResponse = try await post("/api/auth/login", body: body)
         if let token = response.token, !token.isEmpty {
-            AuthTokenStore.save(token)
+            guard AuthTokenStore.save(token) else {
+                throw APIError(status: 0, message: "Unable to securely save auth token")
+            }
         } else {
-            AuthTokenStore.clear()
+            _ = AuthTokenStore.clear()
         }
         return response.user
     }
@@ -119,22 +123,12 @@ public actor APIClient {
     // MARK: - HTTP Helpers
 
     private func get<T: Decodable>(_ path: String) async throws -> T {
-        let url = baseURL.appendingPathComponent(path)
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("ios", forHTTPHeaderField: "X-Still-Point-Client")
-        applyAuthorizationHeader(to: &request)
+        let request = makeRequest(method: "GET", path: path)
         return try await execute(request)
     }
 
     private func post<T: Decodable, B: Encodable>(_ path: String, body: B?) async throws -> T {
-        let url = baseURL.appendingPathComponent(path)
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("ios", forHTTPHeaderField: "X-Still-Point-Client")
-        applyAuthorizationHeader(to: &request)
+        var request = makeRequest(method: "POST", path: path)
         if let body {
             request.httpBody = try JSONEncoder().encode(body)
         }
@@ -142,23 +136,13 @@ public actor APIClient {
     }
 
     private func patch<T: Decodable, B: Encodable>(_ path: String, body: B) async throws -> T {
-        let url = baseURL.appendingPathComponent(path)
-        var request = URLRequest(url: url)
-        request.httpMethod = "PATCH"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("ios", forHTTPHeaderField: "X-Still-Point-Client")
-        applyAuthorizationHeader(to: &request)
+        var request = makeRequest(method: "PATCH", path: path)
         request.httpBody = try JSONEncoder().encode(body)
         return try await execute(request)
     }
 
     private func delete(_ path: String) async throws {
-        let url = baseURL.appendingPathComponent(path)
-        var request = URLRequest(url: url)
-        request.httpMethod = "DELETE"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("ios", forHTTPHeaderField: "X-Still-Point-Client")
-        applyAuthorizationHeader(to: &request)
+        let request = makeRequest(method: "DELETE", path: path)
         _ = try await executeRaw(request)
     }
 
@@ -184,7 +168,7 @@ public actor APIClient {
     }
 
     private func clearLocalSessionArtifacts() {
-        AuthTokenStore.clear()
+        _ = AuthTokenStore.clear()
 
         let cookieStorage = session.configuration.httpCookieStorage ?? .shared
         for cookie in cookieStorage.cookies ?? [] {
@@ -202,6 +186,16 @@ public actor APIClient {
     private func applyAuthorizationHeader(to request: inout URLRequest) {
         guard let token = AuthTokenStore.load(), !token.isEmpty else { return }
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    }
+
+    private func makeRequest(method: String, path: String) -> URLRequest {
+        let url = baseURL.appendingPathComponent(path)
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("ios", forHTTPHeaderField: "X-Still-Point-Client")
+        applyAuthorizationHeader(to: &request)
+        return request
     }
 }
 

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Network client for the Still Point web API.
-/// Uses cookie-based auth (sp_token) matching the web app.
+/// Uses cookie auth where available and bearer token auth for native reliability.
 public actor APIClient {
     public static let shared = APIClient()
 
@@ -33,6 +33,9 @@ public actor APIClient {
     public func signup(email: String, username: String, password: String) async throws -> UserDTO {
         let body: [String: String] = ["email": email, "username": username, "password": password]
         let response: UserResponse = try await post("/api/auth/signup", body: body)
+        if let token = response.token {
+            AuthTokenStore.save(token)
+        }
         return response.user
     }
 
@@ -40,11 +43,15 @@ public actor APIClient {
         // Web app sends username too but only uses email+password for login
         let body: [String: String] = ["email": email, "username": "", "password": password]
         let response: UserResponse = try await post("/api/auth/login", body: body)
+        if let token = response.token {
+            AuthTokenStore.save(token)
+        }
         return response.user
     }
 
     public func logout() async throws {
         let _: [String: Bool] = try await post("/api/auth/logout", body: Optional<String>.none)
+        AuthTokenStore.clear()
     }
 
     public func deleteAccount() async throws {
@@ -112,6 +119,7 @@ public actor APIClient {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuthorizationHeader(to: &request)
         return try await execute(request)
     }
 
@@ -120,6 +128,7 @@ public actor APIClient {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuthorizationHeader(to: &request)
         if let body {
             request.httpBody = try JSONEncoder().encode(body)
         }
@@ -131,6 +140,7 @@ public actor APIClient {
         var request = URLRequest(url: url)
         request.httpMethod = "PATCH"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuthorizationHeader(to: &request)
         request.httpBody = try JSONEncoder().encode(body)
         return try await execute(request)
     }
@@ -140,6 +150,7 @@ public actor APIClient {
         var request = URLRequest(url: url)
         request.httpMethod = "DELETE"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuthorizationHeader(to: &request)
         _ = try await executeRaw(request)
     }
 
@@ -165,6 +176,8 @@ public actor APIClient {
     }
 
     private func clearLocalSessionArtifacts() {
+        AuthTokenStore.clear()
+
         let cookieStorage = session.configuration.httpCookieStorage ?? .shared
         for cookie in cookieStorage.cookies ?? [] {
             cookieStorage.deleteCookie(cookie)
@@ -176,6 +189,11 @@ public actor APIClient {
                 credentialStorage.remove(credential, for: protectionSpace)
             }
         }
+    }
+
+    private func applyAuthorizationHeader(to request: inout URLRequest) {
+        guard let token = AuthTokenStore.load(), !token.isEmpty else { return }
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
     }
 }
 

--- a/ios/StillPointShared/Sources/StillPointShared/AuthTokenStore.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AuthTokenStore.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Security
+
+enum AuthTokenStore {
+    private static let account = "sp-auth-token"
+    private static let service = "still-point.auth"
+
+    static func save(_ token: String) {
+        let data = Data(token.utf8)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+
+        SecItemDelete(query as CFDictionary)
+
+        var attributes = query
+        attributes[kSecValueData as String] = data
+        SecItemAdd(attributes as CFDictionary, nil)
+    }
+
+    static func load() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnData as String: true,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let token = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        return token
+    }
+
+    static func clear() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/AuthTokenStore.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AuthTokenStore.swift
@@ -5,7 +5,8 @@ enum AuthTokenStore {
     private static let account = "sp-auth-token"
     private static let service = "still-point.auth"
 
-    static func save(_ token: String) {
+    @discardableResult
+    static func save(_ token: String) -> Bool {
         let data = Data(token.utf8)
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -16,6 +17,7 @@ enum AuthTokenStore {
         let deleteStatus = SecItemDelete(query as CFDictionary)
         if deleteStatus != errSecSuccess && deleteStatus != errSecItemNotFound {
             logKeychainFailure(operation: "delete-before-save", status: deleteStatus)
+            return false
         }
 
         var attributes = query
@@ -25,7 +27,9 @@ enum AuthTokenStore {
         let addStatus = SecItemAdd(attributes as CFDictionary, nil)
         if addStatus != errSecSuccess {
             logKeychainFailure(operation: "save", status: addStatus)
+            return false
         }
+        return true
     }
 
     static func load() -> String? {
@@ -54,7 +58,8 @@ enum AuthTokenStore {
         return token
     }
 
-    static func clear() {
+    @discardableResult
+    static func clear() -> Bool {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
@@ -63,7 +68,9 @@ enum AuthTokenStore {
         let status = SecItemDelete(query as CFDictionary)
         if status != errSecSuccess && status != errSecItemNotFound {
             logKeychainFailure(operation: "clear", status: status)
+            return false
         }
+        return true
     }
 
     private static func logKeychainFailure(operation: String, status: OSStatus) {

--- a/ios/StillPointShared/Sources/StillPointShared/AuthTokenStore.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AuthTokenStore.swift
@@ -13,11 +13,19 @@ enum AuthTokenStore {
             kSecAttrAccount as String: account,
         ]
 
-        SecItemDelete(query as CFDictionary)
+        let deleteStatus = SecItemDelete(query as CFDictionary)
+        if deleteStatus != errSecSuccess && deleteStatus != errSecItemNotFound {
+            logKeychainFailure(operation: "delete-before-save", status: deleteStatus)
+        }
 
         var attributes = query
         attributes[kSecValueData as String] = data
-        SecItemAdd(attributes as CFDictionary, nil)
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+
+        let addStatus = SecItemAdd(attributes as CFDictionary, nil)
+        if addStatus != errSecSuccess {
+            logKeychainFailure(operation: "save", status: addStatus)
+        }
     }
 
     static func load() -> String? {
@@ -31,6 +39,11 @@ enum AuthTokenStore {
 
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        if status != errSecSuccess && status != errSecItemNotFound {
+            logKeychainFailure(operation: "load", status: status)
+            return nil
+        }
 
         guard status == errSecSuccess,
               let data = result as? Data,
@@ -47,6 +60,14 @@ enum AuthTokenStore {
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
         ]
-        SecItemDelete(query as CFDictionary)
+        let status = SecItemDelete(query as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            logKeychainFailure(operation: "clear", status: status)
+        }
+    }
+
+    private static func logKeychainFailure(operation: String, status: OSStatus) {
+        let message = SecCopyErrorMessageString(status, nil) as String? ?? "Unknown Keychain error"
+        print("AuthTokenStore \(operation) failed (\(status)): \(message)")
     }
 }

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -99,6 +99,7 @@ public struct BatchThoughtsRequest: Codable, Sendable {
 
 public struct UserResponse: Codable, Sendable {
     public let user: UserDTO
+    public let token: String?
 }
 
 public struct SessionResponse: Codable, Sendable {

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -6,6 +6,7 @@ import { eq } from "drizzle-orm";
 
 export async function POST(request: NextRequest) {
   try {
+    const includeToken = request.headers.get("x-still-point-client") === "ios";
     const body = await request.json();
     const email = typeof body?.email === "string" ? body.email.trim().toLowerCase() : "";
     const password = typeof body?.password === "string" ? body.password : "";
@@ -35,7 +36,7 @@ export async function POST(request: NextRequest) {
         isPublic: user.isPublic,
         currentDay: user.currentDay,
       },
-      token,
+      ...(includeToken ? { token } : {}),
     });
   } catch (error) {
     console.error("Login error:", error);

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -35,6 +35,7 @@ export async function POST(request: NextRequest) {
         isPublic: user.isPublic,
         currentDay: user.currentDay,
       },
+      token,
     });
   } catch (error) {
     console.error("Login error:", error);

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -54,6 +54,7 @@ export async function POST(request: NextRequest) {
         isPublic: newUser.isPublic,
         currentDay: newUser.currentDay,
       },
+      token,
     });
   } catch (error) {
     console.error("Signup error:", error);

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -6,6 +6,7 @@ import { eq } from "drizzle-orm";
 
 export async function POST(request: NextRequest) {
   try {
+    const includeToken = request.headers.get("x-still-point-client") === "ios";
     const { email, username, password } = await request.json();
 
     if (!email || !username || !password) {
@@ -54,7 +55,7 @@ export async function POST(request: NextRequest) {
         isPublic: newUser.isPublic,
         currentDay: newUser.currentDay,
       },
-      token,
+      ...(includeToken ? { token } : {}),
     });
   } catch (error) {
     console.error("Signup error:", error);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -58,7 +58,7 @@ export async function getCurrentUser(): Promise<{ userId: string; email: string 
   const authorization = (await headers()).get("authorization");
   const tokenFromBearer =
     authorization?.startsWith("Bearer ") ? authorization.slice("Bearer ".length).trim() : null;
-  const token = tokenFromCookie ?? tokenFromBearer;
+  const token = tokenFromBearer ?? tokenFromCookie;
   if (!token) return null;
   return verifyToken(token);
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import { SignJWT, jwtVerify } from "jose";
 import bcrypt from "bcryptjs";
 import { cookies } from "next/headers";
+import { headers } from "next/headers";
 
 const COOKIE_NAME = "sp_token";
 
@@ -53,7 +54,11 @@ export async function clearAuthCookie() {
 
 export async function getCurrentUser(): Promise<{ userId: string; email: string } | null> {
   const cookieStore = await cookies();
-  const token = cookieStore.get(COOKIE_NAME)?.value;
+  const tokenFromCookie = cookieStore.get(COOKIE_NAME)?.value;
+  const authorization = (await headers()).get("authorization");
+  const tokenFromBearer =
+    authorization?.startsWith("Bearer ") ? authorization.slice("Bearer ".length).trim() : null;
+  const token = tokenFromCookie ?? tokenFromBearer;
   if (!token) return null;
   return verifyToken(token);
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -29,7 +29,12 @@ export async function middleware(request: NextRequest) {
   }
 
   // Protected routes need valid JWT
-  const token = request.cookies.get(COOKIE_NAME)?.value;
+  const tokenFromCookie = request.cookies.get(COOKIE_NAME)?.value;
+  const authorization = request.headers.get("authorization");
+  const tokenFromBearer = authorization?.startsWith("Bearer ")
+    ? authorization.slice("Bearer ".length).trim()
+    : null;
+  const token = tokenFromCookie ?? tokenFromBearer;
   if (!token) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -34,7 +34,7 @@ export async function middleware(request: NextRequest) {
   const tokenFromBearer = authorization?.startsWith("Bearer ")
     ? authorization.slice("Bearer ".length).trim()
     : null;
-  const token = tokenFromCookie ?? tokenFromBearer;
+  const token = tokenFromBearer ?? tokenFromCookie;
   if (!token) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }


### PR DESCRIPTION
## Summary
- add bearer-token fallback auth on backend (`middleware` and `getCurrentUser`) so authenticated API calls from native iOS do not depend on cookie behavior
- return `token` in login/signup responses and store it in iOS Keychain; send `Authorization: Bearer` on all iOS API requests
- keep cookie auth fully compatible and clear local token state on logout/account deletion

Closes #171. Related to #60 (same symptom class: iOS note save failures tied to auth/response expectations).

## Done Definition (AC)
- notes save successfully on iOS device and still appear after app relaunch/login restoration
- buddy path is not in current iOS app flow (web-only), so this PR scopes to solo iOS note/session endpoints

## Test plan
- [x] `npm run build`
- [x] `xcodebuild -project ios/StillPoint.xcodeproj -scheme StillPoint -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO`
- [ ] On iOS device: log in, complete solo session, save end note, relaunch app, verify note appears in Thought Journal
- [ ] On iOS device: capture mid-session thought, complete session, relaunch app, verify both thought and end note persist

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS app now persists and clears bearer tokens locally and includes a client identifier in requests.
  * Auth endpoints will return tokens to iOS clients on signup/login to enable bearer-based flows.

* **Behavior Changes**
  * Server and middleware now accept and preferentially use bearer tokens (Authorization: Bearer ...) in addition to cookies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->