### PR TITLE
iOS: add buddy session host/join flow with deep links

### DIFF
--- a/ios/StillPoint.xcodeproj/project.pbxproj
+++ b/ios/StillPoint.xcodeproj/project.pbxproj
@@ -9,18 +9,24 @@
 /* Begin PBXBuildFile section */
 		15177B86F124B5A10AB03456 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C683A9F0586D58020E60DD87 /* RootView.swift */; };
 		1649BE1D765A6851D5802BBA /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D356465C1B0F69C57FE47A80 /* SettingsView.swift */; };
+		16697A0A2D8E95D300EEA791 /* BuddyVideoWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0F8BA13F32BC68EEA0198C /* BuddyVideoWebView.swift */; };
 		1BE60070F826B7B31DFAB315 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FA6DAE71EE23FAF8EE0F12 /* HomeView.swift */; };
+		25295F15540B9986B15EB839 /* BuddySessionContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D8D4FA0580148DEAB74CC3 /* BuddySessionContainerView.swift */; };
 		2E31C1B6A86E612EF7171348 /* ThoughtJournalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44912B427658554F984CCC3A /* ThoughtJournalView.swift */; };
 		3E8960D90E815E3462FF241B /* ThoughtJournalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42927B68B0A976D71FE0637F /* ThoughtJournalViewModel.swift */; };
+		3F95AB4ED8A3AB01D8D2B042 /* BuddySessionHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4D291539A7556C58555EC6 /* BuddySessionHubView.swift */; };
+		42BF1908A778629F7C747264 /* BuddySessionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAF68030111C6FA73098D17 /* BuddySessionViewModel.swift */; };
 		3F1BEE1BEA197162093263CB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9311B0CBDED4DF207E799ACC /* Assets.xcassets */; };
 		432648A182B69A2E98314B0C /* BoardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D22599DCB705628A5CB6F51 /* BoardViewModel.swift */; };
 		4BC69FCAE79FAF2487A6E152 /* JetBrainsMono-Variable.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 797A65A5FC78734F7733B1BD /* JetBrainsMono-Variable.ttf */; };
 		4D652980F04840078B8FC938 /* SessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F95E6E47148AEF494393FDB /* SessionView.swift */; };
+		4FF6F665DB343AF63E7E1718 /* BuddyWaitingRoomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D903EE2C350B6705F6917952 /* BuddyWaitingRoomView.swift */; };
 		50CD873CA594B5A6FCDBB251 /* HistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F75039BBEED880C73680860 /* HistoryViewModel.swift */; };
 		55CB825BEE151D314A4DD2FA /* AppViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 218693B76FDAF56B6E0321DE /* AppViewModel.swift */; };
 		5CD3F9D38AB8369BA65DD128 /* Newsreader-Italic-Variable.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4F0CE80470C4C3CE0D9B4C00 /* Newsreader-Italic-Variable.ttf */; };
 		5EA3E8C9B84298DE1F37251F /* AuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00D7B1EDF2C56A1B6EB4C28 /* AuthView.swift */; };
 		74AE784447C3D50E1E6980E9 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7766937C968433C205A250C /* HistoryView.swift */; };
+		760C4A2F57E6B207F729ABEA /* BuddyActiveSessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E9BBE4830753E3B8FCC1C0 /* BuddyActiveSessionView.swift */; };
 		80005A5883007151E3A9C5C3 /* MindStateBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB771FA099C779B2F3A86AB /* MindStateBarView.swift */; };
 		8260BE3D7302FE11A35677B2 /* StillPointShared in Frameworks */ = {isa = PBXBuildFile; productRef = FE1475755D9C9BA63C80748F /* StillPointShared */; };
 		8A9734076E9FB3D5477913A0 /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6CBD1A192FD74748A6D36BF /* AuthViewModel.swift */; };
@@ -51,8 +57,10 @@
 		797A65A5FC78734F7733B1BD /* JetBrainsMono-Variable.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMono-Variable.ttf"; sourceTree = "<group>"; };
 		7CB771FA099C779B2F3A86AB /* MindStateBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindStateBarView.swift; sourceTree = "<group>"; };
 		7D13B1D65F99CF21AA713D32 /* CompletionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionView.swift; sourceTree = "<group>"; };
+		7E4D291539A7556C58555EC6 /* BuddySessionHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddySessionHubView.swift; sourceTree = "<group>"; };
 		85EAF998E3470CBB4056699F /* BlockGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockGridView.swift; sourceTree = "<group>"; };
 		9311B0CBDED4DF207E799ACC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		9A0F8BA13F32BC68EEA0198C /* BuddyVideoWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyVideoWebView.swift; sourceTree = "<group>"; };
 		A00D7B1EDF2C56A1B6EB4C28 /* AuthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthView.swift; sourceTree = "<group>"; };
 		A67F64CE400EF98ED2925FF9 /* StillPointShared */ = {isa = PBXFileReference; lastKnownFileType = folder; name = StillPointShared; path = StillPointShared; sourceTree = SOURCE_ROOT; };
 		AB8762D63FDB945A01DEA97F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -62,8 +70,12 @@
 		CDB4B1423B22DD22F5B6E069 /* DesignTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignTokens.swift; sourceTree = "<group>"; };
 		D15A7FF17302B1E2FD147920 /* StillPoint.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = StillPoint.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D356465C1B0F69C57FE47A80 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		D6D8D4FA0580148DEAB74CC3 /* BuddySessionContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddySessionContainerView.swift; sourceTree = "<group>"; };
 		D7B5A3374B6B8AC64C22F537 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
+		D903EE2C350B6705F6917952 /* BuddyWaitingRoomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyWaitingRoomView.swift; sourceTree = "<group>"; };
+		DAAF68030111C6FA73098D17 /* BuddySessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddySessionViewModel.swift; sourceTree = "<group>"; };
 		FDE2D028ACC5D7FEFD82703D /* SessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionViewModel.swift; sourceTree = "<group>"; };
+		09E9BBE4830753E3B8FCC1C0 /* BuddyActiveSessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyActiveSessionView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,6 +94,7 @@
 			isa = PBXGroup;
 			children = (
 				A00D7B1EDF2C56A1B6EB4C28 /* AuthView.swift */,
+				9AEB18D5D4C55CB98F814D43 /* BuddySession */,
 				7D13B1D65F99CF21AA713D32 /* CompletionView.swift */,
 				C7766937C968433C205A250C /* HistoryView.swift */,
 				23FA6DAE71EE23FAF8EE0F12 /* HomeView.swift */,
@@ -146,6 +159,18 @@
 			path = Navigation;
 			sourceTree = "<group>";
 		};
