### PR TITLE
Fix iOS archive compile errors

### DIFF
--- a/ios/QA_CHECKLIST.md
+++ b/ios/QA_CHECKLIST.md
@@ -1,7 +1,7 @@
 # iOS Release Candidate QA Checklist (Issue #210)
 
-Release candidate: 1.0.3 (6)  
-Last updated: 2026-04-24  
+Release candidate: 1.0.3 (7)
+Last updated: 2026-04-25
 QA owner: iOS QA DRI
 
 ## 1) Smoke + regression pass
@@ -31,7 +31,7 @@ QA owner: iOS QA DRI
 
 ## 3) Release metadata + submission readiness
 
-- [x] `ios/project.yml` versioning finalized: `MARKETING_VERSION = 1.0.3`, `CURRENT_PROJECT_VERSION = 6`.
+- [x] `ios/project.yml` versioning finalized: `MARKETING_VERSION = 1.0.3`, `CURRENT_PROJECT_VERSION = 7`.
 - [x] App Store release notes finalized for this build (see `ios/RELEASING.md`).
 - [x] App Store metadata checklist finalized (privacy policy URL, support URL, account deletion review notes).
 - [ ] Build submitted to App Store review in App Store Connect.

--- a/ios/RELEASING.md
+++ b/ios/RELEASING.md
@@ -36,17 +36,17 @@ Before your first TestFlight release, configure a tester group and handle encryp
 2. Update the version in `ios/project.yml`:
    ```yaml
    MARKETING_VERSION: "1.0.3"
-   CURRENT_PROJECT_VERSION: 6
+   CURRENT_PROJECT_VERSION: 7
    ```
 3. Commit release artifacts + version bump:
    ```bash
    git add ios/project.yml ios/PARITY_CHECKLIST.md ios/QA_CHECKLIST.md ios/RELEASING.md
-   git commit -m "Finalize iOS 1.0.3 (build 6) release readiness"
+   git commit -m "Finalize iOS 1.0.3 (build 7) release readiness"
    ```
 4. Tag and push:
    ```bash
-   git tag ios-v1.0.3
-   git push origin ios-v1.0.3
+   git tag ios-v1.0.3-build7
+   git push origin ios-v1.0.3-build7
    ```
 5. The GitHub Actions workflow builds and uploads to TestFlight automatically.
 6. After Apple processes the build (~15 minutes), it appears in the TestFlight app.

--- a/ios/StillPointApp/ViewModels/BuddySessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/BuddySessionViewModel.swift
@@ -54,8 +54,7 @@ final class BuddySessionViewModel {
     func startPolling() {
         guard pollTask == nil else { return }
         pollTask = Task { [weak self] in
-            guard let self else { return }
-            await self.refreshSnapshot()
+            await self?.refreshSnapshot()
             while !Task.isCancelled {
                 do {
                     try await Task.sleep(nanoseconds: 1_500_000_000)
@@ -63,6 +62,7 @@ final class BuddySessionViewModel {
                     return
                 }
                 guard !Task.isCancelled else { return }
+                guard let self else { return }
                 await self.refreshSnapshot()
             }
         }

--- a/ios/StillPointApp/ViewModels/BuddySessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/BuddySessionViewModel.swift
@@ -46,6 +46,7 @@ final class BuddySessionViewModel {
         self.currentUserId = currentUserId
     }
 
+    @MainActor
     deinit {
         pollTask?.cancel()
     }

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -194,6 +194,22 @@ public struct RecordBuddyPersonalSessionRequest: Codable, Sendable {
     public let actualTime: Int
     public let sessionDate: String
     public let thoughts: [BatchThoughtsRequest.ThoughtInput]?
+
+    public init(
+        clearPercent: Int,
+        thoughtCount: Int,
+        mindStateLog: [MindStateEntry],
+        actualTime: Int,
+        sessionDate: String,
+        thoughts: [BatchThoughtsRequest.ThoughtInput]?
+    ) {
+        self.clearPercent = clearPercent
+        self.thoughtCount = thoughtCount
+        self.mindStateLog = mindStateLog
+        self.actualTime = actualTime
+        self.sessionDate = sessionDate
+        self.thoughts = thoughts
+    }
 }
 
 // MARK: - API Wrappers (match JSON response shapes)

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -47,7 +47,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint
         MARKETING_VERSION: "1.0.3"
-        CURRENT_PROJECT_VERSION: 6
+        CURRENT_PROJECT_VERSION: 7
         DEVELOPMENT_TEAM: T5UU4BP6AV
         CODE_SIGN_STYLE: Automatic
         SWIFT_VERSION: "5.9"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a public initializer for `RecordBuddyPersonalSessionRequest` so the app target can construct the shared DTO.
- Mark `BuddySessionViewModel` deinit as `@MainActor` so polling cleanup can access the main-actor-isolated task.
- Avoid retaining `BuddySessionViewModel` for the lifetime of the polling task.
- Bump the iOS release candidate from `1.0.3 (6)` to `1.0.3 (7)` and document the next TestFlight tag as `ios-v1.0.3-build7` because `ios-v1.0.3` was already used for the failed archive attempt.

## Testing
- `git diff --check`
- Validated `ios/project.yml`, `ios/QA_CHECKLIST.md`, and `ios/RELEASING.md` agree on build 7 / `ios-v1.0.3-build7`.
- Attempted TestFlight tag `ios-v1.0.3`; workflow failed during archive before upload with the compile errors fixed here.
- PR CI was green before the build bump and is being re-run after this update.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e69cf7c-d9ff-4c2e-b7f0-2109960156a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e69cf7c-d9ff-4c2e-b7f0-2109960156a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved thread-safety for session polling and cancellation to reduce race conditions and ensure UI-related work runs on the main thread.
  * Added a memberwise initializer to improve reliability of personal session recording and related submissions.

* **Documentation**
  * Bumped iOS build version and updated release instructions and checklist to reflect the new build number.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->