### PR TITLE
Fix minute rollover after final 10-second blocks

### DIFF
--- a/ios/StillPointShared/Sources/StillPointShared/SessionLogic.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/SessionLogic.swift
@@ -181,6 +181,8 @@ public enum SessionLogic {
                 let minIdx = Int(elapsed) / 60
                 return "minute \(minIdx + 1) of \(totalMinuteCount)"
             } else {
+                // Intentionally hold on the last fully completed minute during final 10s blocks.
+                // The label rolls to the final minute only when the session reaches completion.
                 return "minute \(minuteBlocks.count) of \(totalMinuteCount)"
             }
         } else if elapsed >= Double(totalSeconds) {

--- a/ios/StillPointShared/Sources/StillPointShared/SessionLogic.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/SessionLogic.swift
@@ -169,18 +169,22 @@ public enum SessionLogic {
         let minuteBlocks = blocks.filter { $0.type == .minute }
         let secondBlocks = blocks.filter { $0.type == .second }
         let useMinuteBlocks = usesMinuteBlocks(totalSeconds: totalSeconds)
+        let totalMinuteCount = minuteBlocks.count + (secondBlocks.isEmpty ? 0 : 1)
 
-        if elapsed >= Double(totalSeconds) {
-            return "session complete"
-        } else if useMinuteBlocks {
+        if useMinuteBlocks {
+            if elapsed >= Double(totalSeconds) {
+                return "minute \(totalMinuteCount) of \(totalMinuteCount)"
+            }
+
             let lastMinuteStart = minuteBlocks.count * 60
             if elapsed < Double(lastMinuteStart) {
                 let minIdx = Int(elapsed) / 60
-                return "minute \(minIdx + 1) of \(minuteBlocks.count)"
+                return "minute \(minIdx + 1) of \(totalMinuteCount)"
             } else {
-                let secIdx = (Int(elapsed) - lastMinuteStart) / StillPoint.blockDuration
-                return "final minute · block \(secIdx + 1) of \(secondBlocks.count)"
+                return "minute \(minuteBlocks.count) of \(totalMinuteCount)"
             }
+        } else if elapsed >= Double(totalSeconds) {
+            return "session complete"
         } else {
             let blockIdx = Int(elapsed) / StillPoint.blockDuration
             return "block \(blockIdx + 1) of \(blocks.count)"

--- a/ios/StillPointShared/Tests/StillPointSharedTests/SessionLogicStatusLabelTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/SessionLogicStatusLabelTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import StillPointShared
+
+final class SessionLogicStatusLabelTests: XCTestCase {
+    func testMinuteZoneLabelUsesFullSessionMinuteCount() {
+        let totalSeconds = 260
+        let blocks = SessionLogic.buildBlocks(totalSeconds: totalSeconds)
+
+        let label = SessionLogic.statusLabel(
+            elapsed: 61,
+            totalSeconds: totalSeconds,
+            blocks: blocks
+        )
+
+        XCTAssertEqual(label, "minute 2 of 5")
+    }
+
+    func testFinalMinutePartialBlockKeepsCurrentMinuteLabel() {
+        let totalSeconds = 260
+        let blocks = SessionLogic.buildBlocks(totalSeconds: totalSeconds)
+
+        let label = SessionLogic.statusLabel(
+            elapsed: 255,
+            totalSeconds: totalSeconds,
+            blocks: blocks
+        )
+
+        XCTAssertEqual(label, "minute 4 of 5")
+    }
+
+    func testFinalTenSecondBlocksRolloverAtMinuteBoundary() {
+        let totalSeconds = 420
+        let blocks = SessionLogic.buildBlocks(totalSeconds: totalSeconds)
+
+        let label = SessionLogic.statusLabel(
+            elapsed: 420,
+            totalSeconds: totalSeconds,
+            blocks: blocks
+        )
+
+        XCTAssertEqual(label, "minute 7 of 7")
+    }
+
+    func testShortSessionsStillShowSessionCompleteAtEnd() {
+        let totalSeconds = 120
+        let blocks = SessionLogic.buildBlocks(totalSeconds: totalSeconds)
+
+        let label = SessionLogic.statusLabel(
+            elapsed: 120,
+            totalSeconds: totalSeconds,
+            blocks: blocks
+        )
+
+        XCTAssertEqual(label, "session complete")
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update shared `SessionLogic.statusLabel` for minute-block sessions to use a full session minute denominator (including the final 10-second block minute)
- roll the minute label over when the final 10-second block completes at session boundary
- keep short session behavior unchanged (`session complete` at end)
- add dedicated status-label regression tests for minute-zone, final-minute partial block, and rollover boundary cases

## Acceptance Criteria
- [x] Minute label rolls over correctly when final 10-second blocks complete a full minute
- [x] Boundary regression tests cover minute-zone, final-minute partial block, and rollover-at-completion behavior
- [x] Short-session completion label behavior remains unchanged

## Notes
- Local `coderabbit review --prompt-only` is currently blocked in this environment by missing CodeRabbit authentication (`coderabbit auth login` / API key).
- Required rule files from task context (`.claude/rules/cr-local-review.mdc`, `.claude/rules/cr-github-review.mdc`) are not present in this checkout.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7db80e9-84c6-4fa2-a989-937be6dae614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7db80e9-84c6-4fa2-a989-937be6dae614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session status messaging to report correct minute counts when sessions include minute/second segments, hold the final-minute label for partial final minutes, and only show "session complete" where appropriate.

* **Tests**
  * Added unit tests covering boundary conditions for session status messaging and minute-count behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->