### PR TITLE
fix(ios): keep tick/chime cadence synchronized with timer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ next-env.d.ts
 # Xcode / Swift — never commit local build products
 ios/build/
 ios/StillPointShared/build/
+ios/StillPointShared/.build/
 
 # Nested agent worktrees (gitlinks); keep out of the app repo
 .claude/worktrees/

--- a/ios/StillPointApp/ViewModels/SessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/SessionViewModel.swift
@@ -108,7 +108,9 @@ final class SessionViewModel {
         isActive = true
         isPaused = false
         startDate = Date().addingTimeInterval(-pausedElapsed)
-        AudioEngine.shared.warmUp()
+        if soundPrefs.tick || soundPrefs.chime || soundPrefs.completion {
+            AudioEngine.shared.warmUp()
+        }
         startTimer()
         scheduleControlHide()
     }

--- a/ios/StillPointApp/ViewModels/SessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/SessionViewModel.swift
@@ -108,6 +108,7 @@ final class SessionViewModel {
         isActive = true
         isPaused = false
         startDate = Date().addingTimeInterval(-pausedElapsed)
+        AudioEngine.shared.warmUp()
         startTimer()
         scheduleControlHide()
     }
@@ -122,6 +123,7 @@ final class SessionViewModel {
     }
 
     func resume() {
+        guard isPaused else { return }
         start()
     }
 

--- a/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
@@ -278,17 +278,32 @@ public final class AudioEngine: @unchecked Sendable {
 
         let sourceNode = AVAudioSourceNode { _, _, frameCount, audioBufferList -> OSStatus in
             let ablPointer = UnsafeMutableAudioBufferListPointer(audioBufferList)
-            let buffer = ablPointer[0]
             let frames = Int(frameCount)
-            guard let data = buffer.mData?.assumingMemoryBound(to: Float.self) else {
+            guard !ablPointer.isEmpty else {
                 return noErr
             }
 
             for frame in 0..<frames {
+                let sample: Float
                 if Int(phase.value) + frame >= totalFrames {
-                    data[frame] = 0
+                    sample = 0
                 } else {
-                    data[frame] = generator(phase.value + Double(frame), renderSampleRate)
+                    sample = generator(phase.value + Double(frame), renderSampleRate)
+                }
+
+                for buffer in ablPointer {
+                    guard let channelData = buffer.mData?.assumingMemoryBound(to: Float.self) else {
+                        continue
+                    }
+                    let channels = Int(buffer.mNumberChannels)
+                    if channels <= 1 {
+                        channelData[frame] = sample
+                    } else {
+                        let frameOffset = frame * channels
+                        for channel in 0..<channels {
+                            channelData[frameOffset + channel] = sample
+                        }
+                    }
                 }
             }
 

--- a/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
@@ -34,6 +34,7 @@ public final class AudioEngine: @unchecked Sendable {
     private let notificationCenter = NotificationCenter.default
     private var observerTokens: [NSObjectProtocol] = []
     private var wasRunningBeforeInterruption = false
+    private var wasRunningBeforeBackground = false
     private var pendingResumeAfterConfigurationChange = false
 
     private init() {
@@ -246,8 +247,11 @@ public final class AudioEngine: @unchecked Sendable {
 
     private func handleDidEnterBackground() {
         serialQueue.async { [weak self] in
-            guard let self, self.engine.isRunning else { return }
-            self.engine.pause()
+            guard let self else { return }
+            self.wasRunningBeforeBackground = self.engine.isRunning
+            if self.wasRunningBeforeBackground {
+                self.engine.pause()
+            }
         }
     }
 
@@ -255,7 +259,11 @@ public final class AudioEngine: @unchecked Sendable {
         serialQueue.async { [weak self] in
             guard let self else { return }
             self.configureAudioSession()
-            self.ensureEngineRunning()
+            let shouldRestart = self.wasRunningBeforeBackground || self.pendingResumeAfterConfigurationChange
+            if shouldRestart {
+                self.ensureEngineRunning()
+            }
+            self.wasRunningBeforeBackground = false
         }
     }
 

--- a/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
@@ -8,6 +8,7 @@ public final class AudioEngine: @unchecked Sendable {
 
     private init() {}
 
+    public func warmUp() {}
     public func playTick() {}
     public func playChime(count: Int) {}
     public func playCompletion() {}
@@ -16,6 +17,7 @@ public final class AudioEngine: @unchecked Sendable {
 #else
 
 import AVFoundation
+import UIKit
 
 /// Synthesized audio matching the web app's Web Audio API sounds.
 /// All sounds are generated programmatically — no external files needed.
@@ -23,11 +25,23 @@ import AVFoundation
 public final class AudioEngine: @unchecked Sendable {
     public static let shared = AudioEngine()
 
-    private let sampleRate: Double = 44100
-    private let serialQueue = DispatchQueue(label: "com.stillpoint.audioengine")
+    private let defaultSampleRate: Double = 44100
+    private let serialQueue = DispatchQueue(
+        label: "com.stillpoint.audioengine",
+        qos: .userInteractive
+    )
+    private let engine = AVAudioEngine()
+    private let notificationCenter = NotificationCenter.default
+    private var observerTokens: [NSObjectProtocol] = []
+    private var wasRunningBeforeInterruption = false
+    private var pendingResumeAfterConfigurationChange = false
 
     private init() {
         configureAudioSession()
+        installLifecycleObservers()
+        serialQueue.async { [self] in
+            ensureEngineRunning()
+        }
     }
 
     private func configureAudioSession() {
@@ -40,6 +54,57 @@ public final class AudioEngine: @unchecked Sendable {
         }
     }
 
+    private func installLifecycleObservers() {
+        let interruptionToken = notificationCenter.addObserver(
+            forName: AVAudioSession.interruptionNotification,
+            object: AVAudioSession.sharedInstance(),
+            queue: nil
+        ) { [weak self] notification in
+            self?.handleInterruption(notification)
+        }
+
+        let engineConfigChangeToken = notificationCenter.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: engine,
+            queue: nil
+        ) { [weak self] _ in
+            self?.handleEngineConfigurationChange()
+        }
+
+        let backgroundToken = notificationCenter.addObserver(
+            forName: UIApplication.didEnterBackgroundNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            self?.handleDidEnterBackground()
+        }
+
+        let foregroundToken = notificationCenter.addObserver(
+            forName: UIApplication.willEnterForegroundNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            self?.handleWillEnterForeground()
+        }
+
+        observerTokens = [
+            interruptionToken,
+            engineConfigChangeToken,
+            backgroundToken,
+            foregroundToken
+        ]
+    }
+
+    deinit {
+        observerTokens.forEach(notificationCenter.removeObserver)
+    }
+
+    public func warmUp() {
+        serialQueue.async { [self] in
+            ensureEngineRunning()
+        }
+    }
+
     // MARK: - Tick (800Hz sine, 60ms, gain 0.06 → 0.001)
 
     public func playTick() {
@@ -47,9 +112,9 @@ public final class AudioEngine: @unchecked Sendable {
     }
 
     private func _playTick() {
-        playSynthesized(duration: 0.06) { phase in
+        playSynthesized(duration: 0.06) { phase, sampleRate in
             let frequency = 800.0
-            let t = phase / self.sampleRate
+            let t = phase / sampleRate
             let totalDuration = 0.06
             let progress = min(t / totalDuration, 1.0)
             // Exponential ramp from 0.06 to 0.001
@@ -66,8 +131,8 @@ public final class AudioEngine: @unchecked Sendable {
 
     private func _playChime(count: Int) {
         let totalDuration = Double(count) * 0.4 + 0.1
-        playSynthesized(duration: totalDuration) { phase in
-            let t = phase / self.sampleRate
+        playSynthesized(duration: totalDuration) { phase, sampleRate in
+            let t = phase / sampleRate
             var sample: Float = 0
 
             for i in 0..<count {
@@ -98,8 +163,8 @@ public final class AudioEngine: @unchecked Sendable {
 
     private func _playCompletion() {
         let totalDuration = 2.5
-        playSynthesized(duration: totalDuration) { phase in
-            let t = phase / self.sampleRate
+        playSynthesized(duration: totalDuration) { phase, sampleRate in
+            let t = phase / sampleRate
             var sample: Float = 0
 
             for freq in [528.0, 660.0] {
@@ -125,11 +190,82 @@ public final class AudioEngine: @unchecked Sendable {
         var value: Double = 0
     }
 
-    private func playSynthesized(duration: Double, generator: @escaping (Double) -> Float) {
-        let engine = AVAudioEngine()
-        let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1)!
+    private func ensureEngineRunning() {
+        guard !engine.isRunning else { return }
+        do {
+            try engine.start()
+        } catch {
+            print("AudioEngine: Failed to start engine: \(error)")
+        }
+    }
 
-        let totalFrames = Int(duration * sampleRate)
+    private func handleInterruption(_ notification: Notification) {
+        serialQueue.async { [weak self] in
+            guard let self,
+                  let info = notification.userInfo,
+                  let typeValue = info[AVAudioSessionInterruptionTypeKey] as? UInt,
+                  let type = AVAudioSession.InterruptionType(rawValue: typeValue) else {
+                return
+            }
+
+            switch type {
+            case .began:
+                self.wasRunningBeforeInterruption = self.engine.isRunning
+                if self.wasRunningBeforeInterruption {
+                    self.engine.pause()
+                }
+            case .ended:
+                let optionsValue = (info[AVAudioSessionInterruptionOptionKey] as? UInt) ?? 0
+                let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
+                let shouldResume = options.contains(.shouldResume)
+                self.pendingResumeAfterConfigurationChange = shouldResume && self.wasRunningBeforeInterruption
+                if self.pendingResumeAfterConfigurationChange {
+                    self.resumeAfterInterruptionIfNeeded()
+                }
+                self.wasRunningBeforeInterruption = false
+            @unknown default:
+                break
+            }
+        }
+    }
+
+    private func handleEngineConfigurationChange() {
+        serialQueue.async { [weak self] in
+            guard let self, self.pendingResumeAfterConfigurationChange else { return }
+            self.resumeAfterInterruptionIfNeeded()
+        }
+    }
+
+    private func resumeAfterInterruptionIfNeeded() {
+        configureAudioSession()
+        ensureEngineRunning()
+        if engine.isRunning {
+            pendingResumeAfterConfigurationChange = false
+        }
+    }
+
+    private func handleDidEnterBackground() {
+        serialQueue.async { [weak self] in
+            guard let self, self.engine.isRunning else { return }
+            self.engine.pause()
+        }
+    }
+
+    private func handleWillEnterForeground() {
+        serialQueue.async { [weak self] in
+            guard let self else { return }
+            self.configureAudioSession()
+            self.ensureEngineRunning()
+        }
+    }
+
+    private func playSynthesized(
+        duration: Double,
+        generator: @escaping (_ phase: Double, _ sampleRate: Double) -> Float
+    ) {
+        let renderFormat = engine.mainMixerNode.outputFormat(forBus: 0)
+        let renderSampleRate = renderFormat.sampleRate > 0 ? renderFormat.sampleRate : defaultSampleRate
+        let totalFrames = Int(duration * renderSampleRate)
         let phase = PhaseBox()
 
         let sourceNode = AVAudioSourceNode { _, _, frameCount, audioBufferList -> OSStatus in
@@ -144,7 +280,7 @@ public final class AudioEngine: @unchecked Sendable {
                 if Int(phase.value) + frame >= totalFrames {
                     data[frame] = 0
                 } else {
-                    data[frame] = generator(phase.value + Double(frame))
+                    data[frame] = generator(phase.value + Double(frame), renderSampleRate)
                 }
             }
 
@@ -153,18 +289,14 @@ public final class AudioEngine: @unchecked Sendable {
         }
 
         engine.attach(sourceNode)
-        engine.connect(sourceNode, to: engine.mainMixerNode, format: format)
+        engine.connect(sourceNode, to: engine.mainMixerNode, format: renderFormat)
+        ensureEngineRunning()
 
-        do {
-            try engine.start()
-        } catch {
-            print("AudioEngine: Failed to start engine: \(error)")
-            return
-        }
-
-        // Stop after duration
-        DispatchQueue.main.asyncAfter(deadline: .now() + duration + 0.1) {
-            engine.stop()
+        // Detach this sound node after playback while keeping the warm engine alive.
+        serialQueue.asyncAfter(deadline: .now() + duration + 0.1) { [weak self] in
+            guard let self else { return }
+            self.engine.disconnectNodeOutput(sourceNode)
+            self.engine.detach(sourceNode)
         }
     }
 }


### PR DESCRIPTION
## Summary
- refactor `AudioEngine` to keep a persistent warm `AVAudioEngine` alive instead of creating a new engine for each tick/chime playback
- add iOS lifecycle + interruption handling so audio only resumes when appropriate and can recover after engine configuration changes
- warm up the audio engine when sessions start/resume so first tick latency does not skew perceived cadence
- ignore `ios/StillPointShared/.build/` artifacts to keep local SwiftPM outputs out of review/PR noise

Closes #201

## Test plan
- [x] `swift test --package-path ios/StillPointShared`
- [ ] Start an iOS session and verify tick cadence stays aligned with the visible second counter through a full run
- [ ] Pause/resume an iOS session several times and verify tick/chime resumes on the correct cadence without drift
- [ ] Background/foreground during an active iOS session and verify audio cues remain aligned with timer progression afterward
- [x] `coderabbit review --prompt-only` (clean pass)
- [x] `coderabbit review --prompt-only` (second clean pass)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced audio reliability during app interruptions and background transitions.
  * Improved timing accuracy for audio feedback sounds.

* **Chores**
  * Updated build artifact exclusions in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->