### PR TITLE
Externalize Neon WS driver to fix prod transactions

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // Externalize Neon's WS driver and `ws` so Next does not bundle them.
+  // Bundling tree-shakes `ws`'s mask path on Vercel and crashes every
+  // `poolDb.transaction()` with `b.mask is not a function`. See #246.
+  serverExternalPackages: ["@neondatabase/serverless", "ws"],
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

- Adds `serverExternalPackages: ["@neondatabase/serverless", "ws"]` to [next.config.ts](next.config.ts).
- Fixes `b.mask is not a function` / `Connection terminated unexpectedly` 500s on every Vercel-hosted `poolDb.transaction(...)` route — confirmed broken today on `/api/auth/password-reset/request` and `/api/thoughts/batch`.
- No code changes, no schema changes, no new dependencies.

Closes #246

## Background

Next.js 15's bundler tree-shakes `ws`'s optional native `bufferutil` and leaves the JS fallback's `mask` reference dangling at runtime. Every WebSocket frame send fails on `BEGIN`. Local development is unaffected (Next does not bundle node_modules in dev). Login and other routes that use the HTTP `db` client are unaffected — only routes that go through `src/db/pool.ts` for `transaction()` break.

The code comment at `src/db/index.ts:31` already anticipated WS hangs on Vercel; this PR closes the bundling gap that completed the failure mode.

Verified prod error trace via `vercel logs --status-code 500 --expand`:

```
Password reset request error: Error: Failed query: begin params:
  at o.transaction (.../password-reset/request/route.js)

[cause]: Error: Connection terminated unexpectedly
TypeError: b.mask is not a function
  at a.exports.mask
  at r.frame
  at r.dispatch
  at r.send
```

`serverExternalPackages` is the upstream-recommended Next 15 setup for Neon's serverless driver.

## Test plan

- [ ] Vercel preview build succeeds for this PR.
- [ ] On the preview deployment, `curl -X POST https://<preview>/api/auth/password-reset/request -H 'Content-Type: application/json' -d '{"email":"<real account email>"}'` returns HTTP 200 with the cover message.
- [ ] On the preview deployment, the recipient receives the Resend email with a working reset link.
- [ ] On the preview deployment, completing a meditation session writes thoughts via `/api/thoughts/batch` (200, no 500 in logs).
- [ ] Login works on the preview (web + iOS) — no regression.
- [ ] `vercel logs <preview-url> --status-code 500 --since 30m` shows no `b.mask is not a function` and no `Connection terminated unexpectedly` after smoke tests.

## Out of scope

- Refactoring `poolDb.transaction(...)` callsites to drop WS dependency entirely. The unique partial index `password_reset_tokens_active_user_unique` already provides race safety, but rewriting business logic is larger and riskier than externalizing the bundle.
- Schema-vs-migration drift on `idx_password_reset_tokens_active_user` (schema declares non-unique, applied SQL is unique). Worth a separate cleanup issue.

## Risk

Very low. `serverExternalPackages` is documented Next 15 API. Worst case: fix doesn't help → revert one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server-side configuration to optimize how external dependencies are handled during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->