### PR TITLE
Add native iOS E2E smoke tests beyond auth (Issue #193)

### DIFF
--- a/ios/StillPointApp/Navigation/MainTabView.swift
+++ b/ios/StillPointApp/Navigation/MainTabView.swift
@@ -15,9 +15,9 @@ struct MainTabView: View {
             HistoryView(appVM: appVM)
                 .tabItem {
                     Label("PROGRESS", systemImage: "chart.bar")
+                        .accessibilityIdentifier("tab.progress")
                 }
                 .tag(1)
-                .accessibilityIdentifier("tab.progress")
 
             ThoughtJournalView()
                 .tabItem {
@@ -34,9 +34,9 @@ struct MainTabView: View {
             SettingsView(appVM: appVM)
                 .tabItem {
                     Label("SETTINGS", systemImage: "gearshape")
+                        .accessibilityIdentifier("tab.settings")
                 }
                 .tag(4)
-                .accessibilityIdentifier("tab.settings")
         }
         .tint(SPColor.green)
         .onAppear {

--- a/ios/StillPointApp/Navigation/MainTabView.swift
+++ b/ios/StillPointApp/Navigation/MainTabView.swift
@@ -17,6 +17,7 @@ struct MainTabView: View {
                     Label("PROGRESS", systemImage: "chart.bar")
                 }
                 .tag(1)
+                .accessibilityIdentifier("tab.progress")
 
             ThoughtJournalView()
                 .tabItem {
@@ -35,6 +36,7 @@ struct MainTabView: View {
                     Label("SETTINGS", systemImage: "gearshape")
                 }
                 .tag(4)
+                .accessibilityIdentifier("tab.settings")
         }
         .tint(SPColor.green)
         .onAppear {

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -43,6 +43,8 @@ final class AppViewModel {
     var currentView: AppView = .auth
     var currentUser: UserDTO?
     var isLoading = true
+    var authStatusMessage: String?
+    var lastColdStartAuthCheckMs: Int?
     var buddyInviteError: String?
     private var pendingBuddyInviteToken: String?
 
@@ -66,6 +68,7 @@ final class AppViewModel {
     }
 
     func checkAuth() async {
+        let startedAt = Date()
         isLoading = true
         defer { isLoading = false }
 
@@ -73,18 +76,29 @@ final class AppViewModel {
             if let user = try await APIClient.shared.me() {
                 currentUser = user
                 currentView = .home
+                authStatusMessage = nil
                 await consumePendingBuddyInviteIfNeeded()
             } else {
                 currentView = .auth
+                authStatusMessage = nil
             }
+        } catch let apiError as APIError where apiError.status == 401 && apiError.code == "TOKEN_EXPIRED" {
+            currentView = .auth
+            authStatusMessage = apiError.message
+        } catch let apiError as APIError {
+            currentView = .auth
+            authStatusMessage = apiError.message
         } catch {
             currentView = .auth
+            authStatusMessage = "Connection failed. Please try again."
         }
+        lastColdStartAuthCheckMs = Int(Date().timeIntervalSince(startedAt) * 1_000)
     }
 
     func didLogin(user: UserDTO) {
         currentUser = user
         currentView = .home
+        authStatusMessage = nil
         Task { await consumePendingBuddyInviteIfNeeded() }
     }
 
@@ -92,6 +106,7 @@ final class AppViewModel {
         currentUser = nil
         pendingBuddyInviteToken = nil
         buddyInviteError = nil
+        authStatusMessage = nil
         currentView = .auth
     }
 

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -77,7 +77,9 @@ final class AppViewModel {
                 currentUser = user
                 currentView = .home
                 authStatusMessage = nil
+                lastColdStartAuthCheckMs = Int(Date().timeIntervalSince(startedAt) * 1_000)
                 await consumePendingBuddyInviteIfNeeded()
+                return
             } else {
                 currentView = .auth
                 authStatusMessage = nil

--- a/ios/StillPointApp/ViewModels/SessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/SessionViewModel.swift
@@ -39,6 +39,7 @@ final class SessionViewModel {
     private var lastTickSec = 0
     private var lastCompletedMinuteBlockIndex = -1
     private var controlHideTimer: AnyCancellable?
+    private let uiTestTimerMultiplier: Double
 
     var remaining: Double {
         max(0, Double(totalSeconds) - elapsed)
@@ -81,8 +82,9 @@ final class SessionViewModel {
 
     init(dayNumber: Int) {
         self.dayNumber = dayNumber
-        self.totalSeconds = StillPoint.duration(forDay: dayNumber)
+        self.totalSeconds = Self.resolveTotalSeconds(for: dayNumber)
         self.soundPrefs = AudioEngine.loadPrefs()
+        self.uiTestTimerMultiplier = Self.resolveUITestTimerMultiplier()
         // Initial mind state log entry
         self.mindStateLog = [MindStateEntry(time: 0, state: "clear")]
     }
@@ -270,7 +272,7 @@ final class SessionViewModel {
     private func tick() {
         guard let startDate, isActive else { return }
 
-        let newElapsed = Date().timeIntervalSince(startDate)
+        let newElapsed = Date().timeIntervalSince(startDate) * uiTestTimerMultiplier
 
         if newElapsed >= Double(totalSeconds) {
             elapsed = Double(totalSeconds)
@@ -328,5 +330,31 @@ final class SessionViewModel {
                     self.controlsVisible = false
                 }
             }
+    }
+
+    private static func resolveTotalSeconds(for dayNumber: Int) -> Int {
+        let env = ProcessInfo.processInfo.environment
+        guard let override = env["SP_UI_TEST_SESSION_SECONDS"],
+              let overrideSeconds = Int(override),
+              overrideSeconds > 0 else {
+            return StillPoint.duration(forDay: dayNumber)
+        }
+        return overrideSeconds
+    }
+
+    private static func resolveUITestTimerMultiplier() -> Double {
+        let env = ProcessInfo.processInfo.environment
+        guard let multiplier = env["SP_UI_TEST_TIMER_MULTIPLIER"],
+              let parsed = Double(multiplier),
+              parsed.isFinite,
+              parsed > 0 else {
+            return 1.0
+        }
+        return parsed
+    }
+
+    static var isUITestTimerActive: Bool {
+        let env = ProcessInfo.processInfo.environment
+        return env["SP_UI_TEST_SESSION_SECONDS"] != nil || env["SP_UI_TEST_TIMER_MULTIPLIER"] != nil
     }
 }

--- a/ios/StillPointApp/ViewModels/SessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/SessionViewModel.swift
@@ -109,7 +109,7 @@ final class SessionViewModel {
 
         isActive = true
         isPaused = false
-        startDate = Date().addingTimeInterval(-pausedElapsed)
+        startDate = Date().addingTimeInterval(-(pausedElapsed / uiTestTimerMultiplier))
         if soundPrefs.tick || soundPrefs.chime || soundPrefs.completion {
             AudioEngine.shared.warmUp()
         }
@@ -353,8 +353,4 @@ final class SessionViewModel {
         return parsed
     }
 
-    static var isUITestTimerActive: Bool {
-        let env = ProcessInfo.processInfo.environment
-        return env["SP_UI_TEST_SESSION_SECONDS"] != nil || env["SP_UI_TEST_TIMER_MULTIPLIER"] != nil
-    }
 }

--- a/ios/StillPointApp/Views/AuthView.swift
+++ b/ios/StillPointApp/Views/AuthView.swift
@@ -4,6 +4,7 @@ import StillPointShared
 struct AuthView: View {
     let appVM: AppViewModel
     @State private var vm = AuthViewModel()
+    let launchAuthStatusMessage: String?
 
     var body: some View {
         ScrollView {
@@ -36,15 +37,25 @@ struct AuthView: View {
 
                 // Form
                 VStack(spacing: SPSpacing.s3) {
+                    if let launchAuthStatusMessage {
+                        Text(launchAuthStatusMessage)
+                            .font(SPFont.mono(12))
+                            .foregroundStyle(SPColor.dangerMuted)
+                            .multilineTextAlignment(.center)
+                            .accessibilityIdentifier("auth.launchStatusMessage")
+                    }
+
                     styledField("Email", text: $vm.email)
                         .textContentType(.emailAddress)
                         .keyboardType(.emailAddress)
                         .textInputAutocapitalization(.never)
+                        .accessibilityIdentifier("auth.emailField")
 
                     if vm.isSignUp {
                         styledField("Username", text: $vm.username)
                             .textContentType(.username)
                             .textInputAutocapitalization(.never)
+                            .accessibilityIdentifier("auth.usernameField")
                     }
 
                     SecureField("Password", text: $vm.password)
@@ -59,6 +70,7 @@ struct AuthView: View {
                                 .stroke(SPColor.border2)
                         )
                         .foregroundStyle(Color(SPColor.fg))
+                        .accessibilityIdentifier("auth.passwordField")
 
                     if let error = vm.error {
                         Text(error)
@@ -82,6 +94,7 @@ struct AuthView: View {
                             .clipShape(Capsule())
                             .overlay(Capsule().stroke(SPColor.border2))
                     }
+                    .accessibilityIdentifier("auth.submitButton")
                     .disabled(!vm.isValid || vm.isSubmitting)
                     .opacity(vm.isValid ? 1 : 0.5)
                 }

--- a/ios/StillPointApp/Views/AuthView.swift
+++ b/ios/StillPointApp/Views/AuthView.swift
@@ -42,7 +42,7 @@ struct AuthView: View {
                             .font(SPFont.mono(12))
                             .foregroundStyle(SPColor.dangerMuted)
                             .multilineTextAlignment(.center)
-                            .accessibilityIdentifier("auth.launchStatusMessage")
+                            .accessibilityIdentifier("authView.launchAuthStatusMessage")
                     }
 
                     styledField("Email", text: $vm.email)

--- a/ios/StillPointApp/Views/CompletionView.swift
+++ b/ios/StillPointApp/Views/CompletionView.swift
@@ -30,11 +30,13 @@ struct CompletionView: View {
                     Text("Day \(dayNumber) Complete")
                         .font(SPFont.serifItalic(32, weight: .light))
                         .foregroundStyle(Color(SPColor.fg))
+                        .accessibilityIdentifier("completion.dayTitle")
 
                     Text("\(duration) seconds of sustained attention")
                         .font(SPFont.mono(13))
                         .foregroundStyle(Color(SPColor.fg3))
                         .tracking(1)
+                        .accessibilityIdentifier("completion.durationLabel")
                 }
 
                 // Stats cards
@@ -192,6 +194,7 @@ struct CompletionView: View {
                         .clipShape(Capsule())
                         .overlay(Capsule().stroke(SPColor.border2))
                 }
+                .accessibilityIdentifier("completion.returnButton")
 
                 Spacer().frame(height: SPSpacing.s4)
             }

--- a/ios/StillPointApp/Views/HistoryView.swift
+++ b/ios/StillPointApp/Views/HistoryView.swift
@@ -20,6 +20,7 @@ struct HistoryView: View {
                 Text("Progress")
                     .font(SPFont.serifItalic(28, weight: .light))
                     .foregroundStyle(Color(SPColor.fg))
+                    .accessibilityIdentifier("history.title")
 
                 if vm.isLoading {
                     ProgressView()
@@ -31,6 +32,7 @@ struct HistoryView: View {
                             .font(SPFont.serif(15))
                             .foregroundStyle(SPColor.dangerMuted)
                             .multilineTextAlignment(.center)
+                            .accessibilityIdentifier("history.errorMessage")
                         Button("Retry") {
                             Task { await vm.load() }
                         }
@@ -180,6 +182,7 @@ struct HistoryView: View {
                 }
                 .padding(.vertical, 2)
             }
+            .accessibilityIdentifier("history.session.day.\(dayNumber)")
 
             // Expanded thoughts
             if isExpanded, let thoughts = vm.dayThoughts[dayNumber] {

--- a/ios/StillPointApp/Views/HomeView.swift
+++ b/ios/StillPointApp/Views/HomeView.swift
@@ -56,6 +56,8 @@ struct HomeView: View {
                             .clipShape(Capsule())
                             .overlay(Capsule().stroke(SPColor.border2))
                     }
+                    .accessibilityIdentifier("home.beginButton")
+                    .accessibilityLabel("Start session")
 
                     Button {
                         withAnimation {

--- a/ios/StillPointApp/Views/RootView.swift
+++ b/ios/StillPointApp/Views/RootView.swift
@@ -18,11 +18,20 @@ struct RootView: View {
                         .font(SPFont.brandSubtitle)
                         .foregroundStyle(Color(SPColor.fg3))
                         .tracking(4)
+                    if let authStatusMessage = appVM.authStatusMessage {
+                        Text(authStatusMessage)
+                            .font(SPFont.mono(12))
+                            .foregroundStyle(SPColor.dangerMuted)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal, SPSpacing.s4)
+                            .padding(.top, SPSpacing.s3)
+                            .accessibilityIdentifier("root.authStatusMessage")
+                    }
                 }
             } else {
                 switch appVM.currentView {
                 case .auth:
-                    AuthView(appVM: appVM)
+                    AuthView(appVM: appVM, launchAuthStatusMessage: appVM.authStatusMessage)
                         .transition(.opacity)
 
                 case .session:
@@ -57,11 +66,43 @@ struct RootView: View {
             }
         }
         .animation(.easeInOut(duration: 0.3), value: appVM.currentView)
+        .accessibilityIdentifier("root.currentView.\(viewAccessibilitySlug)")
+        .accessibilityValue(coldStartMetricAccessibilityValue)
         .task {
             await appVM.checkAuth()
         }
         .onOpenURL { url in
             appVM.handleIncomingURL(url)
         }
+    }
+
+    private var viewAccessibilitySlug: String {
+        switch appVM.currentView {
+        case .auth:
+            return "auth"
+        case .home:
+            return "home"
+        case .session:
+            return "session"
+        case .buddyHub:
+            return "buddyHub"
+        case .buddySession:
+            return "buddySession"
+        case .completion:
+            return "completion"
+        case .history:
+            return "history"
+        case .journal:
+            return "journal"
+        case .board:
+            return "board"
+        case .settings:
+            return "settings"
+        }
+    }
+
+    private var coldStartMetricAccessibilityValue: String {
+        guard let ms = appVM.lastColdStartAuthCheckMs else { return "coldStartAuthCheckMs=unknown" }
+        return "coldStartAuthCheckMs=\(ms)"
     }
 }

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -34,6 +34,8 @@ struct SessionView: View {
                             )
                             .monospacedDigit()
                             .contentTransition(.numericText())
+                            .accessibilityIdentifier("session.timerLabel")
+                            .accessibilityLabel("Time remaining \(vm.timeString)")
 
                         // 60-second progress bar
                         progressBar
@@ -250,7 +252,9 @@ struct SessionView: View {
                         )
                     )
                     .opacity(vm.isActive ? 1 : 0.45)
+                    .accessibilityValue(vm.mindState == "thinking" ? "active" : "inactive")
                     .accessibilityLabel("Hold for light distraction. Release when aware again.")
+                    .accessibilityIdentifier("session.lightDistractionHoldButton")
                     .simultaneousGesture(
                         DragGesture(minimumDistance: 0)
                             .onChanged { _ in
@@ -282,7 +286,9 @@ struct SessionView: View {
                         )
                     )
                     .opacity(vm.isActive ? 1 : 0.45)
+                    .accessibilityValue(vm.mindState == "hyperfocus" ? "active" : "inactive")
                     .accessibilityLabel("Hold for hyperfocus. Release to return to aware.")
+                    .accessibilityIdentifier("session.hyperfocusHoldButton")
                     .simultaneousGesture(
                         DragGesture(minimumDistance: 0)
                             .onChanged { _ in
@@ -326,6 +332,7 @@ struct SessionView: View {
                         .clipShape(Capsule())
                         .overlay(Capsule().stroke(SPColor.border1))
                 }
+                .accessibilityIdentifier("session.pauseResumeButton")
 
                 // End Early — sets isComplete, onChange handles save + navigation
                 Button {
@@ -340,6 +347,7 @@ struct SessionView: View {
                         .clipShape(Capsule())
                         .overlay(Capsule().stroke(SPColor.border1))
                 }
+                .accessibilityIdentifier("session.endEarlyButton")
 
                 Button {
                     vm.openThoughtCapture()
@@ -353,6 +361,7 @@ struct SessionView: View {
                         .clipShape(Capsule())
                         .overlay(Capsule().stroke(SPColor.amberBorderSubtle))
                 }
+                .accessibilityIdentifier("session.captureButton")
                 .disabled(!vm.isActive)
                 .opacity(vm.isActive ? 1 : 0.45)
 
@@ -370,6 +379,7 @@ struct SessionView: View {
                         .clipShape(Capsule())
                         .overlay(Capsule().stroke(SPColor.dangerBorderSubtle))
                 }
+                .accessibilityIdentifier("session.abandonButton")
             }
 
             // Sound toggles

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -18,6 +18,7 @@ struct SettingsView: View {
                     .font(SPFont.serifItalic(28, weight: .light))
                     .foregroundStyle(Color(SPColor.fg))
                     .padding(.top, SPSpacing.s4)
+                    .accessibilityIdentifier("settings.title")
 
                 // Account info
                 VStack(alignment: .leading, spacing: SPSpacing.s2) {
@@ -113,6 +114,7 @@ struct SettingsView: View {
                         .clipShape(Capsule())
                         .overlay(Capsule().stroke(SPColor.dangerBorderSubtle))
                 }
+                .accessibilityIdentifier("settings.logoutButton")
                 .disabled(isDeletingAccount)
 
                 Button {

--- a/ios/StillPointAppUITests/README.md
+++ b/ios/StillPointAppUITests/README.md
@@ -1,0 +1,67 @@
+# StillPoint iOS UI Tests
+
+This directory contains native iOS UI smoke tests for Issue #193 ("journeys beyond auth, layout & VoiceOver smoke").
+
+## Reference simulator
+
+- **Model:** `iPhone 15 Pro` (notch + Dynamic Island + home indicator)
+- **OS:** iOS 17.0+
+
+## Test coverage map (Issue #193)
+
+- Launch → login (fixture) → main session surface + cold-start bound (`testLaunchLoginCompleteSessionAndHistoryPersistence`)
+- Start session → complete → stats visible + relaunch history persistence (`testLaunchLoginCompleteSessionAndHistoryPersistence`)
+- Thought/distraction hold controls do not stick (`testLaunchLoginCompleteSessionAndHistoryPersistence`)
+- History/Settings smoke navigation path (`testHistoryAndSettingsNavigationSmoke`)
+- Layout on reference device safe areas (`testPrimaryControlsVisibleAboveHomeIndicator`)
+- Rotation policy assertion (product decision: supported and still usable) (`testRotationDecisionSessionRemainsUsableInLandscape`)
+- Keyboard overlap reachability (`testKeyboardOverlapKeepsSubmitReachable`)
+- VoiceOver smoke labels for timer + primary button (`testVoiceOverLabelsForTimerAndPrimaryButton`)
+- Airplane-mode style launch failure message (`testLaunchOfflineShowsUserVisibleMessage`)
+- Token expiry re-auth path (`testTokenExpiryRoutesBackToAuthWithMessage`)
+- Failed sessions API displays visible error (no silent hang) (`testSessionsFailureShowsVisibleRetryMessage`)
+
+Cold-start acceptance guard used by tests: **auth check must complete within 5,000 ms** (captured via root accessibility value `coldStartAuthCheckMs=<n>`).
+
+## Environment knobs used by tests
+
+The app reads these launch environment keys in UI test mode:
+
+- `SP_UI_TEST_MODE=1`
+- `SP_UI_TEST_RESET_STORE=1` (start each test from a deterministic fixture store)
+- `SP_UI_TEST_SEED_AUTH=1` (boot already-authenticated fixture user)
+- `SP_UI_TEST_SESSION_SECONDS=<int>` (short deterministic session duration)
+- `SP_UI_TEST_TIMER_MULTIPLIER=<double>` (accelerate timer without changing UI copy)
+- `SP_UI_TEST_FORCE_LAUNCH_OFFLINE=1` (simulate failed API/airplane mode on launch)
+- `SP_UI_TEST_FORCE_TOKEN_EXPIRED=1` (simulate expired token during cold-start auth check)
+- `SP_UI_TEST_FORCE_SESSIONS_FAILURE=1` (optional sessions API failure simulation)
+
+Fixture login account (used when auth screen is shown):
+
+- Email: `ios.fixture@stillpoint.test`
+- Password: `stillpoint-pass`
+
+## Run locally
+
+```bash
+cd ios
+xcodebuild test \
+  -project StillPoint.xcodeproj \
+  -scheme StillPoint \
+  -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=17.0' \
+  -only-testing:StillPointAppUITests
+```
+
+## CI lane plan (stub until #152 merges)
+
+Planned lane: `ios-ui-smoke`
+
+1. Boot simulator `iPhone 15 Pro` on iOS 17.x.
+2. Run the command above (or equivalent lane wrapper).
+3. Upload XCTest result bundle artifact.
+4. Publish summarized pass/fail output back to PR checks.
+
+## CI setup de-duplication notes
+
+- **Cross-reference #155/#156:** reuse shared simulator boot, xcodegen generation, and cache priming steps from those issues so iOS lanes do not duplicate setup work unnecessarily.
+- Keep auth/session fixture bootstrapping in app-side launch environment (this folder) rather than cloning separate backend setup in each lane.

--- a/ios/StillPointAppUITests/README.md
+++ b/ios/StillPointAppUITests/README.md
@@ -19,7 +19,7 @@ This directory contains native iOS UI smoke tests for Issue #193 ("journeys beyo
 - Keyboard overlap reachability (`testKeyboardOverlapKeepsSubmitReachable`)
 - VoiceOver smoke labels for timer + primary button (`testVoiceOverLabelsForTimerAndPrimaryButton`)
 - Airplane-mode style launch failure message (`testLaunchOfflineShowsUserVisibleMessage`)
-- Token expiry re-auth path (`testTokenExpiryRoutesBackToAuthWithMessage`)
+- Token expiry re-auth path (`testTokenExpiryRoutesToReauthMessage`)
 - Failed sessions API displays visible error (no silent hang) (`testSessionsFailureShowsVisibleRetryMessage`)
 
 Cold-start acceptance guard used by tests: **auth check must complete within 5,000 ms** (captured via root accessibility value `coldStartAuthCheckMs=<n>`).

--- a/ios/StillPointAppUITests/README.md
+++ b/ios/StillPointAppUITests/README.md
@@ -6,6 +6,7 @@ This directory contains native iOS UI smoke tests for Issue #193 ("journeys beyo
 
 - **Model:** `iPhone 15 Pro` (notch + Dynamic Island + home indicator)
 - **OS:** iOS 17.0+
+- **Cold-start auth bound (documented):** auth check should complete within **5,000 ms** on this simulator class.
 
 ## Test coverage map (Issue #193)
 
@@ -65,3 +66,11 @@ Planned lane: `ios-ui-smoke`
 
 - **Cross-reference #155/#156:** reuse shared simulator boot, xcodegen generation, and cache priming steps from those issues so iOS lanes do not duplicate setup work unnecessarily.
 - Keep auth/session fixture bootstrapping in app-side launch environment (this folder) rather than cloning separate backend setup in each lane.
+
+## VoiceOver smoke steps (manual fallback)
+
+1. Enable VoiceOver in the simulator (`Settings -> Accessibility -> VoiceOver`).
+2. Launch the app with UI-test fixture mode (`SP_UI_TEST_MODE=1`) and log in as the fixture user.
+3. Focus the Home primary CTA and confirm it is announced as **"Start session"**.
+4. Activate Start session, then focus the timer element and confirm it announces **"Time remaining mm:ss"**.
+5. Use swipe/right navigation to move to the primary session controls and confirm the path remains navigable through start -> completion -> return.

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -1,0 +1,261 @@
+import XCTest
+
+final class StillPointAppUITests: XCTestCase {
+    private let launchTimeout: TimeInterval = 15
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testLaunchLoginCompleteSessionAndHistoryPersistence() throws {
+        let app = makeApp(
+            seedAuthenticated: false,
+            resetStore: true,
+            sessionSeconds: 6,
+            timerMultiplier: 3
+        )
+        app.launch()
+
+        let authRoot = app.otherElements["root.currentView.auth"]
+        XCTAssertTrue(authRoot.waitForExistence(timeout: launchTimeout), "Auth screen did not appear")
+        assertColdStartBound(app: app, maxMs: 5_000)
+
+        let emailField = app.textFields["auth.emailField"]
+        XCTAssertTrue(emailField.waitForExistence(timeout: 5))
+        emailField.tap()
+        emailField.typeText("ios.fixture@stillpoint.test")
+
+        let passwordField = app.secureTextFields["auth.passwordField"]
+        XCTAssertTrue(passwordField.waitForExistence(timeout: 5))
+        passwordField.tap()
+        passwordField.typeText("stillpoint-pass")
+
+        let submitButton = app.buttons["auth.submitButton"]
+        XCTAssertTrue(submitButton.isHittable)
+        submitButton.tap()
+
+        XCTAssertTrue(app.otherElements["root.currentView.home"].waitForExistence(timeout: 8))
+        let beginButton = app.buttons["home.beginButton"]
+        XCTAssertTrue(beginButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(beginButton.isHittable)
+        beginButton.tap()
+
+        XCTAssertTrue(app.otherElements["root.currentView.session"].waitForExistence(timeout: 8))
+        let timerLabel = app.staticTexts["session.timerLabel"]
+        XCTAssertTrue(timerLabel.waitForExistence(timeout: 3))
+        XCTAssertTrue(timerLabel.label.contains(":"), "Timer format should contain mm:ss delimiter")
+        XCTAssertTrue(timerLabel.label.contains("Time remaining"), "Timer should expose VoiceOver-friendly label")
+
+        let lightHold = app.staticTexts["session.lightDistractionHoldButton"]
+        XCTAssertTrue(lightHold.waitForExistence(timeout: 3))
+        XCTAssertEqual(lightHold.value as? String, "inactive")
+        pressAndHold(element: lightHold, duration: 1.0)
+        XCTAssertEqual(lightHold.value as? String, "inactive", "Release should end hold state and avoid stuck distraction")
+
+        XCTAssertTrue(app.otherElements["root.currentView.completion"].waitForExistence(timeout: 12))
+        XCTAssertTrue(app.staticTexts["completion.dayTitle"].exists)
+        XCTAssertTrue(app.staticTexts["completion.durationLabel"].exists)
+
+        let returnButton = app.buttons["completion.returnButton"]
+        XCTAssertTrue(returnButton.waitForExistence(timeout: 5))
+        returnButton.tap()
+        XCTAssertTrue(app.otherElements["root.currentView.home"].waitForExistence(timeout: 8))
+
+        app.terminate()
+
+        let relaunch = makeApp(
+            seedAuthenticated: true,
+            resetStore: false,
+            sessionSeconds: 6,
+            timerMultiplier: 3
+        )
+        relaunch.launch()
+
+        XCTAssertTrue(relaunch.otherElements["root.currentView.home"].waitForExistence(timeout: launchTimeout))
+        assertColdStartBound(app: relaunch, maxMs: 5_000)
+
+        openTab(named: "PROGRESS", in: relaunch)
+        XCTAssertTrue(relaunch.staticTexts["history.title"].waitForExistence(timeout: 8))
+        let dayRow = relaunch.buttons.matching(NSPredicate(format: "identifier BEGINSWITH %@", "history.session.day.")).firstMatch
+        XCTAssertTrue(dayRow.waitForExistence(timeout: 8), "Expected persisted history row after relaunch")
+    }
+
+    @MainActor
+    func testHistoryAndSettingsNavigationSmoke() throws {
+        let app = makeApp(seedAuthenticated: true, resetStore: true)
+        app.launch()
+
+        XCTAssertTrue(app.otherElements["root.currentView.home"].waitForExistence(timeout: launchTimeout))
+        openTab(named: "PROGRESS", in: app)
+        XCTAssertTrue(app.staticTexts["history.title"].waitForExistence(timeout: 6))
+
+        openTab(named: "SETTINGS", in: app)
+        XCTAssertTrue(app.staticTexts["settings.title"].waitForExistence(timeout: 6))
+        XCTAssertTrue(app.buttons["settings.logoutButton"].exists)
+    }
+
+    @MainActor
+    func testKeyboardOverlapKeepsSubmitReachable() throws {
+        let app = makeApp(seedAuthenticated: false, resetStore: true)
+        app.launch()
+
+        XCTAssertTrue(app.otherElements["root.currentView.auth"].waitForExistence(timeout: launchTimeout))
+        let emailField = app.textFields["auth.emailField"]
+        let passwordField = app.secureTextFields["auth.passwordField"]
+        let submitButton = app.buttons["auth.submitButton"]
+
+        XCTAssertTrue(emailField.waitForExistence(timeout: 5))
+        XCTAssertTrue(passwordField.waitForExistence(timeout: 5))
+        XCTAssertTrue(submitButton.waitForExistence(timeout: 5))
+
+        emailField.tap()
+        emailField.typeText("ios.fixture@stillpoint.test")
+        passwordField.tap()
+        passwordField.typeText("stillpoint-pass")
+        XCTAssertTrue(submitButton.isHittable, "Submit should remain reachable with keyboard visible")
+    }
+
+    @MainActor
+    func testLaunchOfflineShowsUserVisibleMessage() throws {
+        let app = makeApp(
+            seedAuthenticated: true,
+            resetStore: true,
+            forceLaunchOffline: true
+        )
+        app.launch()
+
+        XCTAssertTrue(app.otherElements["root.currentView.auth"].waitForExistence(timeout: launchTimeout))
+        let message = app.staticTexts["auth.launchStatusMessage"]
+        XCTAssertTrue(message.waitForExistence(timeout: 5))
+        XCTAssertTrue(message.label.localizedCaseInsensitiveContains("internet")
+                        || message.label.localizedCaseInsensitiveContains("connection"))
+    }
+
+    @MainActor
+    func testTokenExpiryRoutesToReauthMessage() throws {
+        let app = makeApp(
+            seedAuthenticated: true,
+            resetStore: true,
+            forceTokenExpired: true
+        )
+        app.launch()
+
+        XCTAssertTrue(app.otherElements["root.currentView.auth"].waitForExistence(timeout: launchTimeout))
+        let message = app.staticTexts["auth.launchStatusMessage"]
+        XCTAssertTrue(message.waitForExistence(timeout: 5))
+        XCTAssertTrue(message.label.localizedCaseInsensitiveContains("expired")
+                        || message.label.localizedCaseInsensitiveContains("log in"))
+    }
+
+    @MainActor
+    func testRotationDecisionSessionRemainsUsableInLandscape() throws {
+        let app = makeApp(seedAuthenticated: true, resetStore: true, sessionSeconds: 8, timerMultiplier: 2)
+        app.launch()
+
+        XCTAssertTrue(app.otherElements["root.currentView.home"].waitForExistence(timeout: launchTimeout))
+        app.buttons["home.beginButton"].tap()
+        XCTAssertTrue(app.otherElements["root.currentView.session"].waitForExistence(timeout: 8))
+
+        XCUIDevice.shared.orientation = .landscapeLeft
+        defer { XCUIDevice.shared.orientation = .portrait }
+
+        let timerLabel = app.staticTexts["session.timerLabel"]
+        XCTAssertTrue(timerLabel.waitForExistence(timeout: 3))
+        XCTAssertTrue(timerLabel.isHittable, "Timer should remain visible and usable after rotation")
+        XCTAssertTrue(app.buttons["session.endEarlyButton"].isHittable, "Primary control should remain reachable in landscape")
+    }
+
+    @MainActor
+    func testPrimaryControlsVisibleAboveHomeIndicator() throws {
+        let app = makeApp(seedAuthenticated: true, resetStore: true)
+        app.launch()
+
+        XCTAssertTrue(app.otherElements["root.currentView.home"].waitForExistence(timeout: launchTimeout))
+        let beginButton = app.buttons["home.beginButton"]
+        XCTAssertTrue(beginButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(beginButton.isHittable, "Home primary action should be visible above safe-area/home indicator")
+    }
+
+    @MainActor
+    func testVoiceOverLabelsForTimerAndPrimaryButton() throws {
+        let app = makeApp(seedAuthenticated: true, resetStore: true, sessionSeconds: 8, timerMultiplier: 2)
+        app.launch()
+
+        XCTAssertTrue(app.otherElements["root.currentView.home"].waitForExistence(timeout: launchTimeout))
+        let beginButton = app.buttons["home.beginButton"]
+        XCTAssertTrue(beginButton.waitForExistence(timeout: 5))
+        XCTAssertEqual(beginButton.label, "Start session")
+        beginButton.tap()
+
+        XCTAssertTrue(app.otherElements["root.currentView.session"].waitForExistence(timeout: 8))
+        let timerLabel = app.staticTexts["session.timerLabel"]
+        XCTAssertTrue(timerLabel.waitForExistence(timeout: 3))
+        XCTAssertTrue(timerLabel.label.localizedCaseInsensitiveContains("time remaining"))
+    }
+
+    @MainActor
+    func testSessionsFailureShowsVisibleRetryMessage() throws {
+        let app = makeApp(seedAuthenticated: true, resetStore: true, forceSessionsFailure: true)
+        app.launch()
+
+        XCTAssertTrue(app.otherElements["root.currentView.home"].waitForExistence(timeout: launchTimeout))
+        openTab(named: "PROGRESS", in: app)
+
+        let errorLabel = app.staticTexts["history.errorMessage"]
+        XCTAssertTrue(errorLabel.waitForExistence(timeout: 8))
+        XCTAssertTrue(errorLabel.label.localizedCaseInsensitiveContains("failed")
+                        || errorLabel.label.localizedCaseInsensitiveContains("connection"))
+    }
+
+    private func makeApp(
+        seedAuthenticated: Bool,
+        resetStore: Bool,
+        sessionSeconds: Int = 10,
+        timerMultiplier: Int = 1,
+        forceLaunchOffline: Bool = false,
+        forceTokenExpired: Bool = false,
+        forceSessionsFailure: Bool = false
+    ) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchEnvironment["SP_UI_TEST_MODE"] = "1"
+        app.launchEnvironment["SP_UI_TEST_SEED_AUTH"] = seedAuthenticated ? "1" : "0"
+        app.launchEnvironment["SP_UI_TEST_RESET_STORE"] = resetStore ? "1" : "0"
+        app.launchEnvironment["SP_UI_TEST_SESSION_SECONDS"] = String(sessionSeconds)
+        app.launchEnvironment["SP_UI_TEST_TIMER_MULTIPLIER"] = String(timerMultiplier)
+        app.launchEnvironment["SP_UI_TEST_FORCE_LAUNCH_OFFLINE"] = forceLaunchOffline ? "1" : "0"
+        app.launchEnvironment["SP_UI_TEST_FORCE_TOKEN_EXPIRED"] = forceTokenExpired ? "1" : "0"
+        app.launchEnvironment["SP_UI_TEST_FORCE_SESSIONS_FAILURE"] = forceSessionsFailure ? "1" : "0"
+        return app
+    }
+
+    private func openTab(named tabTitle: String, in app: XCUIApplication) {
+        let tabButton = app.tabBars.buttons[tabTitle]
+        XCTAssertTrue(tabButton.waitForExistence(timeout: 5))
+        tabButton.tap()
+    }
+
+    private func pressAndHold(element: XCUIElement, duration: TimeInterval) {
+        let start = element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+        let end = start.withOffset(CGVector(dx: 0, dy: 0))
+        start.press(forDuration: duration, thenDragTo: end)
+    }
+
+    private func assertColdStartBound(app: XCUIApplication, maxMs: Int) {
+        let roots = app.otherElements.matching(NSPredicate(format: "identifier BEGINSWITH %@", "root.currentView."))
+        let root = roots.firstMatch
+        let value = (root.value as? String) ?? ""
+        guard let ms = parseMetricMs(from: value) else {
+            XCTFail("Missing cold-start metric in root accessibility value: \(value)")
+            return
+        }
+        XCTAssertLessThanOrEqual(ms, maxMs, "Cold start auth check exceeded documented bound")
+    }
+
+    private func parseMetricMs(from value: String) -> Int? {
+        let prefix = "coldStartAuthCheckMs="
+        guard let range = value.range(of: prefix) else { return nil }
+        let msRaw = value[range.upperBound...]
+        return Int(msRaw)
+    }
+}

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -13,13 +13,13 @@ final class StillPointAppUITests: XCTestCase {
             seedAuthenticated: false,
             resetStore: true,
             sessionSeconds: 6,
-            timerMultiplier: 3
+            timerMultiplier: 3.0
         )
         app.launch()
 
         let authRoot = app.otherElements["root.currentView.auth"]
         XCTAssertTrue(authRoot.waitForExistence(timeout: launchTimeout), "Auth screen did not appear")
-        assertColdStartBound(app: app, maxMs: 5_000)
+        assertColdStartBound(root: authRoot, maxMs: 5_000)
 
         let emailField = app.textFields["auth.emailField"]
         XCTAssertTrue(emailField.waitForExistence(timeout: 5))
@@ -68,12 +68,12 @@ final class StillPointAppUITests: XCTestCase {
             seedAuthenticated: true,
             resetStore: false,
             sessionSeconds: 6,
-            timerMultiplier: 3
+            timerMultiplier: 3.0
         )
         relaunch.launch()
 
         XCTAssertTrue(relaunch.otherElements["root.currentView.home"].waitForExistence(timeout: launchTimeout))
-        assertColdStartBound(app: relaunch, maxMs: 5_000)
+        assertColdStartBound(root: relaunch.otherElements["root.currentView.home"], maxMs: 5_000)
 
         openTab(named: "PROGRESS", in: relaunch)
         XCTAssertTrue(relaunch.staticTexts["history.title"].waitForExistence(timeout: 8))
@@ -150,7 +150,7 @@ final class StillPointAppUITests: XCTestCase {
 
     @MainActor
     func testRotationDecisionSessionRemainsUsableInLandscape() throws {
-        let app = makeApp(seedAuthenticated: true, resetStore: true, sessionSeconds: 8, timerMultiplier: 2)
+        let app = makeApp(seedAuthenticated: true, resetStore: true, sessionSeconds: 8, timerMultiplier: 2.0)
         app.launch()
 
         XCTAssertTrue(app.otherElements["root.currentView.home"].waitForExistence(timeout: launchTimeout))
@@ -179,7 +179,7 @@ final class StillPointAppUITests: XCTestCase {
 
     @MainActor
     func testVoiceOverLabelsForTimerAndPrimaryButton() throws {
-        let app = makeApp(seedAuthenticated: true, resetStore: true, sessionSeconds: 8, timerMultiplier: 2)
+        let app = makeApp(seedAuthenticated: true, resetStore: true, sessionSeconds: 8, timerMultiplier: 2.0)
         app.launch()
 
         XCTAssertTrue(app.otherElements["root.currentView.home"].waitForExistence(timeout: launchTimeout))
@@ -212,7 +212,7 @@ final class StillPointAppUITests: XCTestCase {
         seedAuthenticated: Bool,
         resetStore: Bool,
         sessionSeconds: Int = 10,
-        timerMultiplier: Int = 1,
+        timerMultiplier: Double = 1.0,
         forceLaunchOffline: Bool = false,
         forceTokenExpired: Bool = false,
         forceSessionsFailure: Bool = false
@@ -241,15 +241,18 @@ final class StillPointAppUITests: XCTestCase {
         start.press(forDuration: duration, thenDragTo: end)
     }
 
-    private func assertColdStartBound(app: XCUIApplication, maxMs: Int) {
-        let roots = app.otherElements.matching(NSPredicate(format: "identifier BEGINSWITH %@", "root.currentView."))
-        let root = roots.firstMatch
-        let value = (root.value as? String) ?? ""
-        guard let ms = parseMetricMs(from: value) else {
-            XCTFail("Missing cold-start metric in root accessibility value: \(value)")
-            return
+    private func assertColdStartBound(root: XCUIElement, maxMs: Int) {
+        let deadline = Date().addingTimeInterval(5)
+        var observedValue = ""
+        while Date() < deadline {
+            observedValue = (root.value as? String) ?? ""
+            if let ms = parseMetricMs(from: observedValue) {
+                XCTAssertLessThanOrEqual(ms, maxMs, "Cold start auth check exceeded documented bound")
+                return
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
         }
-        XCTAssertLessThanOrEqual(ms, maxMs, "Cold start auth check exceeded documented bound")
+        XCTFail("Missing cold-start metric in root accessibility value: \(observedValue)")
     }
 
     private func parseMetricMs(from value: String) -> Int? {

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -113,6 +113,8 @@ final class StillPointAppUITests: XCTestCase {
         emailField.typeText("ios.fixture@stillpoint.test")
         passwordField.tap()
         passwordField.typeText("stillpoint-pass")
+        let keyboard = app.keyboards.firstMatch
+        XCTAssertTrue(keyboard.waitForExistence(timeout: 5), "Keyboard should be visible for overlap reachability check")
         XCTAssertTrue(submitButton.isHittable, "Submit should remain reachable with keyboard visible")
     }
 

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -50,7 +50,9 @@ final class StillPointAppUITests: XCTestCase {
         let lightHold = app.staticTexts["session.lightDistractionHoldButton"]
         XCTAssertTrue(lightHold.waitForExistence(timeout: 3))
         XCTAssertEqual(lightHold.value as? String, "inactive")
-        pressAndHold(element: lightHold, duration: 1.0)
+        pressAndHold(element: lightHold, duration: 1.0) {
+            XCTAssertEqual(lightHold.value as? String, "active", "Hold should enter active state while gesture is in progress")
+        }
         XCTAssertEqual(lightHold.value as? String, "inactive", "Release should end hold state and avoid stuck distraction")
 
         XCTAssertTrue(app.otherElements["root.currentView.completion"].waitForExistence(timeout: 12))
@@ -75,7 +77,7 @@ final class StillPointAppUITests: XCTestCase {
         XCTAssertTrue(relaunch.otherElements["root.currentView.home"].waitForExistence(timeout: launchTimeout))
         assertColdStartBound(root: relaunch.otherElements["root.currentView.home"], maxMs: 5_000)
 
-        openTab(named: "PROGRESS", in: relaunch)
+        openTab(identifier: "tab.progress", in: relaunch)
         XCTAssertTrue(relaunch.staticTexts["history.title"].waitForExistence(timeout: 8))
         let dayRow = relaunch.buttons.matching(NSPredicate(format: "identifier BEGINSWITH %@", "history.session.day.")).firstMatch
         XCTAssertTrue(dayRow.waitForExistence(timeout: 8), "Expected persisted history row after relaunch")
@@ -87,10 +89,10 @@ final class StillPointAppUITests: XCTestCase {
         app.launch()
 
         XCTAssertTrue(app.otherElements["root.currentView.home"].waitForExistence(timeout: launchTimeout))
-        openTab(named: "PROGRESS", in: app)
+        openTab(identifier: "tab.progress", in: app)
         XCTAssertTrue(app.staticTexts["history.title"].waitForExistence(timeout: 6))
 
-        openTab(named: "SETTINGS", in: app)
+        openTab(identifier: "tab.settings", in: app)
         XCTAssertTrue(app.staticTexts["settings.title"].waitForExistence(timeout: 6))
         XCTAssertTrue(app.buttons["settings.logoutButton"].exists)
     }
@@ -202,7 +204,7 @@ final class StillPointAppUITests: XCTestCase {
         app.launch()
 
         XCTAssertTrue(app.otherElements["root.currentView.home"].waitForExistence(timeout: launchTimeout))
-        openTab(named: "PROGRESS", in: app)
+        openTab(identifier: "tab.progress", in: app)
 
         let errorLabel = app.staticTexts["history.errorMessage"]
         XCTAssertTrue(errorLabel.waitForExistence(timeout: 8))
@@ -231,16 +233,26 @@ final class StillPointAppUITests: XCTestCase {
         return app
     }
 
-    private func openTab(named tabTitle: String, in app: XCUIApplication) {
-        let tabButton = app.tabBars.buttons[tabTitle]
+    private func openTab(identifier: String, in app: XCUIApplication) {
+        let tabButton = app.tabBars.buttons[identifier]
         XCTAssertTrue(tabButton.waitForExistence(timeout: 5))
         tabButton.tap()
     }
 
-    private func pressAndHold(element: XCUIElement, duration: TimeInterval) {
+    private func pressAndHold(element: XCUIElement, duration: TimeInterval, onHold: @escaping () -> Void) {
         let start = element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
         let end = start.withOffset(CGVector(dx: 0, dy: 0))
-        start.press(forDuration: duration, thenDragTo: end)
+        let holdFinished = expectation(description: "Hold gesture finished")
+        DispatchQueue.global(qos: .userInitiated).async {
+            start.press(forDuration: duration, thenDragTo: end)
+            holdFinished.fulfill()
+        }
+
+        let holdBecameActive = NSPredicate(format: "value == %@", "active")
+        let activeExpectation = expectation(for: holdBecameActive, evaluatedWith: element)
+        wait(for: [activeExpectation], timeout: duration)
+        onHold()
+        wait(for: [holdFinished], timeout: duration + 2)
     }
 
     private func assertColdStartBound(root: XCUIElement, maxMs: Int) {

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -126,7 +126,7 @@ final class StillPointAppUITests: XCTestCase {
         app.launch()
 
         XCTAssertTrue(app.otherElements["root.currentView.auth"].waitForExistence(timeout: launchTimeout))
-        let message = app.staticTexts["auth.launchStatusMessage"]
+        let message = app.staticTexts["authView.launchAuthStatusMessage"]
         XCTAssertTrue(message.waitForExistence(timeout: 5))
         XCTAssertTrue(message.label.localizedCaseInsensitiveContains("internet")
                         || message.label.localizedCaseInsensitiveContains("connection"))
@@ -142,7 +142,7 @@ final class StillPointAppUITests: XCTestCase {
         app.launch()
 
         XCTAssertTrue(app.otherElements["root.currentView.auth"].waitForExistence(timeout: launchTimeout))
-        let message = app.staticTexts["auth.launchStatusMessage"]
+        let message = app.staticTexts["authView.launchAuthStatusMessage"]
         XCTAssertTrue(message.waitForExistence(timeout: 5))
         XCTAssertTrue(message.label.localizedCaseInsensitiveContains("expired")
                         || message.label.localizedCaseInsensitiveContains("log in"))

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -9,6 +9,9 @@ public actor APIClient {
     private var baseURL: URL
 
     private let session: URLSession
+    private let uiTestConfig: UITestConfig?
+    private var uiTestStore: UITestStore?
+    private let uiTestStoreDefaultsKey = "StillPoint.UITest.Store"
 
     private init() {
         #if DEBUG
@@ -22,6 +25,23 @@ public actor APIClient {
         config.httpShouldSetCookies = true
         config.httpCookieStorage = .shared
         self.session = URLSession(configuration: config)
+
+        let parsedUITestConfig = UITestConfig.fromProcessInfo()
+        self.uiTestConfig = parsedUITestConfig
+        if let parsedUITestConfig {
+            let defaults = UserDefaults.standard
+            if parsedUITestConfig.resetStore {
+                defaults.removeObject(forKey: uiTestStoreDefaultsKey)
+            }
+
+            if let persistedData = defaults.data(forKey: uiTestStoreDefaultsKey),
+               let persistedStore = try? JSONDecoder().decode(UITestStore.self, from: persistedData) {
+                self.uiTestStore = persistedStore
+            } else {
+                self.uiTestStore = UITestStore.makeDefault(seedAuthenticated: parsedUITestConfig.seedAuthenticated)
+                persistUITestStore()
+            }
+        }
     }
 
     public func setBaseURL(_ url: URL) {
@@ -31,6 +51,9 @@ public actor APIClient {
     // MARK: - Auth
 
     public func signup(email: String, username: String, password: String) async throws -> UserDTO {
+        if let user = try uiTestSignup(email: email, username: username, password: password) {
+            return user
+        }
         let body: [String: String] = ["email": email, "username": username, "password": password]
         let response: UserResponse = try await post("/api/auth/signup", body: body)
         if let token = response.token, !token.isEmpty {
@@ -44,6 +67,9 @@ public actor APIClient {
     }
 
     public func login(email: String, password: String) async throws -> UserDTO {
+        if let user = try uiTestLogin(email: email, password: password) {
+            return user
+        }
         // Web app sends username too but only uses email+password for login
         let body: [String: String] = ["email": email, "username": "", "password": password]
         let response: UserResponse = try await post("/api/auth/login", body: body)
@@ -58,20 +84,29 @@ public actor APIClient {
     }
 
     public func logout() async throws {
+        if uiTestLogout() {
+            return
+        }
         defer { clearLocalSessionArtifacts() }
         let _: [String: Bool] = try await post("/api/auth/logout", body: Optional<String>.none)
     }
 
     public func deleteAccount() async throws {
+        if uiTestDeleteAccount() {
+            return
+        }
         try await delete("/api/account")
         clearLocalSessionArtifacts()
     }
 
     public func me() async throws -> UserDTO? {
+        if let uiTestResult = try uiTestMe() {
+            return uiTestResult
+        }
         do {
             let response: UserResponse = try await get("/api/auth/me")
             return response.user
-        } catch let error as APIError where error.status == 401 {
+        } catch let error as APIError where error.status == 401 && error.code != "TOKEN_EXPIRED" {
             return nil
         }
     }
@@ -79,16 +114,25 @@ public actor APIClient {
     // MARK: - Sessions
 
     public func getSessions() async throws -> (sessions: [SessionDTO], stats: StatsDTO) {
+        if let uiTestResult = try uiTestGetSessions() {
+            return uiTestResult
+        }
         let response: SessionsResponse = try await get("/api/sessions")
         return (response.sessions, response.stats)
     }
 
     public func createSession(_ data: CreateSessionRequest) async throws -> SessionDTO {
+        if let session = try uiTestCreateSession(data) {
+            return session
+        }
         let response: SessionResponse = try await post("/api/sessions", body: data)
         return response.session
     }
 
     public func getSession(dayNumber: Int) async throws -> (session: SessionDTO, thoughts: [ThoughtDTO]) {
+        if let uiTestResult = try uiTestGetSession(dayNumber: dayNumber) {
+            return uiTestResult
+        }
         let response: SessionDetailResponse = try await get("/api/sessions/\(dayNumber)")
         return (response.session, response.thoughts)
     }
@@ -96,11 +140,17 @@ public actor APIClient {
     // MARK: - Thoughts
 
     public func getThoughts() async throws -> [ThoughtDTO] {
+        if let thoughts = try uiTestGetThoughts() {
+            return thoughts
+        }
         let response: ThoughtsResponse = try await get("/api/thoughts")
         return response.thoughts
     }
 
     public func batchThoughts(_ data: BatchThoughtsRequest) async throws -> [ThoughtDTO] {
+        if let thoughts = try uiTestBatchThoughts(data) {
+            return thoughts
+        }
         let response: ThoughtsResponse = try await post("/api/thoughts/batch", body: data)
         return response.thoughts
     }
@@ -108,6 +158,9 @@ public actor APIClient {
     // MARK: - Board
 
     public func getBoard() async throws -> [BoardEntryDTO] {
+        if uiTestConfig != nil {
+            return []
+        }
         let response: BoardResponse = try await get("/api/board")
         return response.board
     }
@@ -115,6 +168,9 @@ public actor APIClient {
     // MARK: - Settings
 
     public func updateSettings(isPublic: Bool) async throws -> UserDTO {
+        if let user = try uiTestUpdateSettings(isPublic: isPublic) {
+            return user
+        }
         let body = ["isPublic": isPublic]
         let response: UserResponse = try await patch("/api/settings", body: body)
         return response.user
@@ -264,6 +320,313 @@ public actor APIClient {
         request.setValue("ios", forHTTPHeaderField: "X-Still-Point-Client")
         applyAuthorizationHeader(to: &request)
         return request
+    }
+
+    // MARK: - UI Test Overrides
+
+    /// Returns a handled value in UI test mode, or `nil` when normal network flow should continue.
+    private func uiTestMe() throws -> UserDTO?? {
+        guard let uiTestConfig else { return nil }
+        guard var store = uiTestStore else {
+            throw APIError(status: 0, message: "UI test store is unavailable")
+        }
+
+        if uiTestConfig.forceLaunchOffline {
+            throw APIError(status: 0, message: "No internet connection")
+        }
+
+        if uiTestConfig.forceTokenExpired {
+            if store.isAuthenticated {
+                store.isAuthenticated = false
+                uiTestStore = store
+                persistUITestStore()
+            }
+            throw APIError(
+                status: 401,
+                message: "Session expired. Please log in again.",
+                code: "TOKEN_EXPIRED"
+            )
+        }
+
+        return store.isAuthenticated ? store.user : .some(nil)
+    }
+
+    private func uiTestSignup(email: String, username: String, password: String) throws -> UserDTO? {
+        guard uiTestConfig != nil else { return nil }
+        guard var store = uiTestStore else {
+            throw APIError(status: 0, message: "UI test store is unavailable")
+        }
+
+        store.user = UserDTO(
+            id: store.user.id,
+            email: email,
+            username: username,
+            isPublic: store.user.isPublic,
+            currentDay: max(store.user.currentDay, 1)
+        )
+        store.loginEmail = email
+        store.loginPassword = password
+        store.isAuthenticated = true
+        uiTestStore = store
+        persistUITestStore()
+        return store.user
+    }
+
+    private func uiTestLogin(email: String, password: String) throws -> UserDTO? {
+        guard uiTestConfig != nil else { return nil }
+        guard var store = uiTestStore else {
+            throw APIError(status: 0, message: "UI test store is unavailable")
+        }
+
+        guard email.lowercased() == store.loginEmail.lowercased(),
+              password == store.loginPassword else {
+            throw APIError(status: 401, message: "Invalid email or password")
+        }
+
+        store.isAuthenticated = true
+        uiTestStore = store
+        persistUITestStore()
+        return store.user
+    }
+
+    private func uiTestLogout() -> Bool {
+        guard uiTestConfig != nil else { return false }
+        guard var store = uiTestStore else { return true }
+        store.isAuthenticated = false
+        uiTestStore = store
+        persistUITestStore()
+        clearLocalSessionArtifacts()
+        return true
+    }
+
+    private func uiTestDeleteAccount() -> Bool {
+        guard uiTestConfig != nil else { return false }
+        guard var store = uiTestStore else { return true }
+        store.isAuthenticated = false
+        store.sessions = []
+        store.thoughts = []
+        uiTestStore = store
+        persistUITestStore()
+        clearLocalSessionArtifacts()
+        return true
+    }
+
+    private func uiTestGetSessions() throws -> (sessions: [SessionDTO], stats: StatsDTO)? {
+        guard let uiTestConfig else { return nil }
+        guard let store = uiTestStore else {
+            throw APIError(status: 0, message: "UI test store is unavailable")
+        }
+        try ensureUITestAuthenticated(store: store)
+
+        if uiTestConfig.forceSessionsFailure {
+            throw APIError(status: 503, message: "Failed to load sessions. Check your connection.")
+        }
+
+        let sortedSessions = store.sessions.sorted { $0.sessionDate < $1.sessionDate }
+        return (sortedSessions, Self.makeUITestStats(for: sortedSessions))
+    }
+
+    private func uiTestCreateSession(_ data: CreateSessionRequest) throws -> SessionDTO? {
+        guard uiTestConfig != nil else { return nil }
+        guard var store = uiTestStore else {
+            throw APIError(status: 0, message: "UI test store is unavailable")
+        }
+        try ensureUITestAuthenticated(store: store)
+
+        let nextOrdinal = store.nextSessionOrdinal
+        let session = SessionDTO(
+            id: "ui-session-\(nextOrdinal)",
+            dayNumber: data.dayNumber,
+            duration: data.duration,
+            completed: data.completed,
+            actualTime: data.actualTime,
+            clearPercent: data.clearPercent,
+            thoughtCount: data.thoughtCount,
+            mindStateLog: data.mindStateLog,
+            sessionDate: data.sessionDate,
+            buddySessionId: nil
+        )
+        store.nextSessionOrdinal += 1
+        store.sessions.append(session)
+
+        if data.completed {
+            store.user = UserDTO(
+                id: store.user.id,
+                email: store.user.email,
+                username: store.user.username,
+                isPublic: store.user.isPublic,
+                currentDay: max(store.user.currentDay, data.dayNumber + 1)
+            )
+        }
+
+        uiTestStore = store
+        persistUITestStore()
+        return session
+    }
+
+    private func uiTestGetSession(dayNumber: Int) throws -> (session: SessionDTO, thoughts: [ThoughtDTO])? {
+        guard uiTestConfig != nil else { return nil }
+        guard let store = uiTestStore else {
+            throw APIError(status: 0, message: "UI test store is unavailable")
+        }
+        try ensureUITestAuthenticated(store: store)
+
+        guard let session = store.sessions.last(where: { $0.dayNumber == dayNumber }) else {
+            throw APIError(status: 404, message: "Session not found")
+        }
+
+        let thoughts = store.thoughts.filter { $0.sessionId == session.id }
+            .sorted { $0.timeInSession < $1.timeInSession }
+        return (session, thoughts)
+    }
+
+    private func uiTestGetThoughts() throws -> [ThoughtDTO]? {
+        guard uiTestConfig != nil else { return nil }
+        guard let store = uiTestStore else {
+            throw APIError(status: 0, message: "UI test store is unavailable")
+        }
+        try ensureUITestAuthenticated(store: store)
+        return store.thoughts
+            .sorted {
+                if $0.dayNumber == $1.dayNumber {
+                    return $0.timeInSession < $1.timeInSession
+                }
+                return $0.dayNumber > $1.dayNumber
+            }
+    }
+
+    private func uiTestBatchThoughts(_ data: BatchThoughtsRequest) throws -> [ThoughtDTO]? {
+        guard uiTestConfig != nil else { return nil }
+        guard var store = uiTestStore else {
+            throw APIError(status: 0, message: "UI test store is unavailable")
+        }
+        try ensureUITestAuthenticated(store: store)
+
+        let createdThoughts = data.thoughts.map { input -> ThoughtDTO in
+            let thought = ThoughtDTO(
+                id: "ui-thought-\(store.nextThoughtOrdinal)",
+                sessionId: data.sessionId,
+                dayNumber: data.dayNumber,
+                timeInSession: input.timeInSession,
+                text: input.text
+            )
+            store.nextThoughtOrdinal += 1
+            return thought
+        }
+        store.thoughts.append(contentsOf: createdThoughts)
+        uiTestStore = store
+        persistUITestStore()
+        return createdThoughts
+    }
+
+    private func uiTestUpdateSettings(isPublic: Bool) throws -> UserDTO? {
+        guard uiTestConfig != nil else { return nil }
+        guard var store = uiTestStore else {
+            throw APIError(status: 0, message: "UI test store is unavailable")
+        }
+        try ensureUITestAuthenticated(store: store)
+        store.user = UserDTO(
+            id: store.user.id,
+            email: store.user.email,
+            username: store.user.username,
+            isPublic: isPublic,
+            currentDay: store.user.currentDay
+        )
+        uiTestStore = store
+        persistUITestStore()
+        return store.user
+    }
+
+    private func ensureUITestAuthenticated(store: UITestStore) throws {
+        guard store.isAuthenticated else {
+            throw APIError(status: 401, message: "Please log in", code: "UNAUTHORIZED")
+        }
+    }
+
+    private func persistUITestStore() {
+        guard let uiTestStore else { return }
+        guard let encoded = try? JSONEncoder().encode(uiTestStore) else { return }
+        UserDefaults.standard.set(encoded, forKey: uiTestStoreDefaultsKey)
+    }
+
+    private static func makeUITestStats(for sessions: [SessionDTO]) -> StatsDTO {
+        guard !sessions.isEmpty else {
+            return StatsDTO(streak: 0, avgClearPercent: 0, avgThoughtsPerSession: 0, avgThoughtsPerMinute: 0)
+        }
+
+        let completedSessions = sessions.filter(\.completed)
+        let streak = completedSessions.count
+        let totalClear = sessions.reduce(0) { $0 + $1.clearPercent }
+        let totalThoughts = sessions.reduce(0) { $0 + $1.thoughtCount }
+        let totalMinutes = sessions.reduce(0.0) { partial, session in
+            let duration = Double(max(session.actualTime ?? session.duration, 1))
+            return partial + (duration / 60.0)
+        }
+        let avgClearPercent = totalClear / sessions.count
+        let avgThoughtsPerSession = Double(totalThoughts) / Double(sessions.count)
+        let avgThoughtsPerMinute = totalMinutes > 0 ? Double(totalThoughts) / totalMinutes : 0
+        return StatsDTO(
+            streak: streak,
+            avgClearPercent: avgClearPercent,
+            avgThoughtsPerSession: avgThoughtsPerSession,
+            avgThoughtsPerMinute: avgThoughtsPerMinute
+        )
+    }
+}
+
+private struct UITestConfig: Sendable {
+    let seedAuthenticated: Bool
+    let resetStore: Bool
+    let forceLaunchOffline: Bool
+    let forceTokenExpired: Bool
+    let forceSessionsFailure: Bool
+
+    static func fromProcessInfo() -> UITestConfig? {
+        let env = ProcessInfo.processInfo.environment
+        guard truthy(env["SP_UI_TEST_MODE"]) else { return nil }
+        return UITestConfig(
+            seedAuthenticated: truthy(env["SP_UI_TEST_SEED_AUTH"]),
+            resetStore: truthy(env["SP_UI_TEST_RESET_STORE"]),
+            forceLaunchOffline: truthy(env["SP_UI_TEST_FORCE_LAUNCH_OFFLINE"]),
+            forceTokenExpired: truthy(env["SP_UI_TEST_FORCE_TOKEN_EXPIRED"]),
+            forceSessionsFailure: truthy(env["SP_UI_TEST_FORCE_SESSIONS_FAILURE"])
+        )
+    }
+
+    private static func truthy(_ value: String?) -> Bool {
+        guard let value else { return false }
+        return ["1", "true", "yes", "on"].contains(value.lowercased())
+    }
+}
+
+private struct UITestStore: Codable, Sendable {
+    var user: UserDTO
+    var loginEmail: String
+    var loginPassword: String
+    var isAuthenticated: Bool
+    var sessions: [SessionDTO]
+    var thoughts: [ThoughtDTO]
+    var nextSessionOrdinal: Int
+    var nextThoughtOrdinal: Int
+
+    static func makeDefault(seedAuthenticated: Bool) -> UITestStore {
+        let fixtureUser = UserDTO(
+            id: "ui-user-1",
+            email: "ios.fixture@stillpoint.test",
+            username: "ios_fixture",
+            isPublic: false,
+            currentDay: 1
+        )
+        return UITestStore(
+            user: fixtureUser,
+            loginEmail: fixtureUser.email,
+            loginPassword: "stillpoint-pass",
+            isAuthenticated: seedAuthenticated,
+            sessions: [],
+            thoughts: [],
+            nextSessionOrdinal: 1,
+            nextThoughtOrdinal: 1
+        )
     }
 }
 

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -8,6 +8,14 @@ public struct UserDTO: Codable, Sendable {
     public let username: String
     public let isPublic: Bool
     public let currentDay: Int
+
+    public init(id: String, email: String, username: String, isPublic: Bool, currentDay: Int) {
+        self.id = id
+        self.email = email
+        self.username = username
+        self.isPublic = isPublic
+        self.currentDay = currentDay
+    }
 }
 
 public struct SessionDTO: Codable, Sendable {
@@ -21,6 +29,30 @@ public struct SessionDTO: Codable, Sendable {
     public let mindStateLog: [MindStateEntry]?
     public let sessionDate: String
     public let buddySessionId: String?
+
+    public init(
+        id: String,
+        dayNumber: Int,
+        duration: Int,
+        completed: Bool,
+        actualTime: Int?,
+        clearPercent: Int,
+        thoughtCount: Int,
+        mindStateLog: [MindStateEntry]?,
+        sessionDate: String,
+        buddySessionId: String?
+    ) {
+        self.id = id
+        self.dayNumber = dayNumber
+        self.duration = duration
+        self.completed = completed
+        self.actualTime = actualTime
+        self.clearPercent = clearPercent
+        self.thoughtCount = thoughtCount
+        self.mindStateLog = mindStateLog
+        self.sessionDate = sessionDate
+        self.buddySessionId = buddySessionId
+    }
 }
 
 public struct ThoughtDTO: Codable, Sendable {
@@ -29,6 +61,14 @@ public struct ThoughtDTO: Codable, Sendable {
     public let dayNumber: Int
     public let timeInSession: Int
     public let text: String
+
+    public init(id: String, sessionId: String, dayNumber: Int, timeInSession: Int, text: String) {
+        self.id = id
+        self.sessionId = sessionId
+        self.dayNumber = dayNumber
+        self.timeInSession = timeInSession
+        self.text = text
+    }
 }
 
 public struct BoardEntryDTO: Codable, Sendable {
@@ -44,6 +84,13 @@ public struct StatsDTO: Codable, Sendable {
     public let avgClearPercent: Int
     public let avgThoughtsPerSession: Double
     public let avgThoughtsPerMinute: Double
+
+    public init(streak: Int, avgClearPercent: Int, avgThoughtsPerSession: Double, avgThoughtsPerMinute: Double) {
+        self.streak = streak
+        self.avgClearPercent = avgClearPercent
+        self.avgThoughtsPerSession = avgThoughtsPerSession
+        self.avgThoughtsPerMinute = avgThoughtsPerMinute
+    }
 }
 
 // MARK: - API Request Types

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -53,3 +53,16 @@ targets:
         SWIFT_VERSION: "5.9"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
+
+  StillPointAppUITests:
+    type: bundle.ui-testing
+    platform: iOS
+    sources:
+      - StillPointAppUITests
+    dependencies:
+      - target: StillPoint
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint.uitests
+        SWIFT_VERSION: "5.9"
+        GENERATE_INFOPLIST_FILE: YES


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a native `StillPointAppUITests` target in `ios/project.yml`
- implement a deterministic UI-test fixture harness in the iOS `APIClient` (launch env toggles for auth seed, offline/token-expiry/session failures, and persisted history state)
- add accessibility identifiers/labels and cold-start auth metric exposure needed for VoiceOver and E2E assertions
- add `ios/StillPointAppUITests/StillPointAppUITests.swift` covering launch/login/session completion/history persistence, hold/release behavior, history/settings smoke navigation, rotation usability, keyboard overlap, VoiceOver labels, and failure messaging
- add `ios/StillPointAppUITests/README.md` with simulator run steps and CI lane stub plan
- align README coverage mapping names with the final XCTest method names

## Acceptance criteria coverage
- launch -> login -> main surface path covered with a documented/asserted cold-start bound
- start -> complete flow covered, including completion stats visibility
- distraction hold/release behavior validated for non-stuck state
- history/settings navigation smoke path validated
- reference simulator documented (`iPhone 15 Pro`) for notch/dynamic island/home-indicator checks
- rotation decision asserted as supported + usable in landscape
- keyboard overlap test verifies primary auth action remains hittable
- VoiceOver smoke verifies timer and primary CTA labels
- offline / failed API launch path shows user-visible message
- token expiry path routes to re-auth with message
- kill/relaunch persistence path verifies completed session appears in history
- CI lane plan and local runbook included

## Notes
- Cross-referenced #155/#156 in the UI test README to avoid duplicating simulator/setup work across CI lanes.
- Local `coderabbit review --prompt-only` and `xcodebuild` commands are unavailable in this execution environment (`command not found`), so this branch currently relies on PR-side CodeRabbit review and CI/macOS execution for runtime verification.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c0bc9b8-30b6-49c6-897f-8d0571ce315c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c0bc9b8-30b6-49c6-897f-8d0571ce315c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cold-start authentication timing is captured and can be displayed at launch; launch-time auth status messages may be surfaced.

* **Bug Fixes**
  * Improved user-facing messaging for auth failures and connection errors; login/logout clear transient auth messages.

* **Accessibility**
  * Added accessibility identifiers and labels across tabs, screens, form fields, buttons, timers, and controls to improve assistive tech and UI automation.

* **Tests**
  * New end-to-end UI test suite covering auth, sessions, navigation, rotation, VoiceOver, timing metrics, and failure scenarios.

* **Documentation**
  * Added UI testing README with configs, scenarios, and run instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->