### PR TITLE
Fix AudioEngine NSException crash on Begin tap (#262)

### DIFF
--- a/ios/StillPointApp/Views/CompletionView.swift
+++ b/ios/StillPointApp/Views/CompletionView.swift
@@ -121,11 +121,13 @@ struct CompletionView: View {
                         .onChange(of: endNote) {
                             if noteSaved { noteSaved = false }
                         }
+                        .accessibilityIdentifier("completion.endNoteEditor")
 
                     if noteSaved {
                         Text("Saved")
                             .font(SPFont.mono(11, weight: .medium))
                             .foregroundStyle(SPColor.green)
+                            .accessibilityIdentifier("completion.savedIndicator")
                     } else {
                         Button {
                             saveEndNote()
@@ -149,6 +151,7 @@ struct CompletionView: View {
                             )
                         }
                         .disabled(isSaveDisabled)
+                        .accessibilityIdentifier("completion.saveNoteButton")
                     }
 
                     if let saveError {

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -83,6 +83,24 @@ final class StillPointAppUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["completion.dayTitle"].exists)
         XCTAssertTrue(app.staticTexts["completion.durationLabel"].exists)
 
+        // Save Note happy path — guards the regression class from issue #254
+        // (note save errored in production) and exercises the path the iOS
+        // E2E gate from issue #253 must catch.
+        let endNoteEditor = app.textViews["completion.endNoteEditor"]
+        XCTAssertTrue(endNoteEditor.waitForExistence(timeout: 5), "End-of-session note editor should be present")
+        endNoteEditor.tap()
+        endNoteEditor.typeText("e2e end note")
+
+        let saveNoteButton = app.buttons["completion.saveNoteButton"]
+        XCTAssertTrue(saveNoteButton.waitForExistence(timeout: 3))
+        XCTAssertTrue(saveNoteButton.isHittable)
+        saveNoteButton.tap()
+
+        XCTAssertTrue(
+            app.staticTexts["completion.savedIndicator"].waitForExistence(timeout: 5),
+            "Save note should produce a 'Saved' indicator"
+        )
+
         let returnButton = app.buttons["completion.returnButton"]
         XCTAssertTrue(returnButton.waitForExistence(timeout: 5))
         returnButton.tap()

--- a/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
@@ -40,9 +40,12 @@ public final class AudioEngine: @unchecked Sendable {
     private init() {
         configureAudioSession()
         installLifecycleObservers()
-        serialQueue.async { [self] in
-            ensureEngineRunning()
-        }
+        // Do NOT call ensureEngineRunning() here. On iOS 26, AVAudioEngine.start()
+        // raises an Objective-C NSException (caught by std::terminate -> abort,
+        // not catchable by Swift try/catch) when invoked on a "bare" engine that
+        // has no source node connected to mainMixerNode. The engine is started
+        // safely inside playSynthesized() once a source node is attached + connected.
+        // See issue #262 for the crash log.
     }
 
     private func configureAudioSession() {
@@ -101,8 +104,11 @@ public final class AudioEngine: @unchecked Sendable {
     }
 
     public func warmUp() {
-        serialQueue.async { [self] in
-            ensureEngineRunning()
+        // Reactivates the audio session (covers post-background / post-interruption
+        // cases); does NOT start the engine — that happens lazily inside
+        // playSynthesized() after a source node is attached. See issue #262.
+        serialQueue.async { [weak self] in
+            self?.configureAudioSession()
         }
     }
 
@@ -238,11 +244,14 @@ public final class AudioEngine: @unchecked Sendable {
     }
 
     private func resumeAfterInterruptionIfNeeded() {
+        // Reconfigure the session and clear the resume flag. We deliberately do
+        // NOT call engine.start() here — by the time we resume, the previously
+        // playing source node has already been detached (see playSynthesized's
+        // asyncAfter cleanup), so starting the engine bare would crash on iOS 26.
+        // The next playSynthesized() call will start the engine safely after
+        // attaching a fresh source node. See issue #262.
         configureAudioSession()
-        ensureEngineRunning()
-        if engine.isRunning {
-            pendingResumeAfterConfigurationChange = false
-        }
+        pendingResumeAfterConfigurationChange = false
     }
 
     private func handleDidEnterBackground() {
@@ -256,14 +265,14 @@ public final class AudioEngine: @unchecked Sendable {
     }
 
     private func handleWillEnterForeground() {
+        // Reactivate the audio session; do NOT call engine.start() — see init()
+        // and resumeAfterInterruptionIfNeeded() comments. The next playSynthesized
+        // call will start the engine safely. Issue #262.
         serialQueue.async { [weak self] in
             guard let self else { return }
             self.configureAudioSession()
-            let shouldRestart = self.wasRunningBeforeBackground || self.pendingResumeAfterConfigurationChange
-            if shouldRestart {
-                self.ensureEngineRunning()
-            }
             self.wasRunningBeforeBackground = false
+            self.pendingResumeAfterConfigurationChange = false
         }
     }
 

--- a/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
@@ -35,7 +35,6 @@ public final class AudioEngine: @unchecked Sendable {
     private var observerTokens: [NSObjectProtocol] = []
     private var wasRunningBeforeInterruption = false
     private var wasRunningBeforeBackground = false
-    private var pendingResumeAfterConfigurationChange = false
 
     private init() {
         configureAudioSession()
@@ -67,14 +66,6 @@ public final class AudioEngine: @unchecked Sendable {
             self?.handleInterruption(notification)
         }
 
-        let engineConfigChangeToken = notificationCenter.addObserver(
-            forName: .AVAudioEngineConfigurationChange,
-            object: engine,
-            queue: nil
-        ) { [weak self] _ in
-            self?.handleEngineConfigurationChange()
-        }
-
         let backgroundToken = notificationCenter.addObserver(
             forName: UIApplication.didEnterBackgroundNotification,
             object: nil,
@@ -93,7 +84,6 @@ public final class AudioEngine: @unchecked Sendable {
 
         observerTokens = [
             interruptionToken,
-            engineConfigChangeToken,
             backgroundToken,
             foregroundToken
         ]
@@ -225,8 +215,7 @@ public final class AudioEngine: @unchecked Sendable {
                 let optionsValue = (info[AVAudioSessionInterruptionOptionKey] as? UInt) ?? 0
                 let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
                 let shouldResume = options.contains(.shouldResume)
-                self.pendingResumeAfterConfigurationChange = shouldResume && self.wasRunningBeforeInterruption
-                if self.pendingResumeAfterConfigurationChange {
+                if shouldResume && self.wasRunningBeforeInterruption {
                     self.resumeAfterInterruptionIfNeeded()
                 }
                 self.wasRunningBeforeInterruption = false
@@ -236,22 +225,14 @@ public final class AudioEngine: @unchecked Sendable {
         }
     }
 
-    private func handleEngineConfigurationChange() {
-        serialQueue.async { [weak self] in
-            guard let self, self.pendingResumeAfterConfigurationChange else { return }
-            self.resumeAfterInterruptionIfNeeded()
-        }
-    }
-
     private func resumeAfterInterruptionIfNeeded() {
-        // Reconfigure the session and clear the resume flag. We deliberately do
-        // NOT call engine.start() here — by the time we resume, the previously
-        // playing source node has already been detached (see playSynthesized's
-        // asyncAfter cleanup), so starting the engine bare would crash on iOS 26.
-        // The next playSynthesized() call will start the engine safely after
-        // attaching a fresh source node. See issue #262.
+        // Reconfigure the session only. We deliberately do NOT call engine.start()
+        // here — by the time we resume, the previously playing source node has
+        // already been detached (see playSynthesized's asyncAfter cleanup), so
+        // starting the engine bare would crash on iOS 26. The next playSynthesized
+        // call will start the engine safely after attaching a fresh source node.
+        // See issue #262.
         configureAudioSession()
-        pendingResumeAfterConfigurationChange = false
     }
 
     private func handleDidEnterBackground() {
@@ -272,7 +253,6 @@ public final class AudioEngine: @unchecked Sendable {
             guard let self else { return }
             self.configureAudioSession()
             self.wasRunningBeforeBackground = false
-            self.pendingResumeAfterConfigurationChange = false
         }
     }
 

--- a/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
@@ -34,7 +34,6 @@ public final class AudioEngine: @unchecked Sendable {
     private let notificationCenter = NotificationCenter.default
     private var observerTokens: [NSObjectProtocol] = []
     private var wasRunningBeforeInterruption = false
-    private var wasRunningBeforeBackground = false
 
     private init() {
         configureAudioSession()
@@ -237,11 +236,8 @@ public final class AudioEngine: @unchecked Sendable {
 
     private func handleDidEnterBackground() {
         serialQueue.async { [weak self] in
-            guard let self else { return }
-            self.wasRunningBeforeBackground = self.engine.isRunning
-            if self.wasRunningBeforeBackground {
-                self.engine.pause()
-            }
+            guard let self, self.engine.isRunning else { return }
+            self.engine.pause()
         }
     }
 
@@ -250,9 +246,7 @@ public final class AudioEngine: @unchecked Sendable {
         // and resumeAfterInterruptionIfNeeded() comments. The next playSynthesized
         // call will start the engine safely. Issue #262.
         serialQueue.async { [weak self] in
-            guard let self else { return }
-            self.configureAudioSession()
-            self.wasRunningBeforeBackground = false
+            self?.configureAudioSession()
         }
     }
 


### PR DESCRIPTION
## **User description**
## Summary

Build 9 (currently shipping on TestFlight) still crashes on Begin tap. The defensive \`currentDay\` clamp from #256 / [PR #256](https://github.com/auerbachb/still-point/pull/256) was a strict improvement but did not address the proximate cause. Symbolicated \`.ips\` from a real device (iPhone 17 Pro / iOS 26.3.1) confirms the actual crash is in \`AVAudioEngine\`.

## Root cause

\`AVAudioEngine.startAndReturnError(_:)\` raises an Objective-C \`NSException\` (not a Swift error) on iOS 26 when called on a "bare" engine — no source node connected to \`mainMixerNode\`. Swift \`try\`/\`catch\` cannot catch ObjC NSExceptions, so it propagates → \`std::terminate\` → \`abort()\` → SIGABRT.

Stack from \`StillPoint-2026-04-27-171902.ips\`:

\`\`\`
+[NSException raise:format:]
AVAudioEngineGraph::Initialize(NSError**)
AVAudioEngineImpl::Initialize(NSError**)
-[AVAudioEngine startAndReturnError:]
[StillPoint warmUp closure]
_dispatch_call_block_and_release   (queue: com.stillpoint.audioengine)
\`\`\`

Trigger: \`AudioEngine.init()\` and \`AudioEngine.warmUp()\` both eagerly called \`engine.start()\` before any source node was scheduled. The previous "warm engine" pattern was undefined behavior on iOS 26.

## Fix

In [\`AudioEngine.swift\`](ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift):

- **init():** drops the eager \`ensureEngineRunning()\` call. Keeps \`configureAudioSession()\` and lifecycle observers.
- **warmUp():** reactivates the audio session only — still useful after backgrounding / interruption — but does not start the engine.
- **resumeAfterInterruptionIfNeeded() / handleWillEnterForeground():** same — reconfigure session and clear flags; do not restart a bare engine.
- **ensureEngineRunning():** only called from \`playSynthesized()\` now, where \`attach\` + \`connect\` have already happened.

## Bundled E2E coverage (closes #254's regression class)

While the production note-save bug from #254 could not be reproduced (closed earlier today), the existing iOS UI test had no coverage for the Save Note path at all — the button had no \`accessibilityIdentifier\`. Adding it here so a future regression fails the new pre-flight gate from #253 / [PR #261](https://github.com/auerbachb/still-point/pull/261).

- [CompletionView.swift](ios/StillPointApp/Views/CompletionView.swift): \`accessibilityIdentifier\`s on the SESSION NOTE \`TextEditor\` (\`completion.endNoteEditor\`), the Save note button (\`completion.saveNoteButton\`), and the "Saved" indicator (\`completion.savedIndicator\`)
- [StillPointAppUITests.swift](ios/StillPointAppUITests/StillPointAppUITests.swift): \`testLaunchLoginCompleteSessionAndHistoryPersistence\` is extended to type a note, tap Save note, and assert the "Saved" indicator before tapping Return

## Test plan

- [ ] \`swift build\` from \`ios/StillPointShared/\` succeeds (verified locally — Build complete in 0.51s)
- [ ] iOS app builds cleanly under Release configuration in CI
- [ ] iOS UI tests pass on simulator (after [PR #261](https://github.com/auerbachb/still-point/pull/261) lands so the runner actually runs them; until then they continue silently skipping per the existing bug)
- [ ] On a Release-signed TestFlight install on iPhone 17 Pro / iOS 26.3.1: tapping **Begin** loads the timer with no crash
- [ ] Audio still plays: tick / chime / completion all fire when their toggles are on
- [ ] Audio session interruption recovery still works (incoming call / Siri / lock-screen)
- [ ] After this lands, cut **build 10** and verify on the same physical device the build 9 \`.ips\` came from

## Coordination with PR #261

This PR adds a UI test that exercises the Begin → SessionView → Completion → Save Note path. PR #261 fixes the runner script so iOS UI tests actually run in CI (they have been silently skipping). Until #261 merges, the new test added here will silently skip too — that's a known interim state, not a regression. Once both land, the gate is fully closed for both the Begin-crash class and the Save-Note regression class.

## Related

- #250 — original P0 (defensive clamp shipped in #256, but real cause was elsewhere)
- #256 — defensive \`currentDay\` clamp (still a strict improvement)
- #259 — build 9 ship (broken — to be superseded by build 10 after this lands)
- #253 / [PR #261](https://github.com/auerbachb/still-point/pull/261) — E2E pre-flight gate that will catch this class of regression
- #254 — note save error (closed; this PR adds the missing E2E coverage)

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to save end-of-session notes with UI editor, indicator, and save confirmation.

* **Accessibility**
  * Enhanced accessibility support by adding identifiers to note editor, save button, and status indicator.

* **Refactor**
  * Optimized audio engine initialization and lifecycle management for improved performance and resource handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Prevent the app from crashing when audio starts or resumes**

### What Changed
- The audio engine no longer starts too early, avoiding the crash that could happen when tapping Begin on iOS 26.
- Backgrounding, foregrounding, and interruption recovery now only reactivate the audio session; the engine starts later, when a sound is actually played.
- The session note field, Save note button, and Saved label now have test hooks so the end-of-session flow can be verified automatically.
- The main UI test now types a note, saves it, and checks for the Saved state before returning home.

### Impact
`✅ Fewer Begin-tap crashes`
`✅ Safer audio resume after interruptions`
`✅ More reliable end-of-session note saving`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=tx7Wf-bO99qNnEUoGujOKlWVoASd2XDrhml26icOZvU&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
