### PR TITLE
Add homepage how-it-works video section

### DIFF
--- a/src/components/HomepageDemoVideo.tsx
+++ b/src/components/HomepageDemoVideo.tsx
@@ -1,6 +1,6 @@
 /**
  * Optional homepage embed: set `STILLPOINT_HOMEPAGE_YOUTUBE_VIDEO_ID` to an
- * 11-character YouTube video id. Unset, empty, or invalid id → renders nothing
+ * 11-character YouTube video id. Unset, empty, or invalid id renders nothing
  * (scaffolding only until the asset exists).
  */
 const YOUTUBE_VIDEO_ID = /^[a-zA-Z0-9_-]{11}$/;
@@ -14,34 +14,86 @@ export function HomepageDemoVideo() {
   const src = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(raw)}?rel=0`;
 
   return (
-    <div
+    <section
+      aria-labelledby="homepage-demo-heading"
       style={{
         width: "100%",
-        maxWidth: "min(100%, 720px)",
-        margin: "0 auto",
-        borderRadius: "12px",
-        overflow: "hidden",
-        border: "1px solid var(--border-2)",
-        position: "relative",
-        aspectRatio: "16 / 9",
-        background: "var(--surface-1)",
+        marginTop: "var(--s3)",
+        display: "grid",
+        gap: "var(--s3)",
       }}
     >
-      <iframe
-        title="How Still Point works"
-        src={src}
-        loading="lazy"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        allowFullScreen
-        referrerPolicy="strict-origin-when-cross-origin"
+      <div
         style={{
-          position: "absolute",
-          inset: 0,
-          width: "100%",
-          height: "100%",
-          border: "none",
+          display: "grid",
+          gap: "var(--s2)",
+          maxWidth: "62ch",
         }}
-      />
-    </div>
+      >
+        <p
+          style={{
+            margin: 0,
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            fontSize: "12px",
+            color: "var(--fg-3)",
+          }}
+        >
+          How it works
+        </p>
+        <h2
+          id="homepage-demo-heading"
+          style={{
+            margin: 0,
+            fontSize: "clamp(26px, 5vw, 40px)",
+            fontWeight: 300,
+            lineHeight: 1.1,
+            color: "var(--fg)",
+          }}
+        >
+          Watch a one-minute sit turn into a daily rhythm.
+        </h2>
+        <p
+          style={{
+            margin: 0,
+            fontSize: "clamp(16px, 2.2vw, 19px)",
+            color: "var(--fg-2)",
+            lineHeight: 1.55,
+          }}
+        >
+          See how Still Point starts small, fills each session block by block, and gradually extends your practice without making meditation feel like another task.
+        </p>
+      </div>
+
+      <div
+        style={{
+          width: "100%",
+          maxWidth: "min(100%, 720px)",
+          borderRadius: "12px",
+          overflow: "hidden",
+          border: "1px solid var(--border-2)",
+          position: "relative",
+          aspectRatio: "16 / 9",
+          background: "var(--surface-1)",
+        }}
+      >
+        <iframe
+          title="How Still Point works"
+          src={src}
+          loading="lazy"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowFullScreen
+          referrerPolicy="strict-origin-when-cross-origin"
+          style={{
+            position: "absolute",
+            inset: 0,
+            width: "100%",
+            height: "100%",
+            border: "none",
+          }}
+        />
+      </div>
+    </section>
   );
 }

--- a/src/components/HomepageDemoVideo.tsx
+++ b/src/components/HomepageDemoVideo.tsx
@@ -18,6 +18,7 @@ export function HomepageDemoVideo() {
       aria-labelledby="homepage-demo-heading"
       style={{
         width: "100%",
+        minWidth: 0,
         marginTop: "var(--s3)",
         display: "grid",
         gap: "var(--s3)",
@@ -69,7 +70,9 @@ export function HomepageDemoVideo() {
       <div
         style={{
           width: "100%",
-          maxWidth: "min(100%, 720px)",
+          minWidth: 0,
+          maxWidth: "720px",
+          boxSizing: "border-box",
           borderRadius: "12px",
           overflow: "hidden",
           border: "1px solid var(--border-2)",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Adds a gated homepage "How it works" section around the optional YouTube demo embed.
- Keeps the section hidden unless `STILLPOINT_HOMEPAGE_YOUTUBE_VIDEO_ID` is an exact 11-character YouTube id.
- Preserves responsive 16:9 layout and privacy-enhanced YouTube embed URL, including mobile-width containment.

### Verification
- `npm run build` with default env: passed.
- `STILLPOINT_HOMEPAGE_YOUTUBE_VIDEO_ID=jNQXAC9IVRw npm run build`: passed.
- Component gate checked for unset, empty, invalid, and valid video IDs.
- Vercel preview fetched through Vercel MCP: hidden state confirmed while env is unset.
- Manual desktop/mobile walkthrough confirmed visible state with a valid sample ID.

[homepage_how_it_works_responsive.mp4](https://cursor.com/agents/bc-78e5c9d1-2c75-4cf3-81ef-3c4f93add264/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_how_it_works_responsive.mp4)
[Desktop how-it-works section](https://cursor.com/agents/bc-78e5c9d1-2c75-4cf3-81ef-3c4f93add264/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_how_it_works_desktop_fixed.webp)
[Mobile how-it-works section](https://cursor.com/agents/bc-78e5c9d1-2c75-4cf3-81ef-3c4f93add264/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_how_it_works_mobile_fixed.webp)

### Notes
- `coderabbit review --prompt-only` could not run locally because the `coderabbit` executable is unavailable in this environment. CodeRabbit posted a draft-skip notice on the PR; no review findings were available to fix.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78e5c9d1-2c75-4cf3-81ef-3c4f93add264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78e5c9d1-2c75-4cf3-81ef-3c4f93add264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

