### PR TITLE
Add iOS App Store submission dry run

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -126,6 +126,7 @@ jobs:
         run: npm run ios:app-store:dry-run -- --release-owner "GitHub Actions preflight"
 
       - name: Upload App Store submission dry-run evidence
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: ios-app-store-dry-run

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -122,6 +122,17 @@ jobs:
             exit 1
           fi
 
+      - name: Generate App Store submission dry-run evidence
+        run: npm run ios:app-store:dry-run -- --release-owner "GitHub Actions preflight"
+
+      - name: Upload App Store submission dry-run evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-app-store-dry-run
+          path: artifacts/ios-app-store-dry-run/**
+          if-no-files-found: error
+          retention-days: 30
+
       - name: Verify Xcode and iOS SDK versions
         shell: bash
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /playwright-report/
 /test-results/
 /artifacts/e2e/
+/artifacts/ios-app-store-dry-run/
 
 # next.js
 /.next/

--- a/README.md
+++ b/README.md
@@ -211,6 +211,14 @@ All iOS release and App Store submission work must reference:
 
 Use these files as the source of truth when creating GitHub issues, delegating release tasks, or asking AI coding agents to prepare release work. The TestFlight upload path is automated through GitHub Actions; the App Store submission runbook identifies which App Store Connect steps are automatable through Apple's API and which still require an Account Holder/Admin or human release decision.
 
+Before the next live App Store submission, run the AI-assisted dry run and save its generated evidence:
+
+```bash
+npm run ios:app-store:dry-run
+```
+
+The dry run reads the canonical runbooks, validates the current iOS version/build/tag plan, checks the TestFlight workflow's required checklist and secret references, maps every issue #242 checklist item, and writes `artifacts/ios-app-store-dry-run/summary.json`, `summary.md`, and `automation.log`. Set `APPSTORE_APP_ID`, `APPSTORE_API_KEY_ID`, `APPSTORE_API_ISSUER_ID`, and `APPSTORE_API_PRIVATE_KEY` to include live App Store Connect read checks; add `-- --require-live` when a release owner wants missing live ASC access to fail the dry run.
+
 ### Neon (database)
 
 Serverless Postgres hosted on [Neon](https://neon.tech). The connection uses `@neondatabase/serverless` with HTTP queries (no persistent connections).

--- a/docs/operations/ios-app-store-submission.md
+++ b/docs/operations/ios-app-store-submission.md
@@ -10,6 +10,22 @@ Use this runbook after an iOS build has been uploaded to TestFlight and before c
 
 Record submission status, reviewer notes, build strings, and final outcome in ops tracker #103. Use `ios/RELEASING.md` for tag format, build bumps, and CI upload details.
 
+## AI-assisted dry run
+
+Before a live submission, generate the issue #242 evidence package:
+
+```bash
+npm run ios:app-store:dry-run
+```
+
+The command reads `README.md`, `ios/RELEASING.md`, this runbook, `.github/workflows/ios-testflight.yml`, `ios/PARITY_CHECKLIST.md`, `ios/QA_CHECKLIST.md`, and `ios/project.yml`. It writes `artifacts/ios-app-store-dry-run/summary.json`, `summary.md`, and `automation.log` with:
+
+- the intended `ios-v*` tag, marketing version, build number, bundle ID, workflow trigger, and release artifact placeholders;
+- a 38-item issue #242 checklist map across phases A-F, App Store Connect API readiness, submission execution, review follow-up, proof, and definition-of-done items;
+- App Store Connect API fallback paths and explicit human-owned gates.
+
+Set `APPSTORE_APP_ID`, `APPSTORE_API_KEY_ID`, `APPSTORE_API_ISSUER_ID`, and `APPSTORE_API_PRIVATE_KEY` to let the dry run query App Store Connect builds and version records. Add `-- --require-live` when a real submission must fail fast if live API validation cannot run. The script does not submit for review; submission remains blocked until the generated human gates are approved.
+
 ## Automation scope
 
 The current pipeline already automates build/archive/upload to TestFlight through GitHub Actions. App Store Connect also has API coverage for many post-upload tasks, so future tooling can automate or prefill parts of this runbook instead of requiring every step to be pasted into the website.

--- a/ios/QA_CHECKLIST.md
+++ b/ios/QA_CHECKLIST.md
@@ -34,6 +34,9 @@ QA owner: iOS QA DRI
 - [x] `ios/project.yml` versioning finalized: `MARKETING_VERSION = 1.0.3`, `CURRENT_PROJECT_VERSION = 10`.
 - [x] App Store release notes finalized for this build (see `ios/RELEASING.md`).
 - [x] App Store metadata checklist finalized (privacy policy URL, support URL, account deletion review notes).
+- [x] App Store submission automation dry-run evidence can be generated with `npm run ios:app-store:dry-run`.
+  - Evidence artifact: `artifacts/ios-app-store-dry-run/summary.md`.
+  - Live ASC validation requires `APPSTORE_APP_ID` plus the App Store Connect API key environment variables.
 - [ ] Build submitted to App Store review in App Store Connect.
   - Owner: iOS release DRI
   - Target date: 2026-04-29 (after TestFlight smoke test for this build passes)

--- a/ios/RELEASING.md
+++ b/ios/RELEASING.md
@@ -51,6 +51,16 @@ Before your first TestFlight release, configure a tester group and handle encryp
 5. The GitHub Actions workflow builds and uploads to TestFlight automatically.
 6. After Apple processes the build (~15 minutes), it appears in the TestFlight app.
 7. Record the processed build number and processing timestamp in `ios/QA_CHECKLIST.md`.
+8. Before App Store submission, run the automation dry run and save its artifact:
+   ```bash
+   npm run ios:app-store:dry-run
+   ```
+   The report in `artifacts/ios-app-store-dry-run/` confirms source-of-truth
+   docs, release-readiness checklists, workflow secret references, version/build
+   values, App Store Connect API readiness, human-owned gates, and fallback
+   paths. For live App Store Connect build/version validation, provide
+   `APPSTORE_APP_ID` plus the App Store Connect API key environment variables
+   and rerun with `-- --require-live`.
 
 ## App Store submission handoff
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "e2e:policy:no-sleep": "node scripts/e2e/check-no-naked-sleep.mjs",
     "e2e:policy:secrets": "node scripts/e2e/check-test-secrets.mjs",
     "e2e:policy": "E2E_BASE_URL=${E2E_BASE_URL:-http://127.0.0.1:3000} npm run e2e:policy:no-sleep && npm run e2e:policy:secrets && E2E_BASE_URL=${E2E_BASE_URL:-http://127.0.0.1:3000} npm run e2e:guard",
+    "ios:app-store:dry-run": "node scripts/ios-app-store-dry-run.mjs",
     "e2e:web:smoke": "E2E_BASE_URL=${E2E_BASE_URL:-http://127.0.0.1:3000} npm run e2e:guard && node scripts/e2e/run-playwright-lane.mjs smoke @smoke 1",
     "e2e:web:critical": "E2E_BASE_URL=${E2E_BASE_URL:-http://127.0.0.1:3000} npm run e2e:guard && node scripts/e2e/run-playwright-lane.mjs critical @critical 2",
     "e2e:web:perf": "node scripts/e2e/report-web-perf.mjs",

--- a/scripts/ios-app-store-dry-run.mjs
+++ b/scripts/ios-app-store-dry-run.mjs
@@ -1,0 +1,548 @@
+#!/usr/bin/env node
+import crypto from "node:crypto";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import https from "node:https";
+import path from "node:path";
+import process from "node:process";
+
+const root = process.cwd();
+const args = parseArgs(process.argv.slice(2));
+const outputDir = path.resolve(root, args.outputDir ?? "artifacts/ios-app-store-dry-run");
+const requireLive = Boolean(args.requireLive);
+
+const requiredWorkflowSecrets = [
+  "BUILD_CERTIFICATE_BASE64",
+  "P12_PASSWORD",
+  "BUILD_PROVISION_PROFILE_BASE64",
+  "APPSTORE_API_KEY_ID",
+  "APPSTORE_API_ISSUER_ID",
+  "APPSTORE_API_PRIVATE_KEY",
+];
+
+const workflowUrl = "https://github.com/auerbachb/still-point/actions/workflows/ios-testflight.yml";
+const appStoreConnectBaseUrl = "https://appstoreconnect.apple.com/apps";
+const appStoreApiMinimumRole =
+  "App Manager or Admin for app/version/build/metadata/screenshot/submission operations; Account Holder/Admin for agreements, tax, banking, and some compliance decisions.";
+
+const issueChecklist = [
+  ["A1", "Read README Release operations and confirm both canonical iOS runbooks are referenced."],
+  ["A2", "Read ios/RELEASING.md and confirm MARKETING_VERSION, CURRENT_PROJECT_VERSION, and ios-v* tag plan."],
+  ["A3", "Read docs/operations/ios-app-store-submission.md and map every Phase A-F item to automation, AI-assisted verification, or human decision."],
+  ["A4", "Read .github/workflows/ios-testflight.yml and confirm the intended tag triggers TestFlight upload."],
+  ["A5", "Confirm ios/PARITY_CHECKLIST.md and ios/QA_CHECKLIST.md satisfy workflow-required checked items before tagging."],
+  ["B1", "Confirm an App Store Connect API key is available with minimum roles for version/build/metadata/screenshot/submission operations."],
+  ["B2", "Confirm GitHub secrets used by the TestFlight workflow are present."],
+  ["B3", "Create or identify a script/tooling approach for App Store Connect API calls instead of manual website entry where possible."],
+  ["B4", "API-check Apple agreements/tax/banking if possible; otherwise record Account Holder/Admin confirmation."],
+  ["B5", "API-query the latest processed TestFlight build for the intended version/build and fail fast on missing, processing, invalid, or non-incremented build."],
+  ["C1", "Create or open the target App Store version programmatically."],
+  ["C2", "Attach the intended processed TestFlight build programmatically."],
+  ["C3", "Set or verify metadata fields programmatically where API-supported."],
+  ["C4", "Verify Privacy Policy URL is exactly https://still-point.me/privacy."],
+  ["C5", "Upload or verify required screenshots/app previews through App Store Connect API where source assets are supplied."],
+  ["C6", "Upload or verify App Review attachment for the physical-iPhone account-deletion recording where source asset is supplied."],
+  ["C7", "Set or verify App Review notes using the canonical template and account-deletion path."],
+  ["C8", "Set or verify demo credentials or reliable signup-path instructions."],
+  ["C9", "Identify fields that cannot be safely automated and present explicit human approval gates."],
+  ["D1", "Generate a machine-readable preflight summary before submission."],
+  ["D2", "Submit for review programmatically if API checks pass and required human gates are approved."],
+  ["D3", "If programmatic submission is blocked, document the blocking field/API error and minimal manual App Store Connect clicks."],
+  ["D4", "Immediately record submission timestamp, version/build, release owner, and submission URL in the release artifact."],
+  ["E1", "Open or update the operational tracking issue for this submission."],
+  ["E2", "Add the daily status log template from ios/RELEASING.md."],
+  ["E3", "Poll App Store review status automatically where possible and post at most one dated log entry per day unless status changes."],
+  ["E4", "If rejected, copy reviewer notes verbatim into the tracking issue and create/link separate engineering issues."],
+  ["E5", "If resubmitting, bump build, create a new ios-v* tag or rerun CI, attach the replacement build, update materials, and log the new URL."],
+  ["E6", "If approved, record final build, outcome, and release strategy."],
+  ["E7", "Close the tracking issue only after approval/release decision or permanent withdrawal."],
+  ["F1", "Save terminal/API logs showing which steps were automated."],
+  ["F2", "Save a concise list of remaining human-owned decisions and why they cannot or should not be automated."],
+  ["F3", "After the next real submission attempt, update issue #242 with what worked, manual website work, and automation to add next."],
+  ["DOD1", "The next iOS App Store submission references the canonical runbooks from the start."],
+  ["DOD2", "AI/human worker can follow issue #242 without rediscovering the workflow."],
+  ["DOD3", "All automatable App Store Connect steps are attempted through API/tooling before website pasting."],
+  ["DOD4", "Every manual step is explicitly justified as Account Holder/Admin, compliance, release-owner, or missing-source-asset work."],
+  ["DOD5", "The live submission or dry run produces enough evidence to decide what to automate next."],
+];
+
+const checks = [];
+const logs = [];
+
+function log(message) {
+  logs.push(`${new Date().toISOString()} ${message}`);
+  console.log(message);
+}
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--require-live") parsed.requireLive = true;
+    else if (arg === "--output-dir") parsed.outputDir = argv[++i];
+    else if (arg === "--intended-tag") parsed.intendedTag = argv[++i];
+    else if (arg === "--release-owner") parsed.releaseOwner = argv[++i];
+    else if (arg === "--submission-url") parsed.submissionUrl = argv[++i];
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return parsed;
+}
+
+function read(file) {
+  return fs.readFileSync(path.join(root, file), "utf8");
+}
+
+function pass(id, message, evidence = {}) {
+  checks.push({ id, status: "pass", message, evidence });
+}
+
+function warn(id, message, evidence = {}) {
+  checks.push({ id, status: "warning", message, evidence });
+}
+
+function fail(id, message, evidence = {}) {
+  checks.push({ id, status: "fail", message, evidence });
+}
+
+function extractProjectVersion(projectYml) {
+  const marketing = projectYml.match(/MARKETING_VERSION:\s*"?([^"\n]+)"?/);
+  const build = projectYml.match(/CURRENT_PROJECT_VERSION:\s*"?([^"\n]+)"?/);
+  const bundleId = projectYml.match(/PRODUCT_BUNDLE_IDENTIFIER:\s*([^\s]+)/);
+  const encryption = projectYml.match(/ITSAppUsesNonExemptEncryption:\s*(false|true)/);
+  return {
+    marketingVersion: marketing?.[1]?.trim(),
+    buildNumber: build?.[1]?.trim(),
+    bundleId: bundleId?.[1]?.trim(),
+    usesNonExemptEncryption: encryption?.[1]?.trim() === "true",
+  };
+}
+
+function requiredChecked(fileContent, requiredText) {
+  const escaped = requiredText.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^- \\[[xX]\\] ${escaped}$`, "m").test(fileContent);
+}
+
+function listGithubSecrets() {
+  const result = spawnSync("gh", ["secret", "list", "--json", "name"], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    return {
+      available: false,
+      reason: result.stderr.trim() || result.stdout.trim() || "gh secret list did not complete",
+      names: [],
+    };
+  }
+
+  try {
+    return {
+      available: true,
+      names: JSON.parse(result.stdout).map((secret) => secret.name),
+    };
+  } catch {
+    return {
+      available: false,
+      reason: "gh secret list returned unexpected JSON",
+      names: [],
+    };
+  }
+}
+
+function base64url(input) {
+  return Buffer.from(input).toString("base64url");
+}
+
+function makeJwt() {
+  const keyId = process.env.APPSTORE_API_KEY_ID;
+  const issuerId = process.env.APPSTORE_API_ISSUER_ID;
+  const privateKey = process.env.APPSTORE_API_PRIVATE_KEY?.replace(/\\n/g, "\n");
+  if (!keyId || !issuerId || !privateKey) return null;
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64url(JSON.stringify({ alg: "ES256", kid: keyId, typ: "JWT" }));
+  const payload = base64url(JSON.stringify({ iss: issuerId, iat: now, exp: now + 900, aud: "appstoreconnect-v1" }));
+  const signingInput = `${header}.${payload}`;
+  const signature = crypto.sign("SHA256", Buffer.from(signingInput), {
+    key: privateKey,
+    dsaEncoding: "ieee-p1363",
+  });
+  return `${signingInput}.${signature.toString("base64url")}`;
+}
+
+function ascGet(pathname, jwt) {
+  return new Promise((resolve, reject) => {
+    const request = https.request(
+      {
+        hostname: "api.appstoreconnect.apple.com",
+        path: pathname,
+        method: "GET",
+        headers: { Authorization: `Bearer ${jwt}` },
+      },
+      (response) => {
+        let body = "";
+        response.setEncoding("utf8");
+        response.on("data", (chunk) => {
+          body += chunk;
+        });
+        response.on("end", () => {
+          let json = null;
+          try {
+            json = body ? JSON.parse(body) : null;
+          } catch {
+            reject(new Error(`ASC returned non-JSON response (${response.statusCode}): ${body.slice(0, 300)}`));
+            return;
+          }
+          if (response.statusCode >= 200 && response.statusCode < 300) {
+            resolve(json);
+          } else {
+            reject(new Error(`ASC ${response.statusCode}: ${JSON.stringify(json)}`));
+          }
+        });
+      },
+    );
+    request.on("error", reject);
+    request.end();
+  });
+}
+
+async function queryAsc(project) {
+  const appId = process.env.APPSTORE_APP_ID;
+  const jwt = makeJwt();
+  if (!jwt || !appId) {
+    return {
+      live: false,
+      reason: "Set APPSTORE_APP_ID, APPSTORE_API_KEY_ID, APPSTORE_API_ISSUER_ID, and APPSTORE_API_PRIVATE_KEY to query App Store Connect.",
+    };
+  }
+
+  const buildQuery = `/v1/builds?filter[app]=${encodeURIComponent(appId)}&filter[version]=${encodeURIComponent(project.marketingVersion)}&include=preReleaseVersion,buildBetaDetail&sort=-uploadedDate&limit=10`;
+  const versionQuery = `/v1/appStoreVersions?filter[app]=${encodeURIComponent(appId)}&filter[platform]=IOS&filter[versionString]=${encodeURIComponent(project.marketingVersion)}&include=build&limit=5`;
+  const [builds, versions] = await Promise.all([ascGet(buildQuery, jwt), ascGet(versionQuery, jwt)]);
+  const intendedBuild = builds.data?.find((build) => build.attributes?.version === String(project.buildNumber));
+  return {
+    live: true,
+    appId,
+    buildQuery,
+    versionQuery,
+    intendedBuild: intendedBuild
+      ? {
+          id: intendedBuild.id,
+          version: intendedBuild.attributes?.version,
+          processingState: intendedBuild.attributes?.processingState,
+          uploadedDate: intendedBuild.attributes?.uploadedDate,
+          expired: intendedBuild.attributes?.expired,
+        }
+      : null,
+    latestBuilds: (builds.data ?? []).map((build) => ({
+      id: build.id,
+      version: build.attributes?.version,
+      processingState: build.attributes?.processingState,
+      uploadedDate: build.attributes?.uploadedDate,
+      expired: build.attributes?.expired,
+    })),
+    appStoreVersions: (versions.data ?? []).map((version) => ({
+      id: version.id,
+      versionString: version.attributes?.versionString,
+      appStoreState: version.attributes?.appStoreState,
+      releaseType: version.attributes?.releaseType,
+    })),
+  };
+}
+
+function classifyIssueChecklist({ project, asc }) {
+  const byId = new Map(checks.map((check) => [check.id, check]));
+  return issueChecklist.map(([id, text]) => {
+    const direct = byId.get(id);
+    if (direct) return { id, text, status: direct.status, evidence: direct.evidence, message: direct.message };
+
+    const apiReady = asc.live ? "pass" : "warning";
+    const mapping = {
+      B1: [apiReady, asc.live ? "ASC API credentials generated a valid query token." : asc.reason],
+      B2: [
+        reportSecretStatus.status,
+        reportSecretStatus.message,
+      ],
+      B3: ["pass", "This script is the dry-run tooling approach and records ASC endpoints for build/version validation."],
+      B4: ["warning", "Apple agreements/tax/banking are not exposed by the public ASC API; Account Holder/Admin confirmation remains required."],
+      B5: [asc.live && asc.intendedBuild?.processingState === "VALID" ? "pass" : "warning", asc.live ? "ASC build query completed; see summary for intended build state." : asc.reason],
+      C1: [apiReady, "ASC appStoreVersions endpoint can locate the target version; creation is reserved for explicit execution tooling."],
+      C2: [apiReady, "ASC version/build relationships can be verified; attaching the build remains gated on human approval."],
+      C3: [apiReady, "ASC metadata endpoints can verify/update supported fields once approved source copy is supplied."],
+      C5: ["warning", "Screenshot/app-preview automation requires approved source assets."],
+      C6: ["warning", "Review attachment automation requires a physical-iPhone account-deletion recording asset."],
+      C8: ["warning", "Demo credentials are private human-owned review fields unless a signup path is approved."],
+      C9: ["pass", "Human gates are listed in the report."],
+      D2: ["warning", "Programmatic submission is intentionally blocked in dry-run mode until human gates are approved."],
+      D3: ["pass", "Fallback paths are listed in the report."],
+      E1: ["warning", "Updating GitHub issue #103 is a release-owner action for the live submission attempt."],
+      E3: [apiReady, "ASC review status can be polled via API after a submission exists."],
+      E4: ["warning", "Reviewer-note triage is human-owned even when API polling captures status."],
+      E5: ["pass", "Resubmission path is documented in ios/RELEASING.md and this report."],
+      E6: ["warning", "Release strategy is a human-owned decision after approval."],
+      E7: ["warning", "Closing the tracking issue waits for approval/release decision or permanent withdrawal."],
+      F3: ["warning", "Requires the next real submission attempt."],
+      DOD3: [apiReady, "API-supported ASC checks are attempted when credentials are supplied; dry-run mode records missing credentials otherwise."],
+      DOD4: ["pass", "Manual gates are explicitly categorized in the report."],
+      DOD5: ["pass", "The dry-run report identifies automation gaps and next actions."],
+    };
+    const [status, message] = mapping[id] ?? ["pass", "Covered by the canonical dry-run report."];
+    return { id, text, status, message, evidence: { version: project.marketingVersion, build: project.buildNumber } };
+  });
+}
+
+let reportSecretStatus = {
+  status: "warning",
+  message: "GitHub secret presence was not checked yet.",
+};
+
+function writeMarkdown(report) {
+  const rows = report.issue242Checklist.map((item) => `| ${item.id} | ${item.status} | ${item.text} | ${item.message.replace(/\|/g, "\\|")} |`);
+  return `# iOS App Store submission dry-run evidence
+
+Generated: ${report.generatedAt}
+
+## Intended submission
+
+- Version/build: ${report.project.marketingVersion} (${report.project.buildNumber})
+- Intended tag: ${report.intendedTag}
+- Bundle ID: ${report.project.bundleId}
+- Release owner: ${report.releaseOwner}
+- Submission URL: ${report.submissionUrl}
+- Workflow URL: ${report.preflightSummary.workflowUrl}
+- TestFlight build status: ${report.preflightSummary.testFlightBuildStatus}
+- App Store version URL: ${report.preflightSummary.appStoreVersionUrl}
+- Attached build: ${report.preflightSummary.attachedBuild}
+- Metadata completeness: ${report.preflightSummary.metadataCompleteness}
+- Screenshot status: ${report.preflightSummary.screenshotStatus}
+- Review notes: ${report.preflightSummary.reviewNotes}
+- Demo credentials/signup path: ${report.preflightSummary.demoCredentialsOrSignupPath}
+
+## Machine-readable summary
+
+The companion \`summary.json\` contains the same evidence in machine-readable form.
+
+## Human-owned gates
+
+${report.humanGates.map((gate) => `- **${gate.owner}:** ${gate.decision} (${gate.reason})`).join("\n")}
+
+## Fallback paths
+
+${report.fallbackPaths.map((fallback) => `- **${fallback.when}:** ${fallback.action}`).join("\n")}
+
+## Issue #242 checklist coverage (${report.issue242Checklist.length} items)
+
+| Item | Status | Checklist requirement | Evidence / next action |
+|---|---|---|---|
+${rows.join("\n")}
+
+## Automation log
+
+${report.logs.map((entry) => `- ${entry}`).join("\n")}
+`;
+}
+
+async function main() {
+  fs.mkdirSync(outputDir, { recursive: true });
+  log("Reading canonical iOS release docs and workflow.");
+
+  const readme = read("README.md");
+  const releasing = read("ios/RELEASING.md");
+  const submissionRunbook = read("docs/operations/ios-app-store-submission.md");
+  const workflow = read(".github/workflows/ios-testflight.yml");
+  const parity = read("ios/PARITY_CHECKLIST.md");
+  const qa = read("ios/QA_CHECKLIST.md");
+  const projectYml = read("ios/project.yml");
+  const project = extractProjectVersion(projectYml);
+  const intendedTag = args.intendedTag ?? `ios-v${project.marketingVersion}-build${project.buildNumber}`;
+
+  readme.includes("ios/RELEASING.md") && readme.includes("docs/operations/ios-app-store-submission.md")
+    ? pass("A1", "README Release operations references both canonical iOS runbooks.")
+    : fail("A1", "README Release operations is missing one or both canonical iOS runbook links.");
+
+  project.marketingVersion && project.buildNumber && /^ios-v/.test(intendedTag)
+    ? pass("A2", "iOS version/build and tag plan found.", { marketingVersion: project.marketingVersion, buildNumber: project.buildNumber, intendedTag })
+    : fail("A2", "Could not determine version/build/tag plan.", { project, intendedTag });
+
+  const phaseMatches = [...submissionRunbook.matchAll(/^## Phase ([A-F]) - /gm)].map((match) => match[1]);
+  phaseMatches.join("") === "ABCDEF"
+    ? pass("A3", "Submission runbook covers phases A-F.", { phases: phaseMatches })
+    : fail("A3", "Submission runbook does not cover every phase A-F.", { phases: phaseMatches });
+
+  workflow.includes("tags:") && workflow.includes("'ios-v*'")
+    ? pass("A4", "TestFlight workflow is triggered by ios-v* tags.", { intendedTag })
+    : fail("A4", "TestFlight workflow is missing ios-v* tag trigger.");
+
+  const parityOk = requiredChecked(parity, "Feature parity checklist between iOS and web is completed.")
+    && requiredChecked(parity, "All critical parity gaps are fixed or explicitly deferred with owner/date.");
+  const qaOk = requiredChecked(qa, "Regression/QA pass for release candidate is completed.")
+    && requiredChecked(qa, "App Store metadata/versioning/release notes are finalized.");
+  parityOk && qaOk
+    ? pass("A5", "Workflow-required release-readiness checklist items are checked.")
+    : fail("A5", "One or more workflow-required release-readiness checklist items are missing.");
+
+  const workflowSecretRefs = requiredWorkflowSecrets.filter((secret) => workflow.includes(`secrets.${secret}`));
+  const githubSecrets = listGithubSecrets();
+  const missingWorkflowRefs = requiredWorkflowSecrets.filter((secret) => !workflowSecretRefs.includes(secret));
+  const missingGithubSecrets = githubSecrets.available
+    ? requiredWorkflowSecrets.filter((secret) => !githubSecrets.names.includes(secret))
+    : [];
+  if (missingWorkflowRefs.length > 0) {
+    fail("B2", "TestFlight workflow is missing required secret references.", {
+      requiredWorkflowSecrets,
+      workflowSecretRefs,
+      missingWorkflowRefs,
+    });
+    reportSecretStatus = {
+      status: "fail",
+      message: `Workflow is missing required secret references: ${missingWorkflowRefs.join(", ")}.`,
+    };
+  } else if (githubSecrets.available && missingGithubSecrets.length === 0) {
+    pass("B2", "TestFlight workflow references every required secret and GitHub reports all required secret names.", {
+      requiredWorkflowSecrets,
+    });
+    reportSecretStatus = {
+      status: "pass",
+      message: "TestFlight workflow references every required secret and GitHub reports all required secret names.",
+    };
+  } else if (githubSecrets.available) {
+    warn("B2", "TestFlight workflow references every required secret, but GitHub is missing one or more required secret names.", {
+      requiredWorkflowSecrets,
+      missingGithubSecrets,
+    });
+    reportSecretStatus = {
+      status: "warning",
+      message: `GitHub secret names missing: ${missingGithubSecrets.join(", ")}.`,
+    };
+  } else {
+    warn("B2", "TestFlight workflow references every required secret, but repository secret visibility could not be confirmed.", {
+      requiredWorkflowSecrets,
+      reason: githubSecrets.reason,
+    });
+    reportSecretStatus = {
+      status: "warning",
+      message: `Workflow references required secrets; GitHub secret list unavailable: ${githubSecrets.reason}.`,
+    };
+  }
+
+  project.usesNonExemptEncryption === false
+    ? pass("C4", "Project declares ITSAppUsesNonExemptEncryption=false; privacy policy URL remains https://still-point.me/privacy.", { privacyPolicyUrl: "https://still-point.me/privacy" })
+    : fail("C4", "Project encryption declaration is missing or non-exempt encryption is enabled.");
+
+  submissionRunbook.includes("Guideline 5.1.1(v)") && releasing.includes("Delete Account")
+    ? pass("C7", "Reviewer notes template and account-deletion path are present in canonical docs.")
+    : fail("C7", "Reviewer notes template or account-deletion path is missing.");
+
+  pass("D1", "Machine-readable preflight summary is generated by this script.", { output: path.join(outputDir, "summary.json") });
+  pass("D4", "Release artifact has placeholders for timestamp, version/build, owner, and submission URL.", {
+    releaseOwner: args.releaseOwner ?? "UNSET_RELEASE_OWNER",
+    submissionUrl: args.submissionUrl ?? "UNSET_SUBMISSION_URL",
+  });
+  pass("E2", "Daily status log template is present in ios/RELEASING.md.");
+  pass("F1", "Automation logs are saved with the dry-run report.", { output: path.join(outputDir, "automation.log") });
+  pass("F2", "Human-owned decisions are saved with the dry-run report.", { output: path.join(outputDir, "summary.json") });
+  pass("DOD1", "Canonical runbooks are referenced before submission work starts.");
+  pass("DOD2", "The dry-run report turns issue #242 into repeatable worker instructions.");
+
+  log("Checking App Store Connect live-query readiness.");
+  let asc;
+  try {
+    asc = await queryAsc(project);
+    if (asc.live) log("App Store Connect build/version queries completed.");
+    else log(`App Store Connect live queries skipped: ${asc.reason}`);
+  } catch (error) {
+    asc = { live: false, reason: error.message };
+    warn("ASC", "App Store Connect query failed.", { error: error.message });
+  }
+
+  if (requireLive && !asc.live) {
+    fail("ASC_REQUIRE_LIVE", "Live App Store Connect validation was required but did not complete.", { reason: asc.reason });
+  }
+  if (asc.live && asc.intendedBuild && asc.intendedBuild.processingState !== "VALID") {
+    fail("ASC_BUILD_STATE", "Intended TestFlight build exists but is not VALID.", asc.intendedBuild);
+  }
+  if (asc.live && !asc.intendedBuild) {
+    fail("ASC_BUILD_MISSING", "Intended TestFlight build was not found in App Store Connect.", { version: project.marketingVersion, build: project.buildNumber });
+  }
+
+  const humanGates = [
+    { owner: "Account Holder/Admin", decision: "Confirm Apple Agreements, Tax, and Banking have no Action required items.", reason: "Not exposed by public ASC API." },
+    { owner: "Product/App Store", decision: "Approve screenshots, app previews, age rating, reviewer notes, demo credentials, and release timing.", reason: "Compliance/copy/assets require human accountability." },
+    { owner: "Release owner", decision: "Approve programmatic Submit for Review for the intended build.", reason: "Dry-run mode must not submit without explicit live approval." },
+    { owner: "Product/App Store", decision: "Choose manual, automatic, or phased release after approval.", reason: "Business release strategy." },
+  ];
+
+  const fallbackPaths = [
+    { when: "ASC credentials or APPSTORE_APP_ID are unavailable", action: "Use App Store Connect website to verify TestFlight build status, version page, attached build, metadata, screenshots, review notes, and demo credentials; paste evidence into the generated report." },
+    { when: "API field is unsupported or returns a blocker", action: "Record the exact API error, open App Store Connect -> app -> Distribution/App Store -> target version, fix only that field, then rerun this dry run." },
+    { when: "Submission is rejected", action: "Copy reviewer notes verbatim to #103, create/link implementation issues, bump CURRENT_PROJECT_VERSION, upload a replacement ios-v* build, attach it, and resubmit." },
+    { when: "Submission is approved", action: "Record final build and outcome in #103, choose held/manual/automatic/phased release, and close tracking only when complete." },
+  ];
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    issue: "https://github.com/auerbachb/still-point/issues/242",
+    dryRunMode: true,
+    project,
+    intendedTag,
+    releaseOwner: args.releaseOwner ?? "UNSET_RELEASE_OWNER",
+    submissionUrl: args.submissionUrl ?? "UNSET_SUBMISSION_URL",
+    workflow: {
+      path: ".github/workflows/ios-testflight.yml",
+      tagTrigger: "ios-v*",
+      url: workflowUrl,
+      requiredSecrets: requiredWorkflowSecrets,
+    },
+    asc,
+    checks,
+    humanGates,
+    fallbackPaths,
+    logs,
+  };
+  report.preflightSummary = {
+    intendedTag,
+    version: project.marketingVersion,
+    build: project.buildNumber,
+    workflowUrl,
+    appStoreApiMinimumRole,
+    testFlightBuildStatus: asc.live
+      ? asc.intendedBuild?.processingState ?? "intended build not found"
+      : asc.reason,
+    appStoreVersionUrl:
+      asc.live && asc.appStoreVersions?.[0]
+        ? `${appStoreConnectBaseUrl}/${asc.appId}/distribution/ios/version/${asc.appStoreVersions[0].id}`
+        : "requires live App Store Connect query",
+    attachedBuild: asc.live
+      ? asc.intendedBuild?.version ?? "intended build not attached or not found"
+      : "requires live App Store Connect query",
+    metadataCompleteness:
+      "Canonical docs and local release-readiness checks are verified; live ASC metadata fields require API credentials or website evidence.",
+    screenshotStatus: "requires approved screenshot/app-preview source assets before API upload or website verification",
+    reviewNotes: "canonical template present in docs/operations/ios-app-store-submission.md",
+    demoCredentialsOrSignupPath: "requires release-owner approval before live submission",
+    unresolvedHumanGates: humanGates,
+  };
+  report.issue242Checklist = classifyIssueChecklist({ project, asc });
+
+  if (report.issue242Checklist.length !== 38) {
+    fail("ISSUE_242_COUNT", "Issue #242 checklist coverage must contain exactly 38 items.", { count: report.issue242Checklist.length });
+  }
+
+  fs.writeFileSync(path.join(outputDir, "summary.json"), `${JSON.stringify(report, null, 2)}\n`);
+  fs.writeFileSync(path.join(outputDir, "summary.md"), writeMarkdown(report));
+  fs.writeFileSync(path.join(outputDir, "automation.log"), `${logs.join("\n")}\n`);
+
+  const failures = checks.filter((check) => check.status === "fail");
+  if (failures.length > 0) {
+    console.error(`Dry run completed with ${failures.length} blocking failure(s). See ${path.join(outputDir, "summary.md")}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  log(`Dry run evidence written to ${outputDir}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/ios-app-store-dry-run.mjs
+++ b/scripts/ios-app-store-dry-run.mjs
@@ -72,16 +72,24 @@ function log(message) {
   console.log(message);
 }
 
+function takeValue(argv, i, flag) {
+  const value = argv[i + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
 function parseArgs(argv) {
   const parsed = {};
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--require-live") parsed.requireLive = true;
-    else if (arg === "--output-dir") parsed.outputDir = argv[++i];
-    else if (arg === "--intended-tag") parsed.intendedTag = argv[++i];
-    else if (arg === "--release-owner") parsed.releaseOwner = argv[++i];
-    else if (arg === "--tracking-issue") parsed.trackingIssue = argv[++i];
-    else if (arg === "--submission-url") parsed.submissionUrl = argv[++i];
+    else if (arg === "--output-dir") { parsed.outputDir = takeValue(argv, i, arg); i += 1; }
+    else if (arg === "--intended-tag") { parsed.intendedTag = takeValue(argv, i, arg); i += 1; }
+    else if (arg === "--release-owner") { parsed.releaseOwner = takeValue(argv, i, arg); i += 1; }
+    else if (arg === "--tracking-issue") { parsed.trackingIssue = takeValue(argv, i, arg); i += 1; }
+    else if (arg === "--submission-url") { parsed.submissionUrl = takeValue(argv, i, arg); i += 1; }
     else throw new Error(`Unknown argument: ${arg}`);
   }
   return parsed;
@@ -252,13 +260,14 @@ async function queryAsc(project) {
   };
 }
 
-function classifyIssueChecklist({ project, asc, trackingIssue }) {
+function classifyIssueChecklist({ project, asc, trackingIssue, requireLive }) {
   const byId = new Map(checks.map((check) => [check.id, check]));
+  const offlineStatus = requireLive ? "fail" : "warning";
   return issueChecklist.map(([id, text]) => {
     const direct = byId.get(id);
     if (direct) return { id, text, status: direct.status, evidence: direct.evidence, message: direct.message };
 
-    const apiReady = asc.live ? "pass" : "warning";
+    const apiReady = asc.live ? "pass" : offlineStatus;
     const mapping = {
       B1: [apiReady, asc.live ? "ASC API credentials generated a valid query token." : asc.reason],
       B2: [
@@ -268,7 +277,7 @@ function classifyIssueChecklist({ project, asc, trackingIssue }) {
       B3: ["pass", "This script is the dry-run tooling approach and records ASC endpoints for build/version validation."],
       B4: ["warning", "Apple agreements/tax/banking are not exposed by the public ASC API; Account Holder/Admin confirmation remains required."],
       B5: !asc.live
-        ? ["warning", asc.reason]
+        ? [offlineStatus, asc.reason]
         : !asc.intendedBuild
           ? ["fail", "Intended TestFlight build was not found in App Store Connect."]
           : asc.intendedBuild.processingState === "VALID"
@@ -534,13 +543,15 @@ async function main() {
       ? asc.intendedBuild?.version ?? "intended build not attached or not found"
       : "requires live App Store Connect query",
     metadataCompleteness:
-      "Canonical docs and local release-readiness checks are verified; live ASC metadata fields require API credentials or website evidence.",
+      checks.find((c) => c.id === "C4")?.status === "pass" && checks.find((c) => c.id === "C7")?.status === "pass"
+        ? "Canonical docs and local release-readiness checks are verified; live ASC metadata fields require API credentials or website evidence."
+        : "Canonical metadata/reviewer-notes prerequisites are incomplete; see checklist failures above.",
     screenshotStatus: "requires approved screenshot/app-preview source assets before API upload or website verification",
-    reviewNotes: "canonical template present in docs/operations/ios-app-store-submission.md",
+    reviewNotes: checks.find((c) => c.id === "C7")?.message ?? "Reviewer notes template status unavailable.",
     demoCredentialsOrSignupPath: "requires release-owner approval before live submission",
     unresolvedHumanGates: humanGates,
   };
-  report.issue242Checklist = classifyIssueChecklist({ project, asc, trackingIssue });
+  report.issue242Checklist = classifyIssueChecklist({ project, asc, trackingIssue, requireLive });
 
   if (report.issue242Checklist.length !== 38) {
     fail("ISSUE_242_COUNT", "Issue #242 checklist coverage must contain exactly 38 items.", { count: report.issue242Checklist.length });

--- a/scripts/ios-app-store-dry-run.mjs
+++ b/scripts/ios-app-store-dry-run.mjs
@@ -201,6 +201,9 @@ function ascGet(pathname, jwt) {
         });
       },
     );
+    request.setTimeout(15000, () => {
+      request.destroy(new Error(`ASC request timed out: ${pathname}`));
+    });
     request.on("error", reject);
     request.end();
   });
@@ -216,7 +219,7 @@ async function queryAsc(project) {
     };
   }
 
-  const buildQuery = `/v1/builds?filter[app]=${encodeURIComponent(appId)}&filter[version]=${encodeURIComponent(project.marketingVersion)}&include=preReleaseVersion,buildBetaDetail&sort=-uploadedDate&limit=10`;
+  const buildQuery = `/v1/builds?filter[app]=${encodeURIComponent(appId)}&filter[preReleaseVersion.version]=${encodeURIComponent(project.marketingVersion)}&include=preReleaseVersion,buildBetaDetail&sort=-uploadedDate&limit=10`;
   const versionQuery = `/v1/appStoreVersions?filter[app]=${encodeURIComponent(appId)}&filter[platform]=IOS&filter[versionString]=${encodeURIComponent(project.marketingVersion)}&include=build&limit=5`;
   const [builds, versions] = await Promise.all([ascGet(buildQuery, jwt), ascGet(versionQuery, jwt)]);
   const intendedBuild = builds.data?.find((build) => build.attributes?.version === String(project.buildNumber));
@@ -425,9 +428,12 @@ async function main() {
     };
   }
 
-  project.usesNonExemptEncryption === false
-    ? pass("C4", "Project declares ITSAppUsesNonExemptEncryption=false; privacy policy URL remains https://still-point.me/privacy.", { privacyPolicyUrl: "https://still-point.me/privacy" })
-    : fail("C4", "Project encryption declaration is missing or non-exempt encryption is enabled.");
+  const privacyPolicyUrl = "https://still-point.me/privacy";
+  const privacyUrlInCanonicalDocs =
+    submissionRunbook.includes(privacyPolicyUrl) || releasing.includes(privacyPolicyUrl);
+  privacyUrlInCanonicalDocs
+    ? pass("C4", `Canonical docs reference the required privacy policy URL ${privacyPolicyUrl}.`, { privacyPolicyUrl })
+    : fail("C4", `Required privacy policy URL ${privacyPolicyUrl} is missing from canonical release docs.`, { privacyPolicyUrl });
 
   submissionRunbook.includes("Guideline 5.1.1(v)") && releasing.includes("Delete Account")
     ? pass("C7", "Reviewer notes template and account-deletion path are present in canonical docs.")

--- a/scripts/ios-app-store-dry-run.mjs
+++ b/scripts/ios-app-store-dry-run.mjs
@@ -7,9 +7,7 @@ import path from "node:path";
 import process from "node:process";
 
 const root = process.cwd();
-const args = parseArgs(process.argv.slice(2));
-const outputDir = path.resolve(root, args.outputDir ?? "artifacts/ios-app-store-dry-run");
-const requireLive = Boolean(args.requireLive);
+const DEFAULT_OUTPUT_DIR = "artifacts/ios-app-store-dry-run";
 
 const requiredWorkflowSecrets = [
   "BUILD_CERTIFICATE_BASE64",
@@ -82,6 +80,7 @@ function parseArgs(argv) {
     else if (arg === "--output-dir") parsed.outputDir = argv[++i];
     else if (arg === "--intended-tag") parsed.intendedTag = argv[++i];
     else if (arg === "--release-owner") parsed.releaseOwner = argv[++i];
+    else if (arg === "--tracking-issue") parsed.trackingIssue = argv[++i];
     else if (arg === "--submission-url") parsed.submissionUrl = argv[++i];
     else throw new Error(`Unknown argument: ${arg}`);
   }
@@ -253,7 +252,7 @@ async function queryAsc(project) {
   };
 }
 
-function classifyIssueChecklist({ project, asc }) {
+function classifyIssueChecklist({ project, asc, trackingIssue }) {
   const byId = new Map(checks.map((check) => [check.id, check]));
   return issueChecklist.map(([id, text]) => {
     const direct = byId.get(id);
@@ -268,7 +267,13 @@ function classifyIssueChecklist({ project, asc }) {
       ],
       B3: ["pass", "This script is the dry-run tooling approach and records ASC endpoints for build/version validation."],
       B4: ["warning", "Apple agreements/tax/banking are not exposed by the public ASC API; Account Holder/Admin confirmation remains required."],
-      B5: [asc.live && asc.intendedBuild?.processingState === "VALID" ? "pass" : "warning", asc.live ? "ASC build query completed; see summary for intended build state." : asc.reason],
+      B5: !asc.live
+        ? ["warning", asc.reason]
+        : !asc.intendedBuild
+          ? ["fail", "Intended TestFlight build was not found in App Store Connect."]
+          : asc.intendedBuild.processingState === "VALID"
+            ? ["pass", "ASC build query completed and the intended build is VALID."]
+            : ["fail", `Intended TestFlight build is ${asc.intendedBuild.processingState}.`],
       C1: [apiReady, "ASC appStoreVersions endpoint can locate the target version; creation is reserved for explicit execution tooling."],
       C2: [apiReady, "ASC version/build relationships can be verified; attaching the build remains gated on human approval."],
       C3: [apiReady, "ASC metadata endpoints can verify/update supported fields once approved source copy is supplied."],
@@ -278,7 +283,7 @@ function classifyIssueChecklist({ project, asc }) {
       C9: ["pass", "Human gates are listed in the report."],
       D2: ["warning", "Programmatic submission is intentionally blocked in dry-run mode until human gates are approved."],
       D3: ["pass", "Fallback paths are listed in the report."],
-      E1: ["warning", "Updating GitHub issue #103 is a release-owner action for the live submission attempt."],
+      E1: ["warning", `Updating GitHub issue ${trackingIssue} is a release-owner action for the live submission attempt.`],
       E3: [apiReady, "ASC review status can be polled via API after a submission exists."],
       E4: ["warning", "Reviewer-note triage is human-owned even when API polling captures status."],
       E5: ["pass", "Resubmission path is documented in ios/RELEASING.md and this report."],
@@ -346,6 +351,9 @@ ${report.logs.map((entry) => `- ${entry}`).join("\n")}
 }
 
 async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const outputDir = path.resolve(root, args.outputDir ?? DEFAULT_OUTPUT_DIR);
+  const requireLive = Boolean(args.requireLive);
   fs.mkdirSync(outputDir, { recursive: true });
   log("Reading canonical iOS release docs and workflow.");
 
@@ -444,7 +452,9 @@ async function main() {
     releaseOwner: args.releaseOwner ?? "UNSET_RELEASE_OWNER",
     submissionUrl: args.submissionUrl ?? "UNSET_SUBMISSION_URL",
   });
-  pass("E2", "Daily status log template is present in ios/RELEASING.md.");
+  releasing.includes("Daily log template")
+    ? pass("E2", "Daily log template is present in ios/RELEASING.md.")
+    : fail("E2", "Daily log template is missing from ios/RELEASING.md.");
   pass("F1", "Automation logs are saved with the dry-run report.", { output: path.join(outputDir, "automation.log") });
   pass("F2", "Human-owned decisions are saved with the dry-run report.", { output: path.join(outputDir, "summary.json") });
   pass("DOD1", "Canonical runbooks are referenced before submission work starts.");
@@ -471,6 +481,8 @@ async function main() {
     fail("ASC_BUILD_MISSING", "Intended TestFlight build was not found in App Store Connect.", { version: project.marketingVersion, build: project.buildNumber });
   }
 
+  const trackingIssue = args.trackingIssue ?? "the tracking issue";
+
   const humanGates = [
     { owner: "Account Holder/Admin", decision: "Confirm Apple Agreements, Tax, and Banking have no Action required items.", reason: "Not exposed by public ASC API." },
     { owner: "Product/App Store", decision: "Approve screenshots, app previews, age rating, reviewer notes, demo credentials, and release timing.", reason: "Compliance/copy/assets require human accountability." },
@@ -481,8 +493,8 @@ async function main() {
   const fallbackPaths = [
     { when: "ASC credentials or APPSTORE_APP_ID are unavailable", action: "Use App Store Connect website to verify TestFlight build status, version page, attached build, metadata, screenshots, review notes, and demo credentials; paste evidence into the generated report." },
     { when: "API field is unsupported or returns a blocker", action: "Record the exact API error, open App Store Connect -> app -> Distribution/App Store -> target version, fix only that field, then rerun this dry run." },
-    { when: "Submission is rejected", action: "Copy reviewer notes verbatim to #103, create/link implementation issues, bump CURRENT_PROJECT_VERSION, upload a replacement ios-v* build, attach it, and resubmit." },
-    { when: "Submission is approved", action: "Record final build and outcome in #103, choose held/manual/automatic/phased release, and close tracking only when complete." },
+    { when: "Submission is rejected", action: `Copy reviewer notes verbatim to ${trackingIssue}, create/link implementation issues, bump CURRENT_PROJECT_VERSION, upload a replacement ios-v* build, attach it, and resubmit.` },
+    { when: "Submission is approved", action: `Record final build and outcome in ${trackingIssue}, choose held/manual/automatic/phased release, and close tracking only when complete.` },
   ];
 
   const report = {
@@ -528,7 +540,7 @@ async function main() {
     demoCredentialsOrSignupPath: "requires release-owner approval before live submission",
     unresolvedHumanGates: humanGates,
   };
-  report.issue242Checklist = classifyIssueChecklist({ project, asc });
+  report.issue242Checklist = classifyIssueChecklist({ project, asc, trackingIssue });
 
   if (report.issue242Checklist.length !== 38) {
     fail("ISSUE_242_COUNT", "Issue #242 checklist coverage must contain exactly 38 items.", { count: report.issue242Checklist.length });
@@ -550,5 +562,22 @@ async function main() {
 
 main().catch((error) => {
   console.error(error);
+  try {
+    const fallbackDir = path.resolve(root, DEFAULT_OUTPUT_DIR);
+    fs.mkdirSync(fallbackDir, { recursive: true });
+    const stamp = new Date().toISOString();
+    const message = error?.message ?? String(error);
+    fs.writeFileSync(
+      path.join(fallbackDir, "summary.json"),
+      `${JSON.stringify({ generatedAt: stamp, fatalError: message }, null, 2)}\n`,
+    );
+    fs.writeFileSync(
+      path.join(fallbackDir, "summary.md"),
+      `# iOS App Store dry-run fatal failure\n\nGenerated: ${stamp}\n\nError: ${message}\n`,
+    );
+    fs.writeFileSync(path.join(fallbackDir, "automation.log"), `${stamp} fatal: ${message}\n`);
+  } catch (writeError) {
+    console.error("Failed to write fatal report:", writeError);
+  }
   process.exitCode = 1;
 });


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `npm run ios:app-store:dry-run` to generate issue #242 dry-run evidence across all 38 checklist items.
- Document the dry-run workflow in README, iOS release docs, and the App Store submission runbook.
- Add TestFlight workflow artifact generation/upload for dry-run evidence and ignore local dry-run artifacts.

## Testing
- `node --check scripts/ios-app-store-dry-run.mjs`
- `npm run ios:app-store:dry-run`
- `npm run build`

## Notes
- Live App Store Connect checks require `APPSTORE_APP_ID`, `APPSTORE_API_KEY_ID`, `APPSTORE_API_ISSUER_ID`, and `APPSTORE_API_PRIVATE_KEY`; dry-run mode records missing live access and human-owned gates without submitting.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8323386-4158-4200-bae6-56ba3ca59a8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8323386-4158-4200-bae6-56ba3ca59a8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an iOS App Store dry-run preflight that generates a validation report and evidence package to check release readiness.

* **Documentation**
  * Added user guidance for the dry-run step, required App Store Connect variables, and how to enforce live validation.
  * Updated runbooks and release checklists with dry-run output locations and checklist mapping.

* **Chores**
  * CI now runs the dry-run, uploads its evidence as a retained artifact (30-day retention), always attempts upload, and fails the job if no artifacts are produced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add an iOS App Store submission dry run that generates evidence for review**

### What Changed
- Added a new dry-run command that checks release docs, version/build details, TestFlight workflow requirements, and issue #242 checklist coverage, then writes a summary report and logs.
- The dry run can also query App Store Connect when the required API credentials are set, and it clearly records when live validation is missing or when the target build is not ready.
- Updated the iOS release docs, README, QA checklist, and submission runbook with the new workflow, required environment variables, and generated artifact location.
- The TestFlight workflow now runs the dry run automatically and uploads the evidence as a build artifact.

### Impact
`✅ Clearer App Store submission preflight`
`✅ Fewer missed release checklist items`
`✅ Faster release handoff with saved evidence`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=cYtasFrTvmj-7nerSkoTib-g06L-Uy9dHZqhyNa4jyU&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
