### PR TITLE
Ensure note save payloads fail visibly

### DIFF
--- a/ios/StillPointShared/Tests/StillPointSharedTests/RecordBuddyPersonalSessionRequestEncodingTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/RecordBuddyPersonalSessionRequestEncodingTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import StillPointShared
+
+final class RecordBuddyPersonalSessionRequestEncodingTests: XCTestCase {
+    func testEncodesEmbeddedThoughtsUsingServerFieldNames() throws {
+        let request = RecordBuddyPersonalSessionRequest(
+            clearPercent: 80,
+            thoughtCount: 1,
+            mindStateLog: [
+                MindStateEntry(time: 0, state: "clear"),
+                MindStateEntry(time: 12, state: "thinking"),
+            ],
+            actualTime: 60,
+            sessionDate: "2026-04-25",
+            thoughts: [
+                BatchThoughtsRequest.ThoughtInput(
+                    timeInSession: 42,
+                    text: "iOS buddy note"
+                )
+            ]
+        )
+
+        let data = try JSONEncoder().encode(request)
+        let jsonObject = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let thoughts = try XCTUnwrap(jsonObject["thoughts"] as? [[String: Any]])
+
+        XCTAssertEqual(jsonObject["clearPercent"] as? Int, 80)
+        XCTAssertEqual(jsonObject["thoughtCount"] as? Int, 1)
+        XCTAssertEqual(jsonObject["actualTime"] as? Int, 60)
+        XCTAssertEqual(jsonObject["sessionDate"] as? String, "2026-04-25")
+        XCTAssertEqual(thoughts.first?["timeInSession"] as? Int, 42)
+        XCTAssertEqual(thoughts.first?["text"] as? String, "iOS buddy note")
+    }
+}

--- a/src/app/api/buddy/sessions/[id]/record-personal-session/route.ts
+++ b/src/app/api/buddy/sessions/[id]/record-personal-session/route.ts
@@ -15,6 +15,7 @@ import {
   requireBuddyActiveParticipant,
   requireBuddySessionCompletedForPersonalRecord,
 } from "@/lib/buddySessionControlsPolicy";
+import { hasRejectedSubmittedThoughts, normalizeThoughtInputs } from "@/lib/thoughtSaving";
 import { and, eq, sql } from "drizzle-orm";
 
 type Params = { params: Promise<{ id: string }> };
@@ -36,23 +37,6 @@ function parseMindStateLog(raw: unknown): Array<{ time: number; state: string }>
     const s = (item as { state?: unknown }).state;
     if (typeof t !== "number" || typeof s !== "string") continue;
     out.push({ time: t, state: s });
-  }
-  return out;
-}
-
-function parseThoughts(
-  raw: unknown,
-): Array<{ timeInSession: number; text: string }> {
-  if (!Array.isArray(raw)) return [];
-  const out: Array<{ timeInSession: number; text: string }> = [];
-  for (const item of raw) {
-    if (!item || typeof item !== "object") continue;
-    const timeInSession = (item as { timeInSession?: unknown }).timeInSession;
-    const text = (item as { text?: unknown }).text;
-    if (typeof timeInSession !== "number" || typeof text !== "string") continue;
-    const trimmed = text.trim().slice(0, 1000);
-    if (!trimmed) continue;
-    out.push({ timeInSession, text: trimmed });
   }
   return out;
 }
