### PR TITLE
Add iOS Release-config UI test gate to TestFlight workflow (#253)

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -76,3 +76,12 @@ jobs:
           path: artifacts/e2e/ios/**
           if-no-files-found: warn
           retention-days: 14
+
+      - name: Upload simulator diagnostic reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-ios-${{ matrix.lane }}-diagreports
+          path: ~/Library/Logs/DiagnosticReports/**
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -13,7 +13,74 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  pre-flight-tests:
+    name: Release-config UI smoke gate
+    runs-on: macos-26
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install XcodeGen
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if brew install xcodegen; then
+              exit 0
+            fi
+            if [[ "$attempt" -lt 3 ]]; then
+              sleep $((attempt * 10))
+            fi
+          done
+          echo "Failed to install xcodegen after 3 attempts."
+          exit 1
+
+      - name: Generate Xcode project
+        working-directory: ios
+        run: xcodegen generate
+
+      - name: Run iOS smoke lane in Release configuration
+        # iOS UI tests run fully in-app via SP_UI_TEST_MODE=1 (set in
+        # StillPointAppUITests.makeApp); no real backend is reached, so
+        # we deliberately omit E2E_BASE_URL and credentials here.
+        env:
+          E2E_ENV: ci
+          E2E_SECRETS_REQUIRED: "false"
+          IOS_TEST_CONFIGURATION: "Release"
+        run: npm run e2e:ios:smoke
+
+      - name: Upload simulator diagnostic reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-testflight-preflight-diagreports
+          path: ~/Library/Logs/DiagnosticReports/**
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload xcresult bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-testflight-preflight-xcresult
+          path: artifacts/e2e/ios/**
+          if-no-files-found: warn
+          retention-days: 14
+
   build-and-upload:
+    needs: pre-flight-tests
     runs-on: macos-26
     timeout-minutes: 30
 

--- a/ios/QA_CHECKLIST.md
+++ b/ios/QA_CHECKLIST.md
@@ -44,3 +44,19 @@ QA owner: iOS QA DRI
 - [x] Regression/QA pass for release candidate is completed.
 - [x] App Store metadata/versioning/release notes are finalized.
 - [ ] Updated iOS build is submitted to App Store by end of week.
+
+## Pre-tag manual smoke (Issue #253)
+
+Run these on a Release-signed device install **before** pushing the `ios-v*` tag.
+The CI pre-flight gate runs the same suite in Release config on simulator, but a
+real-device pass before tagging is the final guard against optimization/codegen
+bugs that only surface on hardware (e.g. the build 8 Begin-tap crash).
+
+- [ ] Build a Release archive locally and install via Xcode → Window → Devices and Simulators → drag `.ipa`.
+- [ ] Sign in with a known account.
+- [ ] Tap **Begin** and verify the timer screen loads without crash.
+- [ ] Let the session run to completion (or End Early) and verify CompletionView appears.
+- [ ] Type a session note, tap **Save note**, and verify the green "Saved" indicator.
+- [ ] Tap **Return** and verify Home reflects the new day count.
+- [ ] Pull crash logs from device after the run (Settings → Privacy & Security → Analytics & Improvements → Analytics Data) and verify no `StillPointApp-*.ips` from this session.
+- [ ] Record the device model + iOS version in the release PR before pushing the tag.

--- a/ios/QA_CHECKLIST.md
+++ b/ios/QA_CHECKLIST.md
@@ -52,7 +52,7 @@ The CI pre-flight gate runs the same suite in Release config on simulator, but a
 real-device pass before tagging is the final guard against optimization/codegen
 bugs that only surface on hardware (e.g. the build 8 Begin-tap crash).
 
-- [ ] Build a Release archive locally and install via Xcode → Window → Devices and Simulators → drag `.ipa`.
+- [ ] Install the just-uploaded TestFlight build on a physical device via the TestFlight app (so QA exercises the exact archive that will ship). Alternative if TestFlight processing is delayed: in Xcode, **Product → Archive**, then **Distribute App → Custom → Ad Hoc** to export an `.ipa`, then drag the `.ipa` onto your device in **Window → Devices and Simulators**. A bare `.xcarchive` is not directly installable.
 - [ ] Sign in with a known account.
 - [ ] Tap **Begin** and verify the timer screen loads without crash.
 - [ ] Let the session run to completion (or End Early) and verify CompletionView appears.

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -70,7 +70,13 @@ final class AppViewModel {
     func checkAuth() async {
         let startedAt = Date()
         isLoading = true
-        defer { isLoading = false }
+        defer {
+            isLoading = false
+            // Diagnostic for issue #266 / PR #261 — log the post-checkAuth view
+            // state so we can correlate with APIClient.init's [E2E-DIAG] line
+            // when iOS UI tests fail on the auth-screen waitForExistence.
+            print("[E2E-DIAG] checkAuth.done currentView=\(viewSlug(currentView)) currentUser=\(currentUser?.email ?? "nil") elapsedMs=\(Int(Date().timeIntervalSince(startedAt) * 1_000))")
+        }
 
         do {
             if let user = try await APIClient.shared.me() {
@@ -95,6 +101,21 @@ final class AppViewModel {
             authStatusMessage = "Connection failed. Please try again."
         }
         lastColdStartAuthCheckMs = Int(Date().timeIntervalSince(startedAt) * 1_000)
+    }
+
+    private func viewSlug(_ view: AppView) -> String {
+        switch view {
+        case .auth: return "auth"
+        case .home: return "home"
+        case .session: return "session"
+        case .buddyHub: return "buddyHub"
+        case .buddySession: return "buddySession"
+        case .completion: return "completion"
+        case .history: return "history"
+        case .journal: return "journal"
+        case .board: return "board"
+        case .settings: return "settings"
+        }
     }
 
     func didLogin(user: UserDTO) {

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -72,10 +72,13 @@ final class AppViewModel {
         isLoading = true
         defer {
             isLoading = false
-            // Diagnostic for issue #266 / PR #261 — log the post-checkAuth view
-            // state so we can correlate with APIClient.init's [E2E-DIAG] line
-            // when iOS UI tests fail on the auth-screen waitForExistence.
-            print("[E2E-DIAG] checkAuth.done currentView=\(viewSlug(currentView)) currentUser=\(currentUser?.email ?? "nil") elapsedMs=\(Int(Date().timeIntervalSince(startedAt) * 1_000))")
+            // Diagnostic for issue #266 / PR #261, gated on UI-test mode so we
+            // don't leak PII (the user's email) in production logs. Only the
+            // UI-test fixture sets SP_UI_TEST_MODE=1, so this print is silent
+            // for real users.
+            if ProcessInfo.processInfo.environment["SP_UI_TEST_MODE"] == "1" {
+                print("[E2E-DIAG] checkAuth.done currentView=\(viewSlug(currentView)) currentUser=\(currentUser?.email ?? "nil") elapsedMs=\(Int(Date().timeIntervalSince(startedAt) * 1_000))")
+            }
         }
 
         do {

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -39,6 +39,9 @@ public actor APIClient {
                 defaults.removeObject(forKey: uiTestStoreDefaultsKey)
                 AudioEngine.resetPersistedPrefs()
                 Self.clearPersistedSessionArtifacts(session: session)
+                // Flush the in-memory cache to cfprefsd so the immediately
+                // following read sees the cleared state. Issue #266 follow-up.
+                defaults.synchronize()
             }
 
             if let persistedData = defaults.data(forKey: uiTestStoreDefaultsKey),
@@ -48,6 +51,15 @@ public actor APIClient {
                 self.uiTestStore = UITestStore.makeDefault(seedAuthenticated: parsedUITestConfig.seedAuthenticated)
                 persistUITestStore()
             }
+
+            // Diagnostic for issue #266 / PR #261 — log what the app actually
+            // observed at init so we can see in xcresult logs whether the env
+            // vars + reset-store contract are doing what we expect on macos-26
+            // CI runners. Cheap, noise-only in test builds since UITestConfig
+            // is nil in production.
+            print("[E2E-DIAG] APIClient.init uiTestMode=YES seedAuth=\(parsedUITestConfig.seedAuthenticated) resetStore=\(parsedUITestConfig.resetStore) forceOffline=\(parsedUITestConfig.forceLaunchOffline) forceTokenExpired=\(parsedUITestConfig.forceTokenExpired) finalIsAuthenticated=\(uiTestStore?.isAuthenticated ?? false)")
+        } else {
+            print("[E2E-DIAG] APIClient.init uiTestMode=NO")
         }
     }
 

--- a/scripts/e2e/run-ios-tests.sh
+++ b/scripts/e2e/run-ios-tests.sh
@@ -47,7 +47,47 @@ if [[ "${E2E_TEST_USER_EMAIL:-}" =~ @still-point\.me$ ]]; then
   exit 1
 fi
 
-TEST_DESTINATION="${IOS_TEST_DESTINATION:-platform=iOS Simulator,name=iPhone 17,OS=latest}"
+resolve_test_destination() {
+  # Honor explicit caller override first.
+  if [[ -n "${IOS_TEST_DESTINATION:-}" ]]; then
+    echo "${IOS_TEST_DESTINATION}"
+    return
+  fi
+
+  # Pick the first iPhone simulator that's actually installed on this host.
+  # Prevents the "iPhone 16 doesn't exist on macos-26 runners" / "iPhone 17 will
+  # eventually disappear too" infra-failure mode CodeAnt flagged. We grep simctl
+  # output with a trailing " (" so "iPhone 17" doesn't accidentally match
+  # "iPhone 17 Pro".
+  local simctl_output
+  simctl_output="$(xcrun simctl list devices available 2>/dev/null || true)"
+  local preferred=(
+    "iPhone 17 Pro"
+    "iPhone 17"
+    "iPhone 17 Pro Max"
+    "iPhone 17e"
+    "iPhone 16e"
+    "iPhone 16 Pro"
+    "iPhone 16"
+    "iPhone 15 Pro"
+    "iPhone 15"
+    "iPhone Air"
+  )
+  local name
+  for name in "${preferred[@]}"; do
+    if grep -F "    ${name} (" <<<"${simctl_output}" >/dev/null 2>&1; then
+      echo "platform=iOS Simulator,name=${name},OS=latest"
+      return
+    fi
+  done
+
+  # Last-resort fallback: keep the prior hardcoded default so we fail with a
+  # clear xcodebuild error instead of an empty destination.
+  echo "platform=iOS Simulator,name=iPhone 17,OS=latest"
+}
+
+TEST_DESTINATION="$(resolve_test_destination)"
+echo "Using iOS test destination: ${TEST_DESTINATION}"
 TEST_SCHEME="${IOS_TEST_SCHEME:-StillPoint}"
 PROJECT_PATH="${IOS_TEST_PROJECT:-ios/StillPoint.xcodeproj}"
 TEST_CONFIGURATION="${IOS_TEST_CONFIGURATION:-}"

--- a/scripts/e2e/run-ios-tests.sh
+++ b/scripts/e2e/run-ios-tests.sh
@@ -47,7 +47,7 @@ if [[ "${E2E_TEST_USER_EMAIL:-}" =~ @still-point\.me$ ]]; then
   exit 1
 fi
 
-TEST_DESTINATION="${IOS_TEST_DESTINATION:-platform=iOS Simulator,name=iPhone 16,OS=latest}"
+TEST_DESTINATION="${IOS_TEST_DESTINATION:-platform=iOS Simulator,name=iPhone 17,OS=latest}"
 TEST_SCHEME="${IOS_TEST_SCHEME:-StillPoint}"
 PROJECT_PATH="${IOS_TEST_PROJECT:-ios/StillPoint.xcodeproj}"
 TEST_CONFIGURATION="${IOS_TEST_CONFIGURATION:-}"

--- a/scripts/e2e/run-ios-tests.sh
+++ b/scripts/e2e/run-ios-tests.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 LANE="${1:-smoke}"
 MAX_RETRIES="${2:-1}"
 ATTEMPT=1
-UI_TESTS_DIR="${IOS_UI_TESTS_DIR:-ios/StillPointUITests}"
+UI_TESTS_DIR="${IOS_UI_TESTS_DIR:-ios/StillPointAppUITests}"
 SECRETS_REQUIRED="${E2E_SECRETS_REQUIRED:-true}"
 STATUS_FILE="artifacts/e2e/ios/${LANE}.status"
 FINAL_STATUS="failed"
@@ -28,9 +28,13 @@ if [[ "${E2E_ENV:-}" == "prod" || "${E2E_BASE_URL:-}" =~ still-point\.me ]]; the
 fi
 
 if [[ ! -d "${UI_TESTS_DIR}" ]]; then
-  echo "iOS E2E suite not present (${UI_TESTS_DIR}); skipping ${LANE} lane."
-  FINAL_STATUS="skipped"
-  exit 0
+  # Hard-fail: a missing test directory was previously silently treated as "skipped"
+  # which let broken-on-Release builds (e.g. build 8 / issue #250) ship with green
+  # CI. The contract is that the suite must be present and runnable.
+  echo "::error::iOS E2E suite not present at expected path '${UI_TESTS_DIR}'."
+  echo "::error::Set IOS_UI_TESTS_DIR to override, or restore the test bundle."
+  FINAL_STATUS="failed"
+  exit 1
 fi
 
 if [[ "${SECRETS_REQUIRED}" == "true" ]] && [[ -z "${E2E_TEST_USER_EMAIL:-}" || -z "${E2E_TEST_USER_PASSWORD:-}" ]]; then
@@ -43,21 +47,25 @@ if [[ "${E2E_TEST_USER_EMAIL:-}" =~ @still-point\.me$ ]]; then
   exit 1
 fi
 
-TEST_PLAN="${IOS_TEST_PLAN:-StillPointE2E}"
 TEST_DESTINATION="${IOS_TEST_DESTINATION:-platform=iOS Simulator,name=iPhone 16,OS=latest}"
 TEST_SCHEME="${IOS_TEST_SCHEME:-StillPoint}"
 PROJECT_PATH="${IOS_TEST_PROJECT:-ios/StillPoint.xcodeproj}"
+TEST_CONFIGURATION="${IOS_TEST_CONFIGURATION:-}"
 
 resolve_test_target() {
+  # The test target and class are both named StillPointAppUITests.
+  # Smoke runs the full Begin -> Session -> Complete -> History golden path
+  # (the test that would have caught issue #250 if the runner had actually
+  # been executing tests). Critical runs the full UI test class.
   case "$1" in
     smoke)
-      echo "StillPointUITests/SmokeTests"
+      echo "StillPointAppUITests/StillPointAppUITests/testLaunchLoginCompleteSessionAndHistoryPersistence"
       ;;
     critical)
-      echo "StillPointUITests/CriticalPathTests"
+      echo "StillPointAppUITests/StillPointAppUITests"
       ;;
     *)
-      echo "StillPointUITests/${1}"
+      echo "StillPointAppUITests/${1}"
       ;;
   esac
 }
@@ -69,14 +77,20 @@ run_lane() {
   test_target="$(resolve_test_target "${lane_tag}")"
   result_bundle="artifacts/e2e/ios/${lane_tag}-attempt-${ATTEMPT}.xcresult"
 
+  local -a xcodebuild_args=(
+    test
+    -project "${PROJECT_PATH}"
+    -scheme "${TEST_SCHEME}"
+    -destination "${TEST_DESTINATION}"
+    -resultBundlePath "${result_bundle}"
+    -only-testing:"${test_target}"
+  )
+  if [[ -n "${TEST_CONFIGURATION}" ]]; then
+    xcodebuild_args+=(-configuration "${TEST_CONFIGURATION}")
+  fi
+
   set +e
-  xcodebuild test \
-    -project "${PROJECT_PATH}" \
-    -scheme "${TEST_SCHEME}" \
-    -testPlan "${TEST_PLAN}" \
-    -destination "${TEST_DESTINATION}" \
-    -resultBundlePath "${result_bundle}" \
-    -only-testing:"${test_target}" \
+  xcodebuild "${xcodebuild_args[@]}" \
     | tee "artifacts/e2e/ios/${lane_tag}-attempt-${ATTEMPT}.log"
   local status=$?
   set -e


### PR DESCRIPTION
## **User description**
## Summary

Closes the E2E gap that let the build 8 Begin-button crash (#250) reach the App Store despite a UI test existing that should have caught it.

**Root cause for the silent miss** ([CI logs from PR #260](https://github.com/auerbachb/still-point/pull/260)):
> `iOS E2E suite not present (ios/StillPointUITests); skipping critical lane.`

[`scripts/e2e/run-ios-tests.sh`](scripts/e2e/run-ios-tests.sh) pointed at `ios/StillPointUITests` (real path is `ios/StillPointAppUITests`), referenced a nonexistent `StillPointE2E` test plan, and on missing-directory set `FINAL_STATUS="skipped" + exit 0`. The `ios-e2e-smoke` / `ios-e2e-critical` CI checks have been "passing" while running zero tests.

## Changes

### 1. Fix the runner ([scripts/e2e/run-ios-tests.sh](scripts/e2e/run-ios-tests.sh))
- `IOS_UI_TESTS_DIR` default → `ios/StillPointAppUITests`
- Drop bogus `-testPlan StillPointE2E` (no `.xctestplan` exists)
- Lane mapping points at real classes:
  - `smoke` → `StillPointAppUITests/StillPointAppUITests/testLaunchLoginCompleteSessionAndHistoryPersistence` (Begin → Session → Complete → History)
  - `critical` → `StillPointAppUITests/StillPointAppUITests` (whole class)
- **Hard-fail (exit 1) on missing test directory** — no more silent skip
- Add `IOS_TEST_CONFIGURATION` knob so callers can pin Release config
- Default simulator `iPhone 16` → `iPhone 17` (iPhone 16 doesn't exist on macos-26 runners)

### 2. Release-config pre-flight gate ([.github/workflows/ios-testflight.yml](.github/workflows/ios-testflight.yml))
- New `pre-flight-tests` job runs the smoke lane with `IOS_TEST_CONFIGURATION=Release` on simulator
- `build-and-upload` now `needs: pre-flight-tests` — a failing UI test blocks the TestFlight upload
- Uploads `~/Library/Logs/DiagnosticReports/**` + xcresult bundle on every run

### 3. Defense in depth on PR-time runs ([.github/workflows/e2e-ios.yml](.github/workflows/e2e-ios.yml))
- Upload simulator DiagnosticReports artifact on every run

### 4. Manual pre-tag smoke ([ios/QA_CHECKLIST.md](ios/QA_CHECKLIST.md))
- New "Pre-tag manual smoke (Issue #253)" section: real-device steps to run before pushing the `ios-v*` tag

## ⚠️ Status update — gate is correct but blocked on flaky underlying tests

After this PR was opened, fixing the silent-skip bug **immediately surfaced 3 pre-existing UI test failures**:

| Test | seedAuthenticated | Expected screen | Result |
|---|---|---|---|
| `testHistoryAndSettingsNavigationSmoke` | `true` | home | ✅ PASS |
| `testKeyboardOverlapKeepsSubmitReachable` | `false` | auth | ❌ FAIL on `XCTAssertTrue(authRoot.waitForExistence(timeout: launchTimeout))` |
| `testLaunchLoginCompleteSessionAndHistoryPersistence` | `false` | auth | ❌ FAIL same |
| `testLaunchOfflineShowsUserVisibleMessage` | `true, forceLaunchOffline: true` | auth | ❌ FAIL same |

**The pattern:** every test expecting the **auth screen** fails. The single test expecting **home** (with `seedAuthenticated: true`) passes. The fail mode is identical: `Auth screen did not appear` after `waitForExistence` times out.

### Things tried that did NOT fix it

1. **#266 / [PR #267](https://github.com/auerbachb/still-point/pull/267) — wiped Keychain, cookies, URL credentials, AudioEngine prefs on `resetStore: true`.** The original `defaults.removeObject(forKey: uiTestStoreDefaultsKey)` only wiped the in-memory UI test store. Now wipes everything. **Did not fix.**
2. **Bumped `launchTimeout` from 15s → 30s.** Failure still happens within the 30s window — the test's 55s total runtime indicates the auth-screen wait timed out at 30s, then teardown took ~25s. **Did not fix.**
3. **Added `defaults.synchronize()` after the reset-store wipe** in case cfprefsd cross-process caching was masking the wipe. **Pushed in [`266394b`](https://github.com/auerbachb/still-point/commit/266394b).**

### What I'm trying next (latest commit on this branch)

Added `[E2E-DIAG]` `print()` calls in two places:
- [`APIClient.init`](ios/StillPointShared/Sources/StillPointShared/APIClient.swift) — logs parsed `UITestConfig` + final `uiTestStore.isAuthenticated`
- [`AppViewModel.checkAuth`](ios/StillPointApp/ViewModels/AppViewModel.swift) — logs final `currentView` + elapsed ms

Goal: see in the next CI run's xcresult logs whether the env vars are being honored, what `isAuthenticated` resolves to, and what `currentView` ends up as. That'll tell us:
- If `[E2E-DIAG] APIClient.init uiTestMode=NO` appears → env vars aren't being passed to the launched app process (test fixture issue)
- If `[E2E-DIAG] APIClient.init ... finalIsAuthenticated=true` despite `seedAuth=false, resetStore=true` → the reset-store path isn't producing a fresh false-auth store (likely UserDefaults persistence / cfprefsd issue)
- If `[E2E-DIAG] checkAuth.done currentView=home currentUser=ios.fixture@stillpoint.test` despite seedAuth false → `me()` is somehow returning a user (most likely cause: `uiTestMe` reading stale store)
- If `[E2E-DIAG] checkAuth.done currentView=auth` but the test still fails → SwiftUI rendering / accessibility identifier issue under iOS 26 simulator

### What I've ruled out

- ❌ AudioEngine NSException at cold start — that bug is fixed in main (#262/PR #263 + build 10 verified working on device)
- ❌ Simulator destination — iPhone 17 is now default, exists on macos-26 runners
- ❌ Test plan reference — removed
- ❌ Shared in-memory state across tests — each `XCUIApplication.launch()` is a new app process

### Coordination

This PR depends on #267 being merged (and is rebased on top). User-facing P0 (Begin crash) is already shipped via build 10 on TestFlight — verified working on iPhone 17 Pro / iOS 26.3.1.

**Recommendation if diagnostics don't crack it:** park PR #261 with the gate infrastructure correct, file a follow-up for the underlying simulator-test issue, and ship future iOS releases via the manual pre-tag smoke checklist (already added to QA_CHECKLIST.md by this PR) until the simulator gate stabilizes.

## Test plan

- [ ] CI passes on this PR (validates the fixed runner actually runs tests, not silently skips)
- [ ] `ios-e2e-smoke` / `ios-e2e-critical` CI logs show real test execution (not "iOS E2E suite not present")
- [ ] `[E2E-DIAG]` lines appear in xcresult bundle for the next CI run on this branch
- [ ] Reading those diagnostic lines should pinpoint where the auth-screen-not-appearing pattern actually originates
- [ ] After diagnosis: either ship final fix and merge, or document findings + park PR

## Related

- #250, #262 — production regressions that this gate exists to prevent
- #259, #264 — build 9 + build 10 ships
- [PR #263](https://github.com/auerbachb/still-point/pull/263) — AudioEngine fix shipped (closes #262)
- [PR #265](https://github.com/auerbachb/still-point/pull/265) — build 10 bump
- #266, [PR #267](https://github.com/auerbachb/still-point/pull/267) — UI test state pollution wipe (merged, didn't crack the issue)

Closes #253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Testing & Quality Assurance**
  * Introduced pre-flight smoke tests for iOS builds to validate core functionality before TestFlight releases
  * Enhanced diagnostic artifact collection and logging for improved test troubleshooting
  * Added comprehensive manual QA checklist for release validation and device testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Add a Release-config UI smoke gate before TestFlight upload

### What Changed
- TestFlight now waits for a Release-config iOS smoke test to pass before building and uploading the app
- The iOS UI test runner now stops failing silently when the test bundle is missing, so broken test setups block CI instead of passing
- The runner now targets the real iOS UI test path, uses an available simulator device, and can be pinned to a specific build configuration
- Added diagnostic output and artifact uploads so UI test crashes leave logs and test results that can be reviewed later
- Updated the iOS release checklist with a manual device smoke step before tagging a release

### Impact
`✅ Fewer TestFlight uploads with untested iOS builds`
`✅ Clearer iOS UI test failures in CI`
`✅ Easier recovery after release-blocking app crashes`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=ap69dte89fdbpBlF2MRGGMcCB3JWRsEzrENU7GNUYlI&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
