### PR TITLE
fix completion tomorrow preview progression for buddy sessions

### DIFF
--- a/src/components/CompletionScreen.tsx
+++ b/src/components/CompletionScreen.tsx
@@ -15,7 +15,7 @@ type CompletionScreenProps = {
 
 export function CompletionScreen({
   dayNumber,
-  duration,
+  duration: completedDuration,
   clearPercent,
   thoughtCount,
   thoughts,
@@ -26,7 +26,8 @@ export function CompletionScreen({
   const [noteSaved, setNoteSaved] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState(false);
-  const nextDuration = duration + INCREMENT;
+  // Progression is based on the user's completed day, not the just-finished sit length.
+  const nextDuration = BASE_DURATION + dayNumber * INCREMENT;
   const nextBlocks = Math.ceil(nextDuration / BLOCK_DURATION);
 
   return (
@@ -49,7 +50,7 @@ export function CompletionScreen({
           fontSize: "13px", color: "var(--accent-green-text)",
           marginTop: "var(--s2)", letterSpacing: "0.07em",
         }}>
-          {duration} seconds of sustained attention
+          {completedDuration} seconds of sustained attention
         </p>
 
         <div style={{


### PR DESCRIPTION
## Summary
- Fix `CompletionScreen` tomorrow preview to use day-based progression (`BASE_DURATION + dayNumber * INCREMENT`) instead of `duration + INCREMENT`.
- Keep completed sit copy accurate by renaming the local prop alias to `completedDuration` and adding a comment to avoid confusing session duration with progression base.
- This resolves issue #132 where buddy completion could show an incorrect tomorrow line when the completed `duration` differs from the viewer's canonical day duration.

Closes #132.

## Test plan
- [x] Run `npm run build`
- [x] Verify logic alignment with `HomeView` progression formula (`BASE_DURATION + (currentDay - 1) * INCREMENT`)
- [x] Confirm solo regression path remains correct (tomorrow computed from completed day progression)
- [x] Confirm buddy regression scenario is fixed (tomorrow no longer depends on completed sit duration)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completion screen now displays "seconds of sustained attention" for your completed session
  * Refined tomorrow's predicted session duration and blocks—calculations now scale based on your progression rather than applying a fixed increment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->