### PR TITLE
Fix buddy group-session completion save reliability

### DIFF
--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -39,6 +39,7 @@ function getLocalIsoDate(): string {
 }
 
 type BuddyMindState = "clear" | "thinking" | "hyperfocus";
+type FinalizeAttemptResult = "started" | "already-saving" | "not-ready";
 
 function formatBuddyActionError(e: unknown, fallback: string): string {
   if (e instanceof ApiError) {
@@ -173,6 +174,13 @@ export function BuddySessionRoom({
   }, [pollStopped, sessionId]);
 
   useEffect(() => {
+    setSnap(null);
+    snapRef.current = null;
+    setMindStateLog([]);
+    mindStateLogRef.current = [];
+    setSessionThoughts([]);
+    sessionThoughtsRef.current = [];
+    timerAnchorRef.current = null;
     setPollStopped(false);
     lastRevision.current = -1;
     serverFinalizeTriggeredRef.current = false;
@@ -349,12 +357,12 @@ export function BuddySessionRoom({
     }
   };
 
-  const finalizePersonalSession = useCallback(async () => {
-    if (!onPersonalRecordComplete) return;
-    if (saveInFlightRef.current) return;
+  const finalizePersonalSession = useCallback(async (): Promise<FinalizeAttemptResult> => {
+    if (!onPersonalRecordComplete) return "not-ready";
+    if (saveInFlightRef.current) return "already-saving";
     const snapNow = snapRef.current;
-    if (!snapNow) return;
-    if (snapNow.state !== "completed" && !localTimerCompletedRef.current) return;
+    if (!snapNow) return "not-ready";
+    if (snapNow.state !== "completed" && !localTimerCompletedRef.current) return "not-ready";
 
     saveInFlightRef.current = true;
     setIsSavingPersonalRecord(true);
@@ -393,27 +401,37 @@ export function BuddySessionRoom({
       saveInFlightRef.current = false;
       setIsSavingPersonalRecord(false);
     }
+    return "started";
   }, [sessionId, onPersonalRecordComplete]);
 
   useEffect(() => {
     if (snap?.state !== "completed" || !onPersonalRecordComplete) return;
     if (serverFinalizeTriggeredRef.current) return;
-    serverFinalizeTriggeredRef.current = true;
-    void finalizePersonalSession();
+    void finalizePersonalSession().then((result) => {
+      if (result !== "not-ready") {
+        serverFinalizeTriggeredRef.current = true;
+      }
+    });
   }, [snap?.state, sessionId, onPersonalRecordComplete, finalizePersonalSession]);
 
   useEffect(() => {
     if (!localTimerCompleted || !onPersonalRecordComplete) return;
     if (localTimerFinalizeTriggeredRef.current) return;
-    localTimerFinalizeTriggeredRef.current = true;
-    void finalizePersonalSession();
+    void finalizePersonalSession().then((result) => {
+      if (result !== "not-ready") {
+        localTimerFinalizeTriggeredRef.current = true;
+      }
+    });
   }, [localTimerCompleted, onPersonalRecordComplete, finalizePersonalSession]);
 
   useEffect(() => {
     if (!pollStopped || !localTimerCompleted || !onPersonalRecordComplete) return;
     if (pollStoppedFinalizeTriggeredRef.current) return;
-    pollStoppedFinalizeTriggeredRef.current = true;
-    void finalizePersonalSession();
+    void finalizePersonalSession().then((result) => {
+      if (result !== "not-ready") {
+        pollStoppedFinalizeTriggeredRef.current = true;
+      }
+    });
   }, [pollStopped, localTimerCompleted, onPersonalRecordComplete, finalizePersonalSession]);
 
   const completeAndExitLegacy = async () => {

--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -93,7 +93,13 @@ export function BuddySessionRoom({
   const [personalRecordError, setPersonalRecordError] = useState<string | null>(null);
   const [dailyMeetingToken, setDailyMeetingToken] = useState<string | null>(null);
   const [dailyTokenError, setDailyTokenError] = useState<string | null>(null);
-  const autoFinalizeAttemptedRef = useRef(false);
+  const serverFinalizeTriggeredRef = useRef(false);
+  const localTimerFinalizeTriggeredRef = useRef(false);
+  const pollStoppedFinalizeTriggeredRef = useRef(false);
+  const saveInFlightRef = useRef(false);
+  const [isSavingPersonalRecord, setIsSavingPersonalRecord] = useState(false);
+  const [localTimerCompleted, setLocalTimerCompleted] = useState(false);
+  const localTimerCompletedRef = useRef(false);
   const snapRef = useRef(snap);
   const mindStateLogRef = useRef(mindStateLog);
   const sessionThoughtsRef = useRef(sessionThoughts);
@@ -159,7 +165,6 @@ export function BuddySessionRoom({
     } catch (e) {
       if (e instanceof ApiError && e.code === BUDDY_POLICY_CODES.NOT_IN_SESSION) {
         setPollStopped(true);
-        setSnap(null);
         setPollError(formatBuddyActionError(e, "Could not refresh session"));
         return;
       }
@@ -170,7 +175,13 @@ export function BuddySessionRoom({
   useEffect(() => {
     setPollStopped(false);
     lastRevision.current = -1;
-    autoFinalizeAttemptedRef.current = false;
+    serverFinalizeTriggeredRef.current = false;
+    localTimerFinalizeTriggeredRef.current = false;
+    pollStoppedFinalizeTriggeredRef.current = false;
+    saveInFlightRef.current = false;
+    setIsSavingPersonalRecord(false);
+    setLocalTimerCompleted(false);
+    localTimerCompletedRef.current = false;
     setPersonalRecordError(null);
     setDailyMeetingToken(null);
     setDailyTokenError(null);
@@ -220,6 +231,12 @@ export function BuddySessionRoom({
     resetHoldTracking();
     setSessionThoughts([]);
     setDistractionSegmentCount(0);
+    setLocalTimerCompleted(false);
+    localTimerCompletedRef.current = false;
+    setPersonalRecordError(null);
+    serverFinalizeTriggeredRef.current = false;
+    localTimerFinalizeTriggeredRef.current = false;
+    pollStoppedFinalizeTriggeredRef.current = false;
   }, [sessionId, snap?.state, snap?.startedAt, resetHoldTracking]);
 
   useEffect(() => {
@@ -285,6 +302,8 @@ export function BuddySessionRoom({
   }, [resetHoldTracking]);
 
   const handleBuddyTimerComplete = useCallback(() => {
+    setLocalTimerCompleted(true);
+    localTimerCompletedRef.current = true;
     closeOpenBuddyHold();
     void poll();
   }, [poll, closeOpenBuddyHold]);
@@ -332,12 +351,19 @@ export function BuddySessionRoom({
 
   const finalizePersonalSession = useCallback(async () => {
     if (!onPersonalRecordComplete) return;
+    if (saveInFlightRef.current) return;
     const snapNow = snapRef.current;
-    if (!snapNow || snapNow.state !== "completed") return;
+    if (!snapNow) return;
+    if (snapNow.state !== "completed" && !localTimerCompletedRef.current) return;
 
+    saveInFlightRef.current = true;
+    setIsSavingPersonalRecord(true);
     setPersonalRecordError(null);
     try {
-      const durationSeconds = snapNow.durationSeconds;
+      const durationSeconds = Math.max(
+        1,
+        snapNow.durationSeconds || Math.round(elapsedRef.current),
+      );
       const clearPercent = computeClearPercentFromLog(mindStateLogRef.current, durationSeconds);
       const thoughtsSnapshot = sessionThoughtsRef.current;
       const { session } = await api.recordBuddyPersonalSession(sessionId, {
@@ -363,15 +389,32 @@ export function BuddySessionRoom({
       });
     } catch (e) {
       setPersonalRecordError(formatBuddyActionError(e, "Could not save your session"));
+    } finally {
+      saveInFlightRef.current = false;
+      setIsSavingPersonalRecord(false);
     }
   }, [sessionId, onPersonalRecordComplete]);
 
   useEffect(() => {
     if (snap?.state !== "completed" || !onPersonalRecordComplete) return;
-    if (autoFinalizeAttemptedRef.current) return;
-    autoFinalizeAttemptedRef.current = true;
+    if (serverFinalizeTriggeredRef.current) return;
+    serverFinalizeTriggeredRef.current = true;
     void finalizePersonalSession();
   }, [snap?.state, sessionId, onPersonalRecordComplete, finalizePersonalSession]);
+
+  useEffect(() => {
+    if (!localTimerCompleted || !onPersonalRecordComplete) return;
+    if (localTimerFinalizeTriggeredRef.current) return;
+    localTimerFinalizeTriggeredRef.current = true;
+    void finalizePersonalSession();
+  }, [localTimerCompleted, onPersonalRecordComplete, finalizePersonalSession]);
+
+  useEffect(() => {
+    if (!pollStopped || !localTimerCompleted || !onPersonalRecordComplete) return;
+    if (pollStoppedFinalizeTriggeredRef.current) return;
+    pollStoppedFinalizeTriggeredRef.current = true;
+    void finalizePersonalSession();
+  }, [pollStopped, localTimerCompleted, onPersonalRecordComplete, finalizePersonalSession]);
 
   const completeAndExitLegacy = async () => {
     try {
@@ -456,8 +499,17 @@ export function BuddySessionRoom({
             <>
               <BuddyRoomErrorBanner message={personalRecordError} />
               <div style={{ display: "flex", flexDirection: "column", gap: "var(--s2)" }}>
-                <button type="button" onClick={() => void finalizePersonalSession()} style={btnPrimary}>
-                  Try again
+                <button
+                  type="button"
+                  onClick={() => void finalizePersonalSession()}
+                  disabled={isSavingPersonalRecord}
+                  style={{
+                    ...btnPrimary,
+                    opacity: isSavingPersonalRecord ? 0.65 : 1,
+                    cursor: isSavingPersonalRecord ? "not-allowed" : "pointer",
+                  }}
+                >
+                  {isSavingPersonalRecord ? "Trying again..." : "Try again"}
                 </button>
                 <button type="button" onClick={() => void leave()} style={btnSecondary}>
                   Return home without saving
@@ -466,7 +518,9 @@ export function BuddySessionRoom({
             </>
           ) : (
             <p style={{ margin: 0, color: "var(--fg-2)", lineHeight: 1.5, fontSize: "14px" }}>
-              Saving your personal session…
+              {isSavingPersonalRecord
+                ? "Saving your personal session..."
+                : "Finalizing your personal session..."}
             </p>
           )}
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- preserve the last known buddy snapshot when polling fails so completion save can still run
- trigger personal-session finalization when the local timer completes (not only when server snapshot flips to `completed`)
- add in-flight guards around personal-session save/retry to prevent concurrent save attempts

## Acceptance Criteria
- [x] Buddy/group session completion save still runs after transient polling errors
- [x] Local timer completion can trigger finalization even before a `completed` snapshot arrives
- [x] Poll stopping after local timer completion can still trigger finalization once
- [x] Retry/finalize actions do not submit concurrent save requests

## Validation
- `npm run build` (pass)
- `coderabbit review --prompt-only` (blocked: command not available in this environment)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7aba7eb0-bd98-455c-b983-749131baeb43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7aba7eb0-bd98-455c-b983-749131baeb43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session completion reliability with multiple completion pathways and better error handling
  * More robust duration calculations with a minimum elapsed fallback
  * Retry button now displays "Trying again..." and is disabled while saving
  * Status text toggles between "Saving..." and "Finalizing..."
  * Polling errors no longer clear the current session snapshot unintentionally
<!-- end of auto-generated comment: release notes by coderabbit.ai -->