### PR TITLE
Fix iOS Begin button crash from invalid currentDay (#250)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"ebaad5d5-7a92-4c36-bec5-0d947d4f6bb2","pid":7032,"procStart":"Mon Apr 27 19:04:08 2026","acquiredAt":1777316876545}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"ebaad5d5-7a92-4c36-bec5-0d947d4f6bb2","pid":7032,"procStart":"Mon Apr 27 19:04:08 2026","acquiredAt":1777316876545}

--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,8 @@ ios/StillPointShared/.build/
 .claude/worktrees/
 .worktrees/
 
+# Local agent runtime artifacts
+.claude/scheduled_tasks.lock
+
 # Auth Keys
 *.p8

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -49,9 +49,7 @@ final class AppViewModel {
     private var pendingBuddyInviteToken: String?
 
     var currentDay: Int {
-        // Server may transiently return 0/negative; clamp to keep `StillPoint.duration(forDay:)`
-        // out of its defensive trap and avoid crashing the session UI.
-        max(currentUser?.currentDay ?? 1, 1)
+        StillPoint.clampedCurrentDay(for: currentUser)
     }
 
     var todayDuration: Int {

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -49,7 +49,9 @@ final class AppViewModel {
     private var pendingBuddyInviteToken: String?
 
     var currentDay: Int {
-        currentUser?.currentDay ?? 1
+        // Server may transiently return 0/negative; clamp to keep `StillPoint.duration(forDay:)`
+        // out of its defensive trap and avoid crashing the session UI.
+        max(currentUser?.currentDay ?? 1, 1)
     }
 
     var todayDuration: Int {

--- a/ios/StillPointShared/Sources/StillPointShared/Constants.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/Constants.swift
@@ -10,10 +10,15 @@ public enum StillPoint {
     /// Visual block duration in seconds
     public static let blockDuration = 10
 
-    /// Calculate session duration for a given day number
+    /// Calculate session duration for a given day number.
+    ///
+    /// Clamps `day` to `>= 1` so production code never traps on bad upstream data
+    /// (e.g. a server returning `0`). A debug-only `assertionFailure` still surfaces
+    /// the upstream bug during development.
     public static func duration(forDay day: Int) -> Int {
-        precondition(day >= 1, "Day must be >= 1")
-        return baseDuration + (day - 1) * increment
+        assert(day >= 1, "Day must be >= 1, got \(day)")
+        let safeDay = max(day, 1)
+        return baseDuration + (safeDay - 1) * increment
     }
 
     /// Calculate number of blocks for a given duration

--- a/ios/StillPointShared/Sources/StillPointShared/Constants.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/Constants.swift
@@ -13,7 +13,7 @@ public enum StillPoint {
     /// Calculate session duration for a given day number.
     ///
     /// Clamps `day` to `>= 1` so production code never traps on bad upstream data
-    /// (e.g. a server returning `0`). A debug-only `assertionFailure` still surfaces
+    /// (e.g. a server returning `0`). A debug-only `assert` still surfaces
     /// the upstream bug during development.
     public static func duration(forDay day: Int) -> Int {
         assert(day >= 1, "Day must be >= 1, got \(day)")

--- a/ios/StillPointShared/Sources/StillPointShared/Constants.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/Constants.swift
@@ -25,4 +25,13 @@ public enum StillPoint {
     public static func blockCount(forDuration duration: Int) -> Int {
         Int(ceil(Double(duration) / Double(blockDuration)))
     }
+
+    /// Resolve the effective `currentDay` for the UI, clamped to `>= 1`.
+    ///
+    /// The server can transiently return `0` or a negative `currentDay`; both
+    /// would otherwise propagate into `duration(forDay:)` and crash callers.
+    /// `nil` (no signed-in user) defaults to day 1.
+    public static func clampedCurrentDay(for user: UserDTO?) -> Int {
+        max(user?.currentDay ?? 1, 1)
+    }
 }

--- a/ios/StillPointShared/Tests/StillPointSharedTests/StillPointDurationTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/StillPointDurationTests.swift
@@ -21,9 +21,38 @@ final class StillPointDurationTests: XCTestCase {
         XCTAssertEqual(StillPoint.blockCount(forDuration: 65), 7)
     }
 
-    // Note: invalid days (`< 1`) are tested implicitly — the production code path
-    // clamps via `max(day, 1)` so a `day == 0` input cannot crash a Release build.
-    // We can't unit-test that branch directly because the companion `assert` traps
-    // in Debug (the test runner's configuration), which is the desired dev-time
-    // behavior. Coverage of `AppViewModel.currentDay`'s clamp lives in the app.
+    // Note: invalid days (`< 1`) are tested via `clampedCurrentDay(for:)` below.
+    // Calling `duration(forDay:)` with `< 1` traps the debug `assert` in the
+    // test runner (intended dev behavior); production builds survive via the
+    // `max(day, 1)` clamp.
+
+    // MARK: - clampedCurrentDay edge cases
+
+    func testClampedCurrentDayWithNilUserReturnsOne() {
+        XCTAssertEqual(StillPoint.clampedCurrentDay(for: nil), 1)
+    }
+
+    func testClampedCurrentDayWithZeroReturnsOne() {
+        XCTAssertEqual(StillPoint.clampedCurrentDay(for: makeUser(currentDay: 0)), 1)
+    }
+
+    func testClampedCurrentDayWithNegativeReturnsOne() {
+        XCTAssertEqual(StillPoint.clampedCurrentDay(for: makeUser(currentDay: -5)), 1)
+    }
+
+    func testClampedCurrentDayWithValidPositiveReturnsValue() {
+        XCTAssertEqual(StillPoint.clampedCurrentDay(for: makeUser(currentDay: 1)), 1)
+        XCTAssertEqual(StillPoint.clampedCurrentDay(for: makeUser(currentDay: 7)), 7)
+        XCTAssertEqual(StillPoint.clampedCurrentDay(for: makeUser(currentDay: 365)), 365)
+    }
+
+    private func makeUser(currentDay: Int) -> UserDTO {
+        UserDTO(
+            id: "u1",
+            email: "test@example.com",
+            username: "tester",
+            isPublic: false,
+            currentDay: currentDay
+        )
+    }
 }

--- a/ios/StillPointShared/Tests/StillPointSharedTests/StillPointDurationTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/StillPointDurationTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import StillPointShared
+
+final class StillPointDurationTests: XCTestCase {
+    func testDurationAtDayOneReturnsBaseDuration() {
+        XCTAssertEqual(StillPoint.duration(forDay: 1), StillPoint.baseDuration)
+    }
+
+    func testDurationGrowsByIncrementPerDay() {
+        XCTAssertEqual(StillPoint.duration(forDay: 2), StillPoint.baseDuration + StillPoint.increment)
+        XCTAssertEqual(StillPoint.duration(forDay: 5), StillPoint.baseDuration + 4 * StillPoint.increment)
+        XCTAssertEqual(StillPoint.duration(forDay: 30), StillPoint.baseDuration + 29 * StillPoint.increment)
+    }
+
+    func testBlockCountForBaseDuration() {
+        XCTAssertEqual(StillPoint.blockCount(forDuration: StillPoint.baseDuration), 6)
+    }
+
+    func testBlockCountRoundsUpForPartialBlocks() {
+        // 65s = 6 full 10s blocks + 1 partial → 7 blocks
+        XCTAssertEqual(StillPoint.blockCount(forDuration: 65), 7)
+    }
+
+    // Note: invalid days (`< 1`) are tested implicitly — the production code path
+    // clamps via `max(day, 1)` so a `day == 0` input cannot crash a Release build.
+    // We can't unit-test that branch directly because the companion `assert` traps
+    // in Debug (the test runner's configuration), which is the desired dev-time
+    // behavior. Coverage of `AppViewModel.currentDay`'s clamp lives in the app.
+}


### PR DESCRIPTION
## Summary

Tapping **Begin** on the iOS Home screen was crashing the app on the App Store build (1.0.3 build 8) before the timer view could render — a hard regression reported in #250.

CodeRabbit's plan-on-issue identified the proximate cause: [`StillPoint.duration(forDay:)`](ios/StillPointShared/Sources/StillPointShared/Constants.swift#L14-L17) has a `precondition(day >= 1)` that traps when the server returns `currentDay: 0` (or negative), and [`AppViewModel.currentDay`](ios/StillPointApp/ViewModels/AppViewModel.swift#L51-L55) only guarded `nil` with `?? 1`. This PR applies CR's targeted clamp **and** adds defense-in-depth at the precondition site so production cannot crash from bad upstream day numbers regardless of caller.

## Changes

- **[AppViewModel.swift](ios/StillPointApp/ViewModels/AppViewModel.swift#L51-L55):** `currentDay` now returns `max(currentUser?.currentDay ?? 1, 1)`. Protects the `SessionView` mount path that the Begin button triggers.
- **[Constants.swift](ios/StillPointShared/Sources/StillPointShared/Constants.swift#L13-L21):** `StillPoint.duration(forDay:)` replaces the fatal `precondition` with a debug-only `assert` + `max(day, 1)` clamp. Dev still gets the trap signal for upstream bugs; Release builds survive bad data.
- **[StillPointDurationTests.swift](ios/StillPointShared/Tests/StillPointSharedTests/StillPointDurationTests.swift):** new tests pinning the duration formula at `day == 1` and beyond, plus the `blockCount` rounding behavior.

## Why both fixes

CR's clamp at `AppViewModel.currentDay` is correct and minimal. But the same precondition is reachable through other call sites ([`SessionViewModel.swift:340`](ios/StillPointApp/ViewModels/SessionViewModel.swift#L340), [`CompletionView.swift:19`](ios/StillPointApp/Views/CompletionView.swift#L19)), and [`HomeView.swift:36`](ios/StillPointApp/Views/HomeView.swift#L36) already exercises that path before Begin is tapped — so a future bug producing a bad day number anywhere should not be able to crash users in production. Hardening the function itself is a strict win and consistent with the existing `max(store.user.currentDay, 1)` clamps already present in [`APIClient.swift:374`](ios/StillPointShared/Sources/StillPointShared/APIClient.swift#L374) and [`:475`](ios/StillPointShared/Sources/StillPointShared/APIClient.swift#L475).

## What this PR does **not** cover

- **Crash log not yet obtained** — without the symbolicated `.ips` we can't 100% confirm this was the proximate cause vs. some other Release-only path (e.g. `AudioEngine` warmUp). The fix is defense-in-depth either way; if a different root cause exists it's a separate fix on top.
- **Server-side data audit** — if real users ended up with `currentDay: 0` in the database, the writer that produced that needs investigation. Tracked separately.
- **Why the existing E2E test didn't catch this** — covered in #253.
- **End-of-session note save error** — covered in #254.

## Test plan

- [ ] `swift test` from `ios/StillPointShared/` passes (new + existing tests)
- [ ] iOS app builds cleanly under Release configuration (Xcode archive)
- [ ] On a Release-signed device install: tapping Begin loads the timer (no crash)
- [ ] On a Release-signed device install: completing a session reaches CompletionView
- [ ] CR review on the PR is clean

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents crashes from invalid "day" values by clamping inputs to a safe minimum and using debug-only checks.
  * Ensures the app reports a safe current day when user data is missing or out-of-range, fixing downstream duration/display issues.

* **Tests**
  * Added tests for duration, block-count calculations, and day-clamping/validation behavior.

* **Chores**
  * Ignore local agent runtime lockfile to avoid committing it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->