### PR TITLE
Document iOS release automation scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,15 @@ Production should continue to use the production Neon URL for `POSTGRES_URL`.
 
 The app is live at [still-point.me](https://still-point.me).
 
+## Release operations
+
+All iOS release and App Store submission work must reference:
+
+- [iOS release / TestFlight runbook](ios/RELEASING.md)
+- [iOS App Store submission and delegation runbook](docs/operations/ios-app-store-submission.md)
+
+Use these files as the source of truth when creating GitHub issues, delegating release tasks, or asking AI coding agents to prepare release work. The TestFlight upload path is automated through GitHub Actions; the App Store submission runbook identifies which App Store Connect steps are automatable through Apple's API and which still require an Account Holder/Admin or human release decision.
+
 ### Neon (database)
 
 Serverless Postgres hosted on [Neon](https://neon.tech). The connection uses `@neondatabase/serverless` with HTTP queries (no persistent connections).

--- a/docs/operations/ios-app-store-submission.md
+++ b/docs/operations/ios-app-store-submission.md
@@ -10,6 +10,24 @@ Use this runbook after an iOS build has been uploaded to TestFlight and before c
 
 Record submission status, reviewer notes, build strings, and final outcome in ops tracker #103. Use `ios/RELEASING.md` for tag format, build bumps, and CI upload details.
 
+## Automation scope
+
+The current pipeline already automates build/archive/upload to TestFlight through GitHub Actions. App Store Connect also has API coverage for many post-upload tasks, so future tooling can automate or prefill parts of this runbook instead of requiring every step to be pasted into the website.
+
+Can be automated:
+
+- Create or locate the target App Store version.
+- Attach the processed TestFlight build to that version.
+- Read and update metadata, release notes, privacy policy URL, and review contact fields where App Store Connect API support exists.
+- Upload screenshots, app previews, and App Review attachments such as the account-deletion recording.
+- Submit the completed version for review and poll review/status transitions.
+
+Must stay human-owned:
+
+- Apple Developer and App Store Connect Agreements, Tax, and Banking must be clear for the account.
+- Screenshots, reviewer notes, demo credentials, age rating, export compliance, and release timing need a human owner unless a dedicated automation issue explicitly supplies approved source files and copy.
+- Rejections need human triage before engineering issues are created, even if status polling and reviewer-note capture are automated.
+
 ## Phase A - Preconditions before submission
 
 | # | Check | Owner | Evidence / action |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a README release operations section that points all iOS release/submission work to the canonical runbooks.
- Document which App Store submission steps can be automated through App Store Connect APIs and which remain human-owned.

## Testing
- Verified README references the iOS submission runbook.
- Verified the submission runbook still has 24 checklist rows.
- Verified automation guidance headings are present.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e69cf7c-d9ff-4c2e-b7f0-2109960156a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e69cf7c-d9ff-4c2e-b7f0-2109960156a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive iOS release operations documentation detailing TestFlight upload and App Store submission workflows as centralized runbooks.
  * Documented automation scope boundaries for App Store Connect tasks, clarifying which steps can be automated through GitHub Actions and Apple's APIs versus those requiring human oversight for approvals and content decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->