### PR TITLE
Add password reset flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,14 @@ POSTGRES_URL=postgresql://user:password@host/database?sslmode=require
 # JWT secret for auth tokens (generate with: openssl rand -base64 32)
 JWT_SECRET=your-secret-here
 
+# Public origin used to build password reset links in email. Defaults to https://still-point.me when unset.
+# NEXT_PUBLIC_APP_URL=https://still-point.me
+
+# Optional email provider config for password reset delivery. If unset, reset links are logged server-side in non-production only.
+# EMAIL_PROVIDER=console
+# EMAIL_FROM="Still Point <noreply@still-point.me>"
+# RESEND_API_KEY=
+
 # Daily.co — server-only REST API key for creating/deleting buddy video rooms (#105). Never expose to the client.
 DAILY_API_KEY=
 

--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,6 @@ JWT_SECRET=your-secret-here
 # NEXT_PUBLIC_APP_URL=https://still-point.me
 
 # Optional email provider config for password reset delivery. If unset, reset links are logged server-side in non-production only.
-# EMAIL_PROVIDER=console
 # EMAIL_FROM="Still Point <noreply@still-point.me>"
 # RESEND_API_KEY=
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ npm run build:turbo
 | `POSTGRES_URL_TEST` | **Not read by the app** — optional team alias for the non-production URL when documenting or mirroring Vercel Preview envs. | Same as non-prod `POSTGRES_URL` |
 | `JWT_SECRET` | Secret for signing auth tokens (`src/lib/auth.ts`, `src/middleware.ts`) | `openssl rand -base64 32` |
 | `NEXT_PUBLIC_APP_URL` | Public absolute URL used when generating password reset links. Defaults to `https://still-point.me` when unset. | Deployment URL such as `https://still-point.me` or local `http://127.0.0.1:3000` |