+		9AEB18D5D4C55CB98F814D43 /* BuddySession */ = {
+			isa = PBXGroup;
+			children = (
+				7E4D291539A7556C58555EC6 /* BuddySessionHubView.swift */,
+				D903EE2C350B6705F6917952 /* BuddyWaitingRoomView.swift */,
+				09E9BBE4830753E3B8FCC1C0 /* BuddyActiveSessionView.swift */,
+				D6D8D4FA0580148DEAB74CC3 /* BuddySessionContainerView.swift */,
+				9A0F8BA13F32BC68EEA0198C /* BuddyVideoWebView.swift */,
+			);
+			path = BuddySession;
+			sourceTree = "<group>";
+		};
 		70234ED5699E0294984184EC = {
 			isa = PBXGroup;
 			children = (
@@ -176,6 +201,7 @@
 			children = (
 				218693B76FDAF56B6E0321DE /* AppViewModel.swift */,
 				B6CBD1A192FD74748A6D36BF /* AuthViewModel.swift */,
+				DAAF68030111C6FA73098D17 /* BuddySessionViewModel.swift */,
 				0D22599DCB705628A5CB6F51 /* BoardViewModel.swift */,
 				1F75039BBEED880C73680860 /* HistoryViewModel.swift */,
 				FDE2D028ACC5D7FEFD82703D /* SessionViewModel.swift */,
@@ -275,6 +301,12 @@
 				5EA3E8C9B84298DE1F37251F /* AuthView.swift in Sources */,
 				8A9734076E9FB3D5477913A0 /* AuthViewModel.swift in Sources */,
 				F370AA8F6AA102355FC599C9 /* BlockGridView.swift in Sources */,
+				760C4A2F57E6B207F729ABEA /* BuddyActiveSessionView.swift in Sources */,
+				25295F15540B9986B15EB839 /* BuddySessionContainerView.swift in Sources */,
+				3F95AB4ED8A3AB01D8D2B042 /* BuddySessionHubView.swift in Sources */,
+				42BF1908A778629F7C747264 /* BuddySessionViewModel.swift in Sources */,
+				16697A0A2D8E95D300EEA791 /* BuddyVideoWebView.swift in Sources */,
+				4FF6F665DB343AF63E7E1718 /* BuddyWaitingRoomView.swift in Sources */,
 				432648A182B69A2E98314B0C /* BoardViewModel.swift in Sources */,
 				9ECB83ED063EDAA82E88004B /* CompletionView.swift in Sources */,
 				C57D92D33ED679E23F5E2E49 /* DesignTokens.swift in Sources */,

--- a/ios/StillPointApp/Info.plist
+++ b/ios/StillPointApp/Info.plist
@@ -20,13 +20,33 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.brettonauerbach.stillpoint</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>stillpoint</string>
+			</array>
+		</dict>
+	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSCameraUsageDescription</key>
+	<string>Still Point needs camera access for partner video sessions.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Still Point needs microphone access for partner video sessions.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Fonts/Newsreader-Variable.ttf</string>
 		<string>Fonts/Newsreader-Italic-Variable.ttf</string>
 		<string>Fonts/JetBrainsMono-Variable.ttf</string>
+	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>voip</string>
+		<string>audio</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>

--- a/ios/StillPointApp/Info.plist
+++ b/ios/StillPointApp/Info.plist
@@ -45,7 +45,6 @@
 	</array>
 	<key>UIBackgroundModes</key>
 	<array>
-		<string>voip</string>
 		<string>audio</string>
 	</array>
 	<key>UILaunchScreen</key>

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -17,10 +17,12 @@ enum AppView: Equatable {
     static func == (lhs: AppView, rhs: AppView) -> Bool {
         switch (lhs, rhs) {
         case (.auth, .auth), (.home, .home), (.session, .session),
-             (.buddyHub, .buddyHub), (.buddySession, .buddySession),
+             (.buddyHub, .buddyHub),
              (.history, .history), (.journal, .journal), (.board, .board),
              (.settings, .settings):
             return true
+        case let (.buddySession(lhsSessionId), .buddySession(rhsSessionId)):
+            return lhsSessionId == rhsSessionId
         case (.completion, .completion):
             return true
         default:

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -111,11 +111,17 @@ final class AppViewModel {
 
     func leaveBuddySession() {
         currentView = .home
+        Task { await consumePendingBuddyInviteIfNeeded() }
     }
 
     func handleIncomingURL(_ url: URL) {
         guard let token = extractBuddyToken(from: url) else { return }
         if currentUser == nil {
+            pendingBuddyInviteToken = token
+            return
+        }
+        if isInSession {
+            // Queue invite while preserving in-progress local session state.
             pendingBuddyInviteToken = token
             return
         }
@@ -146,6 +152,7 @@ final class AppViewModel {
             currentUser = user
         }
         currentView = .home
+        await consumePendingBuddyInviteIfNeeded()
     }
 
     private func consumePendingBuddyInviteIfNeeded() async {

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -6,6 +6,8 @@ enum AppView: Equatable {
     case auth
     case home
     case session
+    case buddyHub
+    case buddySession(sessionId: String)
     case completion(sessionId: String, clearPercent: Int, thoughtCount: Int, thoughts: [CapturedThought], dayNumber: Int, duration: Int)
     case history
     case journal
@@ -15,6 +17,7 @@ enum AppView: Equatable {
     static func == (lhs: AppView, rhs: AppView) -> Bool {
         switch (lhs, rhs) {
         case (.auth, .auth), (.home, .home), (.session, .session),
+             (.buddyHub, .buddyHub), (.buddySession, .buddySession),
              (.history, .history), (.journal, .journal), (.board, .board),
              (.settings, .settings):
             return true
@@ -37,6 +40,8 @@ final class AppViewModel {
     var currentView: AppView = .auth
     var currentUser: UserDTO?
     var isLoading = true
+    var buddyInviteError: String?
+    private var pendingBuddyInviteToken: String?
 
     var currentDay: Int {
         currentUser?.currentDay ?? 1
@@ -52,6 +57,7 @@ final class AppViewModel {
 
     var isInSession: Bool {
         if case .session = currentView { return true }
+        if case .buddySession = currentView { return true }
         if case .completion = currentView { return true }
         return false
     }
@@ -64,6 +70,7 @@ final class AppViewModel {
             if let user = try await APIClient.shared.me() {
                 currentUser = user
                 currentView = .home
+                await consumePendingBuddyInviteIfNeeded()
             } else {
                 currentView = .auth
             }
@@ -75,15 +82,41 @@ final class AppViewModel {
     func didLogin(user: UserDTO) {
         currentUser = user
         currentView = .home
+        Task { await consumePendingBuddyInviteIfNeeded() }
     }
 
     func didLogout() {
         currentUser = nil
+        pendingBuddyInviteToken = nil
+        buddyInviteError = nil
         currentView = .auth
     }
 
     func beginSession() {
         currentView = .session
+    }
+
+    func beginBuddySession() {
+        buddyInviteError = nil
+        currentView = .buddyHub
+    }
+
+    func enterBuddySession(sessionId: String) {
+        buddyInviteError = nil
+        currentView = .buddySession(sessionId: sessionId)
+    }
+
+    func leaveBuddySession() {
+        currentView = .home
+    }
+
+    func handleIncomingURL(_ url: URL) {
+        guard let token = extractBuddyToken(from: url) else { return }
+        if currentUser == nil {
+            pendingBuddyInviteToken = token
+            return
+        }
+        Task { await joinBuddySession(token: token) }
     }
 
     func completeSession(
@@ -110,5 +143,49 @@ final class AppViewModel {
             currentUser = user
         }
         currentView = .home
+    }
+
+    private func consumePendingBuddyInviteIfNeeded() async {
+        guard currentUser != nil, let token = pendingBuddyInviteToken else { return }
+        pendingBuddyInviteToken = nil
+        await joinBuddySession(token: token)
+    }
+
+    private func joinBuddySession(token: String) async {
+        do {
+            let sessionId = try await APIClient.shared.joinBuddySession(token: token)
+            buddyInviteError = nil
+            currentView = .buddySession(sessionId: sessionId)
+        } catch let error as APIError {
+            buddyInviteError = error.message
+            if case .auth = currentView {} else {
+                currentView = .buddyHub
+            }
+        } catch {
+            buddyInviteError = "Could not open buddy invite."
+            if case .auth = currentView {} else {
+                currentView = .buddyHub
+            }
+        }
+    }
+
+    private func extractBuddyToken(from url: URL) -> String? {
+        if let components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+            if let buddy = components.queryItems?.first(where: { $0.name == "buddy" })?.value?.trimmingCharacters(in: .whitespacesAndNewlines), !buddy.isEmpty {
+                return buddy
+            }
+            if let token = components.queryItems?.first(where: { $0.name == "token" })?.value?.trimmingCharacters(in: .whitespacesAndNewlines), !token.isEmpty {
+                return token
+            }
+        }
+
+        let scheme = (url.scheme ?? "").lowercased()
+        let host = (url.host ?? "").lowercased()
+        if scheme == "stillpoint" && host == "buddy" {
+            let token = url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/")).trimmingCharacters(in: .whitespacesAndNewlines)
+            return token.isEmpty ? nil : token
+        }
+
+        return nil
     }
 }

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -38,6 +38,7 @@ struct CapturedThought: Identifiable {
 }
 
 @Observable
+@MainActor
 final class AppViewModel {
     var currentView: AppView = .auth
     var currentUser: UserDTO?

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -168,14 +168,8 @@ final class AppViewModel {
             currentView = .buddySession(sessionId: sessionId)
         } catch let error as APIError {
             buddyInviteError = error.message
-            if case .auth = currentView {} else {
-                currentView = .buddyHub
-            }
         } catch {
             buddyInviteError = "Could not open buddy invite."
-            if case .auth = currentView {} else {
-                currentView = .buddyHub
-            }
         }
     }
 

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -173,11 +173,37 @@ final class AppViewModel {
     }
 
     private func extractBuddyToken(from url: URL) -> String? {
+        BuddyInviteTokenParser.token(from: url)
+    }
+}
+
+enum BuddyInviteTokenParser {
+    static func token(from raw: String, allowRawFallback: Bool) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let url = URL(string: trimmed), let token = token(from: url) {
+            return token
+        }
+
+        if let range = trimmed.range(of: "buddy=") {
+            let rest = String(trimmed[range.upperBound...])
+            if let amp = rest.firstIndex(of: "&") {
+                return String(rest[..<amp]).trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            return rest.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        return allowRawFallback ? trimmed : nil
+    }
+
+    static func token(from url: URL) -> String? {
         if let components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
-            if let buddy = components.queryItems?.first(where: { $0.name == "buddy" })?.value?.trimmingCharacters(in: .whitespacesAndNewlines), !buddy.isEmpty {
+            if let buddy = queryValue(named: "buddy", in: components) {
                 return buddy
             }
-            if let token = components.queryItems?.first(where: { $0.name == "token" })?.value?.trimmingCharacters(in: .whitespacesAndNewlines), !token.isEmpty {
+
+            if isBuddyRoute(components), let token = queryValue(named: "token", in: components) {
                 return token
             }
         }
@@ -185,10 +211,27 @@ final class AppViewModel {
         let scheme = (url.scheme ?? "").lowercased()
         let host = (url.host ?? "").lowercased()
         if scheme == "stillpoint" && host == "buddy" {
-            let token = url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/")).trimmingCharacters(in: .whitespacesAndNewlines)
+            let token = url.path
+                .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
             return token.isEmpty ? nil : token
         }
 
         return nil
+    }
+
+    private static func queryValue(named name: String, in components: URLComponents) -> String? {
+        guard let value = components.queryItems?.first(where: { $0.name == name })?.value?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    private static func isBuddyRoute(_ components: URLComponents) -> Bool {
+        let host = (components.host ?? "").lowercased()
+        let path = components.path.lowercased()
+        return host == "buddy" || path == "/buddy" || path.hasPrefix("/buddy/") || path.contains("/invite/buddy")
     }
 }

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -193,12 +193,8 @@ enum BuddyInviteTokenParser {
             return token
         }
 
-        if let range = trimmed.range(of: "buddy=") {
-            let rest = String(trimmed[range.upperBound...])
-            if let amp = rest.firstIndex(of: "&") {
-                return String(rest[..<amp]).trimmingCharacters(in: .whitespacesAndNewlines)
-            }
-            return rest.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let buddy = tokenFromBuddyQueryFragment(in: trimmed) {
+            return buddy
         }
 
         return allowRawFallback ? trimmed : nil
@@ -240,5 +236,26 @@ enum BuddyInviteTokenParser {
         let host = (components.host ?? "").lowercased()
         let path = components.path.lowercased()
         return host == "buddy" || path == "/buddy" || path.hasPrefix("/buddy/") || path.contains("/invite/buddy")
+    }
+
+    private static func tokenFromBuddyQueryFragment(in raw: String) -> String? {
+        if raw.hasPrefix("buddy=") {
+            return valueAfterParameterPrefix("buddy=", in: raw)
+        }
+        if let range = raw.range(of: "?buddy=") {
+            return valueAfterParameterPrefix("?buddy=", in: String(raw[range.lowerBound...]))
+        }
+        if let range = raw.range(of: "&buddy=") {
+            return valueAfterParameterPrefix("&buddy=", in: String(raw[range.lowerBound...]))
+        }
+        return nil
+    }
+
+    private static func valueAfterParameterPrefix(_ prefix: String, in raw: String) -> String? {
+        guard let range = raw.range(of: prefix) else { return nil }
+        let rest = raw[range.upperBound...]
+        let value = rest.split(separator: "&", maxSplits: 1, omittingEmptySubsequences: false).first.map(String.init) ?? ""
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }

--- a/ios/StillPointApp/ViewModels/BuddySessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/BuddySessionViewModel.swift
@@ -287,6 +287,10 @@ final class BuddySessionViewModel {
         }
         let requestKey = "\(snapshot.id):\(snapshot.revision):\(dailyRoomURL)"
         if latestMeetingTokenRequestKey == requestKey, meetingToken != nil { return }
+        if latestMeetingTokenRequestKey != requestKey {
+            meetingToken = nil
+            meetingTokenError = nil
+        }
         latestMeetingTokenRequestKey = requestKey
 
         Task { [weak self] in

--- a/ios/StillPointApp/ViewModels/BuddySessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/BuddySessionViewModel.swift
@@ -1,0 +1,345 @@
+import Foundation
+import SwiftUI
+import StillPointShared
+
+@Observable
+@MainActor
+final class BuddySessionViewModel {
+    let sessionId: String
+    let currentUserId: String
+
+    var snapshot: BuddySnapshotDTO?
+    var isLoading = true
+    var pollError: String?
+    var actionError: String?
+
+    var mindState: String = "clear"
+    var mindStateLog: [MindStateEntry] = []
+    var capturedThoughts: [CapturedThought] = []
+    var pendingThought = ""
+    var distractionSegmentCount = 0
+
+    var meetingToken: String?
+    var meetingTokenError: String?
+
+    var isSavingCompletion = false
+    var completionSaveError: String?
+
+    private var pollTask: Task<Void, Never>?
+    private var activeAnchor: ActiveAnchor?
+    private var lastActiveKey: String?
+    private var lastMeetingTokenFetchKey: String?
+    private let isoFormatter = ISO8601DateFormatter()
+
+    init(sessionId: String, currentUserId: String) {
+        self.sessionId = sessionId
+        self.currentUserId = currentUserId
+    }
+
+    deinit {
+        pollTask?.cancel()
+    }
+
+    func startPolling() {
+        guard pollTask == nil else { return }
+        pollTask = Task { [weak self] in
+            guard let self else { return }
+            await self.refreshSnapshot()
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 1_500_000_000)
+                await self.refreshSnapshot()
+            }
+        }
+    }
+
+    func stopPolling() {
+        pollTask?.cancel()
+        pollTask = nil
+    }
+
+    func refreshSnapshot() async {
+        do {
+            let snapshot = try await APIClient.shared.getBuddySnapshot(sessionId: sessionId)
+            self.snapshot = snapshot
+            pollError = nil
+            isLoading = false
+            handleSnapshotUpdate(snapshot)
+        } catch let error as APIError {
+            pollError = error.message
+            isLoading = false
+        } catch {
+            pollError = "Could not refresh session."
+            isLoading = false
+        }
+    }
+
+    func setReady(_ ready: Bool) async {
+        do {
+            try await APIClient.shared.setBuddyReady(sessionId: sessionId, ready: ready)
+            actionError = nil
+            await refreshSnapshot()
+        } catch let error as APIError {
+            actionError = error.message
+        } catch {
+            actionError = "Could not update ready state."
+        }
+    }
+
+    func startSession() async {
+        do {
+            try await APIClient.shared.startBuddySession(sessionId: sessionId)
+            actionError = nil
+            await refreshSnapshot()
+        } catch let error as APIError {
+            actionError = error.message
+        } catch {
+            actionError = "Could not start shared session."
+        }
+    }
+
+    @discardableResult
+    func cancelSession() async -> Bool {
+        do {
+            try await APIClient.shared.cancelBuddySession(sessionId: sessionId)
+            actionError = nil
+            await refreshSnapshot()
+            return true
+        } catch let error as APIError {
+            actionError = error.message
+            return false
+        } catch {
+            actionError = "Could not cancel session."
+            return false
+        }
+    }
+
+    @discardableResult
+    func leaveSession() async -> Bool {
+        do {
+            try await APIClient.shared.leaveBuddySession(sessionId: sessionId)
+            actionError = nil
+            return true
+        } catch let error as APIError {
+            actionError = error.message
+            return false
+        } catch {
+            actionError = "Could not leave session."
+            return false
+        }
+    }
+
+    func participantCompleteAndLeave() async {
+        do {
+            try await APIClient.shared.buddyParticipantComplete(sessionId: sessionId)
+        } catch {
+            // best effort for backwards compatibility
+        }
+        _ = await leaveSession()
+    }
+
+    func beginDistraction() {
+        guard isActive, mindState == "clear" else { return }
+        mindState = "thinking"
+        distractionSegmentCount += 1
+        mindStateLog.append(MindStateEntry(time: Double(currentElapsedSeconds()), state: "thinking"))
+    }
+
+    func beginHyperfocus() {
+        guard isActive, mindState == "clear" else { return }
+        mindState = "hyperfocus"
+        mindStateLog.append(MindStateEntry(time: Double(currentElapsedSeconds()), state: "hyperfocus"))
+    }
+
+    func endMindStateHold() {
+        guard mindState == "thinking" || mindState == "hyperfocus" else { return }
+        mindState = "clear"
+        mindStateLog.append(MindStateEntry(time: Double(currentElapsedSeconds()), state: "clear"))
+    }
+
+    func addPendingThought() {
+        let trimmed = pendingThought.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        capturedThoughts.append(CapturedThought(timeInSession: currentElapsedSeconds(), text: trimmed))
+        pendingThought = ""
+    }
+
+    func currentElapsedSeconds(at now: Date = Date()) -> Int {
+        guard let anchor = activeAnchor else {
+            return snapshot?.elapsedSeconds ?? 0
+        }
+        let localDelta = now.timeIntervalSince(anchor.localNow)
+        let estimated = anchor.serverElapsedAtSync + Int(localDelta.rounded(.towardZero))
+        return max(0, min(anchor.durationSeconds, estimated))
+    }
+
+    func currentRemainingSeconds(at now: Date = Date()) -> Int {
+        guard let duration = snapshot?.durationSeconds else { return 0 }
+        return max(0, duration - currentElapsedSeconds(at: now))
+    }
+
+    func formattedRemaining(at now: Date = Date()) -> String {
+        let remaining = currentRemainingSeconds(at: now)
+        return "\(remaining / 60):\(String(format: "%02d", remaining % 60))"
+    }
+
+    func savePersonalSession() async -> SessionDTO? {
+        guard let snapshot, snapshot.state == "completed" else { return nil }
+        isSavingCompletion = true
+        completionSaveError = nil
+        defer { isSavingCompletion = false }
+
+        finalizeOpenMindStateSegmentIfNeeded(duration: snapshot.durationSeconds)
+
+        let logToSave = normalizedMindStateLog(forDuration: snapshot.durationSeconds)
+        let clearPercent = SessionLogic.calculateClearPercent(
+            mindStateLog: logToSave,
+            totalElapsed: Double(snapshot.durationSeconds)
+        )
+        let thoughtInputs = capturedThoughts.map {
+            BatchThoughtsRequest.ThoughtInput(timeInSession: $0.timeInSession, text: $0.text)
+        }
+        let request = RecordBuddyPersonalSessionRequest(
+            clearPercent: clearPercent,
+            thoughtCount: thoughtInputs.count,
+            mindStateLog: logToSave,
+            actualTime: snapshot.durationSeconds,
+            sessionDate: localISODate(),
+            thoughts: thoughtInputs.isEmpty ? nil : thoughtInputs
+        )
+
+        do {
+            let session = try await APIClient.shared.recordBuddyPersonalSession(
+                sessionId: sessionId,
+                request: request
+            )
+            _ = await leaveSession()
+            return session
+        } catch let error as APIError {
+            completionSaveError = error.message
+            return nil
+        } catch {
+            completionSaveError = "Could not save personal session."
+            return nil
+        }
+    }
+
+    var isLobby: Bool {
+        snapshot?.state == "waiting" || snapshot?.state == "ready_check"
+    }
+
+    var isActive: Bool {
+        snapshot?.state == "active"
+    }
+
+    var isHost: Bool {
+        snapshot?.isHost ?? false
+    }
+
+    private func handleSnapshotUpdate(_ snapshot: BuddySnapshotDTO) {
+        if snapshot.state == "active", let startedAt = parseISO(snapshot.startedAt) {
+            let key = "\(snapshot.id):\(startedAt.timeIntervalSince1970)"
+            if key != lastActiveKey {
+                lastActiveKey = key
+                mindState = "clear"
+                mindStateLog = [MindStateEntry(time: 0, state: "clear")]
+                capturedThoughts = []
+                pendingThought = ""
+                distractionSegmentCount = 0
+            }
+
+            let serverNow = parseISO(snapshot.serverNow) ?? Date()
+            let elapsedAtSync = snapshot.elapsedSeconds ?? max(
+                0,
+                min(snapshot.durationSeconds, Int(serverNow.timeIntervalSince(startedAt)))
+            )
+            activeAnchor = ActiveAnchor(
+                localNow: Date(),
+                serverElapsedAtSync: elapsedAtSync,
+                durationSeconds: snapshot.durationSeconds
+            )
+            maybeFetchMeetingToken(snapshot: snapshot)
+            return
+        }
+
+        activeAnchor = nil
+        lastMeetingTokenFetchKey = nil
+        meetingToken = nil
+        meetingTokenError = nil
+    }
+
+    private func maybeFetchMeetingToken(snapshot: BuddySnapshotDTO) {
+        guard let dailyRoomURL = snapshot.dailyRoomUrl, !dailyRoomURL.isEmpty else {
+            meetingToken = nil
+            meetingTokenError = nil
+            lastMeetingTokenFetchKey = nil
+            return
+        }
+        let key = "\(snapshot.id):\(snapshot.revision):\(dailyRoomURL)"
+        guard key != lastMeetingTokenFetchKey else { return }
+        lastMeetingTokenFetchKey = key
+
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let token = try await APIClient.shared.getBuddyMeetingToken(sessionId: sessionId)
+                await MainActor.run {
+                    self.meetingToken = token
+                    self.meetingTokenError = nil
+                }
+            } catch let error as APIError {
+                await MainActor.run {
+                    self.meetingToken = nil
+                    self.meetingTokenError = error.message
+                }
+            } catch {
+                await MainActor.run {
+                    self.meetingToken = nil
+                    self.meetingTokenError = "Could not get video token."
+                }
+            }
+        }
+    }
+
+    private func finalizeOpenMindStateSegmentIfNeeded(duration: Int) {
+        guard mindState == "thinking" || mindState == "hyperfocus" else { return }
+        mindState = "clear"
+        mindStateLog.append(MindStateEntry(time: Double(duration), state: "clear"))
+    }
+
+    private func normalizedMindStateLog(forDuration duration: Int) -> [MindStateEntry] {
+        if mindStateLog.isEmpty {
+            return [MindStateEntry(time: 0, state: "clear")]
+        }
+
+        var log = mindStateLog.sorted { $0.time < $1.time }
+        if let first = log.first, first.time > 0 {
+            log.insert(MindStateEntry(time: 0, state: "clear"), at: 0)
+        }
+        if log.first?.time != 0 {
+            log.insert(MindStateEntry(time: 0, state: "clear"), at: 0)
+        }
+        if log.last?.state != "clear" {
+            log.append(MindStateEntry(time: Double(duration), state: "clear"))
+        }
+        return log
+    }
+
+    private func localISODate() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        return formatter.string(from: Date())
+    }
+
+    private func parseISO(_ raw: String?) -> Date? {
+        guard let raw, !raw.isEmpty else { return nil }
+        return isoFormatter.date(from: raw)
+    }
+}
+
+private struct ActiveAnchor {
+    let localNow: Date
+    let serverElapsedAtSync: Int
+    let durationSeconds: Int
+}

--- a/ios/StillPointApp/ViewModels/BuddySessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/BuddySessionViewModel.swift
@@ -306,23 +306,17 @@ final class BuddySessionViewModel {
             guard let self else { return }
             do {
                 let token = try await APIClient.shared.getBuddyMeetingToken(sessionId: sessionId)
-                await MainActor.run {
-                    guard self.latestMeetingTokenRequestKey == requestKey else { return }
-                    self.meetingToken = token
-                    self.meetingTokenError = nil
-                }
+                guard self.latestMeetingTokenRequestKey == requestKey else { return }
+                self.meetingToken = token
+                self.meetingTokenError = nil
             } catch let error as APIError {
-                await MainActor.run {
-                    guard self.latestMeetingTokenRequestKey == requestKey else { return }
-                    self.meetingToken = nil
-                    self.meetingTokenError = error.message
-                }
+                guard self.latestMeetingTokenRequestKey == requestKey else { return }
+                self.meetingToken = nil
+                self.meetingTokenError = error.message
             } catch {
-                await MainActor.run {
-                    guard self.latestMeetingTokenRequestKey == requestKey else { return }
-                    self.meetingToken = nil
-                    self.meetingTokenError = "Could not get video token."
-                }
+                guard self.latestMeetingTokenRequestKey == requestKey else { return }
+                self.meetingToken = nil
+                self.meetingTokenError = "Could not get video token."
             }
         }
     }

--- a/ios/StillPointApp/ViewModels/BuddySessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/BuddySessionViewModel.swift
@@ -28,7 +28,8 @@ final class BuddySessionViewModel {
     private var pollTask: Task<Void, Never>?
     private var activeAnchor: ActiveAnchor?
     private var lastActiveKey: String?
-    private var lastMeetingTokenFetchKey: String?
+    private var latestMeetingTokenRequestKey: String?
+    private var refreshRequestCounter = 0
     private let isoFormatter = ISO8601DateFormatter()
 
     init(sessionId: String, currentUserId: String) {
@@ -46,7 +47,12 @@ final class BuddySessionViewModel {
             guard let self else { return }
             await self.refreshSnapshot()
             while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: 1_500_000_000)
+                do {
+                    try await Task.sleep(nanoseconds: 1_500_000_000)
+                } catch {
+                    return
+                }
+                guard !Task.isCancelled else { return }
                 await self.refreshSnapshot()
             }
         }
@@ -58,30 +64,39 @@ final class BuddySessionViewModel {
     }
 
     func refreshSnapshot() async {
+        refreshRequestCounter += 1
+        let requestID = refreshRequestCounter
         do {
             let snapshot = try await APIClient.shared.getBuddySnapshot(sessionId: sessionId)
+            guard requestID == refreshRequestCounter else { return }
             self.snapshot = snapshot
             pollError = nil
             isLoading = false
             handleSnapshotUpdate(snapshot)
         } catch let error as APIError {
+            guard requestID == refreshRequestCounter else { return }
             pollError = error.message
             isLoading = false
         } catch {
+            guard requestID == refreshRequestCounter else { return }
             pollError = "Could not refresh session."
             isLoading = false
         }
     }
 
-    func setReady(_ ready: Bool) async {
+    @discardableResult
+    func setReady(_ ready: Bool) async -> Bool {
         do {
             try await APIClient.shared.setBuddyReady(sessionId: sessionId, ready: ready)
             actionError = nil
             await refreshSnapshot()
+            return true
         } catch let error as APIError {
             actionError = error.message
+            return false
         } catch {
             actionError = "Could not update ready state."
+            return false
         }
     }
 
@@ -223,10 +238,6 @@ final class BuddySessionViewModel {
         }
     }
 
-    var isLobby: Bool {
-        snapshot?.state == "waiting" || snapshot?.state == "ready_check"
-    }
-
     var isActive: Bool {
         snapshot?.state == "active"
     }
@@ -262,7 +273,7 @@ final class BuddySessionViewModel {
         }
 
         activeAnchor = nil
-        lastMeetingTokenFetchKey = nil
+        latestMeetingTokenRequestKey = nil
         meetingToken = nil
         meetingTokenError = nil
     }
@@ -271,28 +282,31 @@ final class BuddySessionViewModel {
         guard let dailyRoomURL = snapshot.dailyRoomUrl, !dailyRoomURL.isEmpty else {
             meetingToken = nil
             meetingTokenError = nil
-            lastMeetingTokenFetchKey = nil
+            latestMeetingTokenRequestKey = nil
             return
         }
-        let key = "\(snapshot.id):\(snapshot.revision):\(dailyRoomURL)"
-        guard key != lastMeetingTokenFetchKey else { return }
-        lastMeetingTokenFetchKey = key
+        let requestKey = "\(snapshot.id):\(snapshot.revision):\(dailyRoomURL)"
+        if latestMeetingTokenRequestKey == requestKey, meetingToken != nil { return }
+        latestMeetingTokenRequestKey = requestKey
 
         Task { [weak self] in
             guard let self else { return }
             do {
                 let token = try await APIClient.shared.getBuddyMeetingToken(sessionId: sessionId)
                 await MainActor.run {
+                    guard self.latestMeetingTokenRequestKey == requestKey else { return }
                     self.meetingToken = token
                     self.meetingTokenError = nil
                 }
             } catch let error as APIError {
                 await MainActor.run {
+                    guard self.latestMeetingTokenRequestKey == requestKey else { return }
                     self.meetingToken = nil
                     self.meetingTokenError = error.message
                 }
             } catch {
                 await MainActor.run {
+                    guard self.latestMeetingTokenRequestKey == requestKey else { return }
                     self.meetingToken = nil
                     self.meetingTokenError = "Could not get video token."
                 }
@@ -313,9 +327,6 @@ final class BuddySessionViewModel {
 
         var log = mindStateLog.sorted { $0.time < $1.time }
         if let first = log.first, first.time > 0 {
-            log.insert(MindStateEntry(time: 0, state: "clear"), at: 0)
-        }
-        if log.first?.time != 0 {
             log.insert(MindStateEntry(time: 0, state: "clear"), at: 0)
         }
         if log.last?.state != "clear" {

--- a/ios/StillPointApp/ViewModels/BuddySessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/BuddySessionViewModel.swift
@@ -152,15 +152,6 @@ final class BuddySessionViewModel {
         }
     }
 
-    func participantCompleteAndLeave() async {
-        do {
-            try await APIClient.shared.buddyParticipantComplete(sessionId: sessionId)
-        } catch {
-            // best effort for backwards compatibility
-        }
-        _ = await leaveSession()
-    }
-
     func beginDistraction() {
         guard isActive, mindState == "clear" else { return }
         mindState = "thinking"

--- a/ios/StillPointApp/ViewModels/BuddySessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/BuddySessionViewModel.swift
@@ -30,7 +30,16 @@ final class BuddySessionViewModel {
     private var lastActiveKey: String?
     private var latestMeetingTokenRequestKey: String?
     private var refreshRequestCounter = 0
-    private let isoFormatter = ISO8601DateFormatter()
+    private let isoFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+    private let isoFormatterFallback: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
 
     init(sessionId: String, currentUserId: String) {
         self.sessionId = sessionId
@@ -349,7 +358,10 @@ final class BuddySessionViewModel {
 
     private func parseISO(_ raw: String?) -> Date? {
         guard let raw, !raw.isEmpty else { return nil }
-        return isoFormatter.date(from: raw)
+        if let date = isoFormatter.date(from: raw) {
+            return date
+        }
+        return isoFormatterFallback.date(from: raw)
     }
 }
 

--- a/ios/StillPointApp/Views/BuddySession/BuddyActiveSessionView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyActiveSessionView.swift
@@ -133,11 +133,6 @@ struct BuddyActiveSessionView: View {
                         .foregroundStyle(Color(SPColor.fg4))
                 }
 
-                Text(roomURL)
-                    .font(SPFont.mono(10))
-                    .foregroundStyle(Color(SPColor.fg4))
-                    .lineLimit(2)
-                    .textSelection(.enabled)
             } else {
                 Text("Video is unavailable for this session.")
                     .font(SPFont.serif(14, weight: .light))

--- a/ios/StillPointApp/Views/BuddySession/BuddyActiveSessionView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyActiveSessionView.swift
@@ -9,6 +9,7 @@ struct BuddyActiveSessionView: View {
     @State private var now = Date()
     @State private var showThoughtCapture = false
     @State private var showExitConfirm = false
+    @State private var didRequestCompletionRefresh = false
 
     private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
@@ -31,10 +32,15 @@ struct BuddyActiveSessionView: View {
         .stillPointBackground()
         .onReceive(timer) { value in
             now = value
-            if vm.currentRemainingSeconds(at: value) == 0 {
+            let remaining = vm.currentRemainingSeconds(at: value)
+            if remaining == 0 {
+                guard !didRequestCompletionRefresh else { return }
+                didRequestCompletionRefresh = true
                 Task {
                     await vm.refreshSnapshot()
                 }
+            } else {
+                didRequestCompletionRefresh = false
             }
         }
         .alert("Leave shared session?", isPresented: $showExitConfirm) {

--- a/ios/StillPointApp/Views/BuddySession/BuddyActiveSessionView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyActiveSessionView.swift
@@ -64,7 +64,7 @@ struct BuddyActiveSessionView: View {
                 .foregroundStyle(Color(SPColor.fg))
                 .monospacedDigit()
 
-            Text("\(snapshot.durationSeconds)s shared timer synced from server")
+            Text("Shared timer synchronized with your buddy")
                 .font(SPFont.mono(11))
                 .foregroundStyle(Color(SPColor.fg4))
                 .tracking(1)

--- a/ios/StillPointApp/Views/BuddySession/BuddyActiveSessionView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyActiveSessionView.swift
@@ -64,7 +64,7 @@ struct BuddyActiveSessionView: View {
                 .foregroundStyle(Color(SPColor.fg))
                 .monospacedDigit()
 
-            Text("Stay present together with one shared timer.")
+            Text("Shared timer")
                 .font(SPFont.mono(11))
                 .foregroundStyle(Color(SPColor.fg4))
                 .tracking(1)

--- a/ios/StillPointApp/Views/BuddySession/BuddyActiveSessionView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyActiveSessionView.swift
@@ -1,0 +1,277 @@
+import SwiftUI
+import StillPointShared
+
+struct BuddyActiveSessionView: View {
+    @Bindable var vm: BuddySessionViewModel
+    let snapshot: BuddySnapshotDTO
+    let onLeave: () -> Void
+    let onComplete: (SessionDTO) -> Void
+
+    @State private var now = Date()
+    @State private var showThoughtCapture = false
+    @State private var showExitConfirm = false
+
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: SPSpacing.s4) {
+                Text("Shared session")
+                    .font(SPFont.serifItalic(28, weight: .light))
+                    .foregroundStyle(Color(SPColor.fg))
+
+                timerCard
+                participantsCard
+                videoCard
+                controlsCard
+                hints
+            }
+            .padding(.horizontal, SPSpacing.s4)
+            .padding(.vertical, SPSpacing.s4)
+        }
+        .stillPointBackground()
+        .onReceive(timer) { value in
+            now = value
+            if vm.currentRemainingSeconds(at: value) == 0 {
+                Task {
+                    await vm.refreshSnapshot()
+                }
+            }
+        }
+        .alert("Leave shared session?", isPresented: $showExitConfirm) {
+            Button("Cancel", role: .cancel) {}
+            Button("Leave", role: .destructive) {
+                Task {
+                    if await vm.leaveSession() {
+                        onLeave()
+                    }
+                }
+            }
+        } message: {
+            Text(snapshot.isHost ? "Leaving as host ends the shared session for everyone." : "You will leave this shared sit for your device.")
+        }
+        .task(id: snapshot.state) {
+            if snapshot.state == "completed" {
+                await handleCompletionSave()
+            }
+        }
+    }
+
+    private var timerCard: some View {
+        VStack(spacing: SPSpacing.s2) {
+            Text(vm.formattedRemaining(at: now))
+                .font(SPFont.timerDisplay)
+                .foregroundStyle(Color(SPColor.fg))
+                .monospacedDigit()
+
+            Text("\(snapshot.durationSeconds)s shared timer synced from server")
+                .font(SPFont.mono(11))
+                .foregroundStyle(Color(SPColor.fg4))
+                .tracking(1)
+
+            ProgressView(value: Double(vm.currentElapsedSeconds(at: now)), total: Double(max(snapshot.durationSeconds, 1)))
+                .tint(SPColor.green)
+        }
+        .padding(SPSpacing.s3)
+        .background(SPColor.surface1)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .overlay(RoundedRectangle(cornerRadius: 14).stroke(SPColor.border2))
+    }
+
+    private var participantsCard: some View {
+        VStack(alignment: .leading, spacing: SPSpacing.s2) {
+            Text("Participants")
+                .font(SPFont.mono(11, weight: .medium))
+                .foregroundStyle(Color(SPColor.fg4))
+                .tracking(2)
+
+            ForEach(snapshot.participants.filter { $0.leftAt == nil }, id: \.userId) { participant in
+                HStack {
+                    Text(participant.username + (participant.isHost ? " · host" : ""))
+                        .font(SPFont.serifItalic(16, weight: .light))
+                        .foregroundStyle(Color(SPColor.fg2))
+                    Spacer()
+                    Circle()
+                        .fill(participant.connected ? SPColor.green : SPColor.fg4)
+                        .frame(width: 8, height: 8)
+                    Text(participant.connected ? "online" : "away")
+                        .font(SPFont.mono(10))
+                        .foregroundStyle(Color(SPColor.fg4))
+                }
+            }
+        }
+        .padding(SPSpacing.s3)
+        .background(SPColor.surface1)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .overlay(RoundedRectangle(cornerRadius: 14).stroke(SPColor.border1))
+    }
+
+    private var videoCard: some View {
+        VStack(alignment: .leading, spacing: SPSpacing.s2) {
+            Text("Video")
+                .font(SPFont.mono(11, weight: .medium))
+                .foregroundStyle(Color(SPColor.fg4))
+                .tracking(2)
+
+            if let roomURL = snapshot.dailyRoomUrl, !roomURL.isEmpty {
+                Text("Room URL received")
+                    .font(SPFont.serif(14, weight: .light))
+                    .foregroundStyle(Color(SPColor.fg3))
+
+                if vm.meetingToken != nil {
+                    BuddyVideoWebView(roomURL: roomURL, meetingToken: vm.meetingToken ?? "")
+                        .frame(height: 260)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                        .overlay(RoundedRectangle(cornerRadius: 10).stroke(SPColor.border2))
+                } else if let tokenError = vm.meetingTokenError {
+                    Text(tokenError)
+                        .font(SPFont.mono(11))
+                        .foregroundStyle(SPColor.dangerMuted)
+                } else {
+                    Text("Preparing video token…")
+                        .font(SPFont.mono(11))
+                        .foregroundStyle(Color(SPColor.fg4))
+                }
+
+                Text(roomURL)
+                    .font(SPFont.mono(10))
+                    .foregroundStyle(Color(SPColor.fg4))
+                    .lineLimit(2)
+                    .textSelection(.enabled)
+            } else {
+                Text("Video is unavailable for this session.")
+                    .font(SPFont.serif(14, weight: .light))
+                    .foregroundStyle(Color(SPColor.fg3))
+            }
+        }
+        .padding(SPSpacing.s3)
+        .background(SPColor.surface1)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .overlay(RoundedRectangle(cornerRadius: 14).stroke(SPColor.border1))
+    }
+
+    private var controlsCard: some View {
+        VStack(spacing: SPSpacing.s3) {
+            HStack(spacing: SPSpacing.s2) {
+                Button {
+                    if vm.mindState == "clear" {
+                        vm.beginDistraction()
+                    } else if vm.mindState == "thinking" {
+                        vm.endMindStateHold()
+                    }
+                } label: {
+                    Text(vm.mindState == "thinking" ? "Release distraction" : "Hold distraction")
+                        .font(SPFont.mono(11, weight: .medium))
+                        .foregroundStyle(vm.mindState == "thinking" ? SPColor.amber : SPColor.green)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, SPSpacing.s2)
+                        .background(vm.mindState == "thinking" ? SPColor.amberBgFaint : SPColor.greenBgFaint)
+                        .clipShape(Capsule())
+                        .overlay(Capsule().stroke(vm.mindState == "thinking" ? SPColor.amberBorderSubtle : SPColor.greenBorderSubtle))
+                }
+
+                Button {
+                    if vm.mindState == "clear" {
+                        vm.beginHyperfocus()
+                    } else if vm.mindState == "hyperfocus" {
+                        vm.endMindStateHold()
+                    }
+                } label: {
+                    Text(vm.mindState == "hyperfocus" ? "Release hyperfocus" : "Hold hyperfocus")
+                        .font(SPFont.mono(11, weight: .medium))
+                        .foregroundStyle(Color(SPColor.fg3))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, SPSpacing.s2)
+                        .background(SPColor.surface2)
+                        .clipShape(Capsule())
+                        .overlay(Capsule().stroke(SPColor.border2))
+                }
+            }
+
+            Button {
+                showThoughtCapture.toggle()
+            } label: {
+                Text(showThoughtCapture ? "Hide thought capture" : "Capture note")
+                    .font(SPFont.mono(11, weight: .medium))
+                    .foregroundStyle(SPColor.amberText)
+                    .padding(.horizontal, SPSpacing.s3)
+                    .padding(.vertical, SPSpacing.s2)
+                    .background(SPColor.amberBgFaint)
+                    .clipShape(Capsule())
+                    .overlay(Capsule().stroke(SPColor.amberBorderSubtle))
+            }
+
+            if showThoughtCapture {
+                VStack(spacing: SPSpacing.s2) {
+                    TextField("What came up?", text: $vm.pendingThought, axis: .vertical)
+                        .lineLimit(3...5)
+                        .font(SPFont.serif(15, weight: .light))
+                        .padding(SPSpacing.s2)
+                        .background(SPColor.surface1)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                        .overlay(RoundedRectangle(cornerRadius: 10).stroke(SPColor.border2))
+
+                    Button {
+                        vm.addPendingThought()
+                        showThoughtCapture = false
+                    } label: {
+                        Text("Save note")
+                            .font(SPFont.mono(11, weight: .medium))
+                            .foregroundStyle(Color(SPColor.fg2))
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, SPSpacing.s2)
+                            .background(SPColor.surface2)
+                            .clipShape(Capsule())
+                            .overlay(Capsule().stroke(SPColor.border2))
+                    }
+                }
+            }
+
+            if vm.distractionSegmentCount > 0 || !vm.capturedThoughts.isEmpty {
+                Text("\(vm.distractionSegmentCount) distraction segments · \(vm.capturedThoughts.count) captured notes")
+                    .font(SPFont.mono(10))
+                    .foregroundStyle(Color(SPColor.fg4))
+                    .multilineTextAlignment(.center)
+            }
+
+            Button {
+                showExitConfirm = true
+            } label: {
+                Text("Leave")
+                    .font(SPFont.mono(11, weight: .medium))
+                    .foregroundStyle(SPColor.dangerMuted)
+                    .padding(.horizontal, SPSpacing.s3)
+                    .padding(.vertical, SPSpacing.s2)
+                    .background(SPColor.surface1)
+                    .clipShape(Capsule())
+                    .overlay(Capsule().stroke(SPColor.dangerBorderSubtle))
+            }
+        }
+        .padding(SPSpacing.s3)
+        .background(SPColor.surface1)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .overlay(RoundedRectangle(cornerRadius: 14).stroke(SPColor.border1))
+    }
+
+    private var hints: some View {
+        Text(snapshot.isHost
+             ? "If you leave, the host departure ends the shared session for everyone."
+             : "If you leave, only your device exits the shared session.")
+        .font(SPFont.mono(10))
+        .foregroundStyle(Color(SPColor.fg4))
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, SPSpacing.s4)
+    }
+
+    private func handleCompletionSave() async {
+        guard !vm.isSavingCompletion else { return }
+        if let session = await vm.savePersonalSession() {
+            onComplete(session)
+            return
+        }
+        if vm.completionSaveError == nil {
+            await vm.participantCompleteAndLeave()
+            onLeave()
+        }
+    }
+}

--- a/ios/StillPointApp/Views/BuddySession/BuddyActiveSessionView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyActiveSessionView.swift
@@ -5,7 +5,6 @@ struct BuddyActiveSessionView: View {
     @Bindable var vm: BuddySessionViewModel
     let snapshot: BuddySnapshotDTO
     let onLeave: () -> Void
-    let onComplete: (SessionDTO) -> Void
 
     @State private var now = Date()
     @State private var showThoughtCapture = false
@@ -49,11 +48,6 @@ struct BuddyActiveSessionView: View {
             }
         } message: {
             Text(snapshot.isHost ? "Leaving as host ends the shared session for everyone." : "You will leave this shared sit for your device.")
-        }
-        .task(id: snapshot.state) {
-            if snapshot.state == "completed" {
-                await handleCompletionSave()
-            }
         }
     }
 
@@ -263,15 +257,4 @@ struct BuddyActiveSessionView: View {
         .padding(.horizontal, SPSpacing.s4)
     }
 
-    private func handleCompletionSave() async {
-        guard !vm.isSavingCompletion else { return }
-        if let session = await vm.savePersonalSession() {
-            onComplete(session)
-            return
-        }
-        if vm.completionSaveError == nil {
-            await vm.participantCompleteAndLeave()
-            onLeave()
-        }
-    }
 }

--- a/ios/StillPointApp/Views/BuddySession/BuddyActiveSessionView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyActiveSessionView.swift
@@ -64,7 +64,7 @@ struct BuddyActiveSessionView: View {
                 .foregroundStyle(Color(SPColor.fg))
                 .monospacedDigit()
 
-            Text("Shared timer synchronized with your buddy")
+            Text("Stay present together with one shared timer.")
                 .font(SPFont.mono(11))
                 .foregroundStyle(Color(SPColor.fg4))
                 .tracking(1)

--- a/ios/StillPointApp/Views/BuddySession/BuddySessionContainerView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddySessionContainerView.swift
@@ -88,7 +88,7 @@ struct BuddySessionContainerView: View {
                     .font(SPFont.serifItalic(17, weight: .light))
                     .foregroundStyle(Color(SPColor.fg))
                 } else {
-                    Text("Saving your personal session...")
+                    Text("Preparing to save your personal session...")
                         .font(SPFont.mono(12))
                         .foregroundStyle(Color(SPColor.fg3))
                 }

--- a/ios/StillPointApp/Views/BuddySession/BuddySessionContainerView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddySessionContainerView.swift
@@ -35,16 +35,6 @@ struct BuddySessionContainerView: View {
                         snapshot: snapshot,
                         onLeave: {
                             appVM.leaveBuddySession()
-                        },
-                        onComplete: { session in
-                            appVM.completeSession(
-                                sessionId: session.id,
-                                clearPercent: session.clearPercent,
-                                thoughtCount: session.thoughtCount,
-                                thoughts: vm.capturedThoughts,
-                                dayNumber: session.dayNumber,
-                                duration: session.duration
-                            )
                         }
                     )
                 case "completed":

--- a/ios/StillPointApp/Views/BuddySession/BuddySessionContainerView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddySessionContainerView.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+import StillPointShared
+
+struct BuddySessionContainerView: View {
+    let appVM: AppViewModel
+    let sessionId: String
+
+    @State private var vm: BuddySessionViewModel
+
+    init(appVM: AppViewModel, sessionId: String) {
+        self.appVM = appVM
+        self.sessionId = sessionId
+        _vm = State(initialValue: BuddySessionViewModel(
+            sessionId: sessionId,
+            currentUserId: appVM.currentUser?.id ?? ""
+        ))
+    }
+
+    var body: some View {
+        Group {
+            if let pollError = vm.pollError, vm.snapshot == nil {
+                failureStateView(message: pollError)
+            } else if vm.isLoading && vm.snapshot == nil {
+                loadingStateView
+            } else if let snapshot = vm.snapshot {
+                switch snapshot.state {
+                case "waiting", "ready_check":
+                    BuddyWaitingRoomView(vm: vm) {
+                        appVM.leaveBuddySession()
+                    }
+                case "active":
+                    BuddyActiveSessionView(
+                        vm: vm,
+                        snapshot: snapshot,
+                        onLeave: {
+                            appVM.leaveBuddySession()
+                        },
+                        onComplete: { session in
+                            appVM.completeSession(
+                                sessionId: session.id,
+                                clearPercent: session.clearPercent,
+                                thoughtCount: session.thoughtCount,
+                                thoughts: vm.capturedThoughts,
+                                dayNumber: session.dayNumber,
+                                duration: session.duration
+                            )
+                        }
+                    )
+                case "completed":
+                    completionStateView
+                case "abandoned":
+                    terminalStateView(message: "The host ended this shared session.")
+                default:
+                    terminalStateView(message: "This session is no longer available.")
+                }
+            } else {
+                failureStateView(message: "Session could not be loaded.")
+            }
+        }
+        .stillPointBackground()
+        .task {
+            vm.startPolling()
+            await saveCompletionIfPossible()
+        }
+        .onDisappear {
+            vm.stopPolling()
+        }
+        .onChange(of: vm.snapshot?.state) { _, newState in
+            guard newState == "completed" else { return }
+            Task { await saveCompletionIfPossible() }
+        }
+    }
+
+    private var completionStateView: some View {
+        VStack(spacing: SPSpacing.s4) {
+            if vm.isSavingCompletion {
+                ProgressView("Saving your personal session…")
+                    .tint(Color(SPColor.fg2))
+                    .font(SPFont.mono(12))
+            } else {
+                Text("Time is complete")
+                    .font(SPFont.serifItalic(28, weight: .light))
+                    .foregroundStyle(Color(SPColor.fg))
+
+                if let error = vm.completionSaveError {
+                    Text(error)
+                        .font(SPFont.mono(12))
+                        .foregroundStyle(SPColor.dangerMuted)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, SPSpacing.s4)
+
+                    Button("Try again") {
+                        Task {
+                            await saveCompletionIfPossible()
+                        }
+                    }
+                    .font(SPFont.serifItalic(17, weight: .light))
+                    .foregroundStyle(Color(SPColor.fg))
+                } else {
+                    Text("Saving your personal session...")
+                        .font(SPFont.mono(12))
+                        .foregroundStyle(Color(SPColor.fg3))
+                }
+            }
+
+            Button("Return home without saving") {
+                Task {
+                    _ = await vm.leaveSession()
+                    appVM.leaveBuddySession()
+                }
+            }
+            .font(SPFont.mono(12, weight: .medium))
+            .foregroundStyle(Color(SPColor.fg3))
+        }
+        .padding(.horizontal, SPSpacing.s4)
+        .padding(.top, SPSpacing.s6)
+    }
+
+    private func terminalStateView(message: String) -> some View {
+        VStack(spacing: SPSpacing.s3) {
+            Text(message)
+                .font(SPFont.serif(16, weight: .light))
+                .foregroundStyle(Color(SPColor.fg2))
+                .multilineTextAlignment(.center)
+            Button("Return home") {
+                appVM.leaveBuddySession()
+            }
+            .font(SPFont.mono(12, weight: .medium))
+            .foregroundStyle(Color(SPColor.fg3))
+        }
+        .padding(.horizontal, SPSpacing.s4)
+        .padding(.top, SPSpacing.s6)
+    }
+
+    private func failureStateView(message: String) -> some View {
+        VStack(spacing: SPSpacing.s3) {
+            Text(message)
+                .font(SPFont.mono(12))
+                .foregroundStyle(Color(SPColor.fg2))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, SPSpacing.s4)
+            Button("Back") {
+                appVM.leaveBuddySession()
+            }
+            .font(SPFont.mono(12, weight: .medium))
+            .foregroundStyle(Color(SPColor.fg3))
+        }
+        .padding(.top, SPSpacing.s6)
+    }
+
+    private var loadingStateView: some View {
+        VStack(spacing: SPSpacing.s3) {
+            ProgressView("Loading session...")
+                .tint(Color(SPColor.fg2))
+                .font(SPFont.mono(12))
+        }
+        .padding(.top, SPSpacing.s6)
+    }
+
+    private func saveCompletionIfPossible() async {
+        guard vm.snapshot?.state == "completed", !vm.isSavingCompletion else { return }
+        guard let saved = await vm.savePersonalSession() else { return }
+        appVM.completeSession(
+            sessionId: saved.id,
+            clearPercent: saved.clearPercent,
+            thoughtCount: saved.thoughtCount,
+            thoughts: vm.capturedThoughts,
+            dayNumber: saved.dayNumber,
+            duration: saved.duration
+        )
+    }
+}

--- a/ios/StillPointApp/Views/BuddySession/BuddySessionContainerView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddySessionContainerView.swift
@@ -154,10 +154,13 @@ struct BuddySessionContainerView: View {
     }
 
     private func saveCompletionIfPossible() async {
-        guard vm.snapshot?.state == "completed", !vm.isSavingCompletion else { return }
+        guard let snapshotBeforeSave = vm.snapshot, snapshotBeforeSave.state == "completed", !vm.isSavingCompletion else { return }
         guard !didExitWithoutSaving else { return }
         guard let saved = await vm.savePersonalSession() else { return }
-        guard !didExitWithoutSaving else { return }
+        guard let snapshotAfterSave = vm.snapshot, snapshotAfterSave.state == "completed" else { return }
+        guard snapshotAfterSave.id == snapshotBeforeSave.id, saved.id == snapshotAfterSave.id else { return }
+        guard !vm.isSavingCompletion, !didExitWithoutSaving else { return }
+        guard appVM.currentView == .buddySession(sessionId: sessionId) else { return }
         appVM.completeSession(
             sessionId: saved.id,
             clearPercent: saved.clearPercent,

--- a/ios/StillPointApp/Views/BuddySession/BuddySessionContainerView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddySessionContainerView.swift
@@ -6,6 +6,7 @@ struct BuddySessionContainerView: View {
     let sessionId: String
 
     @State private var vm: BuddySessionViewModel
+    @State private var didExitWithoutSaving = false
 
     init(appVM: AppViewModel, sessionId: String) {
         self.appVM = appVM
@@ -104,13 +105,18 @@ struct BuddySessionContainerView: View {
             }
 
             Button("Return home without saving") {
+                guard !vm.isSavingCompletion else { return }
                 Task {
-                    _ = await vm.leaveSession()
-                    appVM.leaveBuddySession()
+                    let didLeave = await vm.leaveSession()
+                    if didLeave {
+                        didExitWithoutSaving = true
+                        appVM.leaveBuddySession()
+                    }
                 }
             }
             .font(SPFont.mono(12, weight: .medium))
             .foregroundStyle(Color(SPColor.fg3))
+            .disabled(vm.isSavingCompletion)
         }
         .padding(.horizontal, SPSpacing.s4)
         .padding(.top, SPSpacing.s6)
@@ -159,7 +165,9 @@ struct BuddySessionContainerView: View {
 
     private func saveCompletionIfPossible() async {
         guard vm.snapshot?.state == "completed", !vm.isSavingCompletion else { return }
+        guard !didExitWithoutSaving else { return }
         guard let saved = await vm.savePersonalSession() else { return }
+        guard !didExitWithoutSaving else { return }
         appVM.completeSession(
             sessionId: saved.id,
             clearPercent: saved.clearPercent,

--- a/ios/StillPointApp/Views/BuddySession/BuddySessionContainerView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddySessionContainerView.swift
@@ -158,7 +158,8 @@ struct BuddySessionContainerView: View {
         guard !didExitWithoutSaving else { return }
         guard let saved = await vm.savePersonalSession() else { return }
         guard let snapshotAfterSave = vm.snapshot, snapshotAfterSave.state == "completed" else { return }
-        guard snapshotAfterSave.id == snapshotBeforeSave.id, saved.id == snapshotAfterSave.id else { return }
+        guard snapshotAfterSave.id == snapshotBeforeSave.id else { return }
+        guard saved.buddySessionId == nil || saved.buddySessionId == snapshotAfterSave.id else { return }
         guard !vm.isSavingCompletion, !didExitWithoutSaving else { return }
         guard appVM.currentView == .buddySession(sessionId: sessionId) else { return }
         appVM.completeSession(

--- a/ios/StillPointApp/Views/BuddySession/BuddySessionHubView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddySessionHubView.swift
@@ -200,38 +200,7 @@ struct BuddySessionHubView: View {
     }
 
     private func extractBuddyToken(_ raw: String) -> String {
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return "" }
-
-        if let url = URL(string: trimmed),
-           let components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
-            if let buddy = components.queryItems?.first(where: { $0.name == "buddy" })?.value?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !buddy.isEmpty {
-                return buddy
-            }
-            if let token = components.queryItems?.first(where: { $0.name == "token" })?.value?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !token.isEmpty {
-                return token
-            }
-            let scheme = (url.scheme ?? "").lowercased()
-            let host = (url.host ?? "").lowercased()
-            if scheme == "stillpoint" && host == "buddy" {
-                let token = url.path
-                    .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                if !token.isEmpty { return token }
-            }
-        }
-
-        if let range = trimmed.range(of: "buddy=") {
-            let rest = String(trimmed[range.upperBound...])
-            if let amp = rest.firstIndex(of: "&") {
-                return String(rest[..<amp]).trimmingCharacters(in: .whitespacesAndNewlines)
-            }
-            return rest.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-
-        return trimmed
+        BuddyInviteTokenParser.token(from: raw, allowRawFallback: true) ?? ""
     }
 
     private func fullLink(for sharePath: String) -> String {

--- a/ios/StillPointApp/Views/BuddySession/BuddySessionHubView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddySessionHubView.swift
@@ -69,6 +69,9 @@ struct BuddySessionHubView: View {
                 errorMessage = newError
             }
         }
+        .onDisappear {
+            appVM.buddyInviteError = nil
+        }
     }
 
     private var createOrJoinSection: some View {

--- a/ios/StillPointApp/Views/BuddySession/BuddySessionHubView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddySessionHubView.swift
@@ -59,6 +59,16 @@ struct BuddySessionHubView: View {
             .padding(.bottom, SPSpacing.s5)
         }
         .stillPointBackground()
+        .onAppear {
+            if let inviteError = appVM.buddyInviteError {
+                errorMessage = inviteError
+            }
+        }
+        .onChange(of: appVM.buddyInviteError) { _, newError in
+            if let newError {
+                errorMessage = newError
+            }
+        }
     }
 
     private var createOrJoinSection: some View {

--- a/ios/StillPointApp/Views/BuddySession/BuddySessionHubView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddySessionHubView.swift
@@ -1,0 +1,231 @@
+import SwiftUI
+import StillPointShared
+
+struct BuddySessionHubView: View {
+    let appVM: AppViewModel
+
+    @State private var joinToken = ""
+    @State private var createdPath: String?
+    @State private var createdSessionId: String?
+    @State private var busy = false
+    @State private var errorMessage: String?
+    @State private var didCopy = false
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: SPSpacing.s4) {
+                Text("Meditate with a friend")
+                    .font(SPFont.serifItalic(28, weight: .light))
+                    .foregroundStyle(Color(SPColor.fg))
+                    .multilineTextAlignment(.center)
+                    .padding(.top, SPSpacing.s4)
+
+                Text("Create a room, share the link, mark ready when both of you are set, then the host starts one shared timer.")
+                    .font(SPFont.serif(16, weight: .light))
+                    .foregroundStyle(Color(SPColor.fg2))
+                    .multilineTextAlignment(.center)
+
+                if let errorMessage {
+                    Text(errorMessage)
+                        .font(SPFont.mono(12))
+                        .foregroundStyle(Color(SPColor.fg2))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, SPSpacing.s3)
+                        .padding(.vertical, SPSpacing.s2)
+                        .background(SPColor.surface1)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                        .overlay(RoundedRectangle(cornerRadius: 10).stroke(SPColor.border2))
+                }
+
+                if let createdPath, let createdSessionId {
+                    createdSessionSection(createdPath: createdPath, sessionId: createdSessionId)
+                } else {
+                    createOrJoinSection
+                }
+
+                Button {
+                    withAnimation {
+                        appVM.leaveBuddySession()
+                    }
+                } label: {
+                    Text("Back to home")
+                        .font(SPFont.mono(12, weight: .medium))
+                        .foregroundStyle(Color(SPColor.fg3))
+                }
+                .padding(.top, SPSpacing.s2)
+            }
+            .padding(.horizontal, SPSpacing.s4)
+            .padding(.bottom, SPSpacing.s5)
+        }
+        .stillPointBackground()
+    }
+
+    private var createOrJoinSection: some View {
+        VStack(spacing: SPSpacing.s3) {
+            Button {
+                Task { await createSession() }
+            } label: {
+                Text("Start shared session")
+                    .font(SPFont.serifItalic(20, weight: .light))
+                    .foregroundStyle(Color(SPColor.bg))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, SPSpacing.s3)
+                    .background(LinearGradient.greenHorizontal)
+                    .clipShape(Capsule())
+            }
+            .disabled(busy)
+            .opacity(busy ? 0.6 : 1)
+
+            Divider()
+                .background(SPColor.border1)
+                .padding(.vertical, SPSpacing.s2)
+
+            VStack(alignment: .leading, spacing: SPSpacing.s2) {
+                Text("Join with link or token")
+                    .font(SPFont.mono(11, weight: .medium))
+                    .foregroundStyle(Color(SPColor.fg4))
+                    .tracking(2)
+
+                TextEditor(text: $joinToken)
+                    .font(SPFont.mono(13))
+                    .frame(minHeight: 90)
+                    .padding(SPSpacing.s1)
+                    .background(SPColor.surface1)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .overlay(RoundedRectangle(cornerRadius: 10).stroke(SPColor.border2))
+                    .foregroundStyle(Color(SPColor.fg))
+
+                Button {
+                    Task { await joinSession() }
+                } label: {
+                    Text("Join session")
+                        .font(SPFont.mono(12, weight: .medium))
+                        .foregroundStyle(Color(SPColor.fg))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, SPSpacing.s2)
+                        .background(SPColor.surface2)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                        .overlay(RoundedRectangle(cornerRadius: 10).stroke(SPColor.border2))
+                }
+                .disabled(busy)
+                .opacity(busy ? 0.6 : 1)
+            }
+        }
+    }
+
+    private func createdSessionSection(createdPath: String, sessionId: String) -> some View {
+        VStack(alignment: .leading, spacing: SPSpacing.s3) {
+            Text("Share this link with your friend (they must be signed in):")
+                .font(SPFont.serif(15, weight: .light))
+                .foregroundStyle(Color(SPColor.fg2))
+
+            Text(fullLink(for: createdPath))
+                .font(SPFont.mono(12))
+                .foregroundStyle(Color(SPColor.fg))
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(SPSpacing.s2)
+                .background(SPColor.surface1)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .overlay(RoundedRectangle(cornerRadius: 10).stroke(SPColor.border2))
+
+            Button {
+                copyLink(fullLink(for: createdPath))
+            } label: {
+                Text(didCopy ? "Copied" : "Copy link")
+                    .font(SPFont.mono(11, weight: .medium))
+                    .foregroundStyle(Color(SPColor.fg))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, SPSpacing.s2)
+                    .background(SPColor.surface1)
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .overlay(RoundedRectangle(cornerRadius: 10).stroke(SPColor.border2))
+            }
+
+            Button {
+                withAnimation {
+                    appVM.enterBuddySession(sessionId: sessionId)
+                }
+            } label: {
+                Text("Enter waiting room")
+                    .font(SPFont.serifItalic(20, weight: .light))
+                    .foregroundStyle(Color(SPColor.bg))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, SPSpacing.s3)
+                    .background(LinearGradient.greenHorizontal)
+                    .clipShape(Capsule())
+            }
+        }
+    }
+
+    private func createSession() async {
+        busy = true
+        errorMessage = nil
+        defer { busy = false }
+
+        do {
+            let created = try await APIClient.shared.createBuddySession()
+            createdPath = created.sharePath
+            createdSessionId = created.id
+            didCopy = false
+        } catch let error as APIError {
+            errorMessage = error.message
+        } catch {
+            errorMessage = "Could not create session."
+        }
+    }
+
+    private func joinSession() async {
+        busy = true
+        errorMessage = nil
+        defer { busy = false }
+
+        let token = extractBuddyToken(joinToken)
+        guard !token.isEmpty else {
+            errorMessage = "Paste a full invite link or token."
+            return
+        }
+
+        do {
+            let sessionId = try await APIClient.shared.joinBuddySession(token: token)
+            withAnimation {
+                appVM.enterBuddySession(sessionId: sessionId)
+            }
+        } catch let error as APIError {
+            errorMessage = error.message
+        } catch {
+            errorMessage = "Could not join session."
+        }
+    }
+
+    private func extractBuddyToken(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+
+        if let url = URL(string: trimmed),
+           let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+           let buddy = components.queryItems?.first(where: { $0.name == "buddy" })?.value?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !buddy.isEmpty {
+            return buddy
+        }
+
+        if let range = trimmed.range(of: "buddy=") {
+            let rest = String(trimmed[range.upperBound...])
+            if let amp = rest.firstIndex(of: "&") {
+                return String(rest[..<amp]).trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            return rest.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        return trimmed
+    }
+
+    private func fullLink(for sharePath: String) -> String {
+        "https://still-point.me\(sharePath)"
+    }
+
+    private func copyLink(_ text: String) {
+        UIPasteboard.general.string = text
+        didCopy = true
+    }
+}

--- a/ios/StillPointApp/Views/BuddySession/BuddySessionHubView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddySessionHubView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 import StillPointShared
 
 struct BuddySessionHubView: View {

--- a/ios/StillPointApp/Views/BuddySession/BuddySessionHubView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddySessionHubView.swift
@@ -204,10 +204,23 @@ struct BuddySessionHubView: View {
         guard !trimmed.isEmpty else { return "" }
 
         if let url = URL(string: trimmed),
-           let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-           let buddy = components.queryItems?.first(where: { $0.name == "buddy" })?.value?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !buddy.isEmpty {
-            return buddy
+           let components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+            if let buddy = components.queryItems?.first(where: { $0.name == "buddy" })?.value?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !buddy.isEmpty {
+                return buddy
+            }
+            if let token = components.queryItems?.first(where: { $0.name == "token" })?.value?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !token.isEmpty {
+                return token
+            }
+            let scheme = (url.scheme ?? "").lowercased()
+            let host = (url.host ?? "").lowercased()
+            if scheme == "stillpoint" && host == "buddy" {
+                let token = url.path
+                    .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if !token.isEmpty { return token }
+            }
         }
 
         if let range = trimmed.range(of: "buddy=") {

--- a/ios/StillPointApp/Views/BuddySession/BuddyVideoWebView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyVideoWebView.swift
@@ -6,19 +6,8 @@ struct BuddyVideoWebView: UIViewRepresentable {
     let roomURL: String
     let meetingToken: String
 
-    final class Coordinator: NSObject, WKUIDelegate {
+    final class Coordinator: NSObject {
         var lastRequestedURL: URL?
-
-        @available(iOS 15.0, *)
-        func webView(
-            _ webView: WKWebView,
-            requestMediaCapturePermissionFor origin: WKSecurityOrigin,
-            initiatedByFrame frame: WKFrameInfo,
-            type: WKMediaCaptureType,
-            decisionHandler: @escaping (WKPermissionDecision) -> Void
-        ) {
-            decisionHandler(.grant)
-        }
     }
 
     func makeCoordinator() -> Coordinator {
@@ -34,7 +23,6 @@ struct BuddyVideoWebView: UIViewRepresentable {
         webView.isOpaque = false
         webView.backgroundColor = .clear
         webView.scrollView.isScrollEnabled = false
-        webView.uiDelegate = context.coordinator
         return webView
     }
 

--- a/ios/StillPointApp/Views/BuddySession/BuddyVideoWebView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyVideoWebView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 import WebKit
 
 struct BuddyVideoWebView: UIViewRepresentable {

--- a/ios/StillPointApp/Views/BuddySession/BuddyVideoWebView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyVideoWebView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+import WebKit
+
+struct BuddyVideoWebView: UIViewRepresentable {
+    let roomURL: String
+    let meetingToken: String
+
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.allowsInlineMediaPlayback = true
+        config.mediaTypesRequiringUserActionForPlayback = []
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        webView.scrollView.isScrollEnabled = false
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        guard var components = URLComponents(string: roomURL) else { return }
+        var query = components.queryItems ?? []
+        let hasToken = query.contains { $0.name == "t" }
+        if !hasToken {
+            query.append(URLQueryItem(name: "t", value: meetingToken))
+        }
+        components.queryItems = query
+        guard let finalURL = components.url else { return }
+        if webView.url != finalURL {
+            webView.load(URLRequest(url: finalURL))
+        }
+    }
+}

--- a/ios/StillPointApp/Views/BuddySession/BuddyVideoWebView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyVideoWebView.swift
@@ -6,8 +6,19 @@ struct BuddyVideoWebView: UIViewRepresentable {
     let roomURL: String
     let meetingToken: String
 
-    final class Coordinator {
+    final class Coordinator: NSObject, WKUIDelegate {
         var lastRequestedURL: URL?
+
+        @available(iOS 15.0, *)
+        func webView(
+            _ webView: WKWebView,
+            requestMediaCapturePermissionFor origin: WKSecurityOrigin,
+            initiatedByFrame frame: WKFrameInfo,
+            type: WKMediaCaptureType,
+            decisionHandler: @escaping (WKPermissionDecision) -> Void
+        ) {
+            decisionHandler(.grant)
+        }
     }
 
     func makeCoordinator() -> Coordinator {
@@ -23,6 +34,7 @@ struct BuddyVideoWebView: UIViewRepresentable {
         webView.isOpaque = false
         webView.backgroundColor = .clear
         webView.scrollView.isScrollEnabled = false
+        webView.uiDelegate = context.coordinator
         return webView
     }
 

--- a/ios/StillPointApp/Views/BuddySession/BuddyVideoWebView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyVideoWebView.swift
@@ -6,6 +6,14 @@ struct BuddyVideoWebView: UIViewRepresentable {
     let roomURL: String
     let meetingToken: String
 
+    final class Coordinator {
+        var lastRequestedURL: URL?
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
     func makeUIView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
         config.allowsInlineMediaPlayback = true
@@ -25,7 +33,8 @@ struct BuddyVideoWebView: UIViewRepresentable {
         query.append(URLQueryItem(name: "t", value: meetingToken))
         components.queryItems = query
         guard let finalURL = components.url else { return }
-        if webView.url != finalURL {
+        if context.coordinator.lastRequestedURL != finalURL {
+            context.coordinator.lastRequestedURL = finalURL
             webView.load(URLRequest(url: finalURL))
         }
     }

--- a/ios/StillPointApp/Views/BuddySession/BuddyVideoWebView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyVideoWebView.swift
@@ -6,8 +6,21 @@ struct BuddyVideoWebView: UIViewRepresentable {
     let roomURL: String
     let meetingToken: String
 
-    final class Coordinator: NSObject {
+    final class Coordinator: NSObject, WKUIDelegate {
         var lastRequestedURL: URL?
+
+        @available(iOS 15.0, *)
+        func webView(
+            _ webView: WKWebView,
+            requestMediaCapturePermissionFor origin: WKSecurityOrigin,
+            initiatedByFrame frame: WKFrameInfo,
+            type: WKMediaCaptureType,
+            decisionHandler: @escaping (WKPermissionDecision) -> Void
+        ) {
+            Task { @MainActor in
+                decisionHandler(.grant)
+            }
+        }
     }
 
     func makeCoordinator() -> Coordinator {
@@ -23,6 +36,7 @@ struct BuddyVideoWebView: UIViewRepresentable {
         webView.isOpaque = false
         webView.backgroundColor = .clear
         webView.scrollView.isScrollEnabled = false
+        webView.uiDelegate = context.coordinator
         return webView
     }
 

--- a/ios/StillPointApp/Views/BuddySession/BuddyVideoWebView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyVideoWebView.swift
@@ -21,10 +21,8 @@ struct BuddyVideoWebView: UIViewRepresentable {
     func updateUIView(_ webView: WKWebView, context: Context) {
         guard var components = URLComponents(string: roomURL) else { return }
         var query = components.queryItems ?? []
-        let hasToken = query.contains { $0.name == "t" }
-        if !hasToken {
-            query.append(URLQueryItem(name: "t", value: meetingToken))
-        }
+        query.removeAll { $0.name == "t" }
+        query.append(URLQueryItem(name: "t", value: meetingToken))
         components.queryItems = query
         guard let finalURL = components.url else { return }
         if webView.url != finalURL {

--- a/ios/StillPointApp/Views/BuddySession/BuddyWaitingRoomView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyWaitingRoomView.swift
@@ -37,13 +37,16 @@ struct BuddyWaitingRoomView: View {
 
                 if let me = meParticipant {
                     Toggle(isOn: Binding(
-                        get: { me.ready || myReady },
+                        get: { me.ready },
                         set: { newValue in
-                            myReady = newValue
+                            let previousValue = me.ready
                             Task {
                                 isUpdatingReady = true
-                                await vm.setReady(newValue)
+                                let success = await vm.setReady(newValue)
                                 await MainActor.run {
+                                    if !success {
+                                        myReady = previousValue
+                                    }
                                     isUpdatingReady = false
                                 }
                             }
@@ -57,11 +60,11 @@ struct BuddyWaitingRoomView: View {
                     .tint(SPColor.green)
                     .padding(.horizontal, SPSpacing.s4)
                     .padding(.vertical, SPSpacing.s3)
-                    .background((me.ready || myReady) ? SPColor.greenBgFaint : SPColor.surface1)
+                    .background(me.ready ? SPColor.greenBgFaint : SPColor.surface1)
                     .clipShape(RoundedRectangle(cornerRadius: 16))
                     .overlay(
                         RoundedRectangle(cornerRadius: 16)
-                            .stroke((me.ready || myReady) ? SPColor.greenBorder : SPColor.border2)
+                            .stroke(me.ready ? SPColor.greenBorder : SPColor.border2)
                     )
                     .padding(.horizontal, SPSpacing.s4)
                     .disabled(isUpdatingReady)
@@ -91,8 +94,9 @@ struct BuddyWaitingRoomView: View {
 
                         Button {
                             Task {
-                                await vm.cancelSession()
-                                onExit()
+                                if await vm.cancelSession() {
+                                    onExit()
+                                }
                             }
                         } label: {
                             Text("Cancel session")
@@ -116,8 +120,9 @@ struct BuddyWaitingRoomView: View {
 
                 Button {
                     Task {
-                        _ = await vm.leaveSession()
-                        onExit()
+                        if await vm.leaveSession() {
+                            onExit()
+                        }
                     }
                 } label: {
                     Text("Leave")
@@ -134,16 +139,6 @@ struct BuddyWaitingRoomView: View {
             .padding(.horizontal, SPSpacing.s3)
         }
         .stillPointBackground()
-        .onAppear {
-            if let me = meParticipant {
-                myReady = me.ready
-            }
-        }
-        .onChange(of: meParticipant?.ready) { _, newValue in
-            if let newValue {
-                myReady = newValue
-            }
-        }
     }
 
     private var snapshot: BuddySnapshotDTO? { vm.snapshot }

--- a/ios/StillPointApp/Views/BuddySession/BuddyWaitingRoomView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyWaitingRoomView.swift
@@ -6,7 +6,6 @@ struct BuddyWaitingRoomView: View {
     let onExit: () -> Void
 
     @State private var isUpdatingReady = false
-    @State private var myReady = false
 
     var body: some View {
         ScrollView {
@@ -44,9 +43,7 @@ struct BuddyWaitingRoomView: View {
                                 isUpdatingReady = true
                                 let success = await vm.setReady(newValue)
                                 await MainActor.run {
-                                    if !success {
-                                        myReady = previousValue
-                                    }
+                                    _ = previousValue // intentionally no optimistic local override
                                     isUpdatingReady = false
                                 }
                             }

--- a/ios/StillPointApp/Views/BuddySession/BuddyWaitingRoomView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyWaitingRoomView.swift
@@ -1,0 +1,208 @@
+import SwiftUI
+import StillPointShared
+
+struct BuddyWaitingRoomView: View {
+    @Bindable var vm: BuddySessionViewModel
+    let onExit: () -> Void
+
+    @State private var isUpdatingReady = false
+    @State private var myReady = false
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: SPSpacing.s4) {
+                Text("Shared session")
+                    .font(SPFont.serifItalic(28, weight: .light))
+                    .foregroundStyle(Color(SPColor.fg))
+                    .padding(.top, SPSpacing.s4)
+
+                if let pollError = vm.pollError {
+                    Text(pollError)
+                        .font(SPFont.mono(12))
+                        .foregroundStyle(Color(SPColor.fg2))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, SPSpacing.s4)
+                }
+
+                if let actionError = vm.actionError {
+                    Text(actionError)
+                        .font(SPFont.mono(12))
+                        .foregroundStyle(Color(SPColor.fg2))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, SPSpacing.s4)
+                }
+
+                waitingStatusCard
+                participantsList
+
+                if let me = meParticipant {
+                    Toggle(isOn: Binding(
+                        get: { me.ready || myReady },
+                        set: { newValue in
+                            myReady = newValue
+                            Task {
+                                isUpdatingReady = true
+                                await vm.setReady(newValue)
+                                await MainActor.run {
+                                    isUpdatingReady = false
+                                }
+                            }
+                        }
+                    )) {
+                        Text("I'm ready")
+                            .font(SPFont.serifItalic(20, weight: .light))
+                            .foregroundStyle(Color(SPColor.fg))
+                    }
+                    .toggleStyle(.switch)
+                    .tint(SPColor.green)
+                    .padding(.horizontal, SPSpacing.s4)
+                    .padding(.vertical, SPSpacing.s3)
+                    .background((me.ready || myReady) ? SPColor.greenBgFaint : SPColor.surface1)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16)
+                            .stroke((me.ready || myReady) ? SPColor.greenBorder : SPColor.border2)
+                    )
+                    .padding(.horizontal, SPSpacing.s4)
+                    .disabled(isUpdatingReady)
+                }
+
+                if vm.isHost {
+                    VStack(spacing: SPSpacing.s2) {
+                        Button {
+                            Task { await vm.startSession() }
+                        } label: {
+                            Text("Start for everyone")
+                                .font(SPFont.serifItalic(19, weight: .light))
+                                .foregroundStyle(Color(SPColor.bg))
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, SPSpacing.s3)
+                                .background(
+                                    snapshot?.state == "ready_check" ? LinearGradient.greenHorizontal : LinearGradient(
+                                        colors: [SPColor.surface2, SPColor.surface2],
+                                        startPoint: .leading,
+                                        endPoint: .trailing
+                                    )
+                                )
+                                .clipShape(Capsule())
+                        }
+                        .disabled(snapshot?.state != "ready_check")
+                        .opacity(snapshot?.state == "ready_check" ? 1 : 0.45)
+
+                        Button {
+                            Task {
+                                await vm.cancelSession()
+                                onExit()
+                            }
+                        } label: {
+                            Text("Cancel session")
+                                .font(SPFont.mono(11, weight: .medium))
+                                .foregroundStyle(Color(SPColor.fg3))
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, SPSpacing.s2)
+                                .background(SPColor.surface1)
+                                .clipShape(Capsule())
+                                .overlay(Capsule().stroke(SPColor.border2))
+                        }
+                    }
+                    .padding(.horizontal, SPSpacing.s4)
+                } else {
+                    Text("Only the host can start or cancel the shared session.")
+                        .font(SPFont.mono(11))
+                        .foregroundStyle(Color(SPColor.fg4))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, SPSpacing.s4)
+                }
+
+                Button {
+                    Task {
+                        _ = await vm.leaveSession()
+                        onExit()
+                    }
+                } label: {
+                    Text("Leave")
+                        .font(SPFont.mono(11, weight: .medium))
+                        .foregroundStyle(Color(SPColor.fg3))
+                        .padding(.horizontal, SPSpacing.s3)
+                        .padding(.vertical, SPSpacing.s2)
+                        .background(SPColor.surface1)
+                        .clipShape(Capsule())
+                        .overlay(Capsule().stroke(SPColor.border2))
+                }
+                .padding(.bottom, SPSpacing.s5)
+            }
+            .padding(.horizontal, SPSpacing.s3)
+        }
+        .stillPointBackground()
+        .onAppear {
+            if let me = meParticipant {
+                myReady = me.ready
+            }
+        }
+        .onChange(of: meParticipant?.ready) { _, newValue in
+            if let newValue {
+                myReady = newValue
+            }
+        }
+    }
+
+    private var snapshot: BuddySnapshotDTO? { vm.snapshot }
+
+    private var activeParticipants: [BuddyParticipantDTO] {
+        snapshot?.participants.filter { $0.leftAt == nil } ?? []
+    }
+
+    private var meParticipant: BuddyParticipantDTO? {
+        activeParticipants.first(where: { $0.userId == vm.currentUserId })
+    }
+
+    private var waitingStatusCard: some View {
+        let isReadyCheck = snapshot?.state == "ready_check"
+        return Text(isReadyCheck ? "Everyone is ready — host can start." : "Waiting for everyone to join and mark ready.")
+            .font(SPFont.mono(14))
+            .foregroundStyle(isReadyCheck ? SPColor.greenText : Color(SPColor.fg2))
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, SPSpacing.s4)
+            .padding(.vertical, SPSpacing.s4)
+            .frame(maxWidth: .infinity)
+            .background(isReadyCheck ? SPColor.greenBgSubtle : SPColor.surface1)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .overlay(
+                RoundedRectangle(cornerRadius: 16)
+                    .stroke(isReadyCheck ? SPColor.greenBorder : SPColor.border2, lineWidth: isReadyCheck ? 2 : 1)
+            )
+            .padding(.horizontal, SPSpacing.s4)
+    }
+
+    private var participantsList: some View {
+        VStack(spacing: SPSpacing.s2) {
+            ForEach(activeParticipants, id: \.userId) { participant in
+                HStack(spacing: SPSpacing.s2) {
+                    Text(participant.username + (participant.isHost ? " · host" : ""))
+                        .font(SPFont.serifItalic(18, weight: .light))
+                        .foregroundStyle(Color(SPColor.fg))
+                    Spacer()
+                    Circle()
+                        .fill(participant.connected ? SPColor.green : SPColor.fg4)
+                        .frame(width: 10, height: 10)
+                    Text(participant.connected ? "online" : "away")
+                        .font(SPFont.mono(11))
+                        .foregroundStyle(Color(SPColor.fg3))
+                    if participant.ready {
+                        Text("· ready")
+                            .font(SPFont.mono(11))
+                            .foregroundStyle(SPColor.greenText)
+                    }
+                }
+                .padding(.horizontal, SPSpacing.s3)
+                .padding(.vertical, SPSpacing.s3)
+                .background(SPColor.surface1)
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14).stroke(SPColor.border2)
+                )
+            }
+        }
+        .padding(.horizontal, SPSpacing.s4)
+    }
+}

--- a/ios/StillPointApp/Views/HomeView.swift
+++ b/ios/StillPointApp/Views/HomeView.swift
@@ -41,19 +41,44 @@ struct HomeView: View {
                 Spacer().frame(height: SPSpacing.s4)
 
                 // Begin button
-                Button {
-                    withAnimation {
-                        appVM.beginSession()
+                VStack(spacing: SPSpacing.s2) {
+                    Button {
+                        withAnimation {
+                            appVM.beginSession()
+                        }
+                    } label: {
+                        Text("Begin")
+                            .font(SPFont.serifItalic(22, weight: .light))
+                            .foregroundStyle(Color(SPColor.fg))
+                            .padding(.horizontal, 48)
+                            .padding(.vertical, SPSpacing.s3)
+                            .background(SPColor.surface2)
+                            .clipShape(Capsule())
+                            .overlay(Capsule().stroke(SPColor.border2))
                     }
-                } label: {
-                    Text("Begin")
-                        .font(SPFont.serifItalic(22, weight: .light))
-                        .foregroundStyle(Color(SPColor.fg))
-                        .padding(.horizontal, 48)
-                        .padding(.vertical, SPSpacing.s3)
-                        .background(SPColor.surface2)
-                        .clipShape(Capsule())
-                        .overlay(Capsule().stroke(SPColor.border2))
+
+                    Button {
+                        withAnimation {
+                            appVM.beginBuddySession()
+                        }
+                    } label: {
+                        Text("Meditate with a friend")
+                            .font(SPFont.serifItalic(18, weight: .light))
+                            .foregroundStyle(Color(SPColor.fg2))
+                            .padding(.horizontal, 32)
+                            .padding(.vertical, SPSpacing.s2)
+                            .background(SPColor.surface1)
+                            .clipShape(Capsule())
+                            .overlay(Capsule().stroke(SPColor.border1))
+                    }
+                }
+
+                if let inviteError = appVM.buddyInviteError {
+                    Text(inviteError)
+                        .font(SPFont.mono(12))
+                        .foregroundStyle(Color(SPColor.fg2))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, SPSpacing.s4)
                 }
 
                 Spacer().frame(height: SPSpacing.s6)

--- a/ios/StillPointApp/Views/RootView.swift
+++ b/ios/StillPointApp/Views/RootView.swift
@@ -29,6 +29,14 @@ struct RootView: View {
                     SessionView(appVM: appVM)
                         .transition(.opacity)
 
+                case .buddyHub:
+                    BuddySessionHubView(appVM: appVM)
+                        .transition(.opacity)
+
+                case .buddySession(let sessionId):
+                    BuddySessionContainerView(appVM: appVM, sessionId: sessionId)
+                        .transition(.opacity)
+
                 case .completion(let sessionId, let clearPercent, let thoughtCount, let thoughts, let dayNumber, let duration):
                     CompletionView(
                         appVM: appVM,
@@ -50,6 +58,9 @@ struct RootView: View {
         .animation(.easeInOut(duration: 0.3), value: appVM.currentView)
         .task {
             await appVM.checkAuth()
+        }
+        .onOpenURL { url in
+            appVM.handleIncomingURL(url)
         }
     }
 }

--- a/ios/StillPointApp/Views/RootView.swift
+++ b/ios/StillPointApp/Views/RootView.swift
@@ -35,6 +35,7 @@ struct RootView: View {
 
                 case .buddySession(let sessionId):
                     BuddySessionContainerView(appVM: appVM, sessionId: sessionId)
+                        .id(sessionId)
                         .transition(.opacity)
 
                 case .completion(let sessionId, let clearPercent, let thoughtCount, let thoughts, let dayNumber, let duration):

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -120,6 +120,80 @@ public actor APIClient {
         return response.user
     }
 
+    // MARK: - Buddy Sessions
+
+    public func createBuddySession() async throws -> BuddySessionCreatedDTO {
+        let response: CreateBuddySessionResponse = try await post("/api/buddy/sessions", body: Optional<String>.none)
+        return response.session
+    }
+
+    public func joinBuddySession(token: String) async throws -> String {
+        let response: JoinBuddySessionResponse = try await post(
+            "/api/buddy/sessions/join",
+            body: JoinBuddySessionRequest(token: token)
+        )
+        return response.sessionId
+    }
+
+    public func getBuddySnapshot(sessionId: String) async throws -> BuddySnapshotDTO {
+        let response: BuddySnapshotResponse = try await get("/api/buddy/sessions/\(sessionId)")
+        return response.snapshot
+    }
+
+    public func getBuddyMeetingToken(sessionId: String) async throws -> String {
+        let response: BuddyMeetingTokenResponse = try await post(
+            "/api/buddy/sessions/\(sessionId)/meeting-token",
+            body: Optional<String>.none
+        )
+        return response.token
+    }
+
+    public func setBuddyReady(sessionId: String, ready: Bool) async throws {
+        _ = try await patch(
+            "/api/buddy/sessions/\(sessionId)/ready",
+            body: SetBuddyReadyRequest(ready: ready)
+        ) as BuddyBooleanResponse
+    }
+
+    public func startBuddySession(sessionId: String) async throws {
+        _ = try await post(
+            "/api/buddy/sessions/\(sessionId)/start",
+            body: Optional<String>.none
+        ) as StartBuddySessionResponse
+    }
+
+    public func leaveBuddySession(sessionId: String) async throws {
+        _ = try await post(
+            "/api/buddy/sessions/\(sessionId)/leave",
+            body: Optional<String>.none
+        ) as BuddyBooleanResponse
+    }
+
+    public func cancelBuddySession(sessionId: String) async throws {
+        _ = try await post(
+            "/api/buddy/sessions/\(sessionId)/cancel",
+            body: Optional<String>.none
+        ) as BuddyBooleanResponse
+    }
+
+    public func buddyParticipantComplete(sessionId: String) async throws {
+        _ = try await post(
+            "/api/buddy/sessions/\(sessionId)/participant-complete",
+            body: Optional<String>.none
+        ) as BuddyBooleanResponse
+    }
+
+    public func recordBuddyPersonalSession(
+        sessionId: String,
+        request: RecordBuddyPersonalSessionRequest
+    ) async throws -> SessionDTO {
+        let response: RecordBuddyPersonalSessionResponse = try await post(
+            "/api/buddy/sessions/\(sessionId)/record-personal-session",
+            body: request
+        )
+        return response.session
+    }
+
     // MARK: - HTTP Helpers
 
     private func get<T: Decodable>(_ path: String) async throws -> T {
@@ -161,7 +235,8 @@ public actor APIClient {
             let errorBody = try? JSONDecoder().decode(ErrorResponse.self, from: data)
             throw APIError(
                 status: httpResponse.statusCode,
-                message: errorBody?.error ?? "Request failed"
+                message: errorBody?.error ?? "Request failed",
+                code: errorBody?.code
             )
         }
         return (data, httpResponse)
@@ -204,10 +279,18 @@ public actor APIClient {
 public struct APIError: Error, LocalizedError {
     public let status: Int
     public let message: String
+    public let code: String?
+
+    public init(status: Int, message: String, code: String? = nil) {
+        self.status = status
+        self.message = message
+        self.code = code
+    }
 
     public var errorDescription: String? { message }
 }
 
 private struct ErrorResponse: Codable {
     let error: String
+    let code: String?
 }

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -176,13 +176,6 @@ public actor APIClient {
         ) as BuddyBooleanResponse
     }
 
-    public func buddyParticipantComplete(sessionId: String) async throws {
-        _ = try await post(
-            "/api/buddy/sessions/\(sessionId)/participant-complete",
-            body: Optional<String>.none
-        ) as BuddyBooleanResponse
-    }
-
     public func recordBuddyPersonalSession(
         sessionId: String,
         request: RecordBuddyPersonalSessionRequest

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -20,6 +20,7 @@ public struct SessionDTO: Codable, Sendable {
     public let thoughtCount: Int
     public let mindStateLog: [MindStateEntry]?
     public let sessionDate: String
+    public let buddySessionId: String?
 }
 
 public struct ThoughtDTO: Codable, Sendable {
@@ -95,6 +96,59 @@ public struct BatchThoughtsRequest: Codable, Sendable {
     }
 }
 
+// MARK: - Buddy Session API Types
+
+public struct BuddySessionCreatedDTO: Codable, Sendable {
+    public let id: String
+    public let shareToken: String
+    public let sharePath: String
+    public let durationSeconds: Int
+}
+
+public struct BuddyParticipantDTO: Codable, Sendable {
+    public let userId: String
+    public let username: String
+    public let isHost: Bool
+    public let ready: Bool
+    public let joinedAt: String
+    public let leftAt: String?
+    public let connected: Bool
+    public let participantCompletedAt: String?
+}
+
+public struct BuddySnapshotDTO: Codable, Sendable {
+    public let id: String
+    public let state: String
+    public let revision: Int
+    public let durationSeconds: Int
+    public let startedAt: String?
+    public let serverNow: String
+    public let endsAt: String?
+    public let elapsedSeconds: Int?
+    public let remainingSeconds: Int?
+    public let dailyRoomUrl: String?
+    public let hostUserId: String
+    public let isHost: Bool
+    public let participants: [BuddyParticipantDTO]
+}
+
+public struct SetBuddyReadyRequest: Codable, Sendable {
+    public let ready: Bool
+}
+
+public struct JoinBuddySessionRequest: Codable, Sendable {
+    public let token: String
+}
+
+public struct RecordBuddyPersonalSessionRequest: Codable, Sendable {
+    public let clearPercent: Int
+    public let thoughtCount: Int
+    public let mindStateLog: [MindStateEntry]
+    public let actualTime: Int
+    public let sessionDate: String
+    public let thoughts: [BatchThoughtsRequest.ThoughtInput]?
+}
+
 // MARK: - API Wrappers (match JSON response shapes)
 
 public struct UserResponse: Codable, Sendable {
@@ -122,4 +176,34 @@ public struct ThoughtsResponse: Codable, Sendable {
 
 public struct BoardResponse: Codable, Sendable {
     public let board: [BoardEntryDTO]
+}
+
+public struct CreateBuddySessionResponse: Codable, Sendable {
+    public let session: BuddySessionCreatedDTO
+}
+
+public struct JoinBuddySessionResponse: Codable, Sendable {
+    public let sessionId: String
+}
+
+public struct BuddySnapshotResponse: Codable, Sendable {
+    public let snapshot: BuddySnapshotDTO
+}
+
+public struct BuddyMeetingTokenResponse: Codable, Sendable {
+    public let token: String
+}
+
+public struct BuddyBooleanResponse: Codable, Sendable {
+    public let ok: Bool
+}
+
+public struct StartBuddySessionResponse: Codable, Sendable {
+    public let ok: Bool
+    public let startedAt: String?
+}
+
+public struct RecordBuddyPersonalSessionResponse: Codable, Sendable {
+    public let session: SessionDTO
+    public let already: Bool?
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add buddy session DTOs and APIClient methods for create/join/snapshot/ready/start/leave/cancel/meeting-token/record-personal-session
- add iOS buddy session navigation states and deep-link handling for `stillpoint://buddy/TOKEN` plus `?buddy=` links
- implement buddy hub, waiting room, active session, completion handling, and container orchestration with polling
- add iOS video embedding path via `WKWebView` using Daily room URL + meeting token
- update Info.plist with URL scheme and camera/mic/background mode entries for partner video sessions
- add compile robustness fix for buddy views by importing UIKit where `UIPasteboard`/`UIViewRepresentable` are used

## Follow-up review fixes
- remove unsupported `voip` background mode from iOS Info.plist (leave `audio`)
- fix `AppView.Equatable` for `.buddySession(sessionId:)` so different sessions are not treated as equal
- force buddy container re-init per session with `.id(sessionId)` in `RootView`
- harden buddy polling loop cancellation handling and prevent stale snapshot overwrite races
- harden meeting token fetch state handling and retry behavior
- ensure waiting room ready toggle/leave/cancel behaviors only exit on successful server updates
- support `stillpoint://buddy/TOKEN` parsing in hub token extraction
- always replace Daily `t` query parameter in buddy web video view
- disable and guard "Return home without saving" while completion save is active
- remove unreachable/dead completion callback path from `BuddyActiveSessionView`
- isolate `AppViewModel` on `@MainActor` to keep observable state mutations on main thread
- clear stale meeting token immediately when buddy snapshot revision/key changes
- throttle active-session timer end refresh to one in-flight completion refresh request

## Final cleanup pass
- centralize invite token parsing into a shared `BuddyInviteTokenParser` and reuse it from both `AppViewModel` and `BuddySessionHubView`
- constrain `?token=` parsing to buddy-specific routes only (prevents misclassifying unrelated deep links)
- configure ISO parsing for fractional-second timestamps with fallback parser for non-fractional server values
- harden completion handoff checks in `BuddySessionContainerView` to prevent stale async completion from overriding newer navigation state
- remove raw Daily room URL from the user-facing active session UI
- avoid deep-link interruption of active sessions by queueing invite tokens while in-session and consuming them when returning home/after leave
- simplify redundant main-actor wrappers in meeting-token fetch updates
- clarify completion UI messaging from "Saving..." to "Preparing to save..." when save has not started yet
- fix completion-screen regression by validating `SessionDTO.buddySessionId` against buddy snapshot id (instead of comparing mismatched entity ids)
- remove unused `participantCompleteAndLeave` dead code from buddy session view model
- prevent `WKWebView` infinite reload loops by tracking the last requested URL in a `UIViewRepresentable` coordinator
- remove unused iOS API client `buddyParticipantComplete` method after dead-code cleanup

## Latest unresolved-thread pass
- surface deep-link join errors in buddy hub by syncing local error state from `appVM.buddyInviteError` and initializing existing error state when navigating into the hub
- tighten raw-string token fallback behavior by disabling raw fallback for app-level deep link parsing while keeping join input fallback in hub UI
- replace diagnostic timer subtitle with clear end-user session phrasing
- add `WKUIDelegate` media-capture permission handling and set `uiDelegate` on `WKWebView` with explicit main-actor decision handling

## Notes
- CodeRabbit local/github rule files referenced in the issue were not present in this repository, so implementation proceeded without those local rule docs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f37bc46c-66a6-4167-a54f-087df061f581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f37bc46c-66a6-4167-a54f-087df061f581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared meditation: hub, waiting room, and active session flows with host controls, join/create via invite link or token, and in-app video playback.
  * Mind-state tracking, note capture, and personal-session save/export; home adds “Meditate with a friend”.
  * Deep-link handling: incoming invite URLs are processed and can auto-join after login; invite link copy/share UI.

* **Permissions / Background**
  * Camera & microphone usage strings added; background audio enabled.

* **Bug Fixes / UX**
  * Improved invite error feedback and join flow resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->