### PR TITLE
Issue #72: Hold-based distraction / awareness tracking (web + iOS)

### DIFF
--- a/ios/StillPointApp/Components/MindStateBarView.swift
+++ b/ios/StillPointApp/Components/MindStateBarView.swift
@@ -6,6 +6,8 @@ struct MindStateBarView: View {
     let elapsed: Double
     let totalSeconds: Int
     let mindStateLog: [MindStateEntry]
+    /// Current mind state so the in-progress tail matches live holds (log updates on release).
+    let currentMindState: String
 
     var body: some View {
         GeometryReader { geo in
@@ -31,9 +33,12 @@ struct MindStateBarView: View {
                     let segmentX = width * startFraction
                     let segmentWidth = max(0, width * (endFraction - startFraction))
 
+                    let isLastSegment = index + 1 == mindStateLog.count
+                    let segmentIsClear = isLastSegment ? (currentMindState == "clear") : entry.isClear
+
                     Rectangle()
-                        .fill(entry.isClear ? SPColor.green : SPColor.amber)
-                        .opacity(entry.isClear ? 0.5 : 0.6)
+                        .fill(segmentIsClear ? SPColor.green : SPColor.amber)
+                        .opacity(segmentIsClear ? 0.5 : 0.6)
                         .frame(width: segmentWidth)
                         .offset(x: segmentX)
                 }

--- a/ios/StillPointApp/Components/MindStateBarView.swift
+++ b/ios/StillPointApp/Components/MindStateBarView.swift
@@ -34,11 +34,11 @@ struct MindStateBarView: View {
                     let segmentWidth = max(0, width * (endFraction - startFraction))
 
                     let isLastSegment = index + 1 == mindStateLog.count
-                    let segmentIsClear = isLastSegment ? (currentMindState == "clear") : entry.isClear
+                    let displayState = isLastSegment ? currentMindState : entry.state
 
                     Rectangle()
-                        .fill(segmentIsClear ? SPColor.green : SPColor.amber)
-                        .opacity(segmentIsClear ? 0.5 : 0.6)
+                        .fill(segmentFill(for: displayState))
+                        .opacity(displayState == "thinking" ? 0.6 : 0.55)
                         .frame(width: segmentWidth)
                         .offset(x: segmentX)
                 }
@@ -47,5 +47,16 @@ struct MindStateBarView: View {
         .frame(height: 8)
         .clipShape(RoundedRectangle(cornerRadius: 4))
         .padding(.horizontal, SPSpacing.s4)
+    }
+
+    private func segmentFill(for state: String) -> Color {
+        switch state {
+        case "clear":
+            return SPColor.green
+        case "hyperfocus":
+            return Color(red: 0.38, green: 0.65, blue: 0.98)
+        default:
+            return SPColor.amber
+        }
     }
 }

--- a/ios/StillPointApp/ViewModels/SessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/SessionViewModel.swift
@@ -21,8 +21,11 @@ final class SessionViewModel {
     // Mind state
     var mindState: String = "clear"
     var mindStateLog: [MindStateEntry] = []
-    var thoughtCount = 0
+    /// Distraction segments started this sit (for in-session badge); API `thoughtCount` uses captured notes only.
+    var distractionSegmentCount = 0
     var capturedThoughts: [CapturedThought] = []
+
+    var thoughtCount: Int { capturedThoughts.count }
 
     // UI state — optional thought prompt after a distraction segment ends
     var showPostDistractionCapture = false
@@ -110,7 +113,7 @@ final class SessionViewModel {
     }
 
     func pause() {
-        finalizeActiveDistractionIfNeeded(at: elapsed, offerThoughtCapture: false)
+        finalizeActiveHoldIfNeeded(at: elapsed, offerThoughtCapture: false)
         isPaused = true
         isActive = false
         pausedElapsed = elapsed
@@ -124,17 +127,30 @@ final class SessionViewModel {
 
     /// Hold to mark a distraction segment (`thinking`); release returns to aware (`clear`).
     func beginDistraction() {
-        guard isActive, mindState == "clear" else { return }
-        showPostDistractionCapture = false
+        guard isActive, mindState == "clear", !showPostDistractionCapture else { return }
         mindState = "thinking"
-        thoughtCount += 1
+        distractionSegmentCount += 1
         mindStateLog.append(MindStateEntry(time: elapsed, state: "thinking"))
         userInteracted()
     }
 
     func endDistraction() {
         guard mindState == "thinking" else { return }
-        finalizeActiveDistractionIfNeeded(at: elapsed, offerThoughtCapture: true)
+        finalizeActiveHoldIfNeeded(at: elapsed, offerThoughtCapture: true)
+        userInteracted()
+    }
+
+    /// Hold to mark hyperfocus; counts toward awareness in `clearPercent`. Release returns to `clear`.
+    func beginHyperfocus() {
+        guard isActive, mindState == "clear", !showPostDistractionCapture else { return }
+        mindState = "hyperfocus"
+        mindStateLog.append(MindStateEntry(time: elapsed, state: "hyperfocus"))
+        userInteracted()
+    }
+
+    func endHyperfocus() {
+        guard mindState == "hyperfocus" else { return }
+        finalizeActiveHoldIfNeeded(at: elapsed, offerThoughtCapture: false)
         userInteracted()
     }
 
@@ -163,7 +179,7 @@ final class SessionViewModel {
 
     /// End session early but keep the data
     func endEarly() -> (clearPercent: Int, thoughtCount: Int, thoughts: [CapturedThought]) {
-        finalizeActiveDistractionIfNeeded(at: elapsed, offerThoughtCapture: false)
+        finalizeActiveHoldIfNeeded(at: elapsed, offerThoughtCapture: false)
         timer?.cancel()
         isActive = false
         isComplete = true
@@ -172,7 +188,7 @@ final class SessionViewModel {
 
     /// Abandon session — discard all data, don't save
     func abandon() {
-        finalizeActiveDistractionIfNeeded(at: elapsed, offerThoughtCapture: false)
+        finalizeActiveHoldIfNeeded(at: elapsed, offerThoughtCapture: false)
         timer?.cancel()
         isActive = false
         isAbandoned = true
@@ -248,7 +264,7 @@ final class SessionViewModel {
         if newElapsed >= Double(totalSeconds) {
             elapsed = Double(totalSeconds)
             pausedElapsed = elapsed
-            finalizeActiveDistractionIfNeeded(at: Double(totalSeconds), offerThoughtCapture: false)
+            finalizeActiveHoldIfNeeded(at: Double(totalSeconds), offerThoughtCapture: false)
             timer?.cancel()
             isActive = false
             completedNaturally = true
@@ -284,11 +300,12 @@ final class SessionViewModel {
         }
     }
 
-    private func finalizeActiveDistractionIfNeeded(at time: Double, offerThoughtCapture: Bool) {
-        guard mindState == "thinking" else { return }
+    private func finalizeActiveHoldIfNeeded(at time: Double, offerThoughtCapture: Bool) {
+        guard mindState == "thinking" || mindState == "hyperfocus" else { return }
+        let wasThinking = mindState == "thinking"
         mindState = "clear"
         mindStateLog.append(MindStateEntry(time: time, state: "clear"))
-        showPostDistractionCapture = offerThoughtCapture
+        showPostDistractionCapture = wasThinking && offerThoughtCapture
     }
 
     private func scheduleControlHide() {

--- a/ios/StillPointApp/ViewModels/SessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/SessionViewModel.swift
@@ -24,8 +24,8 @@ final class SessionViewModel {
     var thoughtCount = 0
     var capturedThoughts: [CapturedThought] = []
 
-    // UI state
-    var showThoughtCapture = false
+    // UI state — optional thought prompt after a distraction segment ends
+    var showPostDistractionCapture = false
     var controlsVisible = true
     var soundPrefs: AudioEngine.SoundPrefs
 
@@ -110,6 +110,7 @@ final class SessionViewModel {
     }
 
     func pause() {
+        finalizeActiveDistractionIfNeeded(at: elapsed, offerThoughtCapture: false)
         isPaused = true
         isActive = false
         pausedElapsed = elapsed
@@ -121,16 +122,19 @@ final class SessionViewModel {
         start()
     }
 
-    func toggleMindState() {
-        if mindState == "clear" {
-            mindState = "thinking"
-            thoughtCount += 1
-            showThoughtCapture = true
-        } else {
-            mindState = "clear"
-            showThoughtCapture = false
-        }
-        mindStateLog.append(MindStateEntry(time: elapsed, state: mindState))
+    /// Hold to mark a distraction segment (`thinking`); release returns to aware (`clear`).
+    func beginDistraction() {
+        guard isActive, mindState == "clear" else { return }
+        showPostDistractionCapture = false
+        mindState = "thinking"
+        thoughtCount += 1
+        mindStateLog.append(MindStateEntry(time: elapsed, state: "thinking"))
+        userInteracted()
+    }
+
+    func endDistraction() {
+        guard mindState == "thinking" else { return }
+        finalizeActiveDistractionIfNeeded(at: elapsed, offerThoughtCapture: true)
         userInteracted()
     }
 
@@ -140,11 +144,11 @@ final class SessionViewModel {
             timeInSession: Int(elapsed),
             text: text
         ))
-        showThoughtCapture = false
+        showPostDistractionCapture = false
     }
 
-    func dismissThoughtCapture() {
-        showThoughtCapture = false
+    func dismissPostDistractionCapture() {
+        showPostDistractionCapture = false
     }
 
     func userInteracted() {
@@ -159,6 +163,7 @@ final class SessionViewModel {
 
     /// End session early but keep the data
     func endEarly() -> (clearPercent: Int, thoughtCount: Int, thoughts: [CapturedThought]) {
+        finalizeActiveDistractionIfNeeded(at: elapsed, offerThoughtCapture: false)
         timer?.cancel()
         isActive = false
         isComplete = true
@@ -167,6 +172,7 @@ final class SessionViewModel {
 
     /// Abandon session — discard all data, don't save
     func abandon() {
+        finalizeActiveDistractionIfNeeded(at: elapsed, offerThoughtCapture: false)
         timer?.cancel()
         isActive = false
         isAbandoned = true
@@ -242,6 +248,7 @@ final class SessionViewModel {
         if newElapsed >= Double(totalSeconds) {
             elapsed = Double(totalSeconds)
             pausedElapsed = elapsed
+            finalizeActiveDistractionIfNeeded(at: Double(totalSeconds), offerThoughtCapture: false)
             timer?.cancel()
             isActive = false
             completedNaturally = true
@@ -275,6 +282,13 @@ final class SessionViewModel {
                 AudioEngine.shared.playChime(count: chimeCount)
             }
         }
+    }
+
+    private func finalizeActiveDistractionIfNeeded(at time: Double, offerThoughtCapture: Bool) {
+        guard mindState == "thinking" else { return }
+        mindState = "clear"
+        mindStateLog.append(MindStateEntry(time: time, state: "clear"))
+        showPostDistractionCapture = offerThoughtCapture
     }
 
     private func scheduleControlHide() {

--- a/ios/StillPointApp/Views/CompletionView.swift
+++ b/ios/StillPointApp/Views/CompletionView.swift
@@ -38,18 +38,28 @@ struct CompletionView: View {
                 }
 
                 // Stats cards
-                HStack(spacing: SPSpacing.s3) {
-                    statCard(
-                        value: "\(clearPercent)%",
-                        label: "CLEAR MIND",
-                        color: SPColor.green,
-                        bgColor: SPColor.greenBgFaint,
-                        borderColor: SPColor.greenBorderSubtle
-                    )
+                VStack(spacing: SPSpacing.s3) {
+                    HStack(spacing: SPSpacing.s3) {
+                        statCard(
+                            value: "\(clearPercent)%",
+                            label: "AWARENESS",
+                            color: SPColor.green,
+                            bgColor: SPColor.greenBgFaint,
+                            borderColor: SPColor.greenBorderSubtle
+                        )
+
+                        statCard(
+                            value: "\(max(0, 100 - clearPercent))%",
+                            label: "DISTRACTION",
+                            color: SPColor.amber,
+                            bgColor: SPColor.amberBgFaint,
+                            borderColor: SPColor.amberBorderSubtle
+                        )
+                    }
 
                     statCard(
                         value: "\(thoughtCount)",
-                        label: "INTERRUPTIONS",
+                        label: "CAPTURED NOTES",
                         color: SPColor.amber,
                         bgColor: SPColor.amberBgFaint,
                         borderColor: SPColor.amberBorderSubtle

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -2,9 +2,8 @@ import SwiftUI
 import StillPointShared
 
 struct SessionView: View {
-    /// Estimated height of the controls overlay:
-    /// mind state toggle (~44) + action buttons (~36) + sound toggles (~24) + VStack spacing (3×16=48) + padding (top 16 + bottom 12 = 28) ≈ 160pt
-    private static let controlPanelHeight: CGFloat = 160
+    /// Space reserved at the bottom for the distraction hold bar plus pause / end / sound controls.
+    private static let bottomOverlayReserve: CGFloat = 268
 
     let appVM: AppViewModel
     @State private var vm: SessionViewModel
@@ -20,7 +19,7 @@ struct SessionView: View {
             SPColor.bg.ignoresSafeArea()
 
             GeometryReader { geo in
-                let contentHeight = geo.size.height - Self.controlPanelHeight
+                let contentHeight = geo.size.height - Self.bottomOverlayReserve
 
                 VStack(spacing: 0) {
                     // Main content — fits in viewport above controls
@@ -51,7 +50,8 @@ struct SessionView: View {
                         MindStateBarView(
                             elapsed: vm.elapsed,
                             totalSeconds: vm.totalSeconds,
-                            mindStateLog: vm.mindStateLog
+                            mindStateLog: vm.mindStateLog,
+                            currentMindState: vm.mindState
                         )
 
                         // Status label
@@ -65,9 +65,12 @@ struct SessionView: View {
                 }
             }
 
-            // Controls overlay (auto-hide)
+            // Bottom chrome: distraction hold (always during sit) + controls (auto-hide while running)
             VStack {
                 Spacer()
+                if sessionInProgress {
+                    persistentDistractionBar
+                }
                 if vm.controlsVisible || !vm.isActive {
                     controlPanel
                         .transition(.move(edge: .bottom).combined(with: .opacity))
@@ -75,8 +78,8 @@ struct SessionView: View {
             }
             .animation(.easeInOut(duration: 0.3), value: vm.controlsVisible)
 
-            // Thought capture overlay
-            if vm.showThoughtCapture {
+            // Thought capture after releasing a distraction hold
+            if vm.showPostDistractionCapture {
                 VStack {
                     Spacer()
                     ThoughtCaptureView(
@@ -84,11 +87,11 @@ struct SessionView: View {
                             vm.captureThought(text)
                         },
                         onDismiss: {
-                            vm.dismissThoughtCapture()
+                            vm.dismissPostDistractionCapture()
                         }
                     )
                     .padding(.horizontal, SPSpacing.s4)
-                    .padding(.bottom, Self.controlPanelHeight)
+                    .padding(.bottom, Self.bottomOverlayReserve + 24)
                 }
                 .transition(.opacity)
             }
@@ -149,35 +152,46 @@ struct SessionView: View {
         .padding(.horizontal, SPSpacing.s5)
     }
 
-    // MARK: - Control Panel
+    private var sessionInProgress: Bool {
+        !vm.isComplete && !vm.isAbandoned && (vm.isActive || vm.isPaused)
+    }
 
-    private var controlPanel: some View {
-        VStack(spacing: SPSpacing.s3) {
-            // Mind state toggle
-            Button {
-                vm.toggleMindState()
-            } label: {
-                HStack(spacing: SPSpacing.s2) {
-                    Circle()
-                        .fill(vm.mindState == "clear" ? SPColor.green : SPColor.amber)
-                        .frame(width: 8, height: 8)
+    /// Hold control + state dot: visible for the whole active sit path (not hidden with other chrome).
+    private var persistentDistractionBar: some View {
+        VStack(spacing: SPSpacing.s2) {
+            HStack(spacing: SPSpacing.s2) {
+                Circle()
+                    .fill(vm.mindState == "clear" ? SPColor.green : SPColor.amber)
+                    .frame(width: 10, height: 10)
+                    .shadow(color: vm.mindState == "clear" ? .clear : SPColor.amber.opacity(0.45), radius: vm.mindState == "clear" ? 0 : 6)
 
-                    Text(vm.mindState == "clear" ? "I'm thinking" : "Clear mind")
-                        .font(SPFont.serifItalic(17))
-                        .foregroundStyle(Color(SPColor.fg))
+                Text(vm.mindState == "clear" ? "Aware" : "Distracted")
+                    .font(SPFont.mono(11, weight: .medium))
+                    .foregroundStyle(Color(SPColor.fg3))
+                    .tracking(1)
 
-                    if vm.thoughtCount > 0 {
-                        Text("\(vm.thoughtCount)")
-                            .font(SPFont.mono(11, weight: .medium))
-                            .foregroundStyle(SPColor.amberText)
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .background(SPColor.amberBgFaint)
-                            .clipShape(Capsule())
-                    }
+                Spacer(minLength: 0)
+
+                if vm.thoughtCount > 0 {
+                    Text("\(vm.thoughtCount) notes")
+                        .font(SPFont.mono(10, weight: .medium))
+                        .foregroundStyle(SPColor.amberText)
                 }
+            }
+            .padding(.horizontal, SPSpacing.s3)
+
+            Text("Hold while distracted — release when you're back")
+                .font(SPFont.mono(10))
+                .foregroundStyle(Color(SPColor.fg4))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, SPSpacing.s4)
+
+            Text("Hold to mark distraction")
+                .font(SPFont.serifItalic(17))
+                .foregroundStyle(Color(SPColor.fg))
                 .padding(.horizontal, SPSpacing.s4)
                 .padding(.vertical, SPSpacing.s2)
+                .frame(maxWidth: .infinity)
                 .background(
                     vm.mindState == "clear"
                         ? SPColor.greenBgFaint
@@ -191,8 +205,31 @@ struct SessionView: View {
                             : SPColor.amberBorderSubtle
                     )
                 )
-            }
+                .opacity(vm.isActive ? 1 : 0.45)
+                .accessibilityLabel("Hold while distracted. Release when aware again.")
+                .simultaneousGesture(
+                    DragGesture(minimumDistance: 0)
+                        .onChanged { _ in
+                            if vm.isActive { vm.beginDistraction() }
+                        }
+                        .onEnded { _ in
+                            vm.endDistraction()
+                        }
+                )
+                .padding(.horizontal, SPSpacing.s4)
+        }
+        .padding(.vertical, SPSpacing.s3)
+        .background(
+            SPColor.bg.opacity(0.92)
+                .background(.ultraThinMaterial)
+                .ignoresSafeArea(edges: .bottom)
+        )
+    }
 
+    // MARK: - Control Panel
+
+    private var controlPanel: some View {
+        VStack(spacing: SPSpacing.s3) {
             // Action buttons
             HStack(spacing: SPSpacing.s3) {
                 // Pause / Resume

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -161,62 +161,116 @@ struct SessionView: View {
         VStack(spacing: SPSpacing.s2) {
             HStack(spacing: SPSpacing.s2) {
                 Circle()
-                    .fill(vm.mindState == "clear" ? SPColor.green : SPColor.amber)
+                    .fill(
+                        vm.mindState == "clear"
+                            ? SPColor.green
+                            : vm.mindState == "hyperfocus"
+                                ? Color(red: 0.38, green: 0.65, blue: 0.98)
+                                : SPColor.amber
+                    )
                     .frame(width: 10, height: 10)
-                    .shadow(color: vm.mindState == "clear" ? .clear : SPColor.amber.opacity(0.45), radius: vm.mindState == "clear" ? 0 : 6)
+                    .shadow(
+                        color: vm.mindState == "clear"
+                            ? .clear
+                            : vm.mindState == "hyperfocus"
+                                ? Color.blue.opacity(0.45)
+                                : SPColor.amber.opacity(0.45),
+                        radius: vm.mindState == "clear" ? 0 : 6
+                    )
 
-                Text(vm.mindState == "clear" ? "Aware" : "Distracted")
+                Text(vm.mindState == "thinking" ? "Distracted" : vm.mindState == "hyperfocus" ? "Hyperfocus" : "Aware")
                     .font(SPFont.mono(11, weight: .medium))
                     .foregroundStyle(Color(SPColor.fg3))
                     .tracking(1)
 
                 Spacer(minLength: 0)
 
-                if vm.thoughtCount > 0 {
-                    Text("\(vm.thoughtCount) notes")
+                if vm.distractionSegmentCount > 0 {
+                    Text("\(vm.distractionSegmentCount) light")
+                        .font(SPFont.mono(10, weight: .medium))
+                        .foregroundStyle(SPColor.amberText)
+                }
+
+                if !vm.capturedThoughts.isEmpty {
+                    Text("\(vm.capturedThoughts.count) captured")
                         .font(SPFont.mono(10, weight: .medium))
                         .foregroundStyle(SPColor.amberText)
                 }
             }
             .padding(.horizontal, SPSpacing.s3)
 
-            Text("Hold while distracted — release when you're back")
+            Text("Hold a button, or hold Space (light distraction) or Comma (hyperfocus) on an external keyboard.")
                 .font(SPFont.mono(10))
                 .foregroundStyle(Color(SPColor.fg4))
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, SPSpacing.s4)
 
-            Text("Hold to mark distraction")
-                .font(SPFont.serifItalic(17))
-                .foregroundStyle(Color(SPColor.fg))
-                .padding(.horizontal, SPSpacing.s4)
-                .padding(.vertical, SPSpacing.s2)
-                .frame(maxWidth: .infinity)
-                .background(
-                    vm.mindState == "clear"
-                        ? SPColor.greenBgFaint
-                        : SPColor.amberBgFaint
-                )
-                .clipShape(Capsule())
-                .overlay(
-                    Capsule().stroke(
-                        vm.mindState == "clear"
-                            ? SPColor.greenBorderSubtle
-                            : SPColor.amberBorderSubtle
+            HStack(spacing: SPSpacing.s2) {
+                Text("Hold — light distraction")
+                    .font(SPFont.serifItalic(15))
+                    .foregroundStyle(Color(SPColor.fg))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, SPSpacing.s3)
+                    .padding(.vertical, SPSpacing.s2)
+                    .frame(maxWidth: .infinity)
+                    .background(
+                        vm.mindState == "thinking"
+                            ? SPColor.amberBgFaint
+                            : SPColor.greenBgFaint
                     )
-                )
-                .opacity(vm.isActive ? 1 : 0.45)
-                .accessibilityLabel("Hold while distracted. Release when aware again.")
-                .simultaneousGesture(
-                    DragGesture(minimumDistance: 0)
-                        .onChanged { _ in
-                            if vm.isActive { vm.beginDistraction() }
-                        }
-                        .onEnded { _ in
-                            vm.endDistraction()
-                        }
-                )
-                .padding(.horizontal, SPSpacing.s4)
+                    .clipShape(Capsule())
+                    .overlay(
+                        Capsule().stroke(
+                            vm.mindState == "thinking"
+                                ? SPColor.amberBorderSubtle
+                                : SPColor.greenBorderSubtle
+                        )
+                    )
+                    .opacity(vm.isActive ? 1 : 0.45)
+                    .accessibilityLabel("Hold for light distraction. Release when aware again.")
+                    .simultaneousGesture(
+                        DragGesture(minimumDistance: 0)
+                            .onChanged { _ in
+                                if vm.isActive { vm.beginDistraction() }
+                            }
+                            .onEnded { _ in
+                                vm.endDistraction()
+                            }
+                    )
+
+                Text("Hold — hyperfocus")
+                    .font(SPFont.serifItalic(15))
+                    .foregroundStyle(Color(SPColor.fg))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, SPSpacing.s3)
+                    .padding(.vertical, SPSpacing.s2)
+                    .frame(maxWidth: .infinity)
+                    .background(
+                        vm.mindState == "hyperfocus"
+                            ? Color(red: 0.15, green: 0.22, blue: 0.38).opacity(0.55)
+                            : SPColor.surface2
+                    )
+                    .clipShape(Capsule())
+                    .overlay(
+                        Capsule().stroke(
+                            vm.mindState == "hyperfocus"
+                                ? Color.blue.opacity(0.45)
+                                : SPColor.border2
+                        )
+                    )
+                    .opacity(vm.isActive ? 1 : 0.45)
+                    .accessibilityLabel("Hold for hyperfocus. Release to return to aware.")
+                    .simultaneousGesture(
+                        DragGesture(minimumDistance: 0)
+                            .onChanged { _ in
+                                if vm.isActive { vm.beginHyperfocus() }
+                            }
+                            .onEnded { _ in
+                                vm.endHyperfocus()
+                            }
+                    )
+            }
+            .padding(.horizontal, SPSpacing.s2)
         }
         .padding(.vertical, SPSpacing.s3)
         .background(

--- a/ios/StillPointShared/Sources/StillPointShared/Models/MindStateEntry.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/Models/MindStateEntry.swift
@@ -6,7 +6,7 @@ public struct MindStateEntry: Codable, Equatable, Sendable {
     /// Seconds elapsed when this state began
     public let time: Double
 
-    /// Either "clear" or "thinking"
+    /// "clear" (aware), "thinking" (distraction), or "hyperfocus" (deep absorption; counts toward awareness in clear %).
     public let state: String
 
     public init(time: Double, state: String) {
@@ -14,5 +14,5 @@ public struct MindStateEntry: Codable, Equatable, Sendable {
         self.state = state
     }
 
-    public var isClear: Bool { state == "clear" }
+    public var isClear: Bool { state == "clear" || state == "hyperfocus" }
 }

--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -87,7 +87,7 @@ export function BuddySessionRoom({
   const [controlsVisible, setControlsVisible] = useState(true);
   const elapsedRef = useRef(0);
   const [displayElapsed, setDisplayElapsed] = useState(0);
-  const holdKindRef = useRef<"none" | "pointerDistraction" | "spaceDistraction" | "commaHyperfocus">("none");
+  const holdKindRef = useRef<"none" | "pointerHold" | "spaceDistraction" | "commaHyperfocus">("none");
   const spaceDownRef = useRef(false);
   const commaDownRef = useRef(false);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -924,7 +924,7 @@ export function BuddySessionRoom({
               <div
                 style={{
                   width: "100%",
-                  maxWidth: "min(420px, calc(100vw - 24px))",
+                  maxWidth: "min(420px, calc(100vw - 40px))",
                   margin: "0 auto",
                   display: "flex",
                   flexDirection: "column",
@@ -1003,18 +1003,18 @@ export function BuddySessionRoom({
                     onMouseDown={(e) => {
                       e.preventDefault();
                       if (mindStateRef.current !== "clear" || showPostDistractionCapture) return;
-                      holdKindRef.current = "pointerDistraction";
+                      holdKindRef.current = "pointerHold";
                       beginBuddyDistraction();
                     }}
                     onMouseUp={() => {
-                      if (holdKindRef.current !== "pointerDistraction" || mindStateRef.current !== "thinking") {
+                      if (holdKindRef.current !== "pointerHold" || mindStateRef.current !== "thinking") {
                         return;
                       }
                       holdKindRef.current = "none";
                       finalizeActiveBuddyHold(elapsedRef.current, true);
                     }}
                     onMouseLeave={() => {
-                      if (holdKindRef.current === "pointerDistraction" && mindStateRef.current === "thinking") {
+                      if (holdKindRef.current === "pointerHold" && mindStateRef.current === "thinking") {
                         holdKindRef.current = "none";
                         finalizeActiveBuddyHold(elapsedRef.current, true);
                       }
@@ -1022,18 +1022,18 @@ export function BuddySessionRoom({
                     onTouchStart={(e) => {
                       e.preventDefault();
                       if (mindStateRef.current !== "clear" || showPostDistractionCapture) return;
-                      holdKindRef.current = "pointerDistraction";
+                      holdKindRef.current = "pointerHold";
                       beginBuddyDistraction();
                     }}
                     onTouchEnd={() => {
-                      if (holdKindRef.current !== "pointerDistraction" || mindStateRef.current !== "thinking") {
+                      if (holdKindRef.current !== "pointerHold" || mindStateRef.current !== "thinking") {
                         return;
                       }
                       holdKindRef.current = "none";
                       finalizeActiveBuddyHold(elapsedRef.current, true);
                     }}
                     onTouchCancel={() => {
-                      if (holdKindRef.current !== "pointerDistraction" || mindStateRef.current !== "thinking") {
+                      if (holdKindRef.current !== "pointerHold" || mindStateRef.current !== "thinking") {
                         return;
                       }
                       holdKindRef.current = "none";
@@ -1090,18 +1090,18 @@ export function BuddySessionRoom({
                     onMouseDown={(e) => {
                       e.preventDefault();
                       if (mindStateRef.current !== "clear" || showPostDistractionCapture) return;
-                      holdKindRef.current = "pointerDistraction";
+                      holdKindRef.current = "pointerHold";
                       beginBuddyHyperfocus();
                     }}
                     onMouseUp={() => {
-                      if (holdKindRef.current !== "pointerDistraction" || mindStateRef.current !== "hyperfocus") {
+                      if (holdKindRef.current !== "pointerHold" || mindStateRef.current !== "hyperfocus") {
                         return;
                       }
                       holdKindRef.current = "none";
                       finalizeActiveBuddyHold(elapsedRef.current, false);
                     }}
                     onMouseLeave={() => {
-                      if (holdKindRef.current === "pointerDistraction" && mindStateRef.current === "hyperfocus") {
+                      if (holdKindRef.current === "pointerHold" && mindStateRef.current === "hyperfocus") {
                         holdKindRef.current = "none";
                         finalizeActiveBuddyHold(elapsedRef.current, false);
                       }
@@ -1109,18 +1109,18 @@ export function BuddySessionRoom({
                     onTouchStart={(e) => {
                       e.preventDefault();
                       if (mindStateRef.current !== "clear" || showPostDistractionCapture) return;
-                      holdKindRef.current = "pointerDistraction";
+                      holdKindRef.current = "pointerHold";
                       beginBuddyHyperfocus();
                     }}
                     onTouchEnd={() => {
-                      if (holdKindRef.current !== "pointerDistraction" || mindStateRef.current !== "hyperfocus") {
+                      if (holdKindRef.current !== "pointerHold" || mindStateRef.current !== "hyperfocus") {
                         return;
                       }
                       holdKindRef.current = "none";
                       finalizeActiveBuddyHold(elapsedRef.current, false);
                     }}
                     onTouchCancel={() => {
-                      if (holdKindRef.current !== "pointerDistraction" || mindStateRef.current !== "hyperfocus") {
+                      if (holdKindRef.current !== "pointerHold" || mindStateRef.current !== "hyperfocus") {
                         return;
                       }
                       holdKindRef.current = "none";

--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -9,7 +9,8 @@ import { BlockTimer } from "./BlockTimer";
 import { BuddyVideo } from "./BuddyVideo";
 import { ThoughtCapture } from "./ThoughtCapture";
 import { loadSoundPrefs, saveSoundPrefs, type SoundPrefs } from "@/lib/audio";
-import { computeClearPercentFromLog, isMindStateTypingTarget } from "@/lib/mindStateSession";
+import { computeClearPercentFromLog } from "@/lib/mindStateSession";
+import { useMindStateHold } from "@/lib/useMindStateHold";
 
 /** Payload for the shared `/app` completion screen after a buddy sit (#119). */
 export type BuddyPersonalRecordPayload = {
@@ -87,9 +88,6 @@ export function BuddySessionRoom({
   const [controlsVisible, setControlsVisible] = useState(true);
   const elapsedRef = useRef(0);
   const [displayElapsed, setDisplayElapsed] = useState(0);
-  const holdKindRef = useRef<"none" | "pointerHold" | "spaceDistraction" | "commaHyperfocus">("none");
-  const spaceDownRef = useRef(false);
-  const commaDownRef = useRef(false);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const timerAnchorRef = useRef<string | null>(null);
   const [personalRecordError, setPersonalRecordError] = useState<string | null>(null);
@@ -101,6 +99,57 @@ export function BuddySessionRoom({
   const sessionThoughtsRef = useRef(sessionThoughts);
   snapRef.current = snap;
   sessionThoughtsRef.current = sessionThoughts;
+
+  const finalizeActiveBuddyHold = useCallback((atTime: number, offerThoughtCapture: boolean) => {
+    const ms = mindStateRef.current;
+    if (ms !== "thinking" && ms !== "hyperfocus") return;
+    setMindState("clear");
+    mindStateRef.current = "clear";
+    setMindStateLog((prev) => {
+      const next = [...prev, { time: atTime, state: "clear" }];
+      mindStateLogRef.current = next;
+      return next;
+    });
+    if (ms === "thinking") {
+      setShowPostDistractionCapture(offerThoughtCapture);
+    }
+  }, []);
+
+  const beginBuddyDistraction = useCallback(() => {
+    if (mindStateRef.current !== "clear" || showPostDistractionCapture) return;
+    setMindState("thinking");
+    mindStateRef.current = "thinking";
+    setMindStateLog((prev) => {
+      const next = [...prev, { time: elapsedRef.current, state: "thinking" }];
+      mindStateLogRef.current = next;
+      return next;
+    });
+    setDistractionSegmentCount((c) => c + 1);
+  }, [showPostDistractionCapture]);
+
+  const beginBuddyHyperfocus = useCallback(() => {
+    if (mindStateRef.current !== "clear" || showPostDistractionCapture) return;
+    setMindState("hyperfocus");
+    mindStateRef.current = "hyperfocus";
+    setMindStateLog((prev) => {
+      const next = [...prev, { time: elapsedRef.current, state: "hyperfocus" }];
+      mindStateLogRef.current = next;
+      return next;
+    });
+  }, [showPostDistractionCapture]);
+
+  const endBuddyHoldFromKeyboard = useCallback(() => {
+    finalizeActiveBuddyHold(elapsedRef.current, true);
+  }, [finalizeActiveBuddyHold]);
+
+  const buddyHoldActive = snap?.state === "active";
+
+  const { holdKindRef, resetHoldTracking } = useMindStateHold({
+    enabled: buddyHoldActive,
+    beginDistraction: beginBuddyDistraction,
+    beginHyperfocus: beginBuddyHyperfocus,
+    endHoldFromKeyboard: endBuddyHoldFromKeyboard,
+  });
 
   const poll = useCallback(async () => {
     if (pollStopped) return;
@@ -171,12 +220,10 @@ export function BuddySessionRoom({
     setMindState("clear");
     setMindStateLog([]);
     setShowPostDistractionCapture(false);
-    holdKindRef.current = "none";
-    spaceDownRef.current = false;
-    commaDownRef.current = false;
+    resetHoldTracking();
     setSessionThoughts([]);
     setDistractionSegmentCount(0);
-  }, [sessionId, snap?.state, snap?.startedAt]);
+  }, [sessionId, snap?.state, snap?.startedAt, resetHoldTracking]);
 
   useEffect(() => {
     const resetTimer = () => {
@@ -210,101 +257,6 @@ export function BuddySessionRoom({
     return computeClearPercentFromLog(mindStateLog, endT);
   }, [snap?.startedAt, snap?.state, snap?.durationSeconds, displayElapsed, mindStateLog]);
 
-  const finalizeActiveBuddyHold = useCallback((atTime: number, offerThoughtCapture: boolean) => {
-    const ms = mindStateRef.current;
-    if (ms !== "thinking" && ms !== "hyperfocus") return;
-    setMindState("clear");
-    mindStateRef.current = "clear";
-    setMindStateLog((prev) => {
-      const next = [...prev, { time: atTime, state: "clear" }];
-      mindStateLogRef.current = next;
-      return next;
-    });
-    if (ms === "thinking") {
-      setShowPostDistractionCapture(offerThoughtCapture);
-    }
-  }, []);
-
-  const beginBuddyDistraction = useCallback(() => {
-    if (mindStateRef.current !== "clear" || showPostDistractionCapture) return;
-    setMindState("thinking");
-    mindStateRef.current = "thinking";
-    setMindStateLog((prev) => {
-      const next = [...prev, { time: elapsedRef.current, state: "thinking" }];
-      mindStateLogRef.current = next;
-      return next;
-    });
-    setDistractionSegmentCount((c) => c + 1);
-  }, [showPostDistractionCapture]);
-
-  const beginBuddyHyperfocus = useCallback(() => {
-    if (mindStateRef.current !== "clear" || showPostDistractionCapture) return;
-    setMindState("hyperfocus");
-    mindStateRef.current = "hyperfocus";
-    setMindStateLog((prev) => {
-      const next = [...prev, { time: elapsedRef.current, state: "hyperfocus" }];
-      mindStateLogRef.current = next;
-      return next;
-    });
-  }, [showPostDistractionCapture]);
-
-  const endBuddyHoldFromKeyboard = useCallback(() => {
-    finalizeActiveBuddyHold(elapsedRef.current, true);
-  }, [finalizeActiveBuddyHold]);
-
-  useEffect(() => {
-    if (snap?.state !== "active") return;
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (isMindStateTypingTarget(e.target)) return;
-
-      if (e.code === "Space" && !e.repeat) {
-        e.preventDefault();
-        spaceDownRef.current = true;
-        if (holdKindRef.current === "none") {
-          holdKindRef.current = "spaceDistraction";
-          beginBuddyDistraction();
-        }
-        return;
-      }
-
-      if ((e.code === "Comma" || e.key === ",") && !e.repeat) {
-        e.preventDefault();
-        commaDownRef.current = true;
-        if (holdKindRef.current === "none") {
-          holdKindRef.current = "commaHyperfocus";
-          beginBuddyHyperfocus();
-        }
-      }
-    };
-    const onKeyUp = (e: KeyboardEvent) => {
-      if (e.code === "Space") {
-        if (!spaceDownRef.current) return;
-        spaceDownRef.current = false;
-        e.preventDefault();
-        if (holdKindRef.current === "spaceDistraction") {
-          holdKindRef.current = "none";
-          endBuddyHoldFromKeyboard();
-        }
-        return;
-      }
-      if (e.code === "Comma" || e.key === ",") {
-        if (!commaDownRef.current) return;
-        commaDownRef.current = false;
-        e.preventDefault();
-        if (holdKindRef.current === "commaHyperfocus") {
-          holdKindRef.current = "none";
-          endBuddyHoldFromKeyboard();
-        }
-      }
-    };
-    window.addEventListener("keydown", onKeyDown, { capture: true });
-    window.addEventListener("keyup", onKeyUp, { capture: true });
-    return () => {
-      window.removeEventListener("keydown", onKeyDown, { capture: true });
-      window.removeEventListener("keyup", onKeyUp, { capture: true });
-    };
-  }, [snap?.state, beginBuddyDistraction, beginBuddyHyperfocus, endBuddyHoldFromKeyboard]);
-
   const handleSaveThought = (text: string) => {
     setSessionThoughts((prev) => [...prev, { timeInSession: Math.round(elapsedRef.current), text }]);
     setShowPostDistractionCapture(false);
@@ -327,10 +279,8 @@ export function BuddySessionRoom({
       return next;
     });
     setShowPostDistractionCapture(false);
-    holdKindRef.current = "none";
-    spaceDownRef.current = false;
-    commaDownRef.current = false;
-  }, []);
+    resetHoldTracking();
+  }, [resetHoldTracking]);
 
   const handleBuddyTimerComplete = useCallback(() => {
     closeOpenBuddyHold();

--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { CSSProperties } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api, ApiError, type BuddySnapshot } from "@/lib/api";
 import { BUDDY_POLICY_CODES, buddyPolicyUserMessage } from "@/lib/buddyPolicyCodes";
 import { useIsMobile } from "@/lib/useIsMobile";
@@ -9,6 +9,7 @@ import { BlockTimer } from "./BlockTimer";
 import { BuddyVideo } from "./BuddyVideo";
 import { ThoughtCapture } from "./ThoughtCapture";
 import { loadSoundPrefs, saveSoundPrefs, type SoundPrefs } from "@/lib/audio";
+import { computeClearPercentFromLog, isMindStateTypingTarget } from "@/lib/mindStateSession";
 
 /** Payload for the shared `/app` completion screen after a buddy sit (#119). */
 export type BuddyPersonalRecordPayload = {
@@ -34,24 +35,6 @@ function getLocalIsoDate(): string {
   const month = String(now.getMonth() + 1).padStart(2, "0");
   const day = String(now.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
-}
-
-function calcBuddyClearPercent(
-  mindStateLog: Array<{ time: number; state: string }>,
-  totalSeconds: number,
-): number {
-  if (mindStateLog.length === 0) return 100;
-  let clearTime = 0;
-  let lastTime = 0;
-  let lastState = "clear";
-  const endTime = totalSeconds;
-  const log = [...mindStateLog, { time: endTime, state: "clear" }];
-  for (const entry of log) {
-    if (lastState === "clear") clearTime += entry.time - lastTime;
-    lastTime = entry.time;
-    lastState = entry.state;
-  }
-  return Math.round((clearTime / endTime) * 100);
 }
 
 function formatBuddyActionError(e: unknown, fallback: string): string {
@@ -90,8 +73,10 @@ export function BuddySessionRoom({
   const [pollStopped, setPollStopped] = useState(false);
   const lastRevision = useRef(-1);
   const [mindState, setMindState] = useState("clear");
+  const mindStateRef = useRef(mindState);
+  mindStateRef.current = mindState;
   const [mindStateLog, setMindStateLog] = useState<Array<{ time: number; state: string }>>([]);
-  const [showThoughtInput, setShowThoughtInput] = useState(false);
+  const [showPostDistractionCapture, setShowPostDistractionCapture] = useState(false);
   const [sessionThoughts, setSessionThoughts] = useState<Array<{ timeInSession: number; text: string }>>(
     [],
   );
@@ -99,6 +84,9 @@ export function BuddySessionRoom({
   const [soundPrefs, setSoundPrefs] = useState<SoundPrefs>(() => loadSoundPrefs());
   const [controlsVisible, setControlsVisible] = useState(true);
   const elapsedRef = useRef(0);
+  const [displayElapsed, setDisplayElapsed] = useState(0);
+  const holdActiveRef = useRef(false);
+  const spaceDownRef = useRef(false);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const timerAnchorRef = useRef<string | null>(null);
   const [personalRecordError, setPersonalRecordError] = useState<string | null>(null);
@@ -111,7 +99,6 @@ export function BuddySessionRoom({
   const sessionThoughtCountRef = useRef(sessionThoughtCount);
 
   snapRef.current = snap;
-  mindStateLogRef.current = mindStateLog;
   sessionThoughtsRef.current = sessionThoughts;
   sessionThoughtCountRef.current = sessionThoughtCount;
 
@@ -183,7 +170,9 @@ export function BuddySessionRoom({
     timerAnchorRef.current = anchor;
     setMindState("clear");
     setMindStateLog([]);
-    setShowThoughtInput(false);
+    setShowPostDistractionCapture(false);
+    holdActiveRef.current = false;
+    spaceDownRef.current = false;
     setSessionThoughts([]);
     setSessionThoughtCount(0);
   }, [sessionId, snap?.state, snap?.startedAt]);
@@ -210,38 +199,108 @@ export function BuddySessionRoom({
 
   const handleElapsedChange = useCallback((elapsed: number) => {
     elapsedRef.current = elapsed;
+    setDisplayElapsed(elapsed);
   }, []);
 
-  const handleBuddyTimerComplete = useCallback(() => {
-    void poll();
-  }, [poll]);
+  const buddyAwarenessPct = useMemo(() => {
+    if (!snap?.startedAt || snap.state !== "active") return 100;
+    const cap = Math.max(snap.durationSeconds, 1);
+    const endT = Math.min(cap, displayElapsed);
+    return computeClearPercentFromLog(mindStateLog, endT);
+  }, [snap?.startedAt, snap?.state, snap?.durationSeconds, displayElapsed, mindStateLog]);
 
-  const handleThinkingToggle = () => {
-    const now = elapsedRef.current;
-    if (mindState === "clear") {
-      setMindState("thinking");
-      setMindStateLog((prev) => [...prev, { time: now, state: "thinking" }]);
-      setSessionThoughtCount((prev) => prev + 1);
-      setShowThoughtInput(true);
-    } else {
-      setMindState("clear");
-      setMindStateLog((prev) => [...prev, { time: now, state: "clear" }]);
-      setShowThoughtInput(false);
-    }
-  };
+  useEffect(() => {
+    mindStateLogRef.current = mindStateLog;
+  }, [mindStateLog]);
+
+  const finalizeActiveBuddyDistraction = useCallback((atTime: number, offerThoughtCapture: boolean) => {
+    if (mindStateRef.current !== "thinking") return;
+    setMindState("clear");
+    mindStateRef.current = "clear";
+    setMindStateLog((prev) => {
+      const next = [...prev, { time: atTime, state: "clear" }];
+      mindStateLogRef.current = next;
+      return next;
+    });
+    setShowPostDistractionCapture(offerThoughtCapture);
+  }, []);
+
+  const beginBuddyDistraction = useCallback(() => {
+    if (mindStateRef.current !== "clear") return;
+    setShowPostDistractionCapture(false);
+    setMindState("thinking");
+    mindStateRef.current = "thinking";
+    setMindStateLog((prev) => {
+      const next = [...prev, { time: elapsedRef.current, state: "thinking" }];
+      mindStateLogRef.current = next;
+      return next;
+    });
+    setSessionThoughtCount((c) => c + 1);
+  }, []);
+
+  const endBuddyDistractionHold = useCallback(() => {
+    if (!holdActiveRef.current) return;
+    holdActiveRef.current = false;
+    finalizeActiveBuddyDistraction(elapsedRef.current, true);
+  }, [finalizeActiveBuddyDistraction]);
+
+  useEffect(() => {
+    if (snap?.state !== "active") return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.code !== "Space" || e.repeat) return;
+      if (isMindStateTypingTarget(e.target)) return;
+      e.preventDefault();
+      spaceDownRef.current = true;
+      if (!holdActiveRef.current) {
+        holdActiveRef.current = true;
+        beginBuddyDistraction();
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.code !== "Space") return;
+      if (!spaceDownRef.current) return;
+      spaceDownRef.current = false;
+      e.preventDefault();
+      endBuddyDistractionHold();
+    };
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    window.addEventListener("keyup", onKeyUp, { capture: true });
+    return () => {
+      window.removeEventListener("keydown", onKeyDown, { capture: true });
+      window.removeEventListener("keyup", onKeyUp, { capture: true });
+    };
+  }, [snap?.state, beginBuddyDistraction, endBuddyDistractionHold]);
 
   const handleSaveThought = (text: string) => {
     setSessionThoughts((prev) => [...prev, { timeInSession: Math.round(elapsedRef.current), text }]);
-    setMindState("clear");
-    setMindStateLog((prev) => [...prev, { time: elapsedRef.current, state: "clear" }]);
-    setShowThoughtInput(false);
+    setShowPostDistractionCapture(false);
   };
 
-  const handleSkipThought = () => {
-    setMindState("clear");
-    setMindStateLog((prev) => [...prev, { time: elapsedRef.current, state: "clear" }]);
-    setShowThoughtInput(false);
+  const handleDismissPostCapture = () => {
+    setShowPostDistractionCapture(false);
   };
+
+  const closeOpenBuddyDistraction = useCallback(() => {
+    if (mindStateRef.current !== "thinking") return;
+    const duration = snapRef.current?.durationSeconds;
+    const at =
+      duration && duration > 0 ? Math.min(duration, elapsedRef.current) : elapsedRef.current;
+    setMindState("clear");
+    mindStateRef.current = "clear";
+    setMindStateLog((prev) => {
+      const next = [...prev, { time: at, state: "clear" }];
+      mindStateLogRef.current = next;
+      return next;
+    });
+    setShowPostDistractionCapture(false);
+    holdActiveRef.current = false;
+    spaceDownRef.current = false;
+  }, []);
+
+  const handleBuddyTimerComplete = useCallback(() => {
+    closeOpenBuddyDistraction();
+    void poll();
+  }, [poll, closeOpenBuddyDistraction]);
 
   const setReady = async (ready: boolean) => {
     try {
@@ -292,7 +351,7 @@ export function BuddySessionRoom({
     setPersonalRecordError(null);
     try {
       const durationSeconds = snapNow.durationSeconds;
-      const clearPercent = calcBuddyClearPercent(mindStateLogRef.current, durationSeconds);
+      const clearPercent = computeClearPercentFromLog(mindStateLogRef.current, durationSeconds);
       const thoughtsSnapshot = sessionThoughtsRef.current;
       const { session } = await api.recordBuddyPersonalSession(sessionId, {
         clearPercent,
@@ -829,10 +888,9 @@ export function BuddySessionRoom({
 
               <div
                 style={{
-                  opacity: controlsVisible ? 1 : 0,
-                  transition: "opacity 0.5s ease",
-                  pointerEvents: controlsVisible ? "auto" : "none",
                   width: "100%",
+                  maxWidth: "min(420px, calc(100vw - 24px))",
+                  margin: "0 auto",
                   display: "flex",
                   flexDirection: "column",
                   alignItems: "center",
@@ -842,16 +900,73 @@ export function BuddySessionRoom({
                   style={{
                     display: "flex",
                     alignItems: "center",
-                    gap: "16px",
+                    gap: "10px",
                     marginTop: "8px",
-                    justifyContent: "center",
-                    flexWrap: "wrap",
+                    fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                    fontSize: "11px",
+                    letterSpacing: "0.12em",
+                    textTransform: "uppercase",
+                    color: "var(--fg-3)",
                   }}
                 >
+                  <span
+                    aria-hidden
+                    style={{
+                      width: "10px",
+                      height: "10px",
+                      borderRadius: "50%",
+                      background: mindState === "thinking" ? "var(--accent-amber)" : "var(--accent-green)",
+                      boxShadow: mindState === "thinking" ? "0 0 12px var(--accent-amber)" : "none",
+                      flexShrink: 0,
+                    }}
+                  />
+                  <span>{mindState === "thinking" ? "Distracted" : "Aware"}</span>
+                  {sessionThoughtCount > 0 && (
+                    <span style={{ color: "var(--accent-amber-border)", marginLeft: "4px" }}>
+                      · {sessionThoughtCount} {sessionThoughtCount === 1 ? "segment" : "segments"}
+                    </span>
+                  )}
+                </div>
+
+                <div style={{ display: "flex", justifyContent: "center", marginTop: "12px", width: "100%" }}>
                   <button
                     type="button"
-                    onClick={handleThinkingToggle}
+                    aria-pressed={mindState === "thinking"}
+                    aria-label="Hold while distracted. Release when you are aware again."
                     title="Mind-state and thoughts stay on this device; others are not notified."
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      if (mindStateRef.current !== "clear") return;
+                      holdActiveRef.current = true;
+                      beginBuddyDistraction();
+                    }}
+                    onMouseUp={() => {
+                      if (!holdActiveRef.current) return;
+                      holdActiveRef.current = false;
+                      finalizeActiveBuddyDistraction(elapsedRef.current, true);
+                    }}
+                    onMouseLeave={() => {
+                      if (holdActiveRef.current) {
+                        holdActiveRef.current = false;
+                        finalizeActiveBuddyDistraction(elapsedRef.current, true);
+                      }
+                    }}
+                    onTouchStart={(e) => {
+                      e.preventDefault();
+                      if (mindStateRef.current !== "clear") return;
+                      holdActiveRef.current = true;
+                      beginBuddyDistraction();
+                    }}
+                    onTouchEnd={() => {
+                      if (!holdActiveRef.current) return;
+                      holdActiveRef.current = false;
+                      finalizeActiveBuddyDistraction(elapsedRef.current, true);
+                    }}
+                    onTouchCancel={() => {
+                      if (!holdActiveRef.current) return;
+                      holdActiveRef.current = false;
+                      finalizeActiveBuddyDistraction(elapsedRef.current, true);
+                    }}
                     style={{
                       background:
                         mindState === "thinking"
@@ -872,40 +987,64 @@ export function BuddySessionRoom({
                       borderRadius: "24px",
                       cursor: "pointer",
                       transition: "all 0.3s",
-                      minWidth: "160px",
+                      minWidth: "200px",
                     }}
                   >
-                    {mindState === "thinking" ? "\u25CB clear mind" : "\u2726 I'm thinking"}
+                    {mindState === "thinking" ? "Release — aware again" : "Hold — distracted"}
                   </button>
-                  {sessionThoughtCount > 0 && (
-                    <div
-                      style={{
-                        fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-                        fontSize: "11px",
-                        color: "var(--accent-amber-border)",
-                        display: "flex",
-                        alignItems: "center",
-                        gap: "4px",
-                      }}
-                    >
-                      💭 {sessionThoughtCount}
-                    </div>
-                  )}
                 </div>
 
-                {showThoughtInput && (
+                <p
+                  style={{
+                    margin: "10px 0 0",
+                    textAlign: "center",
+                    fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                    fontSize: "10px",
+                    color: "var(--fg-4)",
+                    letterSpacing: "0.06em",
+                  }}
+                >
+                  Spacebar (hold) when not typing — only on your device.
+                </p>
+
+                <div
+                  style={{
+                    marginTop: "12px",
+                    fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                    fontSize: "10px",
+                    color: "var(--fg-4)",
+                    letterSpacing: "0.08em",
+                    textAlign: "center",
+                  }}
+                >
+                  <span style={{ color: "var(--accent-green-dim)" }}>{buddyAwarenessPct}% awareness</span>
+                  <span style={{ margin: "0 6px", color: "var(--fg-4)" }}>·</span>
+                  <span style={{ color: "var(--accent-amber-border)" }}>
+                    {100 - buddyAwarenessPct}% distraction
+                  </span>
+                </div>
+
+                {showPostDistractionCapture && (
                   <div
-                    style={{
-                      marginTop: "20px",
-                      width: "100%",
-                      display: "flex",
-                      justifyContent: "center",
-                    }}
+                    data-no-space-distraction
+                    style={{ marginTop: "16px", width: "100%", display: "flex", justifyContent: "center" }}
                   >
-                    <ThoughtCapture onSave={handleSaveThought} onCancel={handleSkipThought} />
+                    <ThoughtCapture onSave={handleSaveThought} onCancel={handleDismissPostCapture} />
                   </div>
                 )}
+              </div>
 
+              <div
+                style={{
+                  opacity: controlsVisible ? 1 : 0,
+                  transition: "opacity 0.5s ease",
+                  pointerEvents: controlsVisible ? "auto" : "none",
+                  width: "100%",
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                }}
+              >
                 <div
                   style={{
                     display: "flex",

--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -37,6 +37,8 @@ function getLocalIsoDate(): string {
   return `${year}-${month}-${day}`;
 }
 
+type BuddyMindState = "clear" | "thinking" | "hyperfocus";
+
 function formatBuddyActionError(e: unknown, fallback: string): string {
   if (e instanceof ApiError) {
     return buddyPolicyUserMessage(e.code) ?? e.message;
@@ -72,21 +74,22 @@ export function BuddySessionRoom({
   const [pollError, setPollError] = useState<string | null>(null);
   const [pollStopped, setPollStopped] = useState(false);
   const lastRevision = useRef(-1);
-  const [mindState, setMindState] = useState("clear");
-  const mindStateRef = useRef(mindState);
+  const [mindState, setMindState] = useState<BuddyMindState>("clear");
+  const mindStateRef = useRef<BuddyMindState>(mindState);
   mindStateRef.current = mindState;
   const [mindStateLog, setMindStateLog] = useState<Array<{ time: number; state: string }>>([]);
   const [showPostDistractionCapture, setShowPostDistractionCapture] = useState(false);
   const [sessionThoughts, setSessionThoughts] = useState<Array<{ timeInSession: number; text: string }>>(
     [],
   );
-  const [sessionThoughtCount, setSessionThoughtCount] = useState(0);
+  const [distractionSegmentCount, setDistractionSegmentCount] = useState(0);
   const [soundPrefs, setSoundPrefs] = useState<SoundPrefs>(() => loadSoundPrefs());
   const [controlsVisible, setControlsVisible] = useState(true);
   const elapsedRef = useRef(0);
   const [displayElapsed, setDisplayElapsed] = useState(0);
-  const holdActiveRef = useRef(false);
+  const holdKindRef = useRef<"none" | "pointerDistraction" | "spaceDistraction" | "commaHyperfocus">("none");
   const spaceDownRef = useRef(false);
+  const commaDownRef = useRef(false);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const timerAnchorRef = useRef<string | null>(null);
   const [personalRecordError, setPersonalRecordError] = useState<string | null>(null);
@@ -96,11 +99,8 @@ export function BuddySessionRoom({
   const snapRef = useRef(snap);
   const mindStateLogRef = useRef(mindStateLog);
   const sessionThoughtsRef = useRef(sessionThoughts);
-  const sessionThoughtCountRef = useRef(sessionThoughtCount);
-
   snapRef.current = snap;
   sessionThoughtsRef.current = sessionThoughts;
-  sessionThoughtCountRef.current = sessionThoughtCount;
 
   const poll = useCallback(async () => {
     if (pollStopped) return;
@@ -171,10 +171,11 @@ export function BuddySessionRoom({
     setMindState("clear");
     setMindStateLog([]);
     setShowPostDistractionCapture(false);
-    holdActiveRef.current = false;
+    holdKindRef.current = "none";
     spaceDownRef.current = false;
+    commaDownRef.current = false;
     setSessionThoughts([]);
-    setSessionThoughtCount(0);
+    setDistractionSegmentCount(0);
   }, [sessionId, snap?.state, snap?.startedAt]);
 
   useEffect(() => {
@@ -209,12 +210,9 @@ export function BuddySessionRoom({
     return computeClearPercentFromLog(mindStateLog, endT);
   }, [snap?.startedAt, snap?.state, snap?.durationSeconds, displayElapsed, mindStateLog]);
 
-  useEffect(() => {
-    mindStateLogRef.current = mindStateLog;
-  }, [mindStateLog]);
-
-  const finalizeActiveBuddyDistraction = useCallback((atTime: number, offerThoughtCapture: boolean) => {
-    if (mindStateRef.current !== "thinking") return;
+  const finalizeActiveBuddyHold = useCallback((atTime: number, offerThoughtCapture: boolean) => {
+    const ms = mindStateRef.current;
+    if (ms !== "thinking" && ms !== "hyperfocus") return;
     setMindState("clear");
     mindStateRef.current = "clear";
     setMindStateLog((prev) => {
@@ -222,12 +220,13 @@ export function BuddySessionRoom({
       mindStateLogRef.current = next;
       return next;
     });
-    setShowPostDistractionCapture(offerThoughtCapture);
+    if (ms === "thinking") {
+      setShowPostDistractionCapture(offerThoughtCapture);
+    }
   }, []);
 
   const beginBuddyDistraction = useCallback(() => {
-    if (mindStateRef.current !== "clear") return;
-    setShowPostDistractionCapture(false);
+    if (mindStateRef.current !== "clear" || showPostDistractionCapture) return;
     setMindState("thinking");
     mindStateRef.current = "thinking";
     setMindStateLog((prev) => {
@@ -235,33 +234,68 @@ export function BuddySessionRoom({
       mindStateLogRef.current = next;
       return next;
     });
-    setSessionThoughtCount((c) => c + 1);
-  }, []);
+    setDistractionSegmentCount((c) => c + 1);
+  }, [showPostDistractionCapture]);
 
-  const endBuddyDistractionHold = useCallback(() => {
-    if (!holdActiveRef.current) return;
-    holdActiveRef.current = false;
-    finalizeActiveBuddyDistraction(elapsedRef.current, true);
-  }, [finalizeActiveBuddyDistraction]);
+  const beginBuddyHyperfocus = useCallback(() => {
+    if (mindStateRef.current !== "clear" || showPostDistractionCapture) return;
+    setMindState("hyperfocus");
+    mindStateRef.current = "hyperfocus";
+    setMindStateLog((prev) => {
+      const next = [...prev, { time: elapsedRef.current, state: "hyperfocus" }];
+      mindStateLogRef.current = next;
+      return next;
+    });
+  }, [showPostDistractionCapture]);
+
+  const endBuddyHoldFromKeyboard = useCallback(() => {
+    finalizeActiveBuddyHold(elapsedRef.current, true);
+  }, [finalizeActiveBuddyHold]);
 
   useEffect(() => {
     if (snap?.state !== "active") return;
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.code !== "Space" || e.repeat) return;
       if (isMindStateTypingTarget(e.target)) return;
-      e.preventDefault();
-      spaceDownRef.current = true;
-      if (!holdActiveRef.current) {
-        holdActiveRef.current = true;
-        beginBuddyDistraction();
+
+      if (e.code === "Space" && !e.repeat) {
+        e.preventDefault();
+        spaceDownRef.current = true;
+        if (holdKindRef.current === "none") {
+          holdKindRef.current = "spaceDistraction";
+          beginBuddyDistraction();
+        }
+        return;
+      }
+
+      if ((e.code === "Comma" || e.key === ",") && !e.repeat) {
+        e.preventDefault();
+        commaDownRef.current = true;
+        if (holdKindRef.current === "none") {
+          holdKindRef.current = "commaHyperfocus";
+          beginBuddyHyperfocus();
+        }
       }
     };
     const onKeyUp = (e: KeyboardEvent) => {
-      if (e.code !== "Space") return;
-      if (!spaceDownRef.current) return;
-      spaceDownRef.current = false;
-      e.preventDefault();
-      endBuddyDistractionHold();
+      if (e.code === "Space") {
+        if (!spaceDownRef.current) return;
+        spaceDownRef.current = false;
+        e.preventDefault();
+        if (holdKindRef.current === "spaceDistraction") {
+          holdKindRef.current = "none";
+          endBuddyHoldFromKeyboard();
+        }
+        return;
+      }
+      if (e.code === "Comma" || e.key === ",") {
+        if (!commaDownRef.current) return;
+        commaDownRef.current = false;
+        e.preventDefault();
+        if (holdKindRef.current === "commaHyperfocus") {
+          holdKindRef.current = "none";
+          endBuddyHoldFromKeyboard();
+        }
+      }
     };
     window.addEventListener("keydown", onKeyDown, { capture: true });
     window.addEventListener("keyup", onKeyUp, { capture: true });
@@ -269,7 +303,7 @@ export function BuddySessionRoom({
       window.removeEventListener("keydown", onKeyDown, { capture: true });
       window.removeEventListener("keyup", onKeyUp, { capture: true });
     };
-  }, [snap?.state, beginBuddyDistraction, endBuddyDistractionHold]);
+  }, [snap?.state, beginBuddyDistraction, beginBuddyHyperfocus, endBuddyHoldFromKeyboard]);
 
   const handleSaveThought = (text: string) => {
     setSessionThoughts((prev) => [...prev, { timeInSession: Math.round(elapsedRef.current), text }]);
@@ -280,8 +314,8 @@ export function BuddySessionRoom({
     setShowPostDistractionCapture(false);
   };
 
-  const closeOpenBuddyDistraction = useCallback(() => {
-    if (mindStateRef.current !== "thinking") return;
+  const closeOpenBuddyHold = useCallback(() => {
+    if (mindStateRef.current !== "thinking" && mindStateRef.current !== "hyperfocus") return;
     const duration = snapRef.current?.durationSeconds;
     const at =
       duration && duration > 0 ? Math.min(duration, elapsedRef.current) : elapsedRef.current;
@@ -293,14 +327,15 @@ export function BuddySessionRoom({
       return next;
     });
     setShowPostDistractionCapture(false);
-    holdActiveRef.current = false;
+    holdKindRef.current = "none";
     spaceDownRef.current = false;
+    commaDownRef.current = false;
   }, []);
 
   const handleBuddyTimerComplete = useCallback(() => {
-    closeOpenBuddyDistraction();
+    closeOpenBuddyHold();
     void poll();
-  }, [poll, closeOpenBuddyDistraction]);
+  }, [poll, closeOpenBuddyHold]);
 
   const setReady = async (ready: boolean) => {
     try {
@@ -355,7 +390,7 @@ export function BuddySessionRoom({
       const thoughtsSnapshot = sessionThoughtsRef.current;
       const { session } = await api.recordBuddyPersonalSession(sessionId, {
         clearPercent,
-        thoughtCount: sessionThoughtCountRef.current,
+        thoughtCount: thoughtsSnapshot.length,
         mindStateLog: mindStateLogRef.current,
         actualTime: durationSeconds,
         sessionDate: getLocalIsoDate(),
@@ -915,57 +950,94 @@ export function BuddySessionRoom({
                       width: "10px",
                       height: "10px",
                       borderRadius: "50%",
-                      background: mindState === "thinking" ? "var(--accent-amber)" : "var(--accent-green)",
-                      boxShadow: mindState === "thinking" ? "0 0 12px var(--accent-amber)" : "none",
+                      background:
+                        mindState === "thinking"
+                          ? "var(--accent-amber)"
+                          : mindState === "hyperfocus"
+                            ? "rgba(96, 165, 250, 0.95)"
+                            : "var(--accent-green)",
+                      boxShadow:
+                        mindState === "thinking"
+                          ? "0 0 12px var(--accent-amber)"
+                          : mindState === "hyperfocus"
+                            ? "0 0 12px rgba(59, 130, 246, 0.6)"
+                            : "none",
                       flexShrink: 0,
                     }}
                   />
-                  <span>{mindState === "thinking" ? "Distracted" : "Aware"}</span>
-                  {sessionThoughtCount > 0 && (
+                  <span>
+                    {mindState === "thinking"
+                      ? "Distracted"
+                      : mindState === "hyperfocus"
+                        ? "Hyperfocus"
+                        : "Aware"}
+                  </span>
+                  {distractionSegmentCount > 0 && (
                     <span style={{ color: "var(--accent-amber-border)", marginLeft: "4px" }}>
-                      · {sessionThoughtCount} {sessionThoughtCount === 1 ? "segment" : "segments"}
+                      · {distractionSegmentCount} light{" "}
+                      {distractionSegmentCount === 1 ? "segment" : "segments"}
+                    </span>
+                  )}
+                  {sessionThoughts.length > 0 && (
+                    <span style={{ color: "var(--accent-amber-border)", marginLeft: "4px" }}>
+                      · {sessionThoughts.length} captured {sessionThoughts.length === 1 ? "note" : "notes"}
                     </span>
                   )}
                 </div>
 
-                <div style={{ display: "flex", justifyContent: "center", marginTop: "12px", width: "100%" }}>
+                <div
+                  style={{
+                    display: "flex",
+                    flexWrap: "wrap",
+                    justifyContent: "center",
+                    gap: "12px",
+                    marginTop: "12px",
+                    width: "100%",
+                  }}
+                >
                   <button
                     type="button"
                     aria-pressed={mindState === "thinking"}
-                    aria-label="Hold while distracted. Release when you are aware again."
+                    aria-label="Hold for light distraction, or hold Space. Only on your device."
                     title="Mind-state and thoughts stay on this device; others are not notified."
                     onMouseDown={(e) => {
                       e.preventDefault();
-                      if (mindStateRef.current !== "clear") return;
-                      holdActiveRef.current = true;
+                      if (mindStateRef.current !== "clear" || showPostDistractionCapture) return;
+                      holdKindRef.current = "pointerDistraction";
                       beginBuddyDistraction();
                     }}
                     onMouseUp={() => {
-                      if (!holdActiveRef.current) return;
-                      holdActiveRef.current = false;
-                      finalizeActiveBuddyDistraction(elapsedRef.current, true);
+                      if (holdKindRef.current !== "pointerDistraction" || mindStateRef.current !== "thinking") {
+                        return;
+                      }
+                      holdKindRef.current = "none";
+                      finalizeActiveBuddyHold(elapsedRef.current, true);
                     }}
                     onMouseLeave={() => {
-                      if (holdActiveRef.current) {
-                        holdActiveRef.current = false;
-                        finalizeActiveBuddyDistraction(elapsedRef.current, true);
+                      if (holdKindRef.current === "pointerDistraction" && mindStateRef.current === "thinking") {
+                        holdKindRef.current = "none";
+                        finalizeActiveBuddyHold(elapsedRef.current, true);
                       }
                     }}
                     onTouchStart={(e) => {
                       e.preventDefault();
-                      if (mindStateRef.current !== "clear") return;
-                      holdActiveRef.current = true;
+                      if (mindStateRef.current !== "clear" || showPostDistractionCapture) return;
+                      holdKindRef.current = "pointerDistraction";
                       beginBuddyDistraction();
                     }}
                     onTouchEnd={() => {
-                      if (!holdActiveRef.current) return;
-                      holdActiveRef.current = false;
-                      finalizeActiveBuddyDistraction(elapsedRef.current, true);
+                      if (holdKindRef.current !== "pointerDistraction" || mindStateRef.current !== "thinking") {
+                        return;
+                      }
+                      holdKindRef.current = "none";
+                      finalizeActiveBuddyHold(elapsedRef.current, true);
                     }}
                     onTouchCancel={() => {
-                      if (!holdActiveRef.current) return;
-                      holdActiveRef.current = false;
-                      finalizeActiveBuddyDistraction(elapsedRef.current, true);
+                      if (holdKindRef.current !== "pointerDistraction" || mindStateRef.current !== "thinking") {
+                        return;
+                      }
+                      holdKindRef.current = "none";
+                      finalizeActiveBuddyHold(elapsedRef.current, true);
                     }}
                     style={{
                       background:
@@ -981,30 +1053,132 @@ export function BuddySessionRoom({
                         mindState === "thinking" ? "var(--accent-amber)" : "var(--accent-green)",
                       fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
                       fontSize: "12px",
-                      letterSpacing: "0.15em",
+                      letterSpacing: "0.12em",
                       textTransform: "uppercase",
-                      padding: "12px 28px",
-                      borderRadius: "24px",
+                      padding: "12px 16px",
+                      borderRadius: "16px",
                       cursor: "pointer",
-                      transition: "all 0.3s",
-                      minWidth: "200px",
+                      transition: "all 0.25s",
+                      flex: "1 1 140px",
+                      minWidth: "min(160px, 42vw)",
+                      maxWidth: "200px",
+                      display: "flex",
+                      flexDirection: "column",
+                      alignItems: "center",
+                      gap: "6px",
                     }}
                   >
-                    {mindState === "thinking" ? "Release — aware again" : "Hold — distracted"}
+                    <span>{mindState === "thinking" ? "Release" : "Hold"} — light distraction</span>
+                    <span
+                      style={{
+                        fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                        fontSize: "9px",
+                        letterSpacing: "0.14em",
+                        opacity: 0.85,
+                        textTransform: "none",
+                      }}
+                    >
+                      or hold Space
+                    </span>
+                  </button>
+
+                  <button
+                    type="button"
+                    aria-pressed={mindState === "hyperfocus"}
+                    aria-label="Hold for hyperfocus, or hold Comma. Only on your device."
+                    title="Mind-state and thoughts stay on this device; others are not notified."
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      if (mindStateRef.current !== "clear" || showPostDistractionCapture) return;
+                      holdKindRef.current = "pointerDistraction";
+                      beginBuddyHyperfocus();
+                    }}
+                    onMouseUp={() => {
+                      if (holdKindRef.current !== "pointerDistraction" || mindStateRef.current !== "hyperfocus") {
+                        return;
+                      }
+                      holdKindRef.current = "none";
+                      finalizeActiveBuddyHold(elapsedRef.current, false);
+                    }}
+                    onMouseLeave={() => {
+                      if (holdKindRef.current === "pointerDistraction" && mindStateRef.current === "hyperfocus") {
+                        holdKindRef.current = "none";
+                        finalizeActiveBuddyHold(elapsedRef.current, false);
+                      }
+                    }}
+                    onTouchStart={(e) => {
+                      e.preventDefault();
+                      if (mindStateRef.current !== "clear" || showPostDistractionCapture) return;
+                      holdKindRef.current = "pointerDistraction";
+                      beginBuddyHyperfocus();
+                    }}
+                    onTouchEnd={() => {
+                      if (holdKindRef.current !== "pointerDistraction" || mindStateRef.current !== "hyperfocus") {
+                        return;
+                      }
+                      holdKindRef.current = "none";
+                      finalizeActiveBuddyHold(elapsedRef.current, false);
+                    }}
+                    onTouchCancel={() => {
+                      if (holdKindRef.current !== "pointerDistraction" || mindStateRef.current !== "hyperfocus") {
+                        return;
+                      }
+                      holdKindRef.current = "none";
+                      finalizeActiveBuddyHold(elapsedRef.current, false);
+                    }}
+                    style={{
+                      background:
+                        mindState === "hyperfocus" ? "rgba(59, 130, 246, 0.12)" : "var(--surface-1)",
+                      border: `1px solid ${
+                        mindState === "hyperfocus" ? "rgba(59, 130, 246, 0.55)" : "var(--border-2)"
+                      }`,
+                      color:
+                        mindState === "hyperfocus" ? "rgba(147, 197, 253, 0.95)" : "var(--fg-2)",
+                      fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                      fontSize: "12px",
+                      letterSpacing: "0.12em",
+                      textTransform: "uppercase",
+                      padding: "12px 16px",
+                      borderRadius: "16px",
+                      cursor: "pointer",
+                      transition: "all 0.25s",
+                      flex: "1 1 140px",
+                      minWidth: "min(160px, 42vw)",
+                      maxWidth: "200px",
+                      display: "flex",
+                      flexDirection: "column",
+                      alignItems: "center",
+                      gap: "6px",
+                    }}
+                  >
+                    <span>{mindState === "hyperfocus" ? "Release" : "Hold"} — hyperfocus</span>
+                    <span
+                      style={{
+                        fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                        fontSize: "9px",
+                        letterSpacing: "0.14em",
+                        opacity: 0.85,
+                        textTransform: "none",
+                      }}
+                    >
+                      or hold ,
+                    </span>
                   </button>
                 </div>
 
                 <p
                   style={{
-                    margin: "10px 0 0",
+                    margin: "12px 0 0",
                     textAlign: "center",
                     fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
                     fontSize: "10px",
                     color: "var(--fg-4)",
-                    letterSpacing: "0.06em",
+                    letterSpacing: "0.05em",
+                    lineHeight: 1.45,
                   }}
                 >
-                  Spacebar (hold) when not typing — only on your device.
+                  Shortcuts when not typing — only on your device. After light distraction you can add an optional
+                  note; captured notes reflect a stronger pull.
                 </p>
 
                 <div
@@ -1020,7 +1194,7 @@ export function BuddySessionRoom({
                   <span style={{ color: "var(--accent-green-dim)" }}>{buddyAwarenessPct}% awareness</span>
                   <span style={{ margin: "0 6px", color: "var(--fg-4)" }}>·</span>
                   <span style={{ color: "var(--accent-amber-border)" }}>
-                    {100 - buddyAwarenessPct}% distraction
+                    {Math.max(0, 100 - buddyAwarenessPct)}% distraction
                   </span>
                 </div>
 

--- a/src/components/CompletionScreen.tsx
+++ b/src/components/CompletionScreen.tsx
@@ -64,7 +64,16 @@ export function CompletionScreen({
               fontSize: "11px", color: "var(--fg-3)",
               letterSpacing: "0.12em", textTransform: "uppercase", marginTop: "4px",
             }}>
-              clear mind
+              awareness
+            </div>
+          </div>
+          <div style={{ textAlign: "center" }}>
+            <div style={{ fontSize: "28px", fontWeight: 200, color: "var(--accent-amber)" }}>{100 - clearPercent}%</div>
+            <div style={{
+              fontSize: "11px", color: "var(--fg-3)",
+              letterSpacing: "0.12em", textTransform: "uppercase", marginTop: "4px",
+            }}>
+              distraction
             </div>
           </div>
           <div style={{ textAlign: "center" }}>
@@ -73,7 +82,7 @@ export function CompletionScreen({
               fontSize: "11px", color: "var(--fg-3)",
               letterSpacing: "0.12em", textTransform: "uppercase", marginTop: "4px",
             }}>
-              interruptions
+              captured notes
             </div>
           </div>
         </div>

--- a/src/components/CompletionScreen.tsx
+++ b/src/components/CompletionScreen.tsx
@@ -29,6 +29,7 @@ export function CompletionScreen({
   // Progression is based on the user's completed day, not the just-finished sit length.
   const nextDuration = BASE_DURATION + dayNumber * INCREMENT;
   const nextBlocks = Math.ceil(nextDuration / BLOCK_DURATION);
+  const distractionPercentDisplayed = Math.max(0, 100 - clearPercent);
 
   return (
     <div style={{
@@ -68,7 +69,7 @@ export function CompletionScreen({
             </div>
           </div>
           <div style={{ textAlign: "center" }}>
-            <div style={{ fontSize: "28px", fontWeight: 200, color: "var(--accent-amber)" }}>{100 - clearPercent}%</div>
+            <div style={{ fontSize: "28px", fontWeight: 200, color: "var(--accent-amber)" }}>{distractionPercentDisplayed}%</div>
             <div style={{
               fontSize: "11px", color: "var(--fg-3)",
               letterSpacing: "0.12em", textTransform: "uppercase", marginTop: "4px",

--- a/src/components/MindStateBar.tsx
+++ b/src/components/MindStateBar.tsx
@@ -50,7 +50,9 @@ export function MindStateBar({
             width: `${(seg.end - seg.start) * 100}%`, height: "100%",
             background: seg.state === "clear"
               ? "linear-gradient(to right, var(--accent-green), var(--accent-green-end))"
-              : "linear-gradient(to right, var(--accent-amber), var(--accent-amber-end))",
+              : seg.state === "hyperfocus"
+                ? "linear-gradient(to right, rgba(96, 165, 250, 0.85), rgba(59, 130, 246, 0.75))"
+                : "linear-gradient(to right, var(--accent-amber), var(--accent-amber-end))",
             opacity: 0.7,
           }} />
         ))}

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -5,7 +5,8 @@ import { BASE_DURATION, INCREMENT } from "@/lib/constants";
 import { BlockTimer } from "./BlockTimer";
 import { ThoughtCapture } from "./ThoughtCapture";
 import { loadSoundPrefs, saveSoundPrefs, type SoundPrefs } from "@/lib/audio";
-import { computeClearPercentFromLog, isMindStateTypingTarget } from "@/lib/mindStateSession";
+import { computeClearPercentFromLog } from "@/lib/mindStateSession";
+import { useMindStateHold } from "@/lib/useMindStateHold";
 
 type MindState = "clear" | "thinking" | "hyperfocus";
 
@@ -52,15 +53,13 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
   sessionThoughtsRef.current = sessionThoughts;
   const [distractionSegmentCount, setDistractionSegmentCount] = useState(0);
   const elapsedRef = useRef(0);
+  // First tuple element intentionally unused: only `setLiveElapsed` is called from
+  // the timer callback to re-render awareness % while elapsed updates in a ref.
   const [, setLiveElapsed] = useState(0);
   const wallStartRef = useRef<number>(Date.now());
   const [soundPrefs, setSoundPrefs] = useState<SoundPrefs>(() => loadSoundPrefs());
   const [controlsVisible, setControlsVisible] = useState(true);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const holdKindRef = useRef<"none" | "pointerHold" | "spaceDistraction" | "commaHyperfocus">("none");
-  const spaceDownRef = useRef(false);
-  const commaDownRef = useRef(false);
 
   useEffect(() => {
     const resetTimer = () => {
@@ -124,59 +123,12 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
     finalizeActiveHold(elapsedRef.current, true);
   }, [finalizeActiveHold]);
 
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (!isActive || isMindStateTypingTarget(e.target)) return;
-
-      if (e.code === "Space" && !e.repeat) {
-        e.preventDefault();
-        spaceDownRef.current = true;
-        if (holdKindRef.current === "none") {
-          holdKindRef.current = "spaceDistraction";
-          beginDistraction();
-        }
-        return;
-      }
-
-      if ((e.code === "Comma" || e.key === ",") && !e.repeat) {
-        e.preventDefault();
-        commaDownRef.current = true;
-        if (holdKindRef.current === "none") {
-          holdKindRef.current = "commaHyperfocus";
-          beginHyperfocus();
-        }
-      }
-    };
-
-    const onKeyUp = (e: KeyboardEvent) => {
-      if (e.code === "Space") {
-        if (!spaceDownRef.current) return;
-        spaceDownRef.current = false;
-        e.preventDefault();
-        if (holdKindRef.current === "spaceDistraction") {
-          holdKindRef.current = "none";
-          endHoldFromKeyboard();
-        }
-        return;
-      }
-      if (e.code === "Comma" || e.key === ",") {
-        if (!commaDownRef.current) return;
-        commaDownRef.current = false;
-        e.preventDefault();
-        if (holdKindRef.current === "commaHyperfocus") {
-          holdKindRef.current = "none";
-          endHoldFromKeyboard();
-        }
-      }
-    };
-
-    window.addEventListener("keydown", onKeyDown, { capture: true });
-    window.addEventListener("keyup", onKeyUp, { capture: true });
-    return () => {
-      window.removeEventListener("keydown", onKeyDown, { capture: true });
-      window.removeEventListener("keyup", onKeyUp, { capture: true });
-    };
-  }, [isActive, beginDistraction, beginHyperfocus, endHoldFromKeyboard]);
+  const { holdKindRef, resetHoldTracking } = useMindStateHold({
+    enabled: isActive,
+    beginDistraction,
+    beginHyperfocus,
+    endHoldFromKeyboard,
+  });
 
   const calcClearPercent = useCallback(() => {
     const endTime = elapsedRef.current || todayDuration;
@@ -186,9 +138,7 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
   const snapshotForComplete = useCallback(() => {
     const at = elapsedRef.current;
     setShowPostDistractionCapture(false);
-    holdKindRef.current = "none";
-    spaceDownRef.current = false;
-    commaDownRef.current = false;
+    resetHoldTracking();
     if (mindStateRef.current === "clear") {
       return mindStateLogRef.current;
     }
@@ -198,7 +148,7 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
     mindStateLogRef.current = next;
     setMindStateLog(next);
     return next;
-  }, []);
+  }, [resetHoldTracking]);
 
   const payloadThoughtCount = () => sessionThoughtsRef.current.length;
 
@@ -293,9 +243,7 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
 
   const togglePause = () => {
     if (isActive) {
-      holdKindRef.current = "none";
-      spaceDownRef.current = false;
-      commaDownRef.current = false;
+      resetHoldTracking();
       finalizeActiveHold(elapsedRef.current, false);
     }
     setIsActive(a => !a);

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -139,7 +139,7 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
 
   const calcClearPercent = useCallback(() => {
     const endTime = elapsedRef.current || todayDuration;
-    return computeClearPercentFromLog(mindStateLogRef.current, endTime);
+    return computeClearPercentFromLog(mindStateLog, endTime);
   }, [mindStateLog, todayDuration]);
 
   const snapshotForComplete = useCallback(() => {

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useState, useRef, useCallback, useEffect } from "react";
+import { useState, useRef, useCallback, useEffect, type CSSProperties } from "react";
 import { BASE_DURATION, INCREMENT } from "@/lib/constants";
 import { BlockTimer } from "./BlockTimer";
 import { ThoughtCapture } from "./ThoughtCapture";
 import { loadSoundPrefs, saveSoundPrefs, type SoundPrefs } from "@/lib/audio";
 import { computeClearPercentFromLog, isMindStateTypingTarget } from "@/lib/mindStateSession";
+
+type MindState = "clear" | "thinking" | "hyperfocus";
 
 type SessionViewProps = {
   currentDay: number;
@@ -31,29 +33,34 @@ type SessionViewProps = {
   }) => void;
 };
 
+const mono: CSSProperties = {
+  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+};
+
 export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewProps) {
   const todayDuration = BASE_DURATION + (currentDay - 1) * INCREMENT;
   const [isActive, setIsActive] = useState(true);
-  const [mindState, setMindState] = useState("clear");
-  const mindStateRef = useRef(mindState);
+  const [mindState, setMindState] = useState<MindState>("clear");
+  const mindStateRef = useRef<MindState>(mindState);
   mindStateRef.current = mindState;
 
   const [mindStateLog, setMindStateLog] = useState<Array<{ time: number; state: string }>>([]);
   const mindStateLogRef = useRef(mindStateLog);
   const [showPostDistractionCapture, setShowPostDistractionCapture] = useState(false);
   const [sessionThoughts, setSessionThoughts] = useState<Array<{ timeInSession: number; text: string }>>([]);
-  const [sessionThoughtCount, setSessionThoughtCount] = useState(0);
+  const sessionThoughtsRef = useRef(sessionThoughts);
+  sessionThoughtsRef.current = sessionThoughts;
+  const [distractionSegmentCount, setDistractionSegmentCount] = useState(0);
   const elapsedRef = useRef(0);
-  /** Drives re-renders while the timer runs so awareness % stays in sync with elapsed time. */
   const [, setLiveElapsed] = useState(0);
   const wallStartRef = useRef<number>(Date.now());
   const [soundPrefs, setSoundPrefs] = useState<SoundPrefs>(() => loadSoundPrefs());
   const [controlsVisible, setControlsVisible] = useState(true);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  /** True while pointer or space is actively holding the distraction control */
-  const holdActiveRef = useRef(false);
+  const holdKindRef = useRef<"none" | "pointerDistraction" | "spaceDistraction" | "commaHyperfocus">("none");
   const spaceDownRef = useRef(false);
+  const commaDownRef = useRef(false);
 
   useEffect(() => {
     const resetTimer = () => {
@@ -75,8 +82,9 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
     };
   }, []);
 
-  const finalizeActiveDistraction = useCallback((atTime: number, offerThoughtCapture: boolean) => {
-    if (mindStateRef.current !== "thinking") return;
+  const finalizeActiveHold = useCallback((atTime: number, offerThoughtCapture: boolean) => {
+    const ms = mindStateRef.current;
+    if (ms !== "thinking" && ms !== "hyperfocus") return;
     setMindState("clear");
     mindStateRef.current = "clear";
     setMindStateLog(prev => {
@@ -84,12 +92,13 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
       mindStateLogRef.current = next;
       return next;
     });
-    setShowPostDistractionCapture(offerThoughtCapture);
+    if (ms === "thinking") {
+      setShowPostDistractionCapture(offerThoughtCapture);
+    }
   }, []);
 
   const beginDistraction = useCallback(() => {
-    if (!isActive || mindStateRef.current !== "clear") return;
-    setShowPostDistractionCapture(false);
+    if (!isActive || mindStateRef.current !== "clear" || showPostDistractionCapture) return;
     setMindState("thinking");
     mindStateRef.current = "thinking";
     setMindStateLog(prev => {
@@ -97,33 +106,68 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
       mindStateLogRef.current = next;
       return next;
     });
-    setSessionThoughtCount(prev => prev + 1);
-  }, [isActive]);
+    setDistractionSegmentCount(c => c + 1);
+  }, [isActive, showPostDistractionCapture]);
 
-  const endDistractionHold = useCallback(() => {
-    if (!holdActiveRef.current) return;
-    holdActiveRef.current = false;
-    finalizeActiveDistraction(elapsedRef.current, true);
-  }, [finalizeActiveDistraction]);
+  const beginHyperfocus = useCallback(() => {
+    if (!isActive || mindStateRef.current !== "clear" || showPostDistractionCapture) return;
+    setMindState("hyperfocus");
+    mindStateRef.current = "hyperfocus";
+    setMindStateLog(prev => {
+      const next = [...prev, { time: elapsedRef.current, state: "hyperfocus" }];
+      mindStateLogRef.current = next;
+      return next;
+    });
+  }, [isActive, showPostDistractionCapture]);
+
+  const endHoldFromKeyboard = useCallback(() => {
+    finalizeActiveHold(elapsedRef.current, true);
+  }, [finalizeActiveHold]);
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.code !== "Space" || e.repeat) return;
       if (!isActive || isMindStateTypingTarget(e.target)) return;
-      e.preventDefault();
-      spaceDownRef.current = true;
-      if (!holdActiveRef.current) {
-        holdActiveRef.current = true;
-        beginDistraction();
+
+      if (e.code === "Space" && !e.repeat) {
+        e.preventDefault();
+        spaceDownRef.current = true;
+        if (holdKindRef.current === "none") {
+          holdKindRef.current = "spaceDistraction";
+          beginDistraction();
+        }
+        return;
+      }
+
+      if ((e.code === "Comma" || e.key === ",") && !e.repeat) {
+        e.preventDefault();
+        commaDownRef.current = true;
+        if (holdKindRef.current === "none") {
+          holdKindRef.current = "commaHyperfocus";
+          beginHyperfocus();
+        }
       }
     };
 
     const onKeyUp = (e: KeyboardEvent) => {
-      if (e.code !== "Space") return;
-      if (!spaceDownRef.current) return;
-      spaceDownRef.current = false;
-      e.preventDefault();
-      endDistractionHold();
+      if (e.code === "Space") {
+        if (!spaceDownRef.current) return;
+        spaceDownRef.current = false;
+        e.preventDefault();
+        if (holdKindRef.current === "spaceDistraction") {
+          holdKindRef.current = "none";
+          endHoldFromKeyboard();
+        }
+        return;
+      }
+      if (e.code === "Comma" || e.key === ",") {
+        if (!commaDownRef.current) return;
+        commaDownRef.current = false;
+        e.preventDefault();
+        if (holdKindRef.current === "commaHyperfocus") {
+          holdKindRef.current = "none";
+          endHoldFromKeyboard();
+        }
+      }
     };
 
     window.addEventListener("keydown", onKeyDown, { capture: true });
@@ -132,7 +176,7 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
       window.removeEventListener("keydown", onKeyDown, { capture: true });
       window.removeEventListener("keyup", onKeyUp, { capture: true });
     };
-  }, [isActive, beginDistraction, endDistractionHold]);
+  }, [isActive, beginDistraction, beginHyperfocus, endHoldFromKeyboard]);
 
   const calcClearPercent = useCallback(() => {
     const endTime = elapsedRef.current || todayDuration;
@@ -142,7 +186,10 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
   const snapshotForComplete = useCallback(() => {
     const at = elapsedRef.current;
     setShowPostDistractionCapture(false);
-    if (mindStateRef.current !== "thinking") {
+    holdKindRef.current = "none";
+    spaceDownRef.current = false;
+    commaDownRef.current = false;
+    if (mindStateRef.current === "clear") {
       return mindStateLogRef.current;
     }
     setMindState("clear");
@@ -152,6 +199,8 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
     setMindStateLog(next);
     return next;
   }, []);
+
+  const payloadThoughtCount = () => sessionThoughtsRef.current.length;
 
   const handleComplete = useCallback(() => {
     const resolvedLog = snapshotForComplete();
@@ -164,22 +213,34 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
       completed: true,
       actualTime,
       clearPercent: computeClearPercentFromLog(resolvedLog, endT),
-      thoughtCount: sessionThoughtCount,
+      thoughtCount: payloadThoughtCount(),
       mindStateLog: resolvedLog,
-      thoughts: sessionThoughts,
+      thoughts: sessionThoughtsRef.current,
     });
-  }, [currentDay, todayDuration, sessionThoughtCount, sessionThoughts, onComplete, snapshotForComplete]);
+  }, [currentDay, todayDuration, onComplete, snapshotForComplete]);
 
   const handlePointerDistractionDown = () => {
-    if (!isActive || mindStateRef.current !== "clear") return;
-    holdActiveRef.current = true;
+    if (!isActive || mindStateRef.current !== "clear" || showPostDistractionCapture) return;
+    holdKindRef.current = "pointerDistraction";
     beginDistraction();
   };
 
   const handlePointerDistractionUp = () => {
-    if (!holdActiveRef.current) return;
-    holdActiveRef.current = false;
-    finalizeActiveDistraction(elapsedRef.current, true);
+    if (holdKindRef.current !== "pointerDistraction") return;
+    holdKindRef.current = "none";
+    finalizeActiveHold(elapsedRef.current, true);
+  };
+
+  const handlePointerHyperfocusDown = () => {
+    if (!isActive || mindStateRef.current !== "clear" || showPostDistractionCapture) return;
+    holdKindRef.current = "pointerDistraction";
+    beginHyperfocus();
+  };
+
+  const handlePointerHyperfocusUp = () => {
+    if (holdKindRef.current !== "pointerDistraction" || mindStateRef.current !== "hyperfocus") return;
+    holdKindRef.current = "none";
+    finalizeActiveHold(elapsedRef.current, false);
   };
 
   const handleSaveThought = (text: string) => {
@@ -202,9 +263,9 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
       completed: false,
       actualTime,
       clearPercent: computeClearPercentFromLog(resolvedLog, endT),
-      thoughtCount: sessionThoughtCount,
+      thoughtCount: payloadThoughtCount(),
       mindStateLog: resolvedLog,
-      thoughts: sessionThoughts,
+      thoughts: sessionThoughtsRef.current,
     });
   };
 
@@ -219,9 +280,9 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
       completed: false,
       actualTime,
       clearPercent: computeClearPercentFromLog(resolvedLog, endT),
-      thoughtCount: sessionThoughtCount,
+      thoughtCount: payloadThoughtCount(),
       mindStateLog: resolvedLog,
-      thoughts: sessionThoughts,
+      thoughts: sessionThoughtsRef.current,
     });
   };
 
@@ -232,16 +293,40 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
 
   const togglePause = () => {
     if (isActive) {
-      if (holdActiveRef.current) {
-        holdActiveRef.current = false;
-        spaceDownRef.current = false;
-      }
-      finalizeActiveDistraction(elapsedRef.current, false);
+      holdKindRef.current = "none";
+      spaceDownRef.current = false;
+      commaDownRef.current = false;
+      finalizeActiveHold(elapsedRef.current, false);
     }
     setIsActive(a => !a);
   };
 
-  const distractionPercent = 100 - calcClearPercent();
+  const distractionPercent = Math.max(0, 100 - calcClearPercent());
+  const stateLabel =
+    mindState === "thinking" ? "Distracted" : mindState === "hyperfocus" ? "Hyperfocus" : "Aware";
+  const capturedCount = sessionThoughts.length;
+
+  const holdButtonBase: CSSProperties = {
+    ...mono,
+    fontSize: "12px",
+    letterSpacing: "0.12em",
+    textTransform: "uppercase",
+    padding: "12px 16px",
+    borderRadius: "16px",
+    cursor: isActive ? "pointer" : "default",
+    transition: "all 0.25s",
+    flex: "1 1 140px",
+    minWidth: "min(160px, 42vw)",
+    maxWidth: "200px",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: "6px",
+    border: "1px solid var(--border-2)",
+    background: "var(--surface-1)",
+    color: "var(--fg-2)",
+    opacity: isActive ? 1 : 0.45,
+  };
 
   return (
     <div style={{ animation: "fadeIn 0.8s ease", display: "flex", flexDirection: "column", alignItems: "center" }}>
@@ -255,15 +340,14 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
         soundPrefs={soundPrefs}
       />
 
-      {/* Persistent aware / distracted indicator (visible even when controls fade) */}
       {isActive && (
-        <div style={{ width: "100%", maxWidth: "min(420px, calc(100vw - 24px))", marginTop: "12px" }}>
+        <div style={{ width: "100%", maxWidth: "min(440px, calc(100vw - 24px))", marginTop: "12px" }}>
           <div
             style={{
               display: "flex",
               alignItems: "center",
               gap: "10px",
-              fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+              ...mono,
               fontSize: "11px",
               letterSpacing: "0.12em",
               textTransform: "uppercase",
@@ -277,29 +361,58 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
                 width: "10px",
                 height: "10px",
                 borderRadius: "50%",
-                background: mindState === "thinking" ? "var(--accent-amber)" : "var(--accent-green)",
-                boxShadow: mindState === "thinking" ? "0 0 12px var(--accent-amber)" : "none",
+                background:
+                  mindState === "thinking"
+                    ? "var(--accent-amber)"
+                    : mindState === "hyperfocus"
+                      ? "rgba(96, 165, 250, 0.95)"
+                      : "var(--accent-green)",
+                boxShadow:
+                  mindState === "thinking"
+                    ? "0 0 12px var(--accent-amber)"
+                    : mindState === "hyperfocus"
+                      ? "0 0 12px rgba(59, 130, 246, 0.6)"
+                      : "none",
                 flexShrink: 0,
               }}
             />
-            <span>{mindState === "thinking" ? "Distracted" : "Aware"}</span>
-            {sessionThoughtCount > 0 && (
+            <span>{stateLabel}</span>
+            {distractionSegmentCount > 0 && (
               <span style={{ color: "var(--accent-amber-border)", marginLeft: "4px" }}>
-                · {sessionThoughtCount} {sessionThoughtCount === 1 ? "segment" : "segments"}
+                · {distractionSegmentCount} light {distractionSegmentCount === 1 ? "segment" : "segments"}
+              </span>
+            )}
+            {capturedCount > 0 && (
+              <span style={{ color: "var(--accent-amber-border)", marginLeft: "4px" }}>
+                · {capturedCount} captured {capturedCount === 1 ? "note" : "notes"}
               </span>
             )}
           </div>
 
-          <div style={{ display: "flex", justifyContent: "center", marginTop: "16px" }}>
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              justifyContent: "center",
+              gap: "12px",
+              marginTop: "16px",
+              width: "100%",
+            }}
+          >
             <button
               type="button"
               disabled={!isActive}
               aria-pressed={mindState === "thinking"}
-              aria-label="Hold while distracted. Release when you are aware again."
-              onMouseDown={e => { e.preventDefault(); handlePointerDistractionDown(); }}
+              aria-label="Hold for light distraction, or hold Space. Release when aware again."
+              onMouseDown={e => {
+                e.preventDefault();
+                handlePointerDistractionDown();
+              }}
               onMouseUp={handlePointerDistractionUp}
               onMouseLeave={() => {
-                if (holdActiveRef.current) handlePointerDistractionUp();
+                if (holdKindRef.current === "pointerDistraction" && mindStateRef.current === "thinking") {
+                  handlePointerDistractionUp();
+                }
               }}
               onTouchStart={e => {
                 e.preventDefault();
@@ -308,44 +421,82 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
               onTouchEnd={handlePointerDistractionUp}
               onTouchCancel={handlePointerDistractionUp}
               style={{
-                background: mindState === "thinking"
-                  ? "var(--accent-amber-bg)"
-                  : "var(--accent-green-bg-subtle)",
-                border: `1px solid ${mindState === "thinking"
-                  ? "var(--accent-amber-border)"
-                  : "var(--accent-green-border)"}`,
+                ...holdButtonBase,
+                borderColor:
+                  mindState === "thinking" ? "var(--accent-amber-border)" : "var(--accent-green-border-subtle)",
+                background:
+                  mindState === "thinking" ? "var(--accent-amber-bg)" : "var(--accent-green-bg-subtle)",
                 color: mindState === "thinking" ? "var(--accent-amber)" : "var(--accent-green)",
-                fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-                fontSize: "12px", letterSpacing: "0.15em", textTransform: "uppercase",
-                padding: "12px 28px", borderRadius: "24px",
-                cursor: isActive ? "pointer" : "default",
-                transition: "all 0.3s", minWidth: "200px",
-                opacity: isActive ? 1 : 0.45,
               }}
             >
-              {mindState === "thinking" ? "Release — aware again" : "Hold — distracted"}
+              <span>{mindState === "thinking" ? "Release" : "Hold"} — light distraction</span>
+              <span style={{ ...mono, fontSize: "9px", letterSpacing: "0.14em", opacity: 0.85, textTransform: "none" }}>
+                or hold Space
+              </span>
+            </button>
+
+            <button
+              type="button"
+              disabled={!isActive}
+              aria-pressed={mindState === "hyperfocus"}
+              aria-label="Hold for hyperfocus, or hold Comma. Release to return to aware."
+              onMouseDown={e => {
+                e.preventDefault();
+                handlePointerHyperfocusDown();
+              }}
+              onMouseUp={handlePointerHyperfocusUp}
+              onMouseLeave={() => {
+                if (holdKindRef.current === "pointerDistraction" && mindStateRef.current === "hyperfocus") {
+                  handlePointerHyperfocusUp();
+                }
+              }}
+              onTouchStart={e => {
+                e.preventDefault();
+                handlePointerHyperfocusDown();
+              }}
+              onTouchEnd={handlePointerHyperfocusUp}
+              onTouchCancel={handlePointerHyperfocusUp}
+              style={{
+                ...holdButtonBase,
+                borderColor:
+                  mindState === "hyperfocus" ? "rgba(59, 130, 246, 0.55)" : "var(--border-2)",
+                background:
+                  mindState === "hyperfocus" ? "rgba(59, 130, 246, 0.12)" : "var(--surface-1)",
+                color: mindState === "hyperfocus" ? "rgba(147, 197, 253, 0.95)" : "var(--fg-2)",
+              }}
+            >
+              <span>{mindState === "hyperfocus" ? "Release" : "Hold"} — hyperfocus</span>
+              <span style={{ ...mono, fontSize: "9px", letterSpacing: "0.14em", opacity: 0.85, textTransform: "none" }}>
+                or hold ,
+              </span>
             </button>
           </div>
 
-          <p style={{
-            margin: "10px 0 0",
-            textAlign: "center",
-            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-            fontSize: "10px",
-            color: "var(--fg-4)",
-            letterSpacing: "0.06em",
-          }}>
-            Spacebar (hold) does the same when you are not typing in a field.
+          <p
+            style={{
+              margin: "12px 0 0",
+              textAlign: "center",
+              ...mono,
+              fontSize: "10px",
+              color: "var(--fg-4)",
+              letterSpacing: "0.05em",
+              lineHeight: 1.45,
+            }}
+          >
+            After a light distraction, you can jot a note (optional). If you need to stop and write because the thought
+            will not wait, use captured notes — that is tracked separately as a stronger pull.
           </p>
 
-          <div style={{
-            marginTop: "14px",
-            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-            fontSize: "10px",
-            color: "var(--fg-4)",
-            letterSpacing: "0.08em",
-            textAlign: "center",
-          }}>
+          <div
+            style={{
+              marginTop: "12px",
+              ...mono,
+              fontSize: "10px",
+              color: "var(--fg-4)",
+              letterSpacing: "0.08em",
+              textAlign: "center",
+            }}
+          >
             <span style={{ color: "var(--accent-green-dim)" }}>{calcClearPercent()}% awareness</span>
             <span style={{ margin: "0 6px", color: "var(--fg-4)" }}>·</span>
             <span style={{ color: "var(--accent-amber-border)" }}>{distractionPercent}% distraction</span>
@@ -362,11 +513,13 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
         </div>
       )}
 
-      <div style={{
-        opacity: controlsVisible ? 1 : 0,
-        transition: "opacity 0.5s ease",
-        pointerEvents: controlsVisible ? "auto" : "none",
-      }}>
+      <div
+        style={{
+          opacity: controlsVisible ? 1 : 0,
+          transition: "opacity 0.5s ease",
+          pointerEvents: controlsVisible ? "auto" : "none",
+        }}
+      >
         {!showPostDistractionCapture && (
           <div style={{ display: "flex", justifyContent: "center", gap: "12px", marginTop: "32px", flexWrap: "wrap" }}>
             <button
@@ -376,9 +529,13 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
                 background: "none",
                 border: "1px solid var(--border-2)",
                 color: "var(--fg-3)",
-                fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-                fontSize: "11px", letterSpacing: "0.15em", textTransform: "uppercase",
-                padding: "10px 24px", borderRadius: "20px", cursor: "pointer",
+                ...mono,
+                fontSize: "11px",
+                letterSpacing: "0.15em",
+                textTransform: "uppercase",
+                padding: "10px 24px",
+                borderRadius: "20px",
+                cursor: "pointer",
               }}
             >
               {isActive ? "pause" : "resume"}
@@ -390,9 +547,13 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
                 background: "none",
                 border: "1px solid var(--accent-green-border)",
                 color: "var(--accent-green-dim)",
-                fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-                fontSize: "11px", letterSpacing: "0.15em", textTransform: "uppercase",
-                padding: "10px 24px", borderRadius: "20px", cursor: "pointer",
+                ...mono,
+                fontSize: "11px",
+                letterSpacing: "0.15em",
+                textTransform: "uppercase",
+                padding: "10px 24px",
+                borderRadius: "20px",
+                cursor: "pointer",
               }}
             >
               end early &amp; keep
@@ -404,9 +565,13 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
                 background: "none",
                 border: "1px solid var(--accent-danger-border)",
                 color: "var(--accent-danger-muted)",
-                fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-                fontSize: "11px", letterSpacing: "0.15em", textTransform: "uppercase",
-                padding: "10px 24px", borderRadius: "20px", cursor: "pointer",
+                ...mono,
+                fontSize: "11px",
+                letterSpacing: "0.15em",
+                textTransform: "uppercase",
+                padding: "10px 24px",
+                borderRadius: "20px",
+                cursor: "pointer",
               }}
             >
               abandon
@@ -414,17 +579,24 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
           </div>
         )}
 
-        {/* Sound toggles */}
-        <div style={{
-          display: "flex", justifyContent: "center", gap: "16px", marginTop: "24px",
-          fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-          fontSize: "11px", letterSpacing: "0.1em",
-        }}>
-          {([
-            ["tick", "tick"],
-            ["chime", "chime"],
-            ["completion", "end"],
-          ] as const).map(([key, label]) => (
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            gap: "16px",
+            marginTop: "24px",
+            ...mono,
+            fontSize: "11px",
+            letterSpacing: "0.1em",
+          }}
+        >
+          {(
+            [
+              ["tick", "tick"],
+              ["chime", "chime"],
+              ["completion", "end"],
+            ] as const
+          ).map(([key, label]) => (
             <button
               type="button"
               key={key}
@@ -434,10 +606,10 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
                 saveSoundPrefs(next);
               }}
               style={{
-                background: "none", border: "none", cursor: "pointer",
-                color: soundPrefs[key]
-                  ? "var(--fg-3)"
-                  : "var(--fg-4)",
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                color: soundPrefs[key] ? "var(--fg-3)" : "var(--fg-4)",
                 transition: "color 0.3s",
                 padding: "4px 8px",
               }}

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -40,9 +40,6 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
 
   const [mindStateLog, setMindStateLog] = useState<Array<{ time: number; state: string }>>([]);
   const mindStateLogRef = useRef(mindStateLog);
-  useEffect(() => {
-    mindStateLogRef.current = mindStateLog;
-  }, [mindStateLog]);
   const [showPostDistractionCapture, setShowPostDistractionCapture] = useState(false);
   const [sessionThoughts, setSessionThoughts] = useState<Array<{ timeInSession: number; text: string }>>([]);
   const [sessionThoughtCount, setSessionThoughtCount] = useState(0);

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -5,6 +5,7 @@ import { BASE_DURATION, INCREMENT } from "@/lib/constants";
 import { BlockTimer } from "./BlockTimer";
 import { ThoughtCapture } from "./ThoughtCapture";
 import { loadSoundPrefs, saveSoundPrefs, type SoundPrefs } from "@/lib/audio";
+import { computeClearPercentFromLog, isMindStateTypingTarget } from "@/lib/mindStateSession";
 
 type SessionViewProps = {
   currentDay: number;
@@ -34,15 +35,28 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
   const todayDuration = BASE_DURATION + (currentDay - 1) * INCREMENT;
   const [isActive, setIsActive] = useState(true);
   const [mindState, setMindState] = useState("clear");
+  const mindStateRef = useRef(mindState);
+  mindStateRef.current = mindState;
+
   const [mindStateLog, setMindStateLog] = useState<Array<{ time: number; state: string }>>([]);
-  const [showThoughtInput, setShowThoughtInput] = useState(false);
+  const mindStateLogRef = useRef(mindStateLog);
+  useEffect(() => {
+    mindStateLogRef.current = mindStateLog;
+  }, [mindStateLog]);
+  const [showPostDistractionCapture, setShowPostDistractionCapture] = useState(false);
   const [sessionThoughts, setSessionThoughts] = useState<Array<{ timeInSession: number; text: string }>>([]);
   const [sessionThoughtCount, setSessionThoughtCount] = useState(0);
   const elapsedRef = useRef(0);
+  /** Drives re-renders while the timer runs so awareness % stays in sync with elapsed time. */
+  const [, setLiveElapsed] = useState(0);
   const wallStartRef = useRef<number>(Date.now());
   const [soundPrefs, setSoundPrefs] = useState<SoundPrefs>(() => loadSoundPrefs());
   const [controlsVisible, setControlsVisible] = useState(true);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  /** True while pointer or space is actively holding the distraction control */
+  const holdActiveRef = useRef(false);
+  const spaceDownRef = useRef(false);
 
   useEffect(() => {
     const resetTimer = () => {
@@ -64,96 +78,173 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
     };
   }, []);
 
+  const finalizeActiveDistraction = useCallback((atTime: number, offerThoughtCapture: boolean) => {
+    if (mindStateRef.current !== "thinking") return;
+    setMindState("clear");
+    mindStateRef.current = "clear";
+    setMindStateLog(prev => {
+      const next = [...prev, { time: atTime, state: "clear" }];
+      mindStateLogRef.current = next;
+      return next;
+    });
+    setShowPostDistractionCapture(offerThoughtCapture);
+  }, []);
+
+  const beginDistraction = useCallback(() => {
+    if (!isActive || mindStateRef.current !== "clear") return;
+    setShowPostDistractionCapture(false);
+    setMindState("thinking");
+    mindStateRef.current = "thinking";
+    setMindStateLog(prev => {
+      const next = [...prev, { time: elapsedRef.current, state: "thinking" }];
+      mindStateLogRef.current = next;
+      return next;
+    });
+    setSessionThoughtCount(prev => prev + 1);
+  }, [isActive]);
+
+  const endDistractionHold = useCallback(() => {
+    if (!holdActiveRef.current) return;
+    holdActiveRef.current = false;
+    finalizeActiveDistraction(elapsedRef.current, true);
+  }, [finalizeActiveDistraction]);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.code !== "Space" || e.repeat) return;
+      if (!isActive || isMindStateTypingTarget(e.target)) return;
+      e.preventDefault();
+      spaceDownRef.current = true;
+      if (!holdActiveRef.current) {
+        holdActiveRef.current = true;
+        beginDistraction();
+      }
+    };
+
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.code !== "Space") return;
+      if (!spaceDownRef.current) return;
+      spaceDownRef.current = false;
+      e.preventDefault();
+      endDistractionHold();
+    };
+
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    window.addEventListener("keyup", onKeyUp, { capture: true });
+    return () => {
+      window.removeEventListener("keydown", onKeyDown, { capture: true });
+      window.removeEventListener("keyup", onKeyUp, { capture: true });
+    };
+  }, [isActive, beginDistraction, endDistractionHold]);
+
   const calcClearPercent = useCallback(() => {
-    if (mindStateLog.length === 0) return 100;
-    let clearTime = 0;
-    let lastTime = 0;
-    let lastState = "clear";
     const endTime = elapsedRef.current || todayDuration;
-    const log = [...mindStateLog, { time: endTime, state: "clear" }];
-    for (const entry of log) {
-      if (lastState === "clear") clearTime += entry.time - lastTime;
-      lastTime = entry.time;
-      lastState = entry.state;
-    }
-    return Math.round((clearTime / endTime) * 100);
+    return computeClearPercentFromLog(mindStateLogRef.current, endTime);
   }, [mindStateLog, todayDuration]);
 
+  const snapshotForComplete = useCallback(() => {
+    const at = elapsedRef.current;
+    setShowPostDistractionCapture(false);
+    if (mindStateRef.current !== "thinking") {
+      return mindStateLogRef.current;
+    }
+    setMindState("clear");
+    mindStateRef.current = "clear";
+    const next = [...mindStateLogRef.current, { time: at, state: "clear" }];
+    mindStateLogRef.current = next;
+    setMindStateLog(next);
+    return next;
+  }, []);
+
   const handleComplete = useCallback(() => {
+    const resolvedLog = snapshotForComplete();
     setIsActive(false);
     const actualTime = Math.round((Date.now() - wallStartRef.current) / 1000);
+    const endT = elapsedRef.current || todayDuration;
     onComplete({
       dayNumber: currentDay,
       duration: todayDuration,
       completed: true,
       actualTime,
-      clearPercent: calcClearPercent(),
+      clearPercent: computeClearPercentFromLog(resolvedLog, endT),
       thoughtCount: sessionThoughtCount,
-      mindStateLog,
+      mindStateLog: resolvedLog,
       thoughts: sessionThoughts,
     });
-  }, [currentDay, todayDuration, sessionThoughtCount, mindStateLog, sessionThoughts, onComplete, calcClearPercent]);
+  }, [currentDay, todayDuration, sessionThoughtCount, sessionThoughts, onComplete, snapshotForComplete]);
 
-  const handleThinkingToggle = () => {
-    const now = elapsedRef.current;
-    if (mindState === "clear") {
-      setMindState("thinking");
-      setMindStateLog(prev => [...prev, { time: now, state: "thinking" }]);
-      setSessionThoughtCount(prev => prev + 1);
-      setShowThoughtInput(true);
-    } else {
-      setMindState("clear");
-      setMindStateLog(prev => [...prev, { time: now, state: "clear" }]);
-      setShowThoughtInput(false);
-    }
+  const handlePointerDistractionDown = () => {
+    if (!isActive || mindStateRef.current !== "clear") return;
+    holdActiveRef.current = true;
+    beginDistraction();
+  };
+
+  const handlePointerDistractionUp = () => {
+    if (!holdActiveRef.current) return;
+    holdActiveRef.current = false;
+    finalizeActiveDistraction(elapsedRef.current, true);
   };
 
   const handleSaveThought = (text: string) => {
     setSessionThoughts(prev => [...prev, { timeInSession: Math.round(elapsedRef.current), text }]);
-    setMindState("clear");
-    setMindStateLog(prev => [...prev, { time: elapsedRef.current, state: "clear" }]);
-    setShowThoughtInput(false);
+    setShowPostDistractionCapture(false);
   };
 
-  const handleSkipThought = () => {
-    setMindState("clear");
-    setMindStateLog(prev => [...prev, { time: elapsedRef.current, state: "clear" }]);
-    setShowThoughtInput(false);
+  const handleDismissPostCapture = () => {
+    setShowPostDistractionCapture(false);
   };
 
   const handleEndEarly = () => {
+    const resolvedLog = snapshotForComplete();
     setIsActive(false);
     const actualTime = Math.round((Date.now() - wallStartRef.current) / 1000);
+    const endT = elapsedRef.current || todayDuration;
     onComplete({
       dayNumber: currentDay,
       duration: todayDuration,
       completed: false,
       actualTime,
-      clearPercent: calcClearPercent(),
+      clearPercent: computeClearPercentFromLog(resolvedLog, endT),
       thoughtCount: sessionThoughtCount,
-      mindStateLog,
+      mindStateLog: resolvedLog,
       thoughts: sessionThoughts,
     });
   };
 
   const handleAbandon = () => {
+    const resolvedLog = snapshotForComplete();
     setIsActive(false);
     const actualTime = Math.round((Date.now() - wallStartRef.current) / 1000);
+    const endT = elapsedRef.current || todayDuration;
     onAbandon({
       dayNumber: currentDay,
       duration: todayDuration,
       completed: false,
       actualTime,
-      clearPercent: calcClearPercent(),
+      clearPercent: computeClearPercentFromLog(resolvedLog, endT),
       thoughtCount: sessionThoughtCount,
-      mindStateLog,
+      mindStateLog: resolvedLog,
       thoughts: sessionThoughts,
     });
   };
 
   const handleElapsedChange = useCallback((elapsed: number) => {
     elapsedRef.current = elapsed;
+    setLiveElapsed(elapsed);
   }, []);
+
+  const togglePause = () => {
+    if (isActive) {
+      if (holdActiveRef.current) {
+        holdActiveRef.current = false;
+        spaceDownRef.current = false;
+      }
+      finalizeActiveDistraction(elapsedRef.current, false);
+    }
+    setIsActive(a => !a);
+  };
+
+  const distractionPercent = 100 - calcClearPercent();
 
   return (
     <div style={{ animation: "fadeIn 0.8s ease", display: "flex", flexDirection: "column", alignItems: "center" }}>
@@ -167,53 +258,123 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
         soundPrefs={soundPrefs}
       />
 
+      {/* Persistent aware / distracted indicator (visible even when controls fade) */}
+      {isActive && (
+        <div style={{ width: "100%", maxWidth: "min(420px, calc(100vw - 24px))", marginTop: "12px" }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "10px",
+              fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+              fontSize: "11px",
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              color: "var(--fg-3)",
+              justifyContent: "center",
+            }}
+          >
+            <span
+              aria-hidden
+              style={{
+                width: "10px",
+                height: "10px",
+                borderRadius: "50%",
+                background: mindState === "thinking" ? "var(--accent-amber)" : "var(--accent-green)",
+                boxShadow: mindState === "thinking" ? "0 0 12px var(--accent-amber)" : "none",
+                flexShrink: 0,
+              }}
+            />
+            <span>{mindState === "thinking" ? "Distracted" : "Aware"}</span>
+            {sessionThoughtCount > 0 && (
+              <span style={{ color: "var(--accent-amber-border)", marginLeft: "4px" }}>
+                · {sessionThoughtCount} {sessionThoughtCount === 1 ? "segment" : "segments"}
+              </span>
+            )}
+          </div>
+
+          <div style={{ display: "flex", justifyContent: "center", marginTop: "16px" }}>
+            <button
+              type="button"
+              disabled={!isActive}
+              aria-pressed={mindState === "thinking"}
+              aria-label="Hold while distracted. Release when you are aware again."
+              onMouseDown={e => { e.preventDefault(); handlePointerDistractionDown(); }}
+              onMouseUp={handlePointerDistractionUp}
+              onMouseLeave={() => {
+                if (holdActiveRef.current) handlePointerDistractionUp();
+              }}
+              onTouchStart={e => {
+                e.preventDefault();
+                handlePointerDistractionDown();
+              }}
+              onTouchEnd={handlePointerDistractionUp}
+              onTouchCancel={handlePointerDistractionUp}
+              style={{
+                background: mindState === "thinking"
+                  ? "var(--accent-amber-bg)"
+                  : "var(--accent-green-bg-subtle)",
+                border: `1px solid ${mindState === "thinking"
+                  ? "var(--accent-amber-border)"
+                  : "var(--accent-green-border)"}`,
+                color: mindState === "thinking" ? "var(--accent-amber)" : "var(--accent-green)",
+                fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                fontSize: "12px", letterSpacing: "0.15em", textTransform: "uppercase",
+                padding: "12px 28px", borderRadius: "24px",
+                cursor: isActive ? "pointer" : "default",
+                transition: "all 0.3s", minWidth: "200px",
+                opacity: isActive ? 1 : 0.45,
+              }}
+            >
+              {mindState === "thinking" ? "Release — aware again" : "Hold — distracted"}
+            </button>
+          </div>
+
+          <p style={{
+            margin: "10px 0 0",
+            textAlign: "center",
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+            fontSize: "10px",
+            color: "var(--fg-4)",
+            letterSpacing: "0.06em",
+          }}>
+            Spacebar (hold) does the same when you are not typing in a field.
+          </p>
+
+          <div style={{
+            marginTop: "14px",
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+            fontSize: "10px",
+            color: "var(--fg-4)",
+            letterSpacing: "0.08em",
+            textAlign: "center",
+          }}>
+            <span style={{ color: "var(--accent-green-dim)" }}>{calcClearPercent()}% awareness</span>
+            <span style={{ margin: "0 6px", color: "var(--fg-4)" }}>·</span>
+            <span style={{ color: "var(--accent-amber-border)" }}>{distractionPercent}% distraction</span>
+          </div>
+
+          {showPostDistractionCapture && (
+            <div
+              data-no-space-distraction
+              style={{ marginTop: "20px", width: "100%", display: "flex", justifyContent: "center" }}
+            >
+              <ThoughtCapture onSave={handleSaveThought} onCancel={handleDismissPostCapture} />
+            </div>
+          )}
+        </div>
+      )}
+
       <div style={{
         opacity: controlsVisible ? 1 : 0,
         transition: "opacity 0.5s ease",
         pointerEvents: controlsVisible ? "auto" : "none",
       }}>
-        <div style={{ display: "flex", alignItems: "center", gap: "16px", marginTop: "32px", justifyContent: "center" }}>
-          <button
-            type="button"
-            onClick={handleThinkingToggle}
-            style={{
-              background: mindState === "thinking"
-                ? "var(--accent-amber-bg)"
-                : "var(--accent-green-bg-subtle)",
-              border: `1px solid ${mindState === "thinking"
-                ? "var(--accent-amber-border)"
-                : "var(--accent-green-border)"}`,
-              color: mindState === "thinking" ? "var(--accent-amber)" : "var(--accent-green)",
-              fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-              fontSize: "12px", letterSpacing: "0.15em", textTransform: "uppercase",
-              padding: "12px 28px", borderRadius: "24px",
-              cursor: "pointer", transition: "all 0.3s", minWidth: "160px",
-            }}
-          >
-            {mindState === "thinking" ? "\u25CB clear mind" : "\u2726 I'm thinking"}
-          </button>
-          {sessionThoughtCount > 0 && (
-            <div style={{
-              fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-              fontSize: "11px", color: "var(--accent-amber-border)",
-              display: "flex", alignItems: "center", gap: "4px",
-            }}>
-              \uD83D\uDCAD {sessionThoughtCount}
-            </div>
-          )}
-        </div>
-
-        {showThoughtInput && (
-          <div style={{ marginTop: "20px", width: "100%", display: "flex", justifyContent: "center" }}>
-            <ThoughtCapture onSave={handleSaveThought} onCancel={handleSkipThought} />
-          </div>
-        )}
-
-        {!showThoughtInput && (
+        {!showPostDistractionCapture && (
           <div style={{ display: "flex", justifyContent: "center", gap: "12px", marginTop: "32px", flexWrap: "wrap" }}>
             <button
               type="button"
-              onClick={() => setIsActive(!isActive)}
+              onClick={togglePause}
               style={{
                 background: "none",
                 border: "1px solid var(--border-2)",

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -58,7 +58,7 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
   const [controlsVisible, setControlsVisible] = useState(true);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const holdKindRef = useRef<"none" | "pointerDistraction" | "spaceDistraction" | "commaHyperfocus">("none");
+  const holdKindRef = useRef<"none" | "pointerHold" | "spaceDistraction" | "commaHyperfocus">("none");
   const spaceDownRef = useRef(false);
   const commaDownRef = useRef(false);
 
@@ -221,24 +221,24 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
 
   const handlePointerDistractionDown = () => {
     if (!isActive || mindStateRef.current !== "clear" || showPostDistractionCapture) return;
-    holdKindRef.current = "pointerDistraction";
+    holdKindRef.current = "pointerHold";
     beginDistraction();
   };
 
   const handlePointerDistractionUp = () => {
-    if (holdKindRef.current !== "pointerDistraction") return;
+    if (holdKindRef.current !== "pointerHold" || mindStateRef.current !== "thinking") return;
     holdKindRef.current = "none";
     finalizeActiveHold(elapsedRef.current, true);
   };
 
   const handlePointerHyperfocusDown = () => {
     if (!isActive || mindStateRef.current !== "clear" || showPostDistractionCapture) return;
-    holdKindRef.current = "pointerDistraction";
+    holdKindRef.current = "pointerHold";
     beginHyperfocus();
   };
 
   const handlePointerHyperfocusUp = () => {
-    if (holdKindRef.current !== "pointerDistraction" || mindStateRef.current !== "hyperfocus") return;
+    if (holdKindRef.current !== "pointerHold" || mindStateRef.current !== "hyperfocus") return;
     holdKindRef.current = "none";
     finalizeActiveHold(elapsedRef.current, false);
   };
@@ -341,7 +341,7 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
       />
 
       {isActive && (
-        <div style={{ width: "100%", maxWidth: "min(440px, calc(100vw - 24px))", marginTop: "12px" }}>
+        <div style={{ width: "100%", maxWidth: "min(440px, calc(100vw - 40px))", marginTop: "12px" }}>
           <div
             style={{
               display: "flex",
@@ -410,7 +410,7 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
               }}
               onMouseUp={handlePointerDistractionUp}
               onMouseLeave={() => {
-                if (holdKindRef.current === "pointerDistraction" && mindStateRef.current === "thinking") {
+                if (holdKindRef.current === "pointerHold" && mindStateRef.current === "thinking") {
                   handlePointerDistractionUp();
                 }
               }}
@@ -446,7 +446,7 @@ export function SessionView({ currentDay, onComplete, onAbandon }: SessionViewPr
               }}
               onMouseUp={handlePointerHyperfocusUp}
               onMouseLeave={() => {
-                if (holdKindRef.current === "pointerDistraction" && mindStateRef.current === "hyperfocus") {
+                if (holdKindRef.current === "pointerHold" && mindStateRef.current === "hyperfocus") {
                   handlePointerHyperfocusUp();
                 }
               }}

--- a/src/lib/mindStateSession.ts
+++ b/src/lib/mindStateSession.ts
@@ -1,0 +1,27 @@
+/** Targets where Space should not start a distraction hold (typing, thought capture, etc.). */
+export function isMindStateTypingTarget(el: EventTarget | null): boolean {
+  if (!(el instanceof HTMLElement)) return false;
+  const tag = el.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  if (el.isContentEditable) return true;
+  return Boolean(el.closest("[data-no-space-distraction]"));
+}
+
+/** Same formula as session completion: % of elapsed time in `"clear"` (aware) vs `"thinking"` (distraction). */
+export function computeClearPercentFromLog(
+  log: Array<{ time: number; state: string }>,
+  endTime: number,
+): number {
+  if (log.length === 0) return 100;
+  let clearTime = 0;
+  let lastTime = 0;
+  let lastState = "clear";
+  const full = [...log, { time: endTime, state: "clear" }];
+  for (const entry of full) {
+    if (lastState === "clear") clearTime += entry.time - lastTime;
+    lastTime = entry.time;
+    lastState = entry.state;
+  }
+  const denom = Math.max(endTime, 1);
+  return Math.round((clearTime / denom) * 100);
+}

--- a/src/lib/mindStateSession.ts
+++ b/src/lib/mindStateSession.ts
@@ -1,4 +1,12 @@
-/** Targets where Space should not start a distraction hold (typing, thought capture, etc.). */
+/**
+ * Helpers for mind-state / distraction keyboard handling and clear-percent math.
+ * Used by solo `SessionView` and `BuddySessionRoom`.
+ */
+
+/**
+ * Returns true when the event target is a control where global shortcuts
+ * (Space, Comma) should not start a distraction/hyperfocus hold.
+ */
 export function isMindStateTypingTarget(el: EventTarget | null): boolean {
   if (!(el instanceof HTMLElement)) return false;
   const tag = el.tagName;
@@ -7,7 +15,17 @@ export function isMindStateTypingTarget(el: EventTarget | null): boolean {
   return Boolean(el.closest("[data-no-space-distraction]"));
 }
 
-/** Same formula as session completion: % of elapsed time in `"clear"` (aware) vs `"thinking"` (distraction). */
+/**
+ * Computes the percentage of `[0, endTime]` spent in `"clear"` (aware) vs other
+ * logged states, using the same replay rules as session completion.
+ *
+ * @param log Ordered transitions `{ time, state }` with `time` in session seconds.
+ * @param endTime Session elapsed seconds to treat as the interval end (exclusive of tail marker logic uses inclusive segments).
+ */
+function isAwareLikeState(state: string): boolean {
+  return state === "clear" || state === "hyperfocus";
+}
+
 export function computeClearPercentFromLog(
   log: Array<{ time: number; state: string }>,
   endTime: number,
@@ -18,7 +36,7 @@ export function computeClearPercentFromLog(
   let lastState = "clear";
   const full = [...log, { time: endTime, state: "clear" }];
   for (const entry of full) {
-    if (lastState === "clear") clearTime += entry.time - lastTime;
+    if (isAwareLikeState(lastState)) clearTime += entry.time - lastTime;
     lastTime = entry.time;
     lastState = entry.state;
   }

--- a/src/lib/useMindStateHold.ts
+++ b/src/lib/useMindStateHold.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useRef } from "react";
+import { isMindStateTypingTarget } from "@/lib/mindStateSession";
+
+export type MindHoldKind = "none" | "pointerHold" | "spaceDistraction" | "commaHyperfocus";
+
+type UseMindStateHoldOptions = {
+  /** When false, Space/Comma listeners are not registered (e.g. paused sit or buddy lobby). */
+  enabled: boolean;
+  beginDistraction: () => void;
+  beginHyperfocus: () => void;
+  /** Release keyboard-driven hold (Space or Comma path). */
+  endHoldFromKeyboard: () => void;
+};
+
+/**
+ * Space (light distraction) and Comma (hyperfocus) hold tracking shared by solo
+ * SessionView and BuddySessionRoom. Pointer holds set `holdKindRef` to
+ * `"pointerHold"` in the parent; this hook only manages keyboard sources and
+ * calls the provided begin/end callbacks.
+ */
+export function useMindStateHold({
+  enabled,
+  beginDistraction,
+  beginHyperfocus,
+  endHoldFromKeyboard,
+}: UseMindStateHoldOptions) {
+  const holdKindRef = useRef<MindHoldKind>("none");
+  const spaceDownRef = useRef(false);
+  const commaDownRef = useRef(false);
+
+  const resetHoldTracking = useCallback(() => {
+    holdKindRef.current = "none";
+    spaceDownRef.current = false;
+    commaDownRef.current = false;
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (isMindStateTypingTarget(e.target)) return;
+
+      if (e.code === "Space" && !e.repeat) {
+        e.preventDefault();
+        spaceDownRef.current = true;
+        if (holdKindRef.current === "none") {
+          holdKindRef.current = "spaceDistraction";
+          beginDistraction();
+        }
+        return;
+      }
+
+      if ((e.code === "Comma" || e.key === ",") && !e.repeat) {
+        e.preventDefault();
+        commaDownRef.current = true;
+        if (holdKindRef.current === "none") {
+          holdKindRef.current = "commaHyperfocus";
+          beginHyperfocus();
+        }
+      }
+    };
+
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.code === "Space") {
+        if (!spaceDownRef.current) return;
+        spaceDownRef.current = false;
+        e.preventDefault();
+        if (holdKindRef.current === "spaceDistraction") {
+          holdKindRef.current = "none";
+          endHoldFromKeyboard();
+        }
+        return;
+      }
+      if (e.code === "Comma" || e.key === ",") {
+        if (!commaDownRef.current) return;
+        commaDownRef.current = false;
+        e.preventDefault();
+        if (holdKindRef.current === "commaHyperfocus") {
+          holdKindRef.current = "none";
+          endHoldFromKeyboard();
+        }
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    window.addEventListener("keyup", onKeyUp, { capture: true });
+    return () => {
+      window.removeEventListener("keydown", onKeyDown, { capture: true });
+      window.removeEventListener("keyup", onKeyUp, { capture: true });
+    };
+  }, [enabled, beginDistraction, beginHyperfocus, endHoldFromKeyboard]);
+
+  return { holdKindRef, resetHoldTracking };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements distraction tracking as **press-and-hold** (not tap-toggle) while keeping persisted `mindStateLog` entries as backward-compatible `"clear"` / `"thinking"` transitions keyed by session elapsed seconds.

## Web (`SessionView`, `BuddySessionRoom`)

- Hold the distraction control (mouse/touch) or **hold Space** (with repeat guard; skipped when focus is in inputs / thought capture via `data-no-space-distraction`).
- On release, append `"clear"` and optionally show **ThoughtCapture** (dismiss with skip / Escape as before).
- **Persistent** aware vs distracted row (dot + label) and live **awareness % / distraction %** strip stay visible even when other chrome auto-hides.
- Session completion / abandon / natural end: any open distraction segment is closed at the current elapsed time so saved `mindStateLog` is consistent.
- Buddy active sit: same behavior and copy for personal session recording.

## iOS (`SessionView`, `SessionViewModel`)

- `beginDistraction()` / `endDistraction()` replace toggle; `showPostDistractionCapture` gates post-release thought capture.
- Distraction hold bar is **always visible** during an in-progress sit (active or paused); pause / complete / abandon / natural end closes an open distraction segment.
- `MindStateBarView` takes `currentMindState` so the tail segment reflects live holds before the log gets the closing `"clear"` entry.

## Summary screens

- Web `CompletionScreen` and iOS `CompletionView`: labels for **awareness**, **distraction** (derived as `100 - clearPercent`), and **captured notes** (thought count).

## Verification

- `npm run build` (includes lint + typecheck) passes locally.
- `coderabbit` CLI was not available in this environment.

## Notes

No API or schema changes: existing `mindStateLog` JSONB and `clearPercent` continue to round-trip; distraction intervals are reconstructible from successive `thinking` → `clear` pairs at logged `time` values relative to session start.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f977d49f-3864-42ba-a92b-1c9887a614ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f977d49f-3864-42ba-a92b-1c9887a614ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hold-based distraction and hyperfocus controls (keyboard & touch) replace toggle behavior.
  * Persistent bottom hold bar and live awareness/distraction/hyperfocus readouts during sessions.
  * Post-distraction capture appears after releasing a light-distraction hold; captured notes count from captures.
  * Distraction percent now computed from the session log for reporting.

* **Style**
  * Reworked stats layout and labels: "Awareness", "Distraction", "Captured Notes".

* **Bug Fixes**
  * Active holds are finalized when pausing/ending to ensure consistent session state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->