-| `EMAIL_PROVIDER` | Optional password reset email provider. Set to `resend` to send mail; unset logs the reset link server-side for local/dev. | `resend` when `RESEND_API_KEY` and `EMAIL_FROM` are configured |
-| `EMAIL_FROM` | Sender address for password reset email. Required only when `EMAIL_PROVIDER=resend`. | Verified sender/domain in the email provider |
+| `EMAIL_FROM` | Sender address for password reset email. Required with `RESEND_API_KEY` for password reset email delivery. | Verified sender/domain in the email provider |
 | `RESEND_API_KEY` | Server-only Resend API key for password reset email delivery. Never expose to the client. | Resend dashboard → API Keys |
 | `DAILY_API_KEY` | [Daily.co](https://www.daily.co/) REST API key — buddy video rooms and meeting tokens (`src/lib/daily.ts`). Server-only; never expose to the client. | Daily dashboard → Developers → API key |
 | `BUDDY_REQUIRE_FRIENDSHIP` | Optional. When exactly `true`, buddy join paths enforce an existing friendship (`src/lib/buddySession.ts`). | Any string other than `true` leaves checks off |
@@ -150,7 +149,7 @@ Third-party keys in use today:
 
 | Service | Variable | Used for |
 |---------|----------|----------|
-| Resend (optional) | `EMAIL_PROVIDER`, `EMAIL_FROM`, `RESEND_API_KEY` | Send password reset links (`src/lib/email.ts`). If unset, links are logged server-side for development only. |
+| Resend (optional) | `EMAIL_FROM`, `RESEND_API_KEY` | Send password reset links (`src/lib/email.ts`). If unset, links are logged server-side for development only. |
 | Daily.co | `DAILY_API_KEY` | Create/delete rooms, issue meeting tokens for buddy video (`src/lib/daily.ts`, `src/app/api/buddy/sessions/[id]/start`, `…/meeting-token`). |
 | YouTube (optional) | `STILLPOINT_HOMEPAGE_YOUTUBE_VIDEO_ID` | **Marketing only:** 11-character video id for the landing-page demo embed. Unset or empty → no embed (#166). |
 

--- a/README.md
+++ b/README.md
@@ -82,10 +82,20 @@ npm run build:turbo
 | `POSTGRES_URL` | Runtime DB connection string used by the app (`src/db/index.ts`, `drizzle.config.ts`). In local dev, point at non-production Neon. | [Neon console](https://console.neon.tech) → project/branch → connection string |
 | `POSTGRES_URL_TEST` | **Not read by the app** — optional team alias for the non-production URL when documenting or mirroring Vercel Preview envs. | Same as non-prod `POSTGRES_URL` |
 | `JWT_SECRET` | Secret for signing auth tokens (`src/lib/auth.ts`, `src/middleware.ts`) | `openssl rand -base64 32` |
+| `NEXT_PUBLIC_APP_URL` | Public absolute URL used when generating password reset links. Defaults to `https://still-point.me` when unset. | Deployment URL such as `https://still-point.me` or local `http://127.0.0.1:3000` |
+| `EMAIL_PROVIDER` | Optional password reset email provider. Set to `resend` to send mail; unset logs the reset link server-side for local/dev. | `resend` when `RESEND_API_KEY` and `EMAIL_FROM` are configured |
+| `EMAIL_FROM` | Sender address for password reset email. Required only when `EMAIL_PROVIDER=resend`. | Verified sender/domain in the email provider |
+| `RESEND_API_KEY` | Server-only Resend API key for password reset email delivery. Never expose to the client. | Resend dashboard → API Keys |
 | `DAILY_API_KEY` | [Daily.co](https://www.daily.co/) REST API key — buddy video rooms and meeting tokens (`src/lib/daily.ts`). Server-only; never expose to the client. | Daily dashboard → Developers → API key |
 | `BUDDY_REQUIRE_FRIENDSHIP` | Optional. When exactly `true`, buddy join paths enforce an existing friendship (`src/lib/buddySession.ts`). | Any string other than `true` leaves checks off |
 
 Never commit credentials. Keep actual values only in local/Vercel environment settings. For a **Production / Preview / Local** map, see [Environment matrix (runbook)](#environment-matrix-runbook) below.
+
+## Password reset behavior
+
+Password reset requests always return the same success message whether or not an account exists, so the endpoint does not reveal registered email addresses. When an account exists, the server stores a single-use hashed reset token that expires after one hour and emails a signed reset link to `/reset-password?token=...`.
+
+The reset request endpoint applies a lightweight per-process rate limit by email plus IP address. Keep platform/WAF throttling enabled in production for stronger abuse protection across serverless instances.
 
 ## Database environment topology
 
@@ -140,6 +150,7 @@ Third-party keys in use today:
 
 | Service | Variable | Used for |
 |---------|----------|----------|
+| Resend (optional) | `EMAIL_PROVIDER`, `EMAIL_FROM`, `RESEND_API_KEY` | Send password reset links (`src/lib/email.ts`). If unset, links are logged server-side for development only. |
 | Daily.co | `DAILY_API_KEY` | Create/delete rooms, issue meeting tokens for buddy video (`src/lib/daily.ts`, `src/app/api/buddy/sessions/[id]/start`, `…/meeting-token`). |
 | YouTube (optional) | `STILLPOINT_HOMEPAGE_YOUTUBE_VIDEO_ID` | **Marketing only:** 11-character video id for the landing-page demo embed. Unset or empty → no embed (#166). |
 

--- a/drizzle/password_reset_tokens_incremental.sql
+++ b/drizzle/password_reset_tokens_incremental.sql
@@ -12,13 +12,25 @@ CREATE TABLE IF NOT EXISTS "password_reset_tokens" (
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 
-ALTER TABLE "password_reset_tokens" ADD CONSTRAINT "password_reset_tokens_user_id_users_id_fk"
-FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'password_reset_tokens_user_id_users_id_fk'
+  ) THEN
+    ALTER TABLE "password_reset_tokens"
+      ADD CONSTRAINT "password_reset_tokens_user_id_users_id_fk"
+      FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+  END IF;
+END
+$$;
 
 CREATE UNIQUE INDEX IF NOT EXISTS "password_reset_tokens_token_hash_unique"
 ON "password_reset_tokens" USING btree ("token_hash");
 CREATE INDEX IF NOT EXISTS "idx_password_reset_tokens_user"
 ON "password_reset_tokens" USING btree ("user_id");
-CREATE INDEX IF NOT EXISTS "idx_password_reset_tokens_active_user"
-ON "password_reset_tokens" USING btree ("user_id", "expires_at")
+DROP INDEX IF EXISTS "idx_password_reset_tokens_active_user";
+CREATE UNIQUE INDEX IF NOT EXISTS "password_reset_tokens_active_user_unique"
+ON "password_reset_tokens" USING btree ("user_id")
 WHERE "used_at" IS NULL;

--- a/drizzle/password_reset_tokens_incremental.sql
+++ b/drizzle/password_reset_tokens_incremental.sql
@@ -1,0 +1,24 @@
+-- Incremental DDL for password reset tokens (issue #160).
+-- Preferred: apply schema with `npx drizzle-kit push` (see README).
+-- This file is a reference for existing databases if you apply SQL manually.
+
+CREATE TABLE IF NOT EXISTS "password_reset_tokens" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"token_hash" varchar(64) NOT NULL,
+	"request_ip_hash" varchar(64),
+	"expires_at" timestamp with time zone NOT NULL,
+	"used_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+ALTER TABLE "password_reset_tokens" ADD CONSTRAINT "password_reset_tokens_user_id_users_id_fk"
+FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "password_reset_tokens_token_hash_unique"
+ON "password_reset_tokens" USING btree ("token_hash");
+CREATE INDEX IF NOT EXISTS "idx_password_reset_tokens_user"
+ON "password_reset_tokens" USING btree ("user_id");
+CREATE INDEX IF NOT EXISTS "idx_password_reset_tokens_active_user"
+ON "password_reset_tokens" USING btree ("user_id", "expires_at")
+WHERE "used_at" IS NULL;

--- a/e2e/auth/password-reset.spec.ts
+++ b/e2e/auth/password-reset.spec.ts
@@ -19,7 +19,16 @@ test.describe("password reset", () => {
 
     await page.route("**/api/auth/password-reset/confirm", async (route) => {
       const body = (route.request().postDataJSON() ?? {}) as { token?: string; password?: string };
-      if (body.token !== "valid-reset-token" || !body.password || body.password.length < 8) {
+      if (!body.token || !body.password || body.password.length < 8) {
+        await route.fulfill({
+          status: 400,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "Valid token and password of at least 8 characters required" }),
+        });
+        return;
+      }
+
+      if (body.token !== "valid-reset-token") {
         await route.fulfill({
           status: 400,
           contentType: "application/json",

--- a/e2e/auth/password-reset.spec.ts
+++ b/e2e/auth/password-reset.spec.ts
@@ -40,15 +40,15 @@ test.describe("password reset", () => {
     await page.goto("/app");
     await page.getByPlaceholder("email").fill(mockApiState.credentials.email);
     await page.getByRole("link", { name: "Forgot password?" }).click();
-    await expect(page).toHaveURL(/\/reset-password\?/);
-    await expect(page.getByPlaceholder("email")).toHaveValue(mockApiState.credentials.email);
+    await expect(page).toHaveURL(/\/reset-password$/);
+    await page.getByLabel("Email").fill(mockApiState.credentials.email);
     await page.getByRole("button", { name: "Send reset link" }).click();
     await expect(page.getByText(/reset link will arrive shortly/i)).toBeVisible();
     expect(resetRequestedFor).toBe(mockApiState.credentials.email);
 
     await page.goto("/reset-password?token=valid-reset-token");
-    await page.getByPlaceholder("new password", { exact: true }).fill("new-password-123");
-    await page.getByPlaceholder("confirm new password").fill("new-password-123");
+    await page.getByLabel("New password", { exact: true }).fill("new-password-123");
+    await page.getByLabel("Confirm new password").fill("new-password-123");
     await page.getByRole("button", { name: "Set new password" }).click();
     await expect(page.getByText(/password has been updated/i)).toBeVisible();
     expect(submittedNewPassword).toBe("new-password-123");
@@ -75,11 +75,11 @@ test.describe("password reset", () => {
     });
 
     await page.goto("/reset-password");
-    await page.getByPlaceholder("email").fill("unknown@stillpoint.test");
+    await page.getByLabel("Email").fill("unknown@stillpoint.test");
     await page.getByRole("button", { name: "Send reset link" }).click();
     await expect(page.getByText(resetMessage)).toBeVisible();
 
-    await page.getByPlaceholder("email").fill("known@stillpoint.test");
+    await page.getByLabel("Email").fill("known@stillpoint.test");
     await page.getByRole("button", { name: "Send reset link" }).click();
     await expect(page.getByText(resetMessage)).toBeVisible();
     expect(requestedEmails).toEqual(["unknown@stillpoint.test", "known@stillpoint.test"]);

--- a/e2e/auth/password-reset.spec.ts
+++ b/e2e/auth/password-reset.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from "../fixtures/auth.fixture";
+
+test.describe("password reset", () => {
+  test("request link and set new password from token", async ({ page, mockApiState }) => {
+    let resetRequestedFor: string | null = null;
+    let submittedNewPassword: string | null = null;
+
+    await page.route("**/api/auth/password-reset/request", async (route) => {
+      const body = (route.request().postDataJSON() ?? {}) as { email?: string };
+      resetRequestedFor = String(body.email ?? "");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          message: "If an account exists for that email, a reset link will arrive shortly.",
+        }),
+      });
+    });
+
+    await page.route("**/api/auth/password-reset/confirm", async (route) => {
+      const body = (route.request().postDataJSON() ?? {}) as { token?: string; password?: string };
+      if (body.token !== "valid-reset-token" || !body.password || body.password.length < 8) {
+        await route.fulfill({
+          status: 400,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "Reset link is invalid or expired" }),
+        });
+        return;
+      }
+
+      submittedNewPassword = body.password;
+      mockApiState.credentials.password = body.password;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true }),
+      });
+    });
+
+    await page.goto("/app");
+    await page.getByPlaceholder("email").fill(mockApiState.credentials.email);
+    await page.getByRole("link", { name: "Forgot password?" }).click();
+    await expect(page).toHaveURL(/\/reset-password$/);
+    await page.getByPlaceholder("email").fill(mockApiState.credentials.email);
+    await page.getByRole("button", { name: "Send reset link" }).click();
+    await expect(page.getByText(/reset link will arrive shortly/i)).toBeVisible();
+    expect(resetRequestedFor).toBe(mockApiState.credentials.email);
+
+    await page.goto("/reset-password?token=valid-reset-token");
+    await page.getByPlaceholder("new password").fill("new-password-123");
+    await page.getByPlaceholder("confirm new password").fill("new-password-123");
+    await page.getByRole("button", { name: "Set new password" }).click();
+    await expect(page.getByText(/password has been updated/i)).toBeVisible();
+    expect(submittedNewPassword).toBe("new-password-123");
+
+    await page.getByRole("link", { name: "Return to login" }).click();
+    await page.getByPlaceholder("email").fill(mockApiState.credentials.email);
+    await page.getByPlaceholder("password").fill("new-password-123");
+    await page.getByRole("button", { name: "Enter" }).click();
+    await expect(page.getByRole("button", { name: "Begin" })).toBeVisible();
+  });
+
+  test("request response does not enumerate accounts", async ({ page }) => {
+    const resetMessage = "If an account exists for that email, a reset link will arrive shortly.";
+    const requestedEmails: string[] = [];
+
+    await page.route("**/api/auth/password-reset/request", async (route) => {
+      const body = (route.request().postDataJSON() ?? {}) as { email?: string };
+      requestedEmails.push(String(body.email ?? ""));
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ message: resetMessage }),
+      });
+    });
+
+    await page.goto("/reset-password");
+    await page.getByPlaceholder("email").fill("unknown@stillpoint.test");
+    await page.getByRole("button", { name: "Send reset link" }).click();
+    await expect(page.getByText(resetMessage)).toBeVisible();
+
+    await page.getByPlaceholder("email").fill("known@stillpoint.test");
+    await page.getByRole("button", { name: "Send reset link" }).click();
+    await expect(page.getByText(resetMessage)).toBeVisible();
+    expect(requestedEmails).toEqual(["unknown@stillpoint.test", "known@stillpoint.test"]);
+  });
+});

--- a/e2e/auth/password-reset.spec.ts
+++ b/e2e/auth/password-reset.spec.ts
@@ -41,7 +41,9 @@ test.describe("password reset", () => {
     await page.getByPlaceholder("email").fill(mockApiState.credentials.email);
     await page.getByRole("link", { name: "Forgot password?" }).click();
     await expect(page).toHaveURL(/\/reset-password$/);
-    await page.getByLabel("Email").fill(mockApiState.credentials.email);
+    await page.getByLabel("Email").click();
+    await page.keyboard.type(mockApiState.credentials.email);
+    await expect(page.getByLabel("Email")).toHaveValue(mockApiState.credentials.email);
     await page.getByRole("button", { name: "Send reset link" }).click();
     await expect(page.getByText(/reset link will arrive shortly/i)).toBeVisible();
     expect(resetRequestedFor).toBe(mockApiState.credentials.email);
@@ -75,12 +77,27 @@ test.describe("password reset", () => {
     });
 
     await page.goto("/reset-password");
-    await page.getByLabel("Email").fill("unknown@stillpoint.test");
-    await page.getByRole("button", { name: "Send reset link" }).click();
+    await page.getByLabel("Email").click();
+    await page.keyboard.type("unknown@stillpoint.test");
+    await expect(page.getByLabel("Email")).toHaveValue("unknown@stillpoint.test");
+    await Promise.all([
+      page.waitForResponse((response) =>
+        response.url().includes("/api/auth/password-reset/request") && response.status() === 200,
+      ),
+      page.getByRole("button", { name: "Send reset link" }).click(),
+    ]);
     await expect(page.getByText(resetMessage)).toBeVisible();
 
-    await page.getByLabel("Email").fill("known@stillpoint.test");
-    await page.getByRole("button", { name: "Send reset link" }).click();
+    await page.getByLabel("Email").click();
+    await page.getByLabel("Email").press(process.platform === "darwin" ? "Meta+A" : "Control+A");
+    await page.keyboard.type("known@stillpoint.test");
+    await expect(page.getByLabel("Email")).toHaveValue("known@stillpoint.test");
+    await Promise.all([
+      page.waitForResponse((response) =>
+        response.url().includes("/api/auth/password-reset/request") && response.status() === 200,
+      ),
+      page.getByRole("button", { name: "Send reset link" }).click(),
+    ]);
     await expect(page.getByText(resetMessage)).toBeVisible();
     expect(requestedEmails).toEqual(["unknown@stillpoint.test", "known@stillpoint.test"]);
   });

--- a/e2e/auth/password-reset.spec.ts
+++ b/e2e/auth/password-reset.spec.ts
@@ -40,14 +40,14 @@ test.describe("password reset", () => {
     await page.goto("/app");
     await page.getByPlaceholder("email").fill(mockApiState.credentials.email);
     await page.getByRole("link", { name: "Forgot password?" }).click();
-    await expect(page).toHaveURL(/\/reset-password$/);
-    await page.getByPlaceholder("email").fill(mockApiState.credentials.email);
+    await expect(page).toHaveURL(/\/reset-password\?/);
+    await expect(page.getByPlaceholder("email")).toHaveValue(mockApiState.credentials.email);
     await page.getByRole("button", { name: "Send reset link" }).click();
     await expect(page.getByText(/reset link will arrive shortly/i)).toBeVisible();
     expect(resetRequestedFor).toBe(mockApiState.credentials.email);
 
     await page.goto("/reset-password?token=valid-reset-token");
-    await page.getByPlaceholder("new password").fill("new-password-123");
+    await page.getByPlaceholder("new password", { exact: true }).fill("new-password-123");
     await page.getByPlaceholder("confirm new password").fill("new-password-123");
     await page.getByRole("button", { name: "Set new password" }).click();
     await expect(page.getByText(/password has been updated/i)).toBeVisible();

--- a/e2e/fixtures/auth.fixture.ts
+++ b/e2e/fixtures/auth.fixture.ts
@@ -169,7 +169,10 @@ async function installMockApiRoutes(page: Page, state: MockApiState) {
 
     if (pathname === "/api/auth/password-reset/confirm" && method === "POST") {
       const body = (request.postDataJSON() ?? {}) as { token?: string; password?: string } | undefined;
-      if (!state.resetToken || body?.token !== state.resetToken || String(body?.password ?? "").length < 8) {
+      if (!body?.token || String(body?.password ?? "").length < 8) {
+        return json(route, 400, { error: "Valid token and password of at least 8 characters required" });
+      }
+      if (!state.resetToken || body.token !== state.resetToken) {
         return json(route, 400, { error: "Reset link is invalid or expired" });
       }
       state.credentials = { ...state.credentials, password: String(body.password) };

--- a/e2e/fixtures/auth.fixture.ts
+++ b/e2e/fixtures/auth.fixture.ts
@@ -39,6 +39,7 @@ type MockApiState = {
   authenticated: boolean;
   user: UserRecord;
   credentials: AuthedContext;
+  resetToken: string | null;
   sessions: SessionRecord[];
   thoughts: ThoughtRecord[];
   ids: { session: number; thought: number };
@@ -152,6 +153,30 @@ async function installMockApiRoutes(page: Page, state: MockApiState) {
       return json(route, 200, { ok: true });
     }
 
+    if (pathname === "/api/auth/password-reset/request" && method === "POST") {
+      const body = (request.postDataJSON() ?? {}) as Partial<AuthedContext>;
+      const email = String(body.email ?? "").trim().toLowerCase();
+      if (!email || !email.includes("@")) {
+        return json(route, 400, { error: "A valid email is required" });
+      }
+      if (email === state.credentials.email) {
+        state.resetToken = `reset-${Date.now()}`;
+      }
+      return json(route, 200, {
+        message: "If an account exists for that email, a reset link will arrive shortly.",
+      });
+    }
+
+    if (pathname === "/api/auth/password-reset/confirm" && method === "POST") {
+      const body = (request.postDataJSON() ?? {}) as { token?: string; password?: string } | undefined;
+      if (!state.resetToken || body?.token !== state.resetToken || String(body?.password ?? "").length < 8) {
+        return json(route, 400, { error: "Reset link is invalid or expired" });
+      }
+      state.credentials = { ...state.credentials, password: String(body.password) };
+      state.resetToken = null;
+      return json(route, 200, { ok: true });
+    }
+
     if (pathname === "/api/sessions" && method === "GET") {
       if (!state.authenticated) return json(route, 401, { error: "Unauthorized" });
       const sessions = [...state.sessions].sort((a, b) => b.dayNumber - a.dayNumber);
@@ -223,6 +248,7 @@ export const test = base.extend<AuthFixture>({
         isPublic: false,
         currentDay: 1,
       },
+      resetToken: null,
       sessions: [],
       thoughts: [],
       ids: { session: 1, thought: 1 },

--- a/ios/StillPointApp/ViewModels/AuthViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AuthViewModel.swift
@@ -53,7 +53,8 @@ final class AuthViewModel {
 
     func requestPasswordReset() async {
         let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmedEmail.contains("@") && trimmedEmail.contains(".") && !isRequestingPasswordReset else {
+        guard !isRequestingPasswordReset else { return }
+        guard trimmedEmail.contains("@") && trimmedEmail.contains(".") else {
             error = "Enter your email first."
             return
         }

--- a/ios/StillPointApp/ViewModels/AuthViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AuthViewModel.swift
@@ -8,7 +8,9 @@ final class AuthViewModel {
     var username = ""
     var password = ""
     var error: String?
+    var resetMessage: String?
     var isSubmitting = false
+    var isRequestingPasswordReset = false
 
     var isValid: Bool {
         let emailValid = email.contains("@") && email.contains(".")
@@ -25,6 +27,7 @@ final class AuthViewModel {
         guard isValid, !isSubmitting else { return nil }
         isSubmitting = true
         error = nil
+        resetMessage = nil
         defer { isSubmitting = false }
 
         do {
@@ -45,6 +48,28 @@ final class AuthViewModel {
         } catch {
             self.error = "Connection failed. Please try again."
             return nil
+        }
+    }
+
+    func requestPasswordReset() async {
+        let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedEmail.contains("@") && trimmedEmail.contains(".") && !isRequestingPasswordReset else {
+            error = "Enter your email first."
+            return
+        }
+
+        isRequestingPasswordReset = true
+        error = nil
+        resetMessage = nil
+        defer { isRequestingPasswordReset = false }
+
+        do {
+            try await APIClient.shared.requestPasswordReset(email: trimmedEmail)
+            resetMessage = "If an account exists for that email, a reset link will arrive shortly."
+        } catch let apiError as APIError {
+            error = apiError.message
+        } catch {
+            error = "Connection failed. Please try again."
         }
     }
 }

--- a/ios/StillPointApp/Views/AuthView.swift
+++ b/ios/StillPointApp/Views/AuthView.swift
@@ -97,6 +97,28 @@ struct AuthView: View {
                     .accessibilityIdentifier("auth.submitButton")
                     .disabled(!vm.isValid || vm.isSubmitting)
                     .opacity(vm.isValid ? 1 : 0.5)
+
+                    if let resetMessage = vm.resetMessage {
+                        Text(resetMessage)
+                            .font(SPFont.mono(12))
+                            .foregroundStyle(SPColor.greenText)
+                            .multilineTextAlignment(.center)
+                            .accessibilityIdentifier("auth.passwordResetMessage")
+                    }
+
+                    if !vm.isSignUp {
+                        Button {
+                            Task { await vm.requestPasswordReset() }
+                        } label: {
+                            Text(vm.isRequestingPasswordReset ? "Sending..." : "Forgot password?")
+                                .font(SPFont.mono(12))
+                                .foregroundStyle(Color(SPColor.fg3))
+                                .underline()
+                        }
+                        .accessibilityIdentifier("auth.forgotPasswordButton")
+                        .disabled(vm.isRequestingPasswordReset)
+                        .padding(.top, SPSpacing.s1)
+                    }
                 }
                 .padding(.horizontal, SPSpacing.s4)
             }

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -8,6 +8,30 @@ final class StillPointAppUITests: XCTestCase {
     }
 
     @MainActor
+    func testPasswordResetEntryIsDiscoverable() throws {
+        let app = makeApp(seedAuthenticated: false, resetStore: true)
+        app.launch()
+
+        let authRoot = app.otherElements["root.currentView.auth"]
+        XCTAssertTrue(authRoot.waitForExistence(timeout: launchTimeout), "Auth screen did not appear")
+
+        let emailField = app.textFields["auth.emailField"]
+        XCTAssertTrue(emailField.waitForExistence(timeout: 5))
+        emailField.tap()
+        emailField.typeText("ios.fixture@stillpoint.test")
+
+        let forgotPasswordButton = app.buttons["auth.forgotPasswordButton"]
+        XCTAssertTrue(forgotPasswordButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(forgotPasswordButton.isHittable)
+        forgotPasswordButton.tap()
+
+        XCTAssertTrue(
+            app.staticTexts["auth.passwordResetMessage"].waitForExistence(timeout: 5),
+            "Password reset request confirmation should be visible"
+        )
+    }
+
+    @MainActor
     func testLaunchLoginCompleteSessionAndHistoryPersistence() throws {
         let app = makeApp(
             seedAuthenticated: false,

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -83,6 +83,15 @@ public actor APIClient {
         return response.user
     }
 
+    public func requestPasswordReset(email: String) async throws -> String {
+        if let message = try uiTestRequestPasswordReset(email: email) {
+            return message
+        }
+        let body: [String: String] = ["email": email]
+        let response: PasswordResetRequestResponse = try await post("/api/auth/password-reset/request", body: body)
+        return response.message
+    }
+
     public func logout() async throws {
         if uiTestLogout() {
             return
@@ -387,6 +396,14 @@ public actor APIClient {
         uiTestStore = store
         persistUITestStore()
         return store.user
+    }
+
+    private func uiTestRequestPasswordReset(email: String) throws -> String? {
+        guard uiTestConfig != nil else { return nil }
+        guard !email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw APIError(status: 400, message: "Email required")
+        }
+        return "If an account exists for that email, a reset link will arrive shortly."
     }
 
     private func uiTestLogout() -> Bool {

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -203,6 +203,10 @@ public struct UserResponse: Codable, Sendable {
     public let token: String?
 }
 
+public struct PasswordResetRequestResponse: Codable, Sendable {
+    public let message: String
+}
+
 public struct SessionResponse: Codable, Sendable {
     public let session: SessionDTO
 }

--- a/src/app/api/auth/password-reset/confirm/route.ts
+++ b/src/app/api/auth/password-reset/confirm/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
-import { db } from "@/db";
-import { users } from "@/db/schema";
+import { and, eq, gt, isNull } from "drizzle-orm";
+import { poolDb } from "@/db/pool";
+import { passwordResetTokens, users } from "@/db/schema";
 import { hashPassword } from "@/lib/auth";
-import { confirmPasswordResetToken } from "@/lib/passwordReset";
+import { getPasswordResetPayload } from "@/lib/passwordReset";
 
 export async function POST(request: NextRequest) {
   try {
@@ -18,15 +18,36 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const confirmed = await confirmPasswordResetToken(token);
-    if (!confirmed.ok) {
+    const resetPayload = await getPasswordResetPayload(token);
+    if (!resetPayload) {
       return NextResponse.json({ error: "Reset link is invalid or expired" }, { status: 400 });
     }
 
     const passwordHash = await hashPassword(password);
-    await db.update(users)
-      .set({ passwordHash, updatedAt: new Date() })
-      .where(eq(users.id, confirmed.userId));
+    const updated = await poolDb.transaction(async (tx) => {
+      const [resetToken] = await tx
+        .update(passwordResetTokens)
+        .set({ usedAt: new Date() })
+        .where(
+          and(
+            eq(passwordResetTokens.userId, resetPayload.userId),
+            eq(passwordResetTokens.tokenHash, resetPayload.tokenHash),
+            isNull(passwordResetTokens.usedAt),
+            gt(passwordResetTokens.expiresAt, new Date()),
+          ),
+        )
+        .returning({ userId: passwordResetTokens.userId });
+      if (!resetToken) {
+        return false;
+      }
+      await tx.update(users)
+        .set({ passwordHash, updatedAt: new Date() })
+        .where(eq(users.id, resetToken.userId));
+      return true;
+    });
+    if (!updated) {
+      return NextResponse.json({ error: "Reset link is invalid or expired" }, { status: 400 });
+    }
 
     return NextResponse.json({ ok: true });
   } catch (error) {

--- a/src/app/api/auth/password-reset/confirm/route.ts
+++ b/src/app/api/auth/password-reset/confirm/route.ts
@@ -7,7 +7,13 @@ import { getPasswordResetPayload } from "@/lib/passwordReset";
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json();
+    const body = await request.json().catch(() => null);
+    if (!body || typeof body !== "object") {
+      return NextResponse.json(
+        { error: "Valid token and password of at least 8 characters required" },
+        { status: 400 },
+      );
+    }
     const token = typeof body?.token === "string" ? body.token.trim() : "";
     const password = typeof body?.password === "string" ? body.password : "";
 

--- a/src/app/api/auth/password-reset/confirm/route.ts
+++ b/src/app/api/auth/password-reset/confirm/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { users } from "@/db/schema";
+import { hashPassword } from "@/lib/auth";
+import { confirmPasswordResetToken } from "@/lib/passwordReset";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const token = typeof body?.token === "string" ? body.token.trim() : "";
+    const password = typeof body?.password === "string" ? body.password : "";
+
+    if (!token || password.length < 8) {
+      return NextResponse.json(
+        { error: "Valid token and password of at least 8 characters required" },
+        { status: 400 },
+      );
+    }
+
+    const confirmed = await confirmPasswordResetToken(token);
+    if (!confirmed.ok) {
+      return NextResponse.json({ error: "Reset link is invalid or expired" }, { status: 400 });
+    }
+
+    const passwordHash = await hashPassword(password);
+    await db.update(users)
+      .set({ passwordHash, updatedAt: new Date() })
+      .where(eq(users.id, confirmed.userId));
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("Password reset confirm error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/auth/password-reset/request/route.ts
+++ b/src/app/api/auth/password-reset/request/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
+import { poolDb } from "@/db/pool";
 import { passwordResetTokens, users } from "@/db/schema";
 import { sendPasswordResetEmail } from "@/lib/email";
 import {
@@ -12,7 +13,7 @@ import {
   recordPasswordResetAttempt,
   requestIpHash,
 } from "@/lib/passwordReset";
-import { and, eq, gt, isNull } from "drizzle-orm";
+import { and, eq, gt, isNull, sql } from "drizzle-orm";
 
 export async function POST(request: NextRequest) {
   try {
@@ -42,31 +43,42 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ message: PASSWORD_RESET_REQUEST_MESSAGE });
     }
 
-    const recentCutoff = new Date(Date.now() - 1000 * 60 * 5);
-    const [activeToken] = await db
-      .select({ id: passwordResetTokens.id })
-      .from(passwordResetTokens)
-      .where(
-        and(
-          eq(passwordResetTokens.userId, user.id),
-          isNull(passwordResetTokens.usedAt),
-          gt(passwordResetTokens.createdAt, recentCutoff),
-        ),
-      )
-      .limit(1);
+    const token = await poolDb.transaction(async (tx) => {
+      await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${`password-reset:${user.id}`}))`);
 
-    if (activeToken) {
-      return NextResponse.json({ message: PASSWORD_RESET_REQUEST_MESSAGE });
-    }
+      const recentCutoff = new Date(Date.now() - 1000 * 60 * 5);
+      const [activeToken] = await tx
+        .select({ id: passwordResetTokens.id })
+        .from(passwordResetTokens)
+        .where(
+          and(
+            eq(passwordResetTokens.userId, user.id),
+            isNull(passwordResetTokens.usedAt),
+            gt(passwordResetTokens.createdAt, recentCutoff),
+          ),
+        )
+        .limit(1);
 
-    const token = await createPasswordResetToken({ userId: user.id, email: user.email });
-    await db.insert(passwordResetTokens).values({
-      userId: user.id,
-      tokenHash: hashResetToken(token),
-      requestIpHash: hashedIp,
-      expiresAt: passwordResetExpiresAt(),
+      if (activeToken) {
+        return null;
+      }
+
+      const resetToken = await createPasswordResetToken({ userId: user.id, email: user.email });
+      await tx.insert(passwordResetTokens).values({
+        userId: user.id,
+        tokenHash: hashResetToken(resetToken),
+        requestIpHash: hashedIp,
+        expiresAt: passwordResetExpiresAt(),
+      });
+      return resetToken;
     });
-    await sendPasswordResetEmail({ to: user.email, token });
+    if (token) {
+      try {
+        await sendPasswordResetEmail({ to: user.email, token });
+      } catch (error) {
+        console.error("Password reset email delivery error:", error);
+      }
+    }
 
     return NextResponse.json({ message: PASSWORD_RESET_REQUEST_MESSAGE });
   } catch (error) {

--- a/src/app/api/auth/password-reset/request/route.ts
+++ b/src/app/api/auth/password-reset/request/route.ts
@@ -14,8 +14,6 @@ import {
 } from "@/lib/passwordReset";
 import { and, eq, gt, isNull } from "drizzle-orm";
 
-const RATE_LIMITED_STATUS = 202;
-
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json().catch(() => ({}));
@@ -27,13 +25,7 @@ export async function POST(request: NextRequest) {
 
     const hashedIp = requestIpHash(request);
     if (isPasswordResetRateLimited(email, hashedIp)) {
-      return NextResponse.json(
-        {
-          message: PASSWORD_RESET_REQUEST_MESSAGE,
-          throttled: true,
-        },
-        { status: RATE_LIMITED_STATUS },
-      );
+      return NextResponse.json({ message: PASSWORD_RESET_REQUEST_MESSAGE });
     }
     recordPasswordResetAttempt(email, hashedIp);
 
@@ -64,13 +56,7 @@ export async function POST(request: NextRequest) {
       .limit(1);
 
     if (activeToken) {
-      return NextResponse.json(
-        {
-          message: PASSWORD_RESET_REQUEST_MESSAGE,
-          throttled: true,
-        },
-        { status: RATE_LIMITED_STATUS },
-      );
+      return NextResponse.json({ message: PASSWORD_RESET_REQUEST_MESSAGE });
     }
 
     const token = await createPasswordResetToken({ userId: user.id, email: user.email });

--- a/src/app/api/auth/password-reset/request/route.ts
+++ b/src/app/api/auth/password-reset/request/route.ts
@@ -63,7 +63,7 @@ export async function POST(request: NextRequest) {
         return null;
       }
 
-      const resetToken = await createPasswordResetToken({ userId: user.id, email: user.email });
+      const resetToken = await createPasswordResetToken({ userId: user.id });
       await tx.insert(passwordResetTokens).values({
         userId: user.id,
         tokenHash: hashResetToken(resetToken),

--- a/src/app/api/auth/password-reset/request/route.ts
+++ b/src/app/api/auth/password-reset/request/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { passwordResetTokens, users } from "@/db/schema";
+import { sendPasswordResetEmail } from "@/lib/email";
+import {
+  PASSWORD_RESET_REQUEST_MESSAGE,
+  createPasswordResetToken,
+  hashResetToken,
+  isPasswordResetRateLimited,
+  normalizeResetEmail,
+  passwordResetExpiresAt,
+  recordPasswordResetAttempt,
+  requestIpHash,
+} from "@/lib/passwordReset";
+import { and, eq, gt, isNull } from "drizzle-orm";
+
+const RATE_LIMITED_STATUS = 202;
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const email = normalizeResetEmail(body?.email);
+
+    if (!email) {
+      return NextResponse.json({ error: "A valid email is required" }, { status: 400 });
+    }
+
+    const hashedIp = requestIpHash(request);
+    if (isPasswordResetRateLimited(email, hashedIp)) {
+      return NextResponse.json(
+        {
+          message: PASSWORD_RESET_REQUEST_MESSAGE,
+          throttled: true,
+        },
+        { status: RATE_LIMITED_STATUS },
+      );
+    }
+    recordPasswordResetAttempt(email, hashedIp);
+
+    const [user] = await db
+      .select({
+        id: users.id,
+        email: users.email,
+      })
+      .from(users)
+      .where(eq(users.email, email))
+      .limit(1);
+
+    if (!user) {
+      return NextResponse.json({ message: PASSWORD_RESET_REQUEST_MESSAGE });
+    }
+
+    const recentCutoff = new Date(Date.now() - 1000 * 60 * 5);
+    const [activeToken] = await db
+      .select({ id: passwordResetTokens.id })
+      .from(passwordResetTokens)
+      .where(
+        and(
+          eq(passwordResetTokens.userId, user.id),
+          isNull(passwordResetTokens.usedAt),
+          gt(passwordResetTokens.createdAt, recentCutoff),
+        ),
+      )
+      .limit(1);
+
+    if (activeToken) {
+      return NextResponse.json(
+        {
+          message: PASSWORD_RESET_REQUEST_MESSAGE,
+          throttled: true,
+        },
+        { status: RATE_LIMITED_STATUS },
+      );
+    }
+
+    const token = await createPasswordResetToken({ userId: user.id, email: user.email });
+    await db.insert(passwordResetTokens).values({
+      userId: user.id,
+      tokenHash: hashResetToken(token),
+      requestIpHash: hashedIp,
+      expiresAt: passwordResetExpiresAt(),
+    });
+    await sendPasswordResetEmail({ to: user.email, token });
+
+    return NextResponse.json({ message: PASSWORD_RESET_REQUEST_MESSAGE });
+  } catch (error) {
+    console.error("Password reset request error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -66,6 +66,7 @@ function ResetPasswordForm() {
       }
 
       setStatus("success");
+      setEmail("");
       setMessage(data.message || "If an account exists for that email, a reset link will arrive shortly.");
     } catch {
       setStatus("error");

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -199,7 +199,13 @@ function ResetPasswordForm() {
               id="reset-email"
               type="email"
               value={email}
-              onChange={(event) => setEmail(event.target.value)}
+              onChange={(event) => {
+                setEmail(event.target.value);
+                if (status !== "submitting") {
+                  setStatus("idle");
+                  setMessage("");
+                }
+              }}
               placeholder="email"
               autoComplete="email"
               style={inputStyle}

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Suspense, useMemo, useState } from "react";
+import { Suspense, useState } from "react";
 import { useSearchParams } from "next/navigation";
 
 type Status = "idle" | "submitting" | "success" | "error";
@@ -33,9 +33,8 @@ const buttonStyle: React.CSSProperties = {
 
 function ResetPasswordForm() {
   const params = useSearchParams();
-  const token = useMemo(() => params.get("token")?.trim() ?? "", [params]);
-  const initialEmail = useMemo(() => params.get("email")?.trim().toLowerCase() ?? "", [params]);
-  const [email, setEmail] = useState(initialEmail);
+  const token = params.get("token")?.trim() ?? "";
+  const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [status, setStatus] = useState<Status>("idle");
@@ -155,10 +154,22 @@ function ResetPasswordForm() {
         </p>
       </div>
 
-      <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (status !== "submitting") {
+            void (token ? submit() : requestReset());
+          }
+        }}
+        style={{ display: "flex", flexDirection: "column", gap: "12px" }}
+      >
         {token ? (
           <>
+            <label htmlFor="new-password" style={{ position: "absolute", width: 1, height: 1, overflow: "hidden" }}>
+              New password
+            </label>
             <input
+              id="new-password"
               type="password"
               value={password}
               onChange={(event) => setPassword(event.target.value)}
@@ -166,7 +177,11 @@ function ResetPasswordForm() {
               autoComplete="new-password"
               style={inputStyle}
             />
+            <label htmlFor="confirm-new-password" style={{ position: "absolute", width: 1, height: 1, overflow: "hidden" }}>
+              Confirm new password
+            </label>
             <input
+              id="confirm-new-password"
               type="password"
               value={confirmPassword}
               onChange={(event) => setConfirmPassword(event.target.value)}
@@ -176,14 +191,20 @@ function ResetPasswordForm() {
             />
           </>
         ) : (
-          <input
-            type="email"
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-            placeholder="email"
-            autoComplete="email"
-            style={inputStyle}
-          />
+          <>
+            <label htmlFor="reset-email" style={{ position: "absolute", width: 1, height: 1, overflow: "hidden" }}>
+              Email
+            </label>
+            <input
+              id="reset-email"
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="email"
+              autoComplete="email"
+              style={inputStyle}
+            />
+          </>
         )}
         {message ? (
           <div
@@ -199,8 +220,7 @@ function ResetPasswordForm() {
           </div>
         ) : null}
         <button
-          type="button"
-          onClick={token ? submit : requestReset}
+          type="submit"
           disabled={status === "submitting"}
           style={{
             ...buttonStyle,
@@ -210,7 +230,7 @@ function ResetPasswordForm() {
         >
           {status === "submitting" ? "..." : token ? "Set new password" : "Send reset link"}
         </button>
-      </div>
+      </form>
 
       <Link
         href="/app"

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -34,7 +34,8 @@ const buttonStyle: React.CSSProperties = {
 function ResetPasswordForm() {
   const params = useSearchParams();
   const token = useMemo(() => params.get("token")?.trim() ?? "", [params]);
-  const [email, setEmail] = useState("");
+  const initialEmail = useMemo(() => params.get("email")?.trim().toLowerCase() ?? "", [params]);
+  const [email, setEmail] = useState(initialEmail);
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [status, setStatus] = useState<Status>("idle");

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import Link from "next/link";
+import { Suspense, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+
+type Status = "idle" | "submitting" | "success" | "error";
+
+const inputStyle: React.CSSProperties = {
+  background: "var(--overlay-bg)",
+  border: "1px solid var(--border-1)",
+  borderRadius: "8px",
+  padding: "12px 16px",
+  color: "var(--fg)",
+  fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+  fontSize: "15px",
+  outline: "none",
+  width: "100%",
+};
+
+const buttonStyle: React.CSSProperties = {
+  background: "var(--surface-1)",
+  border: "1px solid var(--border-2)",
+  color: "var(--fg)",
+  fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+  fontSize: "16px",
+  fontStyle: "italic",
+  padding: "14px",
+  borderRadius: "30px",
+  cursor: "pointer",
+  transition: "all 0.3s",
+};
+
+function ResetPasswordForm() {
+  const params = useSearchParams();
+  const token = useMemo(() => params.get("token")?.trim() ?? "", [params]);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [status, setStatus] = useState<Status>("idle");
+  const [message, setMessage] = useState("");
+
+  const requestReset = async () => {
+    const trimmedEmail = email.trim().toLowerCase();
+    if (!trimmedEmail) {
+      setStatus("error");
+      setMessage("Enter your email first.");
+      return;
+    }
+
+    setStatus("submitting");
+    setMessage("");
+
+    try {
+      const res = await fetch("/api/auth/password-reset/request", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: trimmedEmail }),
+      });
+      const data = await res.json();
+
+      if (!res.ok) {
+        setStatus("error");
+        setMessage(data.error || "Unable to request a reset link. Please try again.");
+        return;
+      }
+
+      setStatus("success");
+      setMessage(data.message || "If an account exists for that email, a reset link will arrive shortly.");
+    } catch {
+      setStatus("error");
+      setMessage("Network error. Please try again.");
+    }
+  };
+
+  const submit = async () => {
+    if (!token) {
+      setStatus("error");
+      setMessage("This reset link is missing a token. Request a new link and try again.");
+      return;
+    }
+    if (password.length < 8) {
+      setStatus("error");
+      setMessage("Password must be at least 8 characters.");
+      return;
+    }
+    if (password !== confirmPassword) {
+      setStatus("error");
+      setMessage("Passwords do not match.");
+      return;
+    }
+
+    setStatus("submitting");
+    setMessage("");
+
+    try {
+      const res = await fetch("/api/auth/password-reset/confirm", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, password }),
+      });
+      const data = await res.json();
+
+      if (!res.ok) {
+        setStatus("error");
+        setMessage(data.error || "Unable to reset password. Request a new link and try again.");
+        return;
+      }
+
+      setStatus("success");
+      setPassword("");
+      setConfirmPassword("");
+      setMessage("Your password has been updated. You can now log in with the new password.");
+    } catch {
+      setStatus("error");
+      setMessage("Network error. Please try again.");
+    }
+  };
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        maxWidth: "min(380px, calc(100vw - 40px))",
+        display: "flex",
+        flexDirection: "column",
+        gap: "18px",
+        textAlign: "center",
+        animation: "fadeIn 0.6s ease",
+      }}
+    >
+      <div>
+        <h1
+          style={{
+            fontSize: "42px",
+            fontWeight: 300,
+            margin: 0,
+            letterSpacing: "-0.02em",
+            fontStyle: "italic",
+            color: "var(--fg)",
+          }}
+        >
+          Reset password
+        </h1>
+        <p
+          style={{
+            fontSize: "14px",
+            color: "var(--fg-2)",
+            lineHeight: 1.5,
+            marginTop: "var(--s2)",
+          }}
+        >
+          {token ? "Choose a new password for Still Point." : "Enter your email and we will send a reset link if an account exists."}
+        </p>
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+        {token ? (
+          <>
+            <input
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              placeholder="new password"
+              autoComplete="new-password"
+              style={inputStyle}
+            />
+            <input
+              type="password"
+              value={confirmPassword}
+              onChange={(event) => setConfirmPassword(event.target.value)}
+              placeholder="confirm new password"
+              autoComplete="new-password"
+              style={inputStyle}
+            />
+          </>
+        ) : (
+          <input
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            placeholder="email"
+            autoComplete="email"
+            style={inputStyle}
+          />
+        )}
+        {message ? (
+          <div
+            role={status === "error" ? "alert" : "status"}
+            style={{
+              fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+              fontSize: "11px",
+              color: status === "error" ? "var(--accent-danger)" : "var(--accent-green-text)",
+              lineHeight: 1.5,
+            }}
+          >
+            {message}
+          </div>
+        ) : null}
+        <button
+          type="button"
+          onClick={token ? submit : requestReset}
+          disabled={status === "submitting"}
+          style={{
+            ...buttonStyle,
+            opacity: status === "submitting" ? 0.5 : 1,
+            cursor: status === "submitting" ? "wait" : "pointer",
+          }}
+        >
+          {status === "submitting" ? "..." : token ? "Set new password" : "Send reset link"}
+        </button>
+      </div>
+
+      <Link
+        href="/app"
+        style={{
+          color: "var(--fg-3)",
+          fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+          fontSize: "11px",
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+          textDecoration: "underline",
+          textUnderlineOffset: "3px",
+        }}
+      >
+        Return to login
+      </Link>
+    </div>
+  );
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <main
+      style={{
+        minHeight: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "40px 20px",
+        fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+      }}
+    >
+      <Suspense fallback={<div style={{ color: "var(--fg-3)" }}>Loading reset link...</div>}>
+        <ResetPasswordForm />
+      </Suspense>
+    </main>
+  );
+}

--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -197,6 +197,23 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
         >
           {loading ? "..." : mode === "login" ? "Enter" : "Begin the journey"}
         </button>
+        {mode === "login" && (
+          <a
+            href="/reset-password"
+            style={{
+              alignSelf: "center",
+              color: "var(--fg-3)",
+              fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+              fontSize: "11px",
+              letterSpacing: "0.08em",
+              textDecoration: "underline",
+              textUnderlineOffset: "3px",
+              textTransform: "uppercase",
+            }}
+          >
+            Forgot password?
+          </a>
+        )}
       </div>
     </div>
   );

--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -50,10 +50,6 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
     if (e.key === "Enter") handleSubmit();
   };
 
-  const resetHref = email.trim()
-    ? `/reset-password?email=${encodeURIComponent(email.trim().toLowerCase())}`
-    : "/reset-password";
-
   const inputStyle: React.CSSProperties = {
     background: "var(--overlay-bg)",
     border: "1px solid var(--border-1)",
@@ -203,7 +199,7 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
         </button>
         {mode === "login" && (
           <a
-            href={resetHref}
+            href="/reset-password"
             style={{
               alignSelf: "center",
               color: "var(--fg-3)",

--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -50,6 +50,10 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
     if (e.key === "Enter") handleSubmit();
   };
 
+  const resetHref = email.trim()
+    ? `/reset-password?email=${encodeURIComponent(email.trim().toLowerCase())}`
+    : "/reset-password";
+
   const inputStyle: React.CSSProperties = {
     background: "var(--overlay-bg)",
     border: "1px solid var(--border-1)",
@@ -199,7 +203,7 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
         </button>
         {mode === "login" && (
           <a
-            href="/reset-password"
+            href={resetHref}
             style={{
               alignSelf: "center",
               color: "var(--fg-3)",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -38,6 +38,21 @@ export const accountDeletionLog = pgTable("account_deletion_log", {
   userIdx: index("idx_account_deletion_log_user").on(table.userId),
 }));
 
+export const passwordResetTokens = pgTable("password_reset_tokens", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  userId: uuid("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
+  tokenHash: varchar("token_hash", { length: 64 }).unique().notNull(),
+  requestIpHash: varchar("request_ip_hash", { length: 64 }),
+  expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+  usedAt: timestamp("used_at", { withTimezone: true }),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  userIdx: index("idx_password_reset_tokens_user").on(table.userId),
+  tokenHashIdx: uniqueIndex("password_reset_tokens_token_hash_unique").on(table.tokenHash),
+  activeUserIdx: index("idx_password_reset_tokens_active_user").on(table.userId, table.expiresAt)
+    .where(sql`${table.usedAt} is null`),
+}));
+
 /** waiting | ready_check | active | completed | abandoned */
 export const buddySessions = pgTable("buddy_sessions", {
   id: uuid("id").primaryKey().defaultRandom(),
@@ -152,6 +167,11 @@ export const friendships = pgTable("friendships", {
 export const usersRelations = relations(users, ({ many }) => ({
   sessions: many(sessions),
   thoughts: many(thoughts),
+  passwordResetTokens: many(passwordResetTokens),
+}));
+
+export const passwordResetTokensRelations = relations(passwordResetTokens, ({ one }) => ({
+  user: one(users, { fields: [passwordResetTokens.userId], references: [users.id] }),
 }));
 
 export const buddySessionsRelations = relations(buddySessions, ({ one, many }) => ({

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -14,6 +14,14 @@ const fromAddress = process.env.EMAIL_FROM;
 const resendApiKey = process.env.RESEND_API_KEY;
 const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://still-point.me";
 
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
 export async function sendEmail({ to, subject, text, html, devLogMessage }: SendEmailParams) {
   if (!fromAddress || !resendApiKey) {
     if (process.env.NODE_ENV === "production") {
@@ -51,12 +59,13 @@ export async function sendPasswordResetEmail({ to, token }: { to: string; token:
   const resetUrl = new URL("/reset-password", appUrl);
   resetUrl.searchParams.set("token", token);
   const link = resetUrl.toString();
+  const escapedLink = escapeHtml(link);
 
   const result = await sendEmail({
     to,
     subject: "Reset your Still Point password",
     text: `Use this link to reset your Still Point password. It expires in ${PASSWORD_RESET_TTL_MINUTES} minutes:\n\n${link}\n\nIf you did not request this, you can ignore this email.`,
-    html: `<p>Use this link to reset your Still Point password. It expires in ${PASSWORD_RESET_TTL_MINUTES} minutes:</p><p><a href="${link}">Reset your password</a></p><p>If you did not request this, you can ignore this email.</p>`,
+    html: `<p>Use this link to reset your Still Point password. It expires in ${PASSWORD_RESET_TTL_MINUTES} minutes:</p><p><a href="${escapedLink}">Reset your password</a></p><p>If you did not request this, you can ignore this email.</p>`,
     devLogMessage: `Password reset link for local development: ${link}`,
   });
   return result;

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,53 @@
+import "server-only";
+
+type SendEmailParams = {
+  to: string;
+  subject: string;
+  text: string;
+  html?: string;
+};
+
+const fromAddress = process.env.EMAIL_FROM;
+const resendApiKey = process.env.RESEND_API_KEY;
+const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://still-point.me";
+
+export async function sendEmail({ to, subject, text, html }: SendEmailParams) {
+  if (!fromAddress || !resendApiKey) {
+    console.info("Email delivery skipped; EMAIL_FROM and RESEND_API_KEY are not both configured.");
+    return { delivered: false };
+  }
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${resendApiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: fromAddress,
+      to,
+      subject,
+      text,
+      ...(html ? { html } : {}),
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Email provider failed with status ${response.status}`);
+  }
+
+  return { delivered: true };
+}
+
+export async function sendPasswordResetEmail({ to, token }: { to: string; token: string }) {
+  const resetUrl = new URL("/reset-password", appUrl);
+  resetUrl.searchParams.set("token", token);
+  const link = resetUrl.toString();
+
+  return sendEmail({
+    to,
+    subject: "Reset your Still Point password",
+    text: `Use this link to reset your Still Point password. It expires in 30 minutes:\n\n${link}\n\nIf you did not request this, you can ignore this email.`,
+    html: `<p>Use this link to reset your Still Point password. It expires in 30 minutes:</p><p><a href="${link}">Reset your password</a></p><p>If you did not request this, you can ignore this email.</p>`,
+  });
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -7,20 +7,26 @@ type SendEmailParams = {
   subject: string;
   text: string;
   html?: string;
+  devLogMessage?: string;
 };
 
 const fromAddress = process.env.EMAIL_FROM;
 const resendApiKey = process.env.RESEND_API_KEY;
 const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://still-point.me";
 
-export async function sendEmail({ to, subject, text, html }: SendEmailParams) {
+export async function sendEmail({ to, subject, text, html, devLogMessage }: SendEmailParams) {
   if (!fromAddress || !resendApiKey) {
-    console.info("Email delivery skipped; EMAIL_FROM and RESEND_API_KEY are not both configured.");
+    if (process.env.NODE_ENV === "production") {
+      throw new Error("Email delivery is not configured");
+    }
+    console.info(devLogMessage ?? "Email delivery skipped; EMAIL_FROM and RESEND_API_KEY are not both configured.");
     return { delivered: false };
   }
 
+  const timeoutSignal = AbortSignal.timeout(10_000);
   const response = await fetch("https://api.resend.com/emails", {
     method: "POST",
+    signal: timeoutSignal,
     headers: {
       Authorization: `Bearer ${resendApiKey}`,
       "Content-Type": "application/json",
@@ -51,9 +57,7 @@ export async function sendPasswordResetEmail({ to, token }: { to: string; token:
     subject: "Reset your Still Point password",
     text: `Use this link to reset your Still Point password. It expires in ${PASSWORD_RESET_TTL_MINUTES} minutes:\n\n${link}\n\nIf you did not request this, you can ignore this email.`,
     html: `<p>Use this link to reset your Still Point password. It expires in ${PASSWORD_RESET_TTL_MINUTES} minutes:</p><p><a href="${link}">Reset your password</a></p><p>If you did not request this, you can ignore this email.</p>`,
+    devLogMessage: `Password reset link for local development: ${link}`,
   });
-  if (!result.delivered && process.env.NODE_ENV !== "production") {
-    console.info(`Password reset link for local development: ${link}`);
-  }
   return result;
 }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,5 +1,7 @@
 import "server-only";
 
+import { PASSWORD_RESET_TTL_MINUTES } from "@/lib/passwordReset";
+
 type SendEmailParams = {
   to: string;
   subject: string;
@@ -44,10 +46,14 @@ export async function sendPasswordResetEmail({ to, token }: { to: string; token:
   resetUrl.searchParams.set("token", token);
   const link = resetUrl.toString();
 
-  return sendEmail({
+  const result = await sendEmail({
     to,
     subject: "Reset your Still Point password",
-    text: `Use this link to reset your Still Point password. It expires in 30 minutes:\n\n${link}\n\nIf you did not request this, you can ignore this email.`,
-    html: `<p>Use this link to reset your Still Point password. It expires in 30 minutes:</p><p><a href="${link}">Reset your password</a></p><p>If you did not request this, you can ignore this email.</p>`,
+    text: `Use this link to reset your Still Point password. It expires in ${PASSWORD_RESET_TTL_MINUTES} minutes:\n\n${link}\n\nIf you did not request this, you can ignore this email.`,
+    html: `<p>Use this link to reset your Still Point password. It expires in ${PASSWORD_RESET_TTL_MINUTES} minutes:</p><p><a href="${link}">Reset your password</a></p><p>If you did not request this, you can ignore this email.</p>`,
   });
+  if (!result.delivered && process.env.NODE_ENV !== "production") {
+    console.info(`Password reset link for local development: ${link}`);
+  }
+  return result;
 }

--- a/src/lib/passwordReset.ts
+++ b/src/lib/passwordReset.ts
@@ -1,0 +1,136 @@
+import "server-only";
+
+import { createHash, randomBytes } from "crypto";
+import { SignJWT, jwtVerify } from "jose";
+import { and, eq, gt, isNull } from "drizzle-orm";
+import type { NextRequest } from "next/server";
+import { db } from "@/db";
+import { passwordResetTokens } from "@/db/schema";
+
+const TOKEN_BYTES = 32;
+export const PASSWORD_RESET_TTL_MINUTES = 60;
+const RESET_JWT_ISSUER = "still-point";
+const RESET_JWT_AUDIENCE = "password-reset";
+export const PASSWORD_RESET_REQUEST_MESSAGE =
+  "If an account exists for that email, a reset link will arrive shortly.";
+
+function getSecret() {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) throw new Error("JWT_SECRET not set");
+  return new TextEncoder().encode(secret);
+}
+
+export function passwordResetExpiresAt(now = new Date()) {
+  return new Date(now.getTime() + PASSWORD_RESET_TTL_MINUTES * 60 * 1000);
+}
+
+export function hashResetToken(token: string) {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+function hashResetRequestIp(ip: string | null) {
+  if (!ip) return null;
+  return createHash("sha256").update(ip).digest("hex");
+}
+
+export function normalizeResetEmail(email: unknown) {
+  if (typeof email !== "string") return "";
+  const normalized = email.trim().toLowerCase();
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized) ? normalized : "";
+}
+
+export function requestIpHash(request: NextRequest) {
+  const forwardedFor = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+  const ip = forwardedFor || request.headers.get("x-real-ip");
+  return hashResetRequestIp(ip);
+}
+
+export async function createPasswordResetToken({
+  userId,
+  email,
+}: {
+  userId: string;
+  email: string;
+}) {
+  const nonce = randomBytes(TOKEN_BYTES).toString("base64url");
+  return new SignJWT({ nonce, email })
+    .setProtectedHeader({ alg: "HS256" })
+    .setSubject(userId)
+    .setIssuer(RESET_JWT_ISSUER)
+    .setAudience(RESET_JWT_AUDIENCE)
+    .setIssuedAt()
+    .setExpirationTime(Math.floor(passwordResetExpiresAt().getTime() / 1000))
+    .sign(getSecret());
+}
+
+export async function confirmPasswordResetToken(token: string) {
+  try {
+    const { payload } = await jwtVerify(token, getSecret(), {
+      issuer: RESET_JWT_ISSUER,
+      audience: RESET_JWT_AUDIENCE,
+    });
+    if (typeof payload.sub !== "string" || typeof payload.nonce !== "string") {
+      return { ok: false as const };
+    }
+
+    const [resetToken] = await db
+      .update(passwordResetTokens)
+      .set({ usedAt: new Date() })
+      .where(
+        and(
+          eq(passwordResetTokens.userId, payload.sub),
+          eq(passwordResetTokens.tokenHash, hashResetToken(token)),
+          isNull(passwordResetTokens.usedAt),
+          gt(passwordResetTokens.expiresAt, new Date()),
+        ),
+      )
+      .returning({ userId: passwordResetTokens.userId });
+
+    if (!resetToken) {
+      return { ok: false as const };
+    }
+
+    return { ok: true as const, userId: resetToken.userId };
+  } catch {
+    return { ok: false as const };
+  }
+}
+
+type ResetAttempt = {
+  count: number;
+  resetAt: number;
+};
+
+const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+const RATE_LIMIT_MAX_ATTEMPTS = 5;
+const globalForPasswordReset = globalThis as typeof globalThis & {
+  __passwordResetAttempts?: Map<string, ResetAttempt>;
+};
+
+function attemptsStore() {
+  if (!globalForPasswordReset.__passwordResetAttempts) {
+    globalForPasswordReset.__passwordResetAttempts = new Map();
+  }
+  return globalForPasswordReset.__passwordResetAttempts;
+}
+
+function rateLimitKey(email: string, ipHash: string | null) {
+  return `${email}:${ipHash ?? "unknown"}`;
+}
+
+export function isPasswordResetRateLimited(email: string, ipHash: string | null) {
+  const now = Date.now();
+  const attempt = attemptsStore().get(rateLimitKey(email, ipHash));
+  return Boolean(attempt && attempt.resetAt > now && attempt.count >= RATE_LIMIT_MAX_ATTEMPTS);
+}
+
+export function recordPasswordResetAttempt(email: string, ipHash: string | null) {
+  const now = Date.now();
+  const key = rateLimitKey(email, ipHash);
+  const attempt = attemptsStore().get(key);
+  if (!attempt || attempt.resetAt <= now) {
+    attemptsStore().set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return;
+  }
+  attempt.count += 1;
+}

--- a/src/lib/passwordReset.ts
+++ b/src/lib/passwordReset.ts
@@ -4,8 +4,8 @@ import { createHash, randomBytes } from "crypto";
 import { SignJWT, jwtVerify } from "jose";
 import { and, eq, gt, isNull } from "drizzle-orm";
 import type { NextRequest } from "next/server";
-import { db } from "@/db";
 import { passwordResetTokens } from "@/db/schema";
+import type { PoolDb } from "@/db/pool";
 
 const TOKEN_BYTES = 32;
 export const PASSWORD_RESET_TTL_MINUTES = 60;
@@ -63,37 +63,45 @@ export async function createPasswordResetToken({
     .sign(getSecret());
 }
 
-export async function confirmPasswordResetToken(token: string) {
+export async function getPasswordResetPayload(token: string) {
   try {
     const { payload } = await jwtVerify(token, getSecret(), {
       issuer: RESET_JWT_ISSUER,
       audience: RESET_JWT_AUDIENCE,
     });
     if (typeof payload.sub !== "string" || typeof payload.nonce !== "string") {
-      return { ok: false as const };
+      return null;
     }
-
-    const [resetToken] = await db
-      .update(passwordResetTokens)
-      .set({ usedAt: new Date() })
-      .where(
-        and(
-          eq(passwordResetTokens.userId, payload.sub),
-          eq(passwordResetTokens.tokenHash, hashResetToken(token)),
-          isNull(passwordResetTokens.usedAt),
-          gt(passwordResetTokens.expiresAt, new Date()),
-        ),
-      )
-      .returning({ userId: passwordResetTokens.userId });
-
-    if (!resetToken) {
-      return { ok: false as const };
-    }
-
-    return { ok: true as const, userId: resetToken.userId };
+    return { userId: payload.sub, tokenHash: hashResetToken(token) };
   } catch {
+    return null;
+  }
+}
+
+export async function consumePasswordResetToken(tx: PoolDb, token: string) {
+  const payload = await getPasswordResetPayload(token);
+  if (!payload) {
     return { ok: false as const };
   }
+
+  const [resetToken] = await tx
+    .update(passwordResetTokens)
+    .set({ usedAt: new Date() })
+    .where(
+      and(
+        eq(passwordResetTokens.userId, payload.userId),
+        eq(passwordResetTokens.tokenHash, payload.tokenHash),
+        isNull(passwordResetTokens.usedAt),
+        gt(passwordResetTokens.expiresAt, new Date()),
+      ),
+    )
+    .returning({ userId: passwordResetTokens.userId });
+
+  if (!resetToken) {
+    return { ok: false as const };
+  }
+
+  return { ok: true as const, userId: resetToken.userId };
 }
 
 type ResetAttempt = {

--- a/src/lib/passwordReset.ts
+++ b/src/lib/passwordReset.ts
@@ -109,6 +109,11 @@ type ResetAttempt = {
   resetAt: number;
 };
 
+/**
+ * Lightweight per-process throttle for reset requests. This is intentionally
+ * paired with README guidance to keep platform/WAF throttling enabled in
+ * production, since serverless instances do not share globalThis state.
+ */
 const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
 const RATE_LIMIT_MAX_ATTEMPTS = 5;
 const globalForPasswordReset = globalThis as typeof globalThis & {

--- a/src/lib/passwordReset.ts
+++ b/src/lib/passwordReset.ts
@@ -47,13 +47,11 @@ export function requestIpHash(request: NextRequest) {
 
 export async function createPasswordResetToken({
   userId,
-  email,
 }: {
   userId: string;
-  email: string;
 }) {
   const nonce = randomBytes(TOKEN_BYTES).toString("base64url");
-  return new SignJWT({ nonce, email })
+  return new SignJWT({ nonce })
     .setProtectedHeader({ alg: "HS256" })
     .setSubject(userId)
     .setIssuer(RESET_JWT_ISSUER)
@@ -116,6 +114,7 @@ type ResetAttempt = {
  */
 const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
 const RATE_LIMIT_MAX_ATTEMPTS = 5;
+const RATE_LIMIT_MAX_KEYS = 1_000;
 const globalForPasswordReset = globalThis as typeof globalThis & {
   __passwordResetAttempts?: Map<string, ResetAttempt>;
 };
@@ -131,18 +130,36 @@ function rateLimitKey(email: string, ipHash: string | null) {
   return `${email}:${ipHash ?? "unknown"}`;
 }
 
+function pruneExpiredAttempts(now: number, store = attemptsStore()) {
+  for (const [key, attempt] of store) {
+    if (attempt.resetAt <= now) {
+      store.delete(key);
+    }
+  }
+}
+
 export function isPasswordResetRateLimited(email: string, ipHash: string | null) {
   const now = Date.now();
-  const attempt = attemptsStore().get(rateLimitKey(email, ipHash));
+  const store = attemptsStore();
+  pruneExpiredAttempts(now, store);
+  const attempt = store.get(rateLimitKey(email, ipHash));
   return Boolean(attempt && attempt.resetAt > now && attempt.count >= RATE_LIMIT_MAX_ATTEMPTS);
 }
 
 export function recordPasswordResetAttempt(email: string, ipHash: string | null) {
   const now = Date.now();
+  const store = attemptsStore();
+  pruneExpiredAttempts(now, store);
+  if (store.size >= RATE_LIMIT_MAX_KEYS) {
+    const oldestKey = store.keys().next().value as string | undefined;
+    if (oldestKey) {
+      store.delete(oldestKey);
+    }
+  }
   const key = rateLimitKey(email, ipHash);
-  const attempt = attemptsStore().get(key);
+  const attempt = store.get(key);
   if (!attempt || attempt.resetAt <= now) {
-    attemptsStore().set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    store.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
     return;
   }
   attempt.count += 1;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,6 +7,7 @@ const publicPaths = [
   "/api/auth/signup",
   "/api/auth/login",
   "/api/auth/logout",
+  "/api/auth/password-reset",
   "/api/board",
 ];
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add DB-backed single-use password reset tokens with expiring signed links.
- Add request and confirm API routes, reset email delivery, and reset web UI.
- Add discoverable web/iOS forgot-password entry points plus env and abuse notes.
- Rebase onto latest `main` and address all visible Bugbot and CodeRabbit comments, including latest follow-up feedback.

## Review comments addressed
- Made the manual SQL migration idempotent for the FK constraint and active-token index.
- Aligned reset email expiry copy with the 60-minute token TTL.
- Kept reset request response shape/status identical for unknown, repeated, rate-limited, and provider-failure paths.
- Serialized per-user reset-token issuance with a transaction/advisory lock and active-token uniqueness.
- Made password reset confirmation handle malformed JSON as 400 and consume the token in the same transaction as password update.
- Logged reset links in non-production when email provider env vars are unset, while failing fast for missing production email config.
- Added a 10s timeout and defensive HTML escaping to the email provider path.
- Removed email PII from reset page URLs and reset JWT payloads.
- Added semantic form submission and accessible labels to the reset form; clear email after successful reset request.
- Aligned E2E mocks with validation vs expired-token response contracts and stabilized WebKit form interactions.
- Documented and bounded the process-local rate limiter.
- Cleaned up the iOS in-flight reset guard.

## Walkthrough
[password_reset_web_flow.mp4](https://cursor.com/agents/bc-623a4a84-d512-4011-b238-3e543022ad4b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpassword_reset_web_flow.mp4)
[Reset request page with prefilled email](https://cursor.com/agents/bc-623a4a84-d512-4011-b238-3e543022ad4b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freset_request_prefilled.webp)
[Set new password page](https://cursor.com/agents/bc-623a4a84-d512-4011-b238-3e543022ad4b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freset_set_password.webp)

## Testing
- `npm run build` passes.
- `npx tsc --noEmit` passes.
- `PORT=3012 npx playwright test e2e/auth/password-reset.spec.ts` passes across mobile Chromium and WebKit iPhone projects.
- `npm run test:unit` currently fails in pre-existing rebased `src/lib/thoughtSaving.test.ts` because it uses `node:test` under the new Vitest runner; unrelated to this password reset PR.

## Notes
- No secrets are committed; `.env.example` documents placeholders only.
- `swift test` could not run because Swift is not installed on this Linux image; GitHub iOS workflows will rerun on push.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-623a4a84-d512-4011-b238-3e543022ad4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-623a4a84-d512-4011-b238-3e543022ad4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password reset via email across web and iOS with single-use links (1‑hour expiry), generic success messaging, per-email+IP rate limits, Reset Password page, and a “Forgot password?” entry; UI shows in-progress state and disables actions during requests.

* **Tests**
  * New end-to-end and iOS UI tests covering request and confirm flows.

* **Documentation**
  * README and .env.example updated with optional email settings, public app URL default, and dev behavior (reset links logged locally when email delivery isn’t configured).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->