### PR TITLE
Fix iOS thought capture popup overlap and tap targets

### DIFF
--- a/ios/StillPointApp/Components/ThoughtCaptureView.swift
+++ b/ios/StillPointApp/Components/ThoughtCaptureView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 /// Inline thought capture card that appears when the user taps "I'm thinking"
 struct ThoughtCaptureView: View {
+    private static let minTapTarget: CGFloat = 44
+
     let onCapture: (String) -> Void
     let onDismiss: () -> Void
 
@@ -24,6 +26,8 @@ struct ThoughtCaptureView: View {
                     Image(systemName: "xmark")
                         .font(.system(size: 12, weight: .medium))
                         .foregroundStyle(Color(SPColor.fg4))
+                        .frame(width: Self.minTapTarget, height: Self.minTapTarget)
+                        .contentShape(Rectangle())
                 }
             }
 
@@ -49,15 +53,17 @@ struct ThoughtCaptureView: View {
                     Text(trimmedText.isEmpty ? "skip" : "save")
                         .font(SPFont.mono(12, weight: .medium))
                         .foregroundStyle(trimmedText.isEmpty ? Color(SPColor.fg4) : SPColor.amber)
+                        .frame(minWidth: Self.minTapTarget, minHeight: Self.minTapTarget)
+                        .contentShape(Rectangle())
                 }
             }
         }
         .padding(SPSpacing.s3)
-        .background(SPColor.amberBgFaint)
+        .background(SPColor.amberBg)
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .overlay(
             RoundedRectangle(cornerRadius: 12)
-                .stroke(SPColor.amberBorderSubtle)
+                .stroke(SPColor.amberBorder)
         )
         .onAppear { isFocused = true }
     }

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -2,8 +2,10 @@ import SwiftUI
 import StillPointShared
 
 struct SessionView: View {
-    /// Space reserved at the bottom for the distraction hold bar plus pause / end / sound controls.
-    private static let bottomOverlayReserve: CGFloat = 268
+    /// Space reserved when both distraction hold bar and controls are visible.
+    private static let bottomOverlayReserveWithControls: CGFloat = 268
+    /// Smaller reserve while controls are hidden to keep timer content readable.
+    private static let bottomOverlayReserveDistractionOnly: CGFloat = 176
 
     let appVM: AppViewModel
     @State private var vm: SessionViewModel
@@ -19,7 +21,7 @@ struct SessionView: View {
             SPColor.bg.ignoresSafeArea()
 
             GeometryReader { geo in
-                let contentHeight = geo.size.height - Self.bottomOverlayReserve
+                let contentHeight = geo.size.height - bottomOverlayReserve
 
                 VStack(spacing: 0) {
                     // Main content — fits in viewport above controls
@@ -91,7 +93,7 @@ struct SessionView: View {
                         }
                     )
                     .padding(.horizontal, SPSpacing.s4)
-                    .padding(.bottom, Self.bottomOverlayReserve + 24)
+                    .padding(.bottom, bottomOverlayReserve + SPSpacing.s2)
                 }
                 .transition(.opacity)
             }
@@ -154,6 +156,13 @@ struct SessionView: View {
 
     private var sessionInProgress: Bool {
         !vm.isComplete && !vm.isAbandoned && (vm.isActive || vm.isPaused)
+    }
+
+    private var bottomOverlayReserve: CGFloat {
+        if vm.controlsVisible || !vm.isActive {
+            return Self.bottomOverlayReserveWithControls
+        }
+        return Self.bottomOverlayReserveDistractionOnly
     }
 
     /// Hold control + state dot: visible for the whole active sit path (not hidden with other chrome).

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -93,7 +93,7 @@ struct SessionView: View {
                         }
                     )
                     .padding(.horizontal, SPSpacing.s4)
-                    .padding(.bottom, bottomOverlayReserve + SPSpacing.s2)
+                    .padding(.bottom, thoughtCaptureBottomPadding)
                 }
                 .transition(.opacity)
             }
@@ -163,6 +163,14 @@ struct SessionView: View {
             return Self.bottomOverlayReserveWithControls
         }
         return Self.bottomOverlayReserveDistractionOnly
+    }
+
+    private var thoughtCaptureBottomPadding: CGFloat {
+        // Keep capture card stable while typing even if controls auto-hide.
+        if vm.showPostDistractionCapture {
+            return Self.bottomOverlayReserveWithControls + SPSpacing.s2
+        }
+        return bottomOverlayReserve + SPSpacing.s2
     }
 
     /// Hold control + state dot: visible for the whole active sit path (not hidden with other chrome).
@@ -345,6 +353,8 @@ struct SessionView: View {
                         .clipShape(Capsule())
                         .overlay(Capsule().stroke(SPColor.amberBorderSubtle))
                 }
+                .disabled(!vm.isActive)
+                .opacity(vm.isActive ? 1 : 0.45)
 
                 // Abandon
                 Button {


### PR DESCRIPTION
Closes #205

## Summary
- increase thought-capture card contrast by switching to stronger amber background/border tokens
- enforce 44x44 minimum tap targets for the popup close and save/skip actions
- make session bottom reserve dynamic so the popup stays above active chrome without intruding into timer content while controls are hidden

## Test plan
- [x] `swift test` in `ios/StillPointShared`
- [ ] Verify on iPhone simulator/device that thought popup no longer obscures timer readability
- [ ] Verify close and save/skip controls are comfortably tappable (>=44pt targets)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tap target sizes for dismiss and action buttons to ensure reliable interaction.
  * Capture button now properly disabled during inactive sessions.

* **Style**
  * Updated accent colors to amber theme throughout the thought capture interface.

* **Improvements**
  * Enhanced UI positioning for thought capture during typing for better stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->