### PR TITLE
Bump iOS to 1.0.3 (build 9) to ship Begin-crash fix (#259)

### DIFF
--- a/ios/QA_CHECKLIST.md
+++ b/ios/QA_CHECKLIST.md
@@ -1,7 +1,7 @@
 # iOS Release Candidate QA Checklist (Issue #210)
 
-Release candidate: 1.0.3 (8)
-Last updated: 2026-04-25
+Release candidate: 1.0.3 (9)
+Last updated: 2026-04-27
 QA owner: iOS QA DRI
 
 ## 1) Smoke + regression pass
@@ -31,7 +31,7 @@ QA owner: iOS QA DRI
 
 ## 3) Release metadata + submission readiness
 
-- [x] `ios/project.yml` versioning finalized: `MARKETING_VERSION = 1.0.3`, `CURRENT_PROJECT_VERSION = 8`.
+- [x] `ios/project.yml` versioning finalized: `MARKETING_VERSION = 1.0.3`, `CURRENT_PROJECT_VERSION = 9`.
 - [x] App Store release notes finalized for this build (see `ios/RELEASING.md`).
 - [x] App Store metadata checklist finalized (privacy policy URL, support URL, account deletion review notes).
 - [ ] Build submitted to App Store review in App Store Connect.

--- a/ios/QA_CHECKLIST.md
+++ b/ios/QA_CHECKLIST.md
@@ -36,7 +36,7 @@ QA owner: iOS QA DRI
 - [x] App Store metadata checklist finalized (privacy policy URL, support URL, account deletion review notes).
 - [ ] Build submitted to App Store review in App Store Connect.
   - Owner: iOS release DRI
-  - Target date: 2026-04-24
+  - Target date: 2026-04-29 (after TestFlight build 9 smoke test passes)
   - Completion evidence: attach App Store Connect submission timestamp and build number in PR comment.
 
 ## Release gate decision (Issue #210)

--- a/ios/RELEASING.md
+++ b/ios/RELEASING.md
@@ -36,17 +36,17 @@ Before your first TestFlight release, configure a tester group and handle encryp
 2. Update the version in `ios/project.yml`:
    ```yaml
    MARKETING_VERSION: "1.0.3"
-   CURRENT_PROJECT_VERSION: 8
+   CURRENT_PROJECT_VERSION: 9
    ```
 3. Commit release artifacts + version bump:
    ```bash
    git add ios/project.yml ios/PARITY_CHECKLIST.md ios/QA_CHECKLIST.md ios/RELEASING.md
-   git commit -m "Finalize iOS 1.0.3 (build 8) release readiness"
+   git commit -m "Finalize iOS 1.0.3 (build 9) release readiness"
    ```
 4. Tag and push:
    ```bash
-   git tag ios-v1.0.3-build8
-   git push origin ios-v1.0.3-build8
+   git tag ios-v1.0.3-build9
+   git push origin ios-v1.0.3-build9
    ```
 5. The GitHub Actions workflow builds and uploads to TestFlight automatically.
 6. After Apple processes the build (~15 minutes), it appears in the TestFlight app.

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -47,7 +47,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint
         MARKETING_VERSION: "1.0.3"
-        CURRENT_PROJECT_VERSION: 8
+        CURRENT_PROJECT_VERSION: 9
         DEVELOPMENT_TEAM: T5UU4BP6AV
         CODE_SIGN_STYLE: Automatic
         SWIFT_VERSION: "5.9"


### PR DESCRIPTION
## Summary

Bump iOS to 1.0.3 (build 9) so the Begin-button crash fix from #250 / [PR #256](https://github.com/auerbachb/still-point/pull/256) reaches TestFlight and the App Store. Build 8 (currently shipping) is broken — every Begin tap crashes.

- [ios/project.yml](ios/project.yml): \`CURRENT_PROJECT_VERSION: 8\` → \`9\`
- [ios/QA_CHECKLIST.md](ios/QA_CHECKLIST.md): header + line 34
- [ios/RELEASING.md](ios/RELEASING.md): example commands updated to \`ios-v1.0.3-build9\`

## Next steps after merge

Per [\`ios/RELEASING.md\`](ios/RELEASING.md):

\`\`\`bash
git checkout main && git pull
git tag ios-v1.0.3-build9
git push origin ios-v1.0.3-build9
\`\`\`

The tag push triggers [.github/workflows/ios-testflight.yml](.github/workflows/ios-testflight.yml) which archives + uploads to TestFlight automatically.

## Test plan

- [ ] Local CR review clean
- [ ] CI green
- [ ] After merge: \`ios-v1.0.3-build9\` tag pushed
- [ ] TestFlight upload succeeds
- [ ] Smoke test on device: Begin → timer loads, complete a session
- [ ] Promote build 9 to App Store after TestFlight smoke passes

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped iOS build number from 8 to 9 across release metadata and documentation.
  * Updated release checklist and procedure text to reflect the new build and suggested commit/tag names.
  * Revised App Store submission target date to 2026-04-29 and added a note linking the sequence to TestFlight build 9 smoke test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->