### PR TITLE
Align password reset active token index schema

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -49,7 +49,8 @@ export const passwordResetTokens = pgTable("password_reset_tokens", {
 }, (table) => ({
   userIdx: index("idx_password_reset_tokens_user").on(table.userId),
   tokenHashIdx: uniqueIndex("password_reset_tokens_token_hash_unique").on(table.tokenHash),
-  activeUserIdx: index("idx_password_reset_tokens_active_user").on(table.userId, table.expiresAt)
+  /** Keep one unused reset token per user; expiresAt remains data, not uniqueness scope. */
+  activeUserIdx: uniqueIndex("password_reset_tokens_active_user_unique").on(table.userId)
     .where(sql`${table.usedAt} is null`),
 }));
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Align `password_reset_tokens.activeUserIdx` with the deployed unique partial index on `user_id` where `used_at is null`.
- Add a one-line schema comment documenting why `expires_at` is not part of the uniqueness scope.

## Testing
- `npx drizzle-kit generate` (emitted an untracked initial baseline because the repo has no Drizzle journal; generated index shape matches the deployed unique partial index)
- `coderabbit review --prompt-only` (blocked: CLI not installed in the cloud image)
- `npx coderabbit review --prompt-only` (blocked: npm could not determine executable)
- `npx tsc --noEmit`
- `npm run test:unit` (existing Vitest collection issue in `src/lib/thoughtSaving.test.ts`)
- Vercel preview deployed: `still-point-git-cursor-password-rese-9a6e72-auerbachbs-projects.vercel.app`; Preview DB row-count check blocked because Vercel CLI requires interactive login and MCP does not expose Preview env secrets.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c8cb888-07f7-4909-8ec4-b77b84625c90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c8cb888-07f7-4909-8ec4-b77b84625c90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

