### PR TITLE
Clarify buddy audio as local

### DIFF
--- a/src/components/BlockTimer.tsx
+++ b/src/components/BlockTimer.tsx
@@ -14,6 +14,7 @@ type BlockTimerProps = {
   mindState: string;
   mindStateLog: Array<{ time: number; state: string }>;
   onElapsedChange?: (elapsed: number) => void;
+  onSoundPlaybackBlocked?: () => void;
   soundPrefs?: SoundPrefs;
   /**
    * When set, elapsed time is driven by the parent (e.g. server-synced buddy session).
@@ -45,6 +46,7 @@ export function BlockTimer({
   mindState,
   mindStateLog,
   onElapsedChange,
+  onSoundPlaybackBlocked,
   soundPrefs,
   controlledElapsed,
   syncClock,
@@ -55,6 +57,8 @@ export function BlockTimer({
   const pausedElapsedRef = useRef(0);
   const onCompleteRef = useRef(onComplete);
   onCompleteRef.current = onComplete;
+  const onSoundPlaybackBlockedRef = useRef(onSoundPlaybackBlocked);
+  onSoundPlaybackBlockedRef.current = onSoundPlaybackBlocked;
   const soundPrefsRef = useRef(soundPrefs);
   soundPrefsRef.current = soundPrefs;
   const lastTickSecRef = useRef(-1);
@@ -70,6 +74,12 @@ export function BlockTimer({
   const blockSize = isMobile ? 56 : 75;
   const blockLabelSize = isMobile ? 13 : 17;
   const blockGap = 11;
+
+  const playEnabledSound = (play: () => boolean) => {
+    if (!play()) {
+      onSoundPlaybackBlockedRef.current?.();
+    }
+  };
 
   // Build block definitions
   const useMinuteBlocks = totalSeconds > 120;
@@ -148,7 +158,7 @@ export function BlockTimer({
           setElapsed(totalSeconds);
           pausedElapsedRef.current = totalSeconds;
           clearInterval(intervalRef.current!);
-          if (soundPrefsRef.current?.completion) playCompletion();
+          if (soundPrefsRef.current?.completion) playEnabledSound(playCompletion);
           onCompleteRef.current();
         } else {
           setElapsed(newElapsed);
@@ -160,7 +170,7 @@ export function BlockTimer({
           // Tick sound — once per second
           if (soundPrefsRef.current?.tick && currentSec > lastTickSecRef.current) {
             lastTickSecRef.current = currentSec;
-            playTick();
+            playEnabledSound(playTick);
           }
 
           // Always advance block progress so re-enabling chimes doesn't replay history
@@ -177,7 +187,7 @@ export function BlockTimer({
                 const blockEnd = (completedBlockIndex + 1) * 60;
                 const chimeCount = Math.floor((totalSeconds - blockEnd) / 60);
                 if (chimeCount >= 1) {
-                  playChime(chimeCount);
+                  playEnabledSound(() => playChime(chimeCount));
                 }
               }
             }
@@ -226,7 +236,7 @@ export function BlockTimer({
         window.clearInterval(id);
         if (!controlledCompleteFiredRef.current) {
           controlledCompleteFiredRef.current = true;
-          if (soundPrefsRef.current?.completion) playCompletion();
+          if (soundPrefsRef.current?.completion) playEnabledSound(playCompletion);
           onCompleteRef.current();
         }
         return;
@@ -238,7 +248,7 @@ export function BlockTimer({
       const currentSec = Math.floor(newElapsed);
       if (soundPrefsRef.current?.tick && currentSec > lastTickSecRef.current) {
         lastTickSecRef.current = currentSec;
-        playTick();
+        playEnabledSound(playTick);
       }
 
       if (useMinuteBlocks && minuteBlockCount > 0) {
@@ -252,7 +262,7 @@ export function BlockTimer({
             const blockEnd = (completedBlockIndex + 1) * 60;
             const chimeCount = Math.floor((duration - blockEnd) / 60);
             if (chimeCount >= 1) {
-              playChime(chimeCount);
+              playEnabledSound(() => playChime(chimeCount));
             }
           }
         }
@@ -272,7 +282,7 @@ export function BlockTimer({
       pausedElapsedRef.current = totalSeconds;
       if (!controlledCompleteFiredRef.current) {
         controlledCompleteFiredRef.current = true;
-        if (soundPrefsRef.current?.completion) playCompletion();
+        if (soundPrefsRef.current?.completion) playEnabledSound(playCompletion);
         onCompleteRef.current();
       }
       return;
@@ -284,7 +294,7 @@ export function BlockTimer({
     const currentSec = Math.floor(newElapsed);
     if (soundPrefsRef.current?.tick && currentSec > lastTickSecRef.current) {
       lastTickSecRef.current = currentSec;
-      playTick();
+      playEnabledSound(playTick);
     }
 
     if (useMinuteBlocks && minuteBlockCount > 0) {
@@ -298,7 +308,7 @@ export function BlockTimer({
           const blockEnd = (completedBlockIndex + 1) * 60;
           const chimeCount = Math.floor((totalSeconds - blockEnd) / 60);
           if (chimeCount >= 1) {
-            playChime(chimeCount);
+            playEnabledSound(() => playChime(chimeCount));
           }
         }
       }

--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -178,6 +178,7 @@ export function BuddySessionRoom({
   }, [pollStopped, sessionId]);
 
   useEffect(() => {
+    audioUnlockRequestRef.current += 1;
     setSnap(null);
     snapRef.current = null;
     setMindStateLog([]);
@@ -1298,6 +1299,7 @@ export function BuddySessionRoom({
                   }}
                 >
                   <div
+                    aria-hidden={!controlsVisible}
                     style={{
                       opacity: controlsVisible ? 1 : 0,
                       transition: "opacity 0.5s ease",
@@ -1307,6 +1309,8 @@ export function BuddySessionRoom({
                     <button
                       type="button"
                       onClick={openThoughtCapture}
+                      disabled={!controlsVisible}
+                      tabIndex={controlsVisible ? 0 : -1}
                       style={{
                         border: "1px solid var(--accent-amber-border)",
                         background: "none",
@@ -1317,7 +1321,7 @@ export function BuddySessionRoom({
                         textTransform: "uppercase",
                         padding: "10px 24px",
                         borderRadius: "20px",
-                        cursor: "pointer",
+                        cursor: controlsVisible ? "pointer" : "default",
                       }}
                     >
                       capture note

--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -8,7 +8,7 @@ import { useIsMobile } from "@/lib/useIsMobile";
 import { BlockTimer } from "./BlockTimer";
 import { BuddyVideo } from "./BuddyVideo";
 import { ThoughtCapture } from "./ThoughtCapture";
-import { loadSoundPrefs, saveSoundPrefs, type SoundPrefs } from "@/lib/audio";
+import { loadSoundPrefs, saveSoundPrefs, unlockAudioContext, type SoundPrefs } from "@/lib/audio";
 import { computeClearPercentFromLog } from "@/lib/mindStateSession";
 import { useMindStateHold } from "@/lib/useMindStateHold";
 
@@ -86,6 +86,7 @@ export function BuddySessionRoom({
   );
   const [distractionSegmentCount, setDistractionSegmentCount] = useState(0);
   const [soundPrefs, setSoundPrefs] = useState<SoundPrefs>(() => loadSoundPrefs());
+  const [audioBlocked, setAudioBlocked] = useState(false);
   const [controlsVisible, setControlsVisible] = useState(true);
   const elapsedRef = useRef(0);
   const [displayElapsed, setDisplayElapsed] = useState(0);
@@ -190,6 +191,7 @@ export function BuddySessionRoom({
     setIsSavingPersonalRecord(false);
     setLocalTimerCompleted(false);
     localTimerCompletedRef.current = false;
+    setAudioBlocked(false);
     setPersonalRecordError(null);
     setDailyMeetingToken(null);
     setDailyTokenError(null);
@@ -270,6 +272,30 @@ export function BuddySessionRoom({
   const handleElapsedChange = useCallback((elapsed: number) => {
     elapsedRef.current = elapsed;
     setDisplayElapsed(elapsed);
+  }, []);
+
+  const handleSoundPlaybackBlocked = useCallback(() => {
+    setAudioBlocked(true);
+  }, []);
+
+  const handleSoundPrefToggle = useCallback(
+    async (key: keyof SoundPrefs) => {
+      const next = { ...soundPrefs, [key]: !soundPrefs[key] };
+      if (next[key]) {
+        const unlockResult = await unlockAudioContext();
+        setAudioBlocked(unlockResult === "blocked");
+      } else {
+        setAudioBlocked(false);
+      }
+      setSoundPrefs(next);
+      saveSoundPrefs(next);
+    },
+    [soundPrefs],
+  );
+
+  const handleEnableLocalAudio = useCallback(async () => {
+    const unlockResult = await unlockAudioContext();
+    setAudioBlocked(unlockResult === "blocked");
   }, []);
 
   const buddyAwarenessPct = useMemo(() => {
@@ -826,6 +852,7 @@ export function BuddySessionRoom({
                 mindState={mindState}
                 mindStateLog={mindStateLog}
                 onElapsedChange={handleElapsedChange}
+                onSoundPlaybackBlocked={handleSoundPlaybackBlocked}
                 soundPrefs={soundPrefs}
                 onComplete={handleBuddyTimerComplete}
               />
@@ -840,7 +867,7 @@ export function BuddySessionRoom({
                   letterSpacing: "0.08em",
                 }}
               >
-                {snap.durationSeconds}s sit · timer synced from server
+                {snap.durationSeconds}s sit · shared timer synced from server · sounds stay local
               </p>
             </div>
 
@@ -1280,8 +1307,33 @@ export function BuddySessionRoom({
                       textAlign: "center",
                     }}
                   >
-                    Sounds are only on your device — they do not affect anyone else.
+                    The timer is shared. Tick, chime, and end sounds are local to this device.
                   </p>
+                  {audioBlocked && (
+                    <p
+                      role="alert"
+                      style={{
+                        margin: 0,
+                        maxWidth: "340px",
+                        fontSize: "11px",
+                        color: "var(--accent-amber)",
+                        fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                        letterSpacing: "0.04em",
+                        textAlign: "center",
+                        lineHeight: 1.45,
+                      }}
+                    >
+                      Browser audio is paused.
+                      <button
+                        type="button"
+                        onClick={() => void handleEnableLocalAudio()}
+                        style={inlineLinkButton}
+                      >
+                        Enable local audio
+                      </button>
+                      on this device.
+                    </p>
+                  )}
                   <div
                     style={{
                       display: "flex",
@@ -1306,11 +1358,7 @@ export function BuddySessionRoom({
                         aria-pressed={soundPrefs[key]}
                         aria-label={`${label} sound ${soundPrefs[key] ? "on" : "off"}; only you hear this`}
                         title="Only you hear this — does not change audio for others"
-                        onClick={() => {
-                          const next = { ...soundPrefs, [key]: !soundPrefs[key] };
-                          setSoundPrefs(next);
-                          saveSoundPrefs(next);
-                        }}
+                        onClick={() => void handleSoundPrefToggle(key)}
                         style={{
                           background: "none",
                           border: "none",
@@ -1420,6 +1468,16 @@ const btnSecondary: CSSProperties = {
   fontSize: "11px",
   letterSpacing: "0.08em",
   textTransform: "uppercase",
+};
+
+const inlineLinkButton: CSSProperties = {
+  background: "none",
+  border: "none",
+  color: "var(--accent-amber)",
+  cursor: "pointer",
+  font: "inherit",
+  padding: 0,
+  textDecoration: "underline",
 };
 
 const btnGhost: CSSProperties = {

--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -86,6 +86,9 @@ export function BuddySessionRoom({
   );
   const [distractionSegmentCount, setDistractionSegmentCount] = useState(0);
   const [soundPrefs, setSoundPrefs] = useState<SoundPrefs>(() => loadSoundPrefs());
+  const soundPrefsRef = useRef(soundPrefs);
+  soundPrefsRef.current = soundPrefs;
+  const audioUnlockRequestRef = useRef(0);
   const [audioBlocked, setAudioBlocked] = useState(false);
   const [controlsVisible, setControlsVisible] = useState(true);
   const elapsedRef = useRef(0);
@@ -278,24 +281,42 @@ export function BuddySessionRoom({
     setAudioBlocked(true);
   }, []);
 
-  const handleSoundPrefToggle = useCallback(
-    async (key: keyof SoundPrefs) => {
-      const next = { ...soundPrefs, [key]: !soundPrefs[key] };
-      if (next[key]) {
-        const unlockResult = await unlockAudioContext();
+  const handleSoundPrefToggle = useCallback((key: keyof SoundPrefs) => {
+    const current = soundPrefsRef.current;
+    const next = { ...current, [key]: !current[key] };
+    const hasEnabledSound = Object.values(next).some(Boolean);
+    soundPrefsRef.current = next;
+    setSoundPrefs(next);
+    saveSoundPrefs(next);
+
+    const requestId = ++audioUnlockRequestRef.current;
+    if (!hasEnabledSound) {
+      setAudioBlocked(false);
+      return;
+    }
+
+    if (!next[key]) {
+      return;
+    }
+
+    void unlockAudioContext().then((unlockResult) => {
+      if (requestId !== audioUnlockRequestRef.current) return;
+      const stillHasEnabledSound = Object.values(soundPrefsRef.current).some(Boolean);
+      setAudioBlocked(stillHasEnabledSound && unlockResult === "blocked");
+    });
+  }, []);
+
+  const handleEnableLocalAudio = useCallback(async () => {
+    const requestId = ++audioUnlockRequestRef.current;
+    const unlockResult = await unlockAudioContext();
+    if (requestId === audioUnlockRequestRef.current) {
+      const hasEnabledSound = Object.values(soundPrefsRef.current).some(Boolean);
+      if (hasEnabledSound) {
         setAudioBlocked(unlockResult === "blocked");
       } else {
         setAudioBlocked(false);
       }
-      setSoundPrefs(next);
-      saveSoundPrefs(next);
-    },
-    [soundPrefs],
-  );
-
-  const handleEnableLocalAudio = useCallback(async () => {
-    const unlockResult = await unlockAudioContext();
-    setAudioBlocked(unlockResult === "blocked");
+    }
   }, []);
 
   const buddyAwarenessPct = useMemo(() => {

--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -1261,9 +1261,6 @@ export function BuddySessionRoom({
 
               <div
                 style={{
-                  opacity: controlsVisible ? 1 : 0,
-                  transition: "opacity 0.5s ease",
-                  pointerEvents: controlsVisible ? "auto" : "none",
                   width: "100%",
                   display: "flex",
                   flexDirection: "column",
@@ -1279,24 +1276,32 @@ export function BuddySessionRoom({
                     marginTop: "24px",
                   }}
                 >
-                  <button
-                    type="button"
-                    onClick={openThoughtCapture}
+                  <div
                     style={{
-                      border: "1px solid var(--accent-amber-border)",
-                      background: "none",
-                      color: "var(--accent-amber-border)",
-                      fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-                      fontSize: "11px",
-                      letterSpacing: "0.15em",
-                      textTransform: "uppercase",
-                      padding: "10px 24px",
-                      borderRadius: "20px",
-                      cursor: "pointer",
+                      opacity: controlsVisible ? 1 : 0,
+                      transition: "opacity 0.5s ease",
+                      pointerEvents: controlsVisible ? "auto" : "none",
                     }}
                   >
-                    capture note
-                  </button>
+                    <button
+                      type="button"
+                      onClick={openThoughtCapture}
+                      style={{
+                        border: "1px solid var(--accent-amber-border)",
+                        background: "none",
+                        color: "var(--accent-amber-border)",
+                        fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                        fontSize: "11px",
+                        letterSpacing: "0.15em",
+                        textTransform: "uppercase",
+                        padding: "10px 24px",
+                        borderRadius: "20px",
+                        cursor: "pointer",
+                      }}
+                    >
+                      capture note
+                    </button>
+                  </div>
                   <p
                     style={{
                       margin: 0,

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -3,20 +3,56 @@
 
 let audioCtx: AudioContext | null = null;
 
-function getAudioContext(): AudioContext {
+export type AudioUnlockResult = "unlocked" | "blocked" | "unavailable";
+
+type WindowWithWebAudio = Window & {
+  AudioContext?: typeof AudioContext;
+  webkitAudioContext?: typeof AudioContext;
+};
+
+function getAudioContextConstructor(): typeof AudioContext | undefined {
+  if (typeof window === "undefined") return undefined;
+  const webAudioWindow = window as WindowWithWebAudio;
+  return webAudioWindow.AudioContext ?? webAudioWindow.webkitAudioContext;
+}
+
+function getAudioContext(): AudioContext | null {
+  const AudioContextCtor = getAudioContextConstructor();
+  if (!AudioContextCtor) return null;
   if (!audioCtx) {
-    audioCtx = new AudioContext();
-  }
-  // Resume if suspended (browsers require user gesture)
-  if (audioCtx.state === "suspended") {
-    audioCtx.resume();
+    audioCtx = new AudioContextCtor();
   }
   return audioCtx;
 }
 
-/** Short, soft tick — like a clock */
-export function playTick() {
+function readAudioContextState(ctx: AudioContext): AudioContextState {
+  return ctx.state;
+}
+
+export async function unlockAudioContext(): Promise<AudioUnlockResult> {
   const ctx = getAudioContext();
+  if (!ctx) return "unavailable";
+  if (ctx.state === "running") return "unlocked";
+  try {
+    await ctx.resume();
+  } catch {
+    return "blocked";
+  }
+  return readAudioContextState(ctx) === "running" ? "unlocked" : "blocked";
+}
+
+function getPlayableAudioContext(): AudioContext | null {
+  const ctx = getAudioContext();
+  if (!ctx) return null;
+  if (ctx.state === "running") return ctx;
+  void ctx.resume().catch(() => undefined);
+  return null;
+}
+
+/** Short, soft tick — like a clock */
+export function playTick(): boolean {
+  const ctx = getPlayableAudioContext();
+  if (!ctx) return false;
   const osc = ctx.createOscillator();
   const gain = ctx.createGain();
 
@@ -29,11 +65,13 @@ export function playTick() {
   gain.connect(ctx.destination);
   osc.start(ctx.currentTime);
   osc.stop(ctx.currentTime + 0.06);
+  return true;
 }
 
 /** Bell chime — repeated `count` times for minute announcements */
-export function playChime(count: number) {
-  const ctx = getAudioContext();
+export function playChime(count: number): boolean {
+  const ctx = getPlayableAudioContext();
+  if (!ctx) return false;
 
   for (let i = 0; i < count; i++) {
     const startTime = ctx.currentTime + i * 0.4;
@@ -53,11 +91,13 @@ export function playChime(count: number) {
     osc.start(startTime);
     osc.stop(startTime + 0.5);
   }
+  return true;
 }
 
 /** Completion sound — a warm, resonant tone */
-export function playCompletion() {
-  const ctx = getAudioContext();
+export function playCompletion(): boolean {
+  const ctx = getPlayableAudioContext();
+  if (!ctx) return false;
 
   // Layer two harmonics for a richer sound
   const freqs = [528, 660];
@@ -77,6 +117,7 @@ export function playCompletion() {
     osc.start(ctx.currentTime);
     osc.stop(ctx.currentTime + 2.5);
   }
+  return true;
 }
 
 // --- Sound preferences (localStorage) ---

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -45,7 +45,6 @@ function getPlayableAudioContext(): AudioContext | null {
   const ctx = getAudioContext();
   if (!ctx) return null;
   if (ctx.state === "running") return ctx;
-  void ctx.resume().catch(() => undefined);
   return null;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Clarifies that buddy session timing is shared while tick/chime/end sounds are local per device.
- Adds Web Audio unlock handling for local sound controls and blocked-audio feedback.
- Reports blocked playback from the shared timer when browser autoplay policy prevents local sound.
- Keeps the buddy sound copy and toggles visible instead of hiding them with auto-fading controls.
- Fixes Bugbot and CodeRabbit findings around rapid sound preference toggles, blocked-audio banner clearing, stale unlock results, hidden focusability, and audio resume side effects.

## Walkthrough
[buddy_audio_local_controls.mp4](https://cursor.com/agents/bc-62e16778-b405-42ee-8c48-f7b6d79d997a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuddy_audio_local_controls.mp4)
[Buddy local audio controls](https://cursor.com/agents/bc-62e16778-b405-42ee-8c48-f7b6d79d997a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuddy_audio_controls_final.png)

## Testing
- `npm run build` passed.
- `coderabbit review --prompt-only` could not run because the CLI was unauthenticated in this environment.
- Manual browser walkthrough used the real `/app?buddy=...` route with API responses intercepted because local auth is blocked by missing Neon database access.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62e16778-b405-42ee-8c48-f7b6d79d997a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62e16778-b405-42ee-8c48-f7b6d79d997a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio unlock flow to enable sounds when browser restrictions block playback.
  * New "Enable local audio" prompt/button when audio is blocked.
  * Sound preference toggles now immediately persist and trigger audio unlocking.

* **Bug Fixes**
  * Consistent blocked-sound notification across all timer modes.
  * More reliable audio handling to reduce missed or blocked sounds.
  * UI tweaks: clearer timer/sound guidance and improved capture-note button behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->