### PR TITLE
fix(timer): move and align bars with six-box row

### DIFF
--- a/src/components/BlockTimer.tsx
+++ b/src/components/BlockTimer.tsx
@@ -451,7 +451,7 @@ export function BlockTimer({
       {useMinuteBlocks ? (
         <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "16px" }}>
           <div style={{
-            display: "flex", flexWrap: "wrap", gap: "11px",
+            display: "flex", flexWrap: "wrap", gap: blockGap,
             justifyContent: "center", maxWidth: boxesAreaWidth,
           }}>
             {minuteBlocks.map(b => renderBlock(b))}
@@ -469,7 +469,7 @@ export function BlockTimer({
               final minute
             </div>
             <div style={{
-              display: "flex", flexWrap: "wrap", gap: "11px",
+              display: "flex", flexWrap: "wrap", gap: blockGap,
               justifyContent: "center", maxWidth: boxesAreaWidth,
             }}>
               {secondBlocks.map(b => renderBlock(b))}
@@ -478,7 +478,7 @@ export function BlockTimer({
         </div>
       ) : (
         <div style={{
-          display: "flex", flexWrap: "wrap", gap: "11px",
+          display: "flex", flexWrap: "wrap", gap: blockGap,
           justifyContent: "center", maxWidth: boxesAreaWidth,
         }}>
           {blocks.map(b => renderBlock(b))}

--- a/src/components/BlockTimer.tsx
+++ b/src/components/BlockTimer.tsx
@@ -69,6 +69,7 @@ export function BlockTimer({
   const [showTimer, setShowTimer] = useState(() => loadDisplayPrefs().showTimer);
   const blockSize = isMobile ? 56 : 75;
   const blockLabelSize = isMobile ? 13 : 17;
+  const blockGap = 11;
 
   // Build block definitions
   const useMinuteBlocks = totalSeconds > 120;
@@ -318,24 +319,6 @@ export function BlockTimer({
   const minutes = Math.floor(remaining / 60);
   const seconds = Math.floor(remaining % 60);
 
-  // Status label
-  let statusLabel = "";
-  if (elapsed >= totalSeconds) {
-    statusLabel = "session complete";
-  } else if (useMinuteBlocks) {
-    const lastMinuteStart = minuteBlocks.length * 60;
-    if (elapsed < lastMinuteStart) {
-      const minIdx = Math.floor(elapsed / 60);
-      statusLabel = `minute ${minIdx + 1} of ${minuteBlocks.length}`;
-    } else {
-      const secIdx = Math.floor((elapsed - lastMinuteStart) / BLOCK_DURATION);
-      statusLabel = `final minute · block ${secIdx + 1} of ${secondBlocks.length}`;
-    }
-  } else {
-    const blockIdx = Math.floor(elapsed / BLOCK_DURATION);
-    statusLabel = `block ${blockIdx + 1} of ${blocks.length}`;
-  }
-
   const renderBlock = (block: BlockDef) => {
     const blockEnd = block.startTime + block.duration;
     const isFilled = elapsed >= blockEnd;
@@ -380,7 +363,7 @@ export function BlockTimer({
     );
   };
 
-  const rowMaxWidth = "min(505px, calc(100vw - 24px))";
+  const boxesAreaWidth = `min(${6 * blockSize + blockGap * 5}px, calc(100vw - 24px))`;
 
   return (
     <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "32px" }}>
@@ -438,22 +421,30 @@ export function BlockTimer({
         </button>
       </div>
 
-      {/* 60-second progress bar */}
-      <div style={{ width: "min(460px, calc(100vw - 40px))", margin: "0 auto" }}>
-        <div style={{
-          height: "8px", borderRadius: "4px", overflow: "hidden",
-          background: "var(--surface-2)",
-        }}>
+      <div style={{ width: boxesAreaWidth, margin: "0 auto", display: "flex", flexDirection: "column", gap: "14px" }}>
+        <MindStateBar
+          elapsed={elapsed}
+          totalSeconds={totalSeconds}
+          mindStateLog={mindStateLog}
+          currentState={mindState}
+          barWidth={boxesAreaWidth}
+        />
+        <div style={{ borderTop: "1px solid var(--border-1)", paddingTop: "14px" }}>
           <div style={{
-            width: `${elapsed >= totalSeconds ? 100 : ((elapsed % 60) / 60) * 100}%`,
-            height: "100%",
-            background: elapsed >= totalSeconds
-              ? "linear-gradient(to right, var(--accent-green), var(--accent-green-end))"
-              : "linear-gradient(to right, var(--accent-amber), var(--accent-amber-end))",
-            opacity: 0.7,
-            transition: elapsed >= totalSeconds ? "width 0.3s" : "none",
-            borderRadius: "4px",
-          }} />
+            height: "8px", borderRadius: "4px", overflow: "hidden",
+            background: "var(--surface-2)",
+          }}>
+            <div style={{
+              width: `${elapsed >= totalSeconds ? 100 : ((elapsed % 60) / 60) * 100}%`,
+              height: "100%",
+              background: elapsed >= totalSeconds
+                ? "linear-gradient(to right, var(--accent-green), var(--accent-green-end))"
+                : "linear-gradient(to right, var(--accent-amber), var(--accent-amber-end))",
+              opacity: 0.7,
+              transition: elapsed >= totalSeconds ? "width 0.3s" : "none",
+              borderRadius: "4px",
+            }} />
+          </div>
         </div>
       </div>
 
@@ -461,7 +452,7 @@ export function BlockTimer({
         <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "16px" }}>
           <div style={{
             display: "flex", flexWrap: "wrap", gap: "11px",
-            justifyContent: "center", maxWidth: rowMaxWidth,
+            justifyContent: "center", maxWidth: boxesAreaWidth,
           }}>
             {minuteBlocks.map(b => renderBlock(b))}
           </div>
@@ -479,7 +470,7 @@ export function BlockTimer({
             </div>
             <div style={{
               display: "flex", flexWrap: "wrap", gap: "11px",
-              justifyContent: "center", maxWidth: rowMaxWidth,
+              justifyContent: "center", maxWidth: boxesAreaWidth,
             }}>
               {secondBlocks.map(b => renderBlock(b))}
             </div>
@@ -488,26 +479,11 @@ export function BlockTimer({
       ) : (
         <div style={{
           display: "flex", flexWrap: "wrap", gap: "11px",
-          justifyContent: "center", maxWidth: rowMaxWidth,
+          justifyContent: "center", maxWidth: boxesAreaWidth,
         }}>
           {blocks.map(b => renderBlock(b))}
         </div>
       )}
-
-      <MindStateBar
-        elapsed={elapsed}
-        totalSeconds={totalSeconds}
-        mindStateLog={mindStateLog}
-        currentState={mindState}
-      />
-
-      <div style={{
-        fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-        fontSize: "14px", color: "var(--fg-3)",
-        letterSpacing: "0.15em", textTransform: "uppercase",
-      }}>
-        {statusLabel}
-      </div>
     </div>
   );
 }

--- a/src/components/MindStateBar.tsx
+++ b/src/components/MindStateBar.tsx
@@ -5,12 +5,17 @@ type MindStateBarProps = {
   totalSeconds: number;
   mindStateLog: Array<{ time: number; state: string }>;
   currentState: string;
+  barWidth?: string;
 };
 
-export function MindStateBar({ elapsed, totalSeconds, mindStateLog, currentState }: MindStateBarProps) {
+export function MindStateBar({
+  elapsed,
+  totalSeconds,
+  mindStateLog,
+  currentState,
+  barWidth = "min(460px, calc(100vw - 40px))",
+}: MindStateBarProps) {
   if (elapsed <= 0) return null;
-
-  const barWidth = "min(460px, calc(100vw - 40px))";
   const segments: Array<{ start: number; end: number; state: string }> = [];
   let lastTime = 0;
   let lastState = "clear";


### PR DESCRIPTION
Closes #169

## Summary
- Move the full-session (green) progress bar + `0s`/`390s` labels directly below the timer clock.
- Couple both progress bars to the same computed boxes-area width so they stay aligned with the six-box row across breakpoints.
- Remove the bottom minute-status text (`MINUTE X OF 6`) and add divider spacing between green and orange bar sections for mockup parity.

## Test plan
- [x] `npm run build`
- [ ] Verify `/app` timer layout at desktop width (~1280px): both bars align to six-box row width.
- [ ] Verify tablet width (~768px): bars remain coupled to boxes row width.
- [ ] Verify mobile width (~390px): bars remain coupled to boxes row width.
- [ ] Verify there is no `MINUTE X OF 6` text anywhere in timer component.
- [ ] Attach before/after screenshots to this PR.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Changes**
  * Reworked timer layout for improved spacing and alignment.
  * Mind state bar moved to the top of the timer area above the progress bar.
  * Progress bar width adjusted to match the timer boxes for consistent sizing.
  * Removed the end-of-session status label and minute/block breakdown from the display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->