### PR TITLE
Stabilize iOS UI tests by wiping all persisted state on resetStore (#266)

### DIFF
--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -1,7 +1,10 @@
 import XCTest
 
 final class StillPointAppUITests: XCTestCase {
-    private let launchTimeout: TimeInterval = 15
+    // 30s is generous for cold simulator boots on macos-26 CI runners — the
+    // previous 15s tripped intermittently on the first launch in a test run.
+    // Issue #266.
+    private let launchTimeout: TimeInterval = 30
 
     override func setUpWithError() throws {
         continueAfterFailure = false

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -326,19 +326,7 @@ public actor APIClient {
     }
 
     private func clearLocalSessionArtifacts() {
-        _ = AuthTokenStore.clear()
-
-        let cookieStorage = session.configuration.httpCookieStorage ?? .shared
-        for cookie in cookieStorage.cookies ?? [] {
-            cookieStorage.deleteCookie(cookie)
-        }
-
-        let credentialStorage = URLCredentialStorage.shared
-        for (protectionSpace, credentialsByUser) in credentialStorage.allCredentials {
-            for credential in credentialsByUser.values {
-                credentialStorage.remove(credential, for: protectionSpace)
-            }
-        }
+        Self.clearPersistedSessionArtifacts(session: session)
     }
 
     private func applyAuthorizationHeader(to request: inout URLRequest) {

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -31,7 +31,14 @@ public actor APIClient {
         if let parsedUITestConfig {
             let defaults = UserDefaults.standard
             if parsedUITestConfig.resetStore {
+                // Wipe ALL persisted state, not just the UI-test store. State that
+                // bled across tests previously: Keychain auth tokens, cookies, URL
+                // credentials, AudioEngine sound prefs. Issue #266 surfaced this
+                // when the runner script started actually running tests after the
+                // silent-skip fix from issue #253.
                 defaults.removeObject(forKey: uiTestStoreDefaultsKey)
+                AudioEngine.resetPersistedPrefs()
+                Self.clearPersistedSessionArtifacts(session: session)
             }
 
             if let persistedData = defaults.data(forKey: uiTestStoreDefaultsKey),
@@ -40,6 +47,24 @@ public actor APIClient {
             } else {
                 self.uiTestStore = UITestStore.makeDefault(seedAuthenticated: parsedUITestConfig.seedAuthenticated)
                 persistUITestStore()
+            }
+        }
+    }
+
+    /// Static analog of `clearLocalSessionArtifacts()` for use during init,
+    /// when the actor's instance methods are not yet available.
+    private static func clearPersistedSessionArtifacts(session: URLSession) {
+        _ = AuthTokenStore.clear()
+
+        let cookieStorage = session.configuration.httpCookieStorage ?? .shared
+        for cookie in cookieStorage.cookies ?? [] {
+            cookieStorage.deleteCookie(cookie)
+        }
+
+        let credentialStorage = URLCredentialStorage.shared
+        for (protectionSpace, credentialsByUser) in credentialStorage.allCredentials {
+            for credential in credentialsByUser.values {
+                credentialStorage.remove(credential, for: protectionSpace)
             }
         }
     }

--- a/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
@@ -335,4 +335,10 @@ extension AudioEngine {
             UserDefaults.standard.set(data, forKey: prefsKey)
         }
     }
+
+    /// Wipes the persisted sound-prefs entry. Used by UI-test reset paths so a
+    /// previous test cannot leak its toggle state into a subsequent test run.
+    public static func resetPersistedPrefs() {
+        UserDefaults.standard.removeObject(forKey: prefsKey)
+    }
 }


### PR DESCRIPTION
## **User description**
## Summary

Closes the test-state pollution that [PR #261](https://github.com/auerbachb/still-point/pull/261) surfaced after fixing the runner script's silent-skip bug. Three iOS UI tests began failing on CI:

- \`testKeyboardOverlapKeepsSubmitReachable\` (\`seedAuthenticated: false\`)
- \`testLaunchLoginCompleteSessionAndHistoryPersistence\` (\`seedAuthenticated: false\`)
- \`testLaunchOfflineShowsUserVisibleMessage\` (\`forceLaunchOffline: true\`)

All failed at the auth-screen \`waitForExistence\` assertion at the start of each test, while \`testHistoryAndSettingsNavigationSmoke\` (\`seedAuthenticated: true\`) passed.

## Root cause (two contributing factors)

### 1. \`resetStore: true\` was only wiping the in-memory store

[\`APIClient.init()\` lines 31-44](ios/StillPointShared/Sources/StillPointShared/APIClient.swift#L31-L44) called \`defaults.removeObject(forKey: uiTestStoreDefaultsKey)\` but never touched:

- **Keychain** (\`AuthTokenStore\`)
- **HTTP cookies** (\`HTTPCookieStorage\`)
- **URL credentials** (\`URLCredentialStorage\`)
- **AudioEngine sound prefs** (\`stillpoint_sound_prefs\` UserDefaults)

So state from a prior \`seedAuthenticated: true\` test bled into a subsequent \`seedAuthenticated: false\` test.

### 2. \`launchTimeout = 15s\` was tight for cold-launch on macos-26 runners

The first \`XCUIApplication.launch()\` on a fresh iPhone 17 simulator can take 15s+ just to attach the test bundle and render the first frame.

## Fix (belt-and-suspenders)

### [\`APIClient.swift\`](ios/StillPointShared/Sources/StillPointShared/APIClient.swift)
\`init()\` now calls a new static \`clearPersistedSessionArtifacts(session:)\` when \`resetStore: true\` — mirrors \`clearLocalSessionArtifacts()\` but is a static so it can run during init before the actor is fully initialized. Wipes Keychain, cookies, URL credentials. Also calls \`AudioEngine.resetPersistedPrefs()\`.

### [\`AudioEngine.swift\`](ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift)
New \`public static func resetPersistedPrefs()\` — wipes the \`stillpoint_sound_prefs\` UserDefaults entry. Used by the UI-test reset path; also useful for any future "factory reset" surface.

### [\`StillPointAppUITests.swift\`](ios/StillPointAppUITests/StillPointAppUITests.swift)
\`launchTimeout\` 15s → 30s with explanatory comment.

## Test plan

- [ ] \`swift build\` clean (verified locally)
- [ ] CI passes on this PR (note: PR's iOS e2e checks will continue to silently skip until this branch rebases on top of PR #261's runner-script fix; I'm filing this fix here so PR #261 can rebase onto it and validate the actual behavior)
- [ ] After this lands and PR #261 rebases: all 10 UI tests pass against the simulator gate
- [ ] Tests pass deterministically across 3 consecutive runs (re-run via \`Re-run all jobs\` 3 times on the rebased PR #261)

## Coordination with PR #261

This PR is the prerequisite for PR #261 to merge. Order:
1. **Merge this PR** (#266 fix)
2. **Rebase PR #261** onto new \`main\`
3. PR #261's iOS e2e tests now run against the fixed reset-store contract and 30s timeout — should pass
4. Merge PR #261 → next release tag has a working pre-flight gate

## Severity

P1 — blocks the E2E release gate from #253. Without that gate, future releases can re-introduce regressions like #250 / #262 with no automated catch.

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Tests**
* Increased UI test launch timeout to reduce failures during cold simulator boots in CI environments
* Improved test isolation by enhancing cleanup of audio settings, authentication tokens, cookies, and session data between test runs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Stabilize iOS UI tests by fully clearing test state and allowing more time for first launch**

### What Changed
- Resetting UI-test state now clears saved sign-in data, cookies, saved credentials, and stored sound settings, so one test no longer affects the next
- The app’s UI tests now wait longer for the first simulator launch, reducing intermittent startup failures on CI
- Sound preferences are also wiped during test reset, matching the rest of the cleaned state

### Impact
`✅ Fewer flaky iOS UI tests`
`✅ Cleaner sign-in resets between test runs`
`✅ Fewer first-launch timeouts on CI`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=Wgfa6f0xaiV1DuILLMtLHhLljS0qmedXt15gTGNQzCM&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