@@ -139,7 +123,17 @@ export async function POST(request: NextRequest, context: Params) {
         : 0;
 
     const mindStateLog = parseMindStateLog(body.mindStateLog);
-    const thoughtItems = parseThoughts(body.thoughts);
+    const normalizedThoughts = normalizeThoughtInputs(body.thoughts);
+    if (hasRejectedSubmittedThoughts(normalizedThoughts)) {
+      console.warn("Buddy personal session rejected invalid thoughts payload", {
+        buddySessionId: sessionId,
+        userId: auth.userId,
+        submittedCount: normalizedThoughts.submittedCount,
+        invalidCount: normalizedThoughts.invalidCount,
+      });
+      return NextResponse.json({ error: "Invalid thoughts payload" }, { status: 400 });
+    }
+    const thoughtItems = normalizedThoughts.thoughts;
 
     const duration = buddyRow!.durationSeconds;
     let actualTime = duration;
@@ -208,15 +202,21 @@ export async function POST(request: NextRequest, context: Params) {
           .where(eq(buddySessions.id, sessionId));
 
         if (thoughtItems.length > 0) {
-          await tx.insert(thoughts).values(
-            thoughtItems.map((t) => ({
-              userId: auth.userId,
-              sessionId: created.id,
-              dayNumber,
-              timeInSession: t.timeInSession,
-              text: t.text,
-            })),
-          );
+          const insertedThoughts = await tx
+            .insert(thoughts)
+            .values(
+              thoughtItems.map((t) => ({
+                userId: auth.userId,
+                sessionId: created.id,
+                dayNumber,
+                timeInSession: t.timeInSession,
+                text: t.text,
+              })),
+            )
+            .returning({ id: thoughts.id });
+          if (insertedThoughts.length !== thoughtItems.length) {
+            throw new Error("THOUGHT_INSERT_MISMATCH");
+          }
         }
 
         return created;

--- a/src/app/api/buddy/sessions/[id]/record-personal-session/route.ts
+++ b/src/app/api/buddy/sessions/[id]/record-personal-session/route.ts
@@ -123,6 +123,14 @@ export async function POST(request: NextRequest, context: Params) {
         : 0;
 
     const mindStateLog = parseMindStateLog(body.mindStateLog);
+    if (body.thoughts != null && !Array.isArray(body.thoughts)) {
+      console.warn("Buddy personal session rejected invalid thoughts payload", {
+        buddySessionId: sessionId,
+        userId: auth.userId,
+        submittedType: typeof body.thoughts,
+      });
+      return NextResponse.json({ error: "Invalid thoughts payload" }, { status: 400 });
+    }
     const normalizedThoughts = normalizeThoughtInputs(body.thoughts);
     if (hasRejectedSubmittedThoughts(normalizedThoughts)) {
       console.warn("Buddy personal session rejected invalid thoughts payload", {

--- a/src/app/api/thoughts/batch/route.ts
+++ b/src/app/api/thoughts/batch/route.ts
@@ -54,6 +54,15 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Invalid thoughts payload" }, { status: 400 });
     }
     const normalized = normalizedResult.thoughts;
+    const completionNoteCount = normalized.filter((t) => t.timeInSession === -1).length;
+    if (completionNoteCount > 1) {
+      console.warn("Batch thoughts rejected duplicate completion notes", {
+        sessionId,
+        userId: auth.userId,
+        completionNoteCount,
+      });
+      return NextResponse.json({ error: "Invalid thoughts payload" }, { status: 400 });
+    }
 
     const completionNote = normalized.filter((t) => t.timeInSession === -1).at(-1);
     const rowsToInsert = [

--- a/src/app/api/thoughts/batch/route.ts
+++ b/src/app/api/thoughts/batch/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/db";
 import { poolDb } from "@/db/pool";
 import { sessions, thoughts } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
+import { hasRejectedSubmittedThoughts, normalizeThoughtInputs } from "@/lib/thoughtSaving";
 import { and, eq } from "drizzle-orm";
 
 export async function POST(request: NextRequest) {
@@ -42,23 +43,17 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Day number mismatch" }, { status: 400 });
     }
 
-    const normalized = thoughtItems
-      .map((t: { timeInSession: unknown; text: unknown }) => {
-        if (typeof t.timeInSession !== "number" || typeof t.text !== "string") {
-          return null;
-        }
-        const text = t.text.trim().slice(0, 1000);
-        if (!text) return null;
-        return {
-          timeInSession: t.timeInSession,
-          text,
-        };
-      })
-      .filter((t): t is { timeInSession: number; text: string } => t != null);
-
-    if (normalized.length === 0) {
-      return NextResponse.json({ thoughts: [] });
+    const normalizedResult = normalizeThoughtInputs(thoughtItems);
+    if (hasRejectedSubmittedThoughts(normalizedResult)) {
+      console.warn("Batch thoughts rejected invalid payload", {
+        sessionId,
+        userId: auth.userId,
+        submittedCount: normalizedResult.submittedCount,
+        invalidCount: normalizedResult.invalidCount,
+      });
+      return NextResponse.json({ error: "Invalid thoughts payload" }, { status: 400 });
     }
+    const normalized = normalizedResult.thoughts;
 
     const completionNote = normalized.filter((t) => t.timeInSession === -1).at(-1);
     const rowsToInsert = [
@@ -83,7 +78,7 @@ export async function POST(request: NextRequest) {
         return [];
       }
 
-      return tx
+      const insertedThoughts = await tx
         .insert(thoughts)
         .values(
           rowsToInsert.map((t) => ({
@@ -101,6 +96,10 @@ export async function POST(request: NextRequest) {
           timeInSession: thoughts.timeInSession,
           text: thoughts.text,
         });
+      if (insertedThoughts.length !== rowsToInsert.length) {
+        throw new Error("THOUGHT_INSERT_MISMATCH");
+      }
+      return insertedThoughts;
     });
 
     return NextResponse.json({ thoughts: inserted });

--- a/src/lib/thoughtSaving.test.ts
+++ b/src/lib/thoughtSaving.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  hasRejectedSubmittedThoughts,
+  normalizeThoughtInputs,
+} from "./thoughtSaving";
+
+describe("normalizeThoughtInputs", () => {
+  it("accepts web completion note payloads", () => {
+    const result = normalizeThoughtInputs([{ timeInSession: -1, text: "  final note  " }]);
+
+    assert.equal(result.submittedCount, 1);
+    assert.equal(result.invalidCount, 0);
+    assert.deepEqual(result.thoughts, [{ timeInSession: -1, text: "final note" }]);
+    assert.equal(hasRejectedSubmittedThoughts(result), false);
+  });
+
+  it("accepts iOS buddy embedded note payloads", () => {
+    const result = normalizeThoughtInputs([
+      { timeInSession: 12, text: "one" },
+      { timeInSession: 58, text: "two" },
+    ]);
+
+    assert.equal(result.submittedCount, 2);
+    assert.equal(result.invalidCount, 0);
+    assert.deepEqual(result.thoughts, [
+      { timeInSession: 12, text: "one" },
+      { timeInSession: 58, text: "two" },
+    ]);
+    assert.equal(hasRejectedSubmittedThoughts(result), false);
+  });
+
+  it("flags submitted payloads that would otherwise save zero notes", () => {
+    const result = normalizeThoughtInputs([{ timeInSession: "12", text: "lost" }]);
+
+    assert.equal(result.submittedCount, 1);
+    assert.equal(result.invalidCount, 1);
+    assert.deepEqual(result.thoughts, []);
+    assert.equal(hasRejectedSubmittedThoughts(result), true);
+  });
+});

--- a/src/lib/thoughtSaving.test.ts
+++ b/src/lib/thoughtSaving.test.ts
@@ -6,6 +6,20 @@ import {
 } from "./thoughtSaving";
 
 describe("normalizeThoughtInputs", () => {
+  it("flags mixed valid and invalid submitted payloads", () => {
+    const result = normalizeThoughtInputs([
+      { timeInSession: 12, text: "kept if normalized alone" },
+      { timeInSession: "13", text: "invalid" },
+    ]);
+
+    assert.equal(result.submittedCount, 2);
+    assert.equal(result.invalidCount, 1);
+    assert.deepEqual(result.thoughts, [
+      { timeInSession: 12, text: "kept if normalized alone" },
+    ]);
+    assert.equal(hasRejectedSubmittedThoughts(result), true);
+  });
+
   it("accepts web completion note payloads", () => {
     const result = normalizeThoughtInputs([{ timeInSession: -1, text: "  final note  " }]);
 

--- a/src/lib/thoughtSaving.test.ts
+++ b/src/lib/thoughtSaving.test.ts
@@ -6,6 +6,15 @@ import {
 } from "./thoughtSaving";
 
 describe("normalizeThoughtInputs", () => {
+  it("accepts empty payload arrays without rejecting them", () => {
+    const result = normalizeThoughtInputs([]);
+
+    assert.equal(result.submittedCount, 0);
+    assert.equal(result.invalidCount, 0);
+    assert.deepEqual(result.thoughts, []);
+    assert.equal(hasRejectedSubmittedThoughts(result), false);
+  });
+
   it("flags mixed valid and invalid submitted payloads", () => {
     const result = normalizeThoughtInputs([
       { timeInSession: 12, text: "kept if normalized alone" },
@@ -40,6 +49,30 @@ describe("normalizeThoughtInputs", () => {
     assert.deepEqual(result.thoughts, [
       { timeInSession: 12, text: "one" },
       { timeInSession: 58, text: "two" },
+    ]);
+    assert.equal(hasRejectedSubmittedThoughts(result), false);
+  });
+
+  it("flags text that is empty after trimming", () => {
+    const result = normalizeThoughtInputs([{ timeInSession: 1, text: "   " }]);
+
+    assert.equal(result.submittedCount, 1);
+    assert.equal(result.invalidCount, 1);
+    assert.deepEqual(result.thoughts, []);
+    assert.equal(hasRejectedSubmittedThoughts(result), true);
+  });
+
+  it("accepts zero and negative in-session timestamps", () => {
+    const result = normalizeThoughtInputs([
+      { timeInSession: 0, text: "start" },
+      { timeInSession: -2, text: "before completion sentinel" },
+    ]);
+
+    assert.equal(result.submittedCount, 2);
+    assert.equal(result.invalidCount, 0);
+    assert.deepEqual(result.thoughts, [
+      { timeInSession: 0, text: "start" },
+      { timeInSession: -2, text: "before completion sentinel" },
     ]);
     assert.equal(hasRejectedSubmittedThoughts(result), false);
   });

--- a/src/lib/thoughtSaving.ts
+++ b/src/lib/thoughtSaving.ts
@@ -1,0 +1,52 @@
+export type ThoughtInput = {
+  timeInSession: number;
+  text: string;
+};
+
+export type ThoughtNormalizationResult = {
+  submittedCount: number;
+  invalidCount: number;
+  thoughts: ThoughtInput[];
+};
+
+export function normalizeThoughtInputs(raw: unknown): ThoughtNormalizationResult {
+  if (!Array.isArray(raw)) {
+    return { submittedCount: 0, invalidCount: 0, thoughts: [] };
+  }
+
+  const thoughts: ThoughtInput[] = [];
+  let invalidCount = 0;
+
+  for (const item of raw) {
+    if (!item || typeof item !== "object") {
+      invalidCount += 1;
+      continue;
+    }
+
+    const timeInSession = (item as { timeInSession?: unknown }).timeInSession;
+    const text = (item as { text?: unknown }).text;
+
+    if (
+      typeof timeInSession !== "number" ||
+      !Number.isFinite(timeInSession) ||
+      typeof text !== "string"
+    ) {
+      invalidCount += 1;
+      continue;
+    }
+
+    const trimmed = text.trim().slice(0, 1000);
+    if (!trimmed) {
+      invalidCount += 1;
+      continue;
+    }
+
+    thoughts.push({ timeInSession, text: trimmed });
+  }
+
+  return { submittedCount: raw.length, invalidCount, thoughts };
+}
+
+export function hasRejectedSubmittedThoughts(result: ThoughtNormalizationResult): boolean {
+  return result.submittedCount > 0 && result.invalidCount > 0;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Shared note/thought payload normalization between web batch saves and buddy personal-session saves.
- Return `400 Invalid thoughts payload` when submitted note payloads are malformed, mixed valid/invalid, non-array in buddy saves, or duplicate completion-note submissions.
- Verify thought insert counts and add regression coverage for web completion notes, iOS buddy embedded-note DTO encoding, and note-normalization edge cases.

### Testing
- ✅ `node --import tsx --test src/lib/thoughtSaving.test.ts`
- ✅ `npm run build`
- ✅ `npx tsc --noEmit`
- ✅ GitHub checks before latest test-only push: Web Build, E2E Web policy/smoke/critical, E2E Mobile Web chromium/webkit lanes, E2E iOS smoke/critical, Vercel, CodeRabbit
- ⚠️ `swift test` (Swift toolchain is not installed in this Linux image)
- ⚠️ `coderabbit review --prompt-only` (CodeRabbit CLI is not installed in this image)
- ⚠️ `npx coderabbit review --prompt-only` (npm could not resolve a CodeRabbit executable)
- ⚠️ `@cursor review` comment attempt failed via GitHub API with `Resource not accessible by integration`; Cursor Bugbot nevertheless started after the PR was marked ready
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1bc4694-2927-429f-a0f1-dcdfe3f8ff92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1bc4694-2927-429f-a0f1-dcdfe3f8ff92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger validation for submitted thoughts: non-array payloads, invalid entries, and duplicate completion notes are now rejected with clear 400 errors instead of being silently ignored.
  * Persistence now verifies inserted thought counts and surface an error if saved rows don’t match expected.

* **Tests**
  * New tests for thought normalization and personal session request encoding to ensure correct acceptance, trimming, counts, and encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->