### PR TITLE
Fix friend request acceptance UUID ordering mismatch

### DIFF
--- a/src/lib/friends.ts
+++ b/src/lib/friends.ts
@@ -13,5 +13,13 @@ function normalizeUuidForComparison(value: string): string {
 export function orderedUserPair(userA: string, userB: string): [string, string] {
   const normalizedA = normalizeUuidForComparison(userA);
   const normalizedB = normalizeUuidForComparison(userB);
-  return normalizedA < normalizedB ? [userA, userB] : [userB, userA];
+  if (normalizedA < normalizedB) {
+    return [userA, userB];
+  }
+
+  if (normalizedA > normalizedB) {
+    return [userB, userA];
+  }
+
+  return userA < userB ? [userA, userB] : [userB, userA];
 }

--- a/src/lib/friends.ts
+++ b/src/lib/friends.ts
@@ -5,7 +5,13 @@ export function isUuid(value: string): boolean {
   return UUID_RE.test(value);
 }
 
-/** Canonical undirected pair: user1Id < user2Id lexicographically. */
+function normalizeUuidForComparison(value: string): string {
+  return value.replace(/-/g, "").toLowerCase();
+}
+
+/** Canonical undirected pair using PostgreSQL UUID ordering semantics. */
 export function orderedUserPair(userA: string, userB: string): [string, string] {
-  return userA < userB ? [userA, userB] : [userB, userA];
+  const normalizedA = normalizeUuidForComparison(userA);
+  const normalizedB = normalizeUuidForComparison(userB);
+  return normalizedA < normalizedB ? [userA, userB] : [userB, userA];
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- normalize UUID values for ordering comparisons in `orderedUserPair()` by lowercasing and removing hyphens
- add deterministic tie-break logic: when normalized UUID values are equal, compare original UUID strings to ensure stable ordering regardless of call-site argument order
- keep returning original UUID strings so no caller behavior changes
- align JS pair ordering with PostgreSQL UUID comparison semantics to prevent friend-request acceptance constraint/order failures

## Validation
- `npm run build`
- `npx tsx -e "import { orderedUserPair } from './src/lib/friends.ts'; ..."` (smoke checks for normalized ordering and deterministic tie-break)

## Review Polling Status
- post-push polling started immediately on PR #217
- CodeRabbit currently reports **"Review skipped"** because the PR is in draft state; no findings/threads posted yet

## Notes
- The issue body did not include explicit acceptance-criteria checkboxes. This PR targets: accepting a friend request no longer fails due to UUID ordering/constraint mismatch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d004d534-b943-4025-8b5d-d36c092651a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d004d534-b943-4025-8b5d-d36c092651a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent user ordering by normalizing UUIDs (hyphens removed, lowercased) and aligning ordering with PostgreSQL UUID semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->