### PR TITLE
fix(iOS): port minute-block chime behavior from web

### DIFF
--- a/ios/StillPointApp/ViewModels/SessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/SessionViewModel.swift
@@ -34,7 +34,7 @@ final class SessionViewModel {
     private var pausedElapsed: Double = 0
     private var timer: AnyCancellable?
     private var lastTickSec = 0
-    private var lastChimeMinutesLeft: Int
+    private var lastCompletedMinuteBlockIndex = -1
     private var controlHideTimer: AnyCancellable?
 
     var remaining: Double {
@@ -80,13 +80,28 @@ final class SessionViewModel {
         self.dayNumber = dayNumber
         self.totalSeconds = StillPoint.duration(forDay: dayNumber)
         self.soundPrefs = AudioEngine.loadPrefs()
-        // Initialize to ceil so the first tick doesn't immediately fire chimes
-        self.lastChimeMinutesLeft = Int(ceil(Double(self.totalSeconds) / 60.0))
         // Initial mind state log entry
         self.mindStateLog = [MindStateEntry(time: 0, state: "clear")]
     }
 
     func start() {
+        let resumeElapsed = pausedElapsed
+        let isResume = resumeElapsed > 0 && resumeElapsed < Double(totalSeconds)
+
+        if isResume {
+            lastTickSec = Int(floor(resumeElapsed))
+            lastCompletedMinuteBlockIndex = SessionLogic.completedMinuteBlockIndex(
+                elapsed: resumeElapsed,
+                totalSeconds: totalSeconds
+            )
+        } else {
+            // Fresh session start: clear any carried timer/chime state.
+            elapsed = 0
+            pausedElapsed = 0
+            lastTickSec = 0
+            lastCompletedMinuteBlockIndex = -1
+        }
+
         isActive = true
         isPaused = false
         startDate = Date().addingTimeInterval(-pausedElapsed)
@@ -241,7 +256,6 @@ final class SessionViewModel {
         pausedElapsed = newElapsed
 
         let currentSec = Int(newElapsed)
-        let remainingTime = Double(totalSeconds) - newElapsed
 
         // Tick sound — once per second
         if soundPrefs.tick && currentSec > lastTickSec {
@@ -249,13 +263,17 @@ final class SessionViewModel {
             AudioEngine.shared.playTick()
         }
 
-        // Minute chime — fire when remaining crosses a whole minute boundary downward
-        if soundPrefs.chime {
-            let wholeMinutesLeft = Int(floor(remainingTime / 60))
-            if wholeMinutesLeft >= 1 && wholeMinutesLeft < lastChimeMinutesLeft {
-                AudioEngine.shared.playChime(count: wholeMinutesLeft)
+        // Advance minute-block boundary progress independent of mute state.
+        let chimeUpdate = SessionLogic.nextMinuteChimeUpdate(
+            elapsed: newElapsed,
+            totalSeconds: totalSeconds,
+            lastCompletedBlockIndex: lastCompletedMinuteBlockIndex
+        )
+        if chimeUpdate.updatedCompletedBlockIndex > lastCompletedMinuteBlockIndex {
+            lastCompletedMinuteBlockIndex = chimeUpdate.updatedCompletedBlockIndex
+            if soundPrefs.chime, let chimeCount = chimeUpdate.chimeCount {
+                AudioEngine.shared.playChime(count: chimeCount)
             }
-            lastChimeMinutesLeft = wholeMinutesLeft
         }
     }
 

--- a/ios/StillPointShared/Package.swift
+++ b/ios/StillPointShared/Package.swift
@@ -6,6 +6,7 @@ let package = Package(
     platforms: [
         .iOS(.v17),
         .watchOS(.v10),
+        .macOS(.v14),
     ],
     products: [
         .library(name: "StillPointShared", targets: ["StillPointShared"]),

--- a/ios/StillPointShared/Package.swift
+++ b/ios/StillPointShared/Package.swift
@@ -12,5 +12,9 @@ let package = Package(
     ],
     targets: [
         .target(name: "StillPointShared"),
+        .testTarget(
+            name: "StillPointSharedTests",
+            dependencies: ["StillPointShared"]
+        ),
     ]
 )

--- a/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
@@ -1,5 +1,45 @@
-import AVFoundation
 import Foundation
+
+#if os(macOS)
+
+/// macOS / host builds: no AVFoundation playback; keeps the package testable with `swift test`.
+public final class AudioEngine: @unchecked Sendable {
+    public static let shared = AudioEngine()
+
+    private init() {}
+
+    public func playTick() {}
+    public func playChime(count: Int) {}
+    public func playCompletion() {}
+
+    public struct SoundPrefs: Codable, Equatable {
+        public var tick: Bool
+        public var chime: Bool
+        public var completion: Bool
+
+        public static let defaults = SoundPrefs(tick: false, chime: true, completion: true)
+    }
+
+    private static let prefsKey = "stillpoint_sound_prefs"
+
+    public static func loadPrefs() -> SoundPrefs {
+        guard let data = UserDefaults.standard.data(forKey: prefsKey),
+              let prefs = try? JSONDecoder().decode(SoundPrefs.self, from: data) else {
+            return .defaults
+        }
+        return prefs
+    }
+
+    public static func savePrefs(_ prefs: SoundPrefs) {
+        if let data = try? JSONEncoder().encode(prefs) {
+            UserDefaults.standard.set(data, forKey: prefsKey)
+        }
+    }
+}
+
+#else
+
+import AVFoundation
 
 /// Synthesized audio matching the web app's Web Audio API sounds.
 /// All sounds are generated programmatically — no external files needed.
@@ -178,3 +218,5 @@ public final class AudioEngine: @unchecked Sendable {
         }
     }
 }
+
+#endif

--- a/ios/StillPointShared/Sources/StillPointShared/SessionLogic.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/SessionLogic.swift
@@ -47,7 +47,7 @@ public enum SessionLogic {
     ) -> Int? {
         guard blockIndex >= 0 else { return nil }
         let blockEnd = (blockIndex + 1) * 60
-        let chimeCount = Int(floor(Double(totalSeconds - blockEnd) / 60.0))
+        let chimeCount = (totalSeconds - blockEnd) / 60
         return chimeCount >= 1 ? chimeCount : nil
     }
 

--- a/ios/StillPointShared/Sources/StillPointShared/SessionLogic.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/SessionLogic.swift
@@ -17,16 +17,77 @@ public struct BlockDef: Identifiable, Sendable {
 
 public enum SessionLogic {
 
+    /// Whether this duration should render/use minute-sized blocks before final ten-second blocks.
+    public static func usesMinuteBlocks(totalSeconds: Int) -> Bool {
+        totalSeconds > 120
+    }
+
+    /// Number of full 60-second blocks before the final-minute ten-second blocks.
+    public static func minuteBlockCount(totalSeconds: Int) -> Int {
+        guard usesMinuteBlocks(totalSeconds: totalSeconds) else { return 0 }
+        let fullMinutes = totalSeconds / 60
+        let remainingSeconds = totalSeconds % 60
+        return remainingSeconds > 0 ? fullMinutes : fullMinutes - 1
+    }
+
+    /// Highest completed minute-block index at a given elapsed time.
+    /// Returns -1 when no minute block is completed yet or minute blocks are not in use.
+    public static func completedMinuteBlockIndex(elapsed: Double, totalSeconds: Int) -> Int {
+        let count = minuteBlockCount(totalSeconds: totalSeconds)
+        guard count > 0 else { return -1 }
+        let rawIndex = Int(floor(elapsed / 60.0)) - 1
+        return min(count - 1, rawIndex)
+    }
+
+    /// Chime count for a completed minute block.
+    /// Returns nil when there is less than one full minute left (including final-minute ten-second blocks).
+    public static func chimeCountForCompletedMinuteBlock(
+        blockIndex: Int,
+        totalSeconds: Int
+    ) -> Int? {
+        guard blockIndex >= 0 else { return nil }
+        let blockEnd = (blockIndex + 1) * 60
+        let chimeCount = Int(floor(Double(totalSeconds - blockEnd) / 60.0))
+        return chimeCount >= 1 ? chimeCount : nil
+    }
+
+    public struct MinuteChimeUpdate: Sendable, Equatable {
+        public let updatedCompletedBlockIndex: Int
+        public let chimeCount: Int?
+    }
+
+    /// Advances minute-block completion and returns optional chime payload.
+    /// This should run regardless of mute state so progress does not replay after unmute.
+    public static func nextMinuteChimeUpdate(
+        elapsed: Double,
+        totalSeconds: Int,
+        lastCompletedBlockIndex: Int
+    ) -> MinuteChimeUpdate {
+        let completedBlockIndex = completedMinuteBlockIndex(elapsed: elapsed, totalSeconds: totalSeconds)
+        guard completedBlockIndex > lastCompletedBlockIndex else {
+            return MinuteChimeUpdate(
+                updatedCompletedBlockIndex: lastCompletedBlockIndex,
+                chimeCount: nil
+            )
+        }
+
+        return MinuteChimeUpdate(
+            updatedCompletedBlockIndex: completedBlockIndex,
+            chimeCount: chimeCountForCompletedMinuteBlock(
+                blockIndex: completedBlockIndex,
+                totalSeconds: totalSeconds
+            )
+        )
+    }
+
     /// Build block definitions for a session of given duration.
     /// Matches the web app's BlockTimer.tsx block-building algorithm exactly.
     public static func buildBlocks(totalSeconds: Int) -> [BlockDef] {
-        let useMinuteBlocks = totalSeconds > 120
+        let useMinuteBlocks = usesMinuteBlocks(totalSeconds: totalSeconds)
         var blocks: [BlockDef] = []
 
         if useMinuteBlocks {
-            let fullMinutes = totalSeconds / 60
-            let remainingSeconds = totalSeconds % 60
-            let minuteBlockCount = remainingSeconds > 0 ? fullMinutes : fullMinutes - 1
+            let minuteBlockCount = minuteBlockCount(totalSeconds: totalSeconds)
 
             for i in 0..<minuteBlockCount {
                 blocks.append(BlockDef(
@@ -107,7 +168,7 @@ public enum SessionLogic {
     ) -> String {
         let minuteBlocks = blocks.filter { $0.type == .minute }
         let secondBlocks = blocks.filter { $0.type == .second }
-        let useMinuteBlocks = totalSeconds > 120
+        let useMinuteBlocks = usesMinuteBlocks(totalSeconds: totalSeconds)
 
         if elapsed >= Double(totalSeconds) {
             return "session complete"

--- a/ios/StillPointShared/Tests/StillPointSharedTests/SessionLogicMinuteChimeTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/SessionLogicMinuteChimeTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+@testable import StillPointShared
+
+final class SessionLogicMinuteChimeTests: XCTestCase {
+    func testFourTwentySessionChimesAtThreeTwentyTwoTwentyOneTwentyOnly() {
+        let totalSeconds = 260
+        var lastCompletedBlockIndex = -1
+        var chimes: [Int] = []
+
+        for elapsed in [60.0, 120.0, 180.0, 240.0, 250.0] {
+            let update = SessionLogic.nextMinuteChimeUpdate(
+                elapsed: elapsed,
+                totalSeconds: totalSeconds,
+                lastCompletedBlockIndex: lastCompletedBlockIndex
+            )
+            lastCompletedBlockIndex = update.updatedCompletedBlockIndex
+            if let chime = update.chimeCount {
+                chimes.append(chime)
+            }
+        }
+
+        XCTAssertEqual(chimes, [3, 2, 1], "Expected chimes at 3:20, 2:20, 1:20 only")
+    }
+
+    func testExactFiveMinuteSessionChimesAtFourThreeTwoOne() {
+        let totalSeconds = 300
+        var lastCompletedBlockIndex = -1
+        var chimes: [Int] = []
+
+        for elapsed in [60.0, 120.0, 180.0, 240.0] {
+            let update = SessionLogic.nextMinuteChimeUpdate(
+                elapsed: elapsed,
+                totalSeconds: totalSeconds,
+                lastCompletedBlockIndex: lastCompletedBlockIndex
+            )
+            lastCompletedBlockIndex = update.updatedCompletedBlockIndex
+            if let chime = update.chimeCount {
+                chimes.append(chime)
+            }
+        }
+
+        XCTAssertEqual(chimes, [4, 3, 2, 1])
+    }
+
+    func testNoMinuteChimeWhenLessThanOneMinuteRemains() {
+        let totalSeconds = 260
+        let update = SessionLogic.nextMinuteChimeUpdate(
+            elapsed: 240.0,
+            totalSeconds: totalSeconds,
+            lastCompletedBlockIndex: 2
+        )
+
+        XCTAssertEqual(update.updatedCompletedBlockIndex, 3)
+        XCTAssertNil(update.chimeCount)
+    }
+
+    func testNoMinuteBlockChimesForSessionsAtOrBelowOneHundredTwentySeconds() {
+        for duration in [120, 110, 60] {
+            let update = SessionLogic.nextMinuteChimeUpdate(
+                elapsed: 60.0,
+                totalSeconds: duration,
+                lastCompletedBlockIndex: -1
+            )
+            XCTAssertEqual(update.updatedCompletedBlockIndex, -1, "Duration \(duration) should not use minute blocks")
+            XCTAssertNil(update.chimeCount, "Duration \(duration) should not produce minute-block chimes")
+        }
+    }
+
+    func testBlockProgressAdvancesEvenIfChimePlaybackIsMuted() {
+        let totalSeconds = 260
+        let mutedUpdate = SessionLogic.nextMinuteChimeUpdate(
+            elapsed: 60.0,
+            totalSeconds: totalSeconds,
+            lastCompletedBlockIndex: -1
+        )
+        XCTAssertEqual(mutedUpdate.updatedCompletedBlockIndex, 0)
+        XCTAssertEqual(mutedUpdate.chimeCount, 3)
+
+        // Simulate unmuting after the boundary: no replay for already-completed block.
+        let unmutedUpdate = SessionLogic.nextMinuteChimeUpdate(
+            elapsed: 61.0,
+            totalSeconds: totalSeconds,
+            lastCompletedBlockIndex: mutedUpdate.updatedCompletedBlockIndex
+        )
+        XCTAssertEqual(unmutedUpdate.updatedCompletedBlockIndex, 0)
+        XCTAssertNil(unmutedUpdate.chimeCount)
+    }
+
+    func testPauseResumeSeedPreventsReplayingCompletedMinuteBlockChimes() {
+        let totalSeconds = 260
+        let seededIndex = SessionLogic.completedMinuteBlockIndex(
+            elapsed: 130.0,
+            totalSeconds: totalSeconds
+        )
+        XCTAssertEqual(seededIndex, 1)
+
+        let afterResume = SessionLogic.nextMinuteChimeUpdate(
+            elapsed: 131.0,
+            totalSeconds: totalSeconds,
+            lastCompletedBlockIndex: seededIndex
+        )
+        XCTAssertEqual(afterResume.updatedCompletedBlockIndex, seededIndex)
+        XCTAssertNil(afterResume.chimeCount)
+    }
+
+    func testFreshSessionStartDoesNotInheritCompletedMinuteBlocks() {
+        let totalSeconds = 260
+
+        let freshUpdate = SessionLogic.nextMinuteChimeUpdate(
+            elapsed: 0.0,
+            totalSeconds: totalSeconds,
+            lastCompletedBlockIndex: -1
+        )
+        XCTAssertEqual(freshUpdate.updatedCompletedBlockIndex, -1)
+        XCTAssertNil(freshUpdate.chimeCount)
+
+        let firstBoundary = SessionLogic.nextMinuteChimeUpdate(
+            elapsed: 60.0,
+            totalSeconds: totalSeconds,
+            lastCompletedBlockIndex: freshUpdate.updatedCompletedBlockIndex
+        )
+        XCTAssertEqual(firstBoundary.updatedCompletedBlockIndex, 0)
+        XCTAssertEqual(firstBoundary.chimeCount, 3)
+    }
+}


### PR DESCRIPTION
Closes #78

## Summary
- port the web minute-block chime logic to iOS so chimes trigger on completed visual minute blocks instead of clock-minute boundaries
- keep minute-block progress tracking independent from mute state, and seed progress on resume so completed chimes are not replayed
- add `StillPointShared` regression tests covering 4:20 and 5:00 sequences, <1 minute/final-minute exclusions, <=120s sessions, mute independence, resume seeding, and fresh-start reset

## Manual test matrix
- [ ] Chime fires when each minute block completes (aligned to visual grid, not clock minutes)
- [ ] For 4:20 session: chimes at 3:20, 2:20, 1:20 remaining (no chime at 0:20)
- [ ] For exact 5:00 session: chimes at 4:00, 3:00, 2:00, 1:00 (no behavioral change)
- [ ] No chime when less than 1 minute remains
- [ ] No chime during final-minute 10-second blocks
- [ ] Sessions <= 120s: no minute-block chimes
- [ ] Block progress tracking works even when chimes are muted
- [ ] Pause/resume doesn't replay completed block chimes
- [ ] Fresh session start doesn't inherit previous session's elapsed state

## Validation run
- [x] `xcodebuild -scheme StillPointShared -destination 'generic/platform=iOS' build`
- [ ] Device/simulator manual verification for the matrix above

## Notes
- `swift test` on this machine compiles the package for macOS host and fails in `AudioEngine` due to iOS-only AVFoundation APIs; iOS scheme build passes.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved chime triggering for more consistent, predictable in-session audio cues.
  * Enhanced resume behavior to correctly preserve elapsed time and chime state.
  * Added macOS support with platform-appropriate audio handling.

* **Tests**
  * Added comprehensive unit tests covering minute-chime behavior and session timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->