### PR TITLE
Align password reset active token index schema

### DIFF
--- a/src/app/api/auth/password-reset/request/route.ts
+++ b/src/app/api/auth/password-reset/request/route.ts
@@ -63,6 +63,11 @@ export async function POST(request: NextRequest) {
         return null;
       }
 
+      await tx
+        .update(passwordResetTokens)
+        .set({ usedAt: new Date() })
+        .where(and(eq(passwordResetTokens.userId, user.id), isNull(passwordResetTokens.usedAt)));
+
       const resetToken = await createPasswordResetToken({ userId: user.id });
       await tx.insert(passwordResetTokens).values({
         userId: user.id,

--- a/src/app/api/auth/password-reset/request/route.ts
+++ b/src/app/api/auth/password-reset/request/route.ts
@@ -64,15 +64,10 @@ export async function POST(request: NextRequest) {
       }
 
       const [previousToken] = await tx
-        .select({ id: passwordResetTokens.id })
-        .from(passwordResetTokens)
-        .where(and(eq(passwordResetTokens.userId, user.id), isNull(passwordResetTokens.usedAt)))
-        .limit(1);
-
-      await tx
         .update(passwordResetTokens)
         .set({ usedAt: new Date() })
-        .where(and(eq(passwordResetTokens.userId, user.id), isNull(passwordResetTokens.usedAt)));
+        .where(and(eq(passwordResetTokens.userId, user.id), isNull(passwordResetTokens.usedAt)))
+        .returning({ id: passwordResetTokens.id });
 
       const resetToken = await createPasswordResetToken({ userId: user.id });
       const [newToken] = await tx

--- a/src/app/api/auth/password-reset/request/route.ts
+++ b/src/app/api/auth/password-reset/request/route.ts
@@ -43,7 +43,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ message: PASSWORD_RESET_REQUEST_MESSAGE });
     }
 
-    const token = await poolDb.transaction(async (tx) => {
+    const tokenIssue = await poolDb.transaction(async (tx) => {
       await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${`password-reset:${user.id}`}))`);
 
       const recentCutoff = new Date(Date.now() - 1000 * 60 * 5);
@@ -63,24 +63,46 @@ export async function POST(request: NextRequest) {
         return null;
       }
 
+      const [previousToken] = await tx
+        .select({ id: passwordResetTokens.id })
+        .from(passwordResetTokens)
+        .where(and(eq(passwordResetTokens.userId, user.id), isNull(passwordResetTokens.usedAt)))
+        .limit(1);
+
       await tx
         .update(passwordResetTokens)
         .set({ usedAt: new Date() })
         .where(and(eq(passwordResetTokens.userId, user.id), isNull(passwordResetTokens.usedAt)));
 
       const resetToken = await createPasswordResetToken({ userId: user.id });
-      await tx.insert(passwordResetTokens).values({
-        userId: user.id,
-        tokenHash: hashResetToken(resetToken),
-        requestIpHash: hashedIp,
-        expiresAt: passwordResetExpiresAt(),
-      });
-      return resetToken;
+      const [newToken] = await tx
+        .insert(passwordResetTokens)
+        .values({
+          userId: user.id,
+          tokenHash: hashResetToken(resetToken),
+          requestIpHash: hashedIp,
+          expiresAt: passwordResetExpiresAt(),
+        })
+        .returning({ id: passwordResetTokens.id });
+      return { token: resetToken, newTokenId: newToken.id, previousTokenId: previousToken?.id ?? null };
     });
-    if (token) {
+    if (tokenIssue) {
       try {
-        await sendPasswordResetEmail({ to: user.email, token });
+        await sendPasswordResetEmail({ to: user.email, token: tokenIssue.token });
       } catch (error) {
+        await poolDb.transaction(async (tx) => {
+          await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${`password-reset:${user.id}`}))`);
+          await tx
+            .update(passwordResetTokens)
+            .set({ usedAt: new Date() })
+            .where(eq(passwordResetTokens.id, tokenIssue.newTokenId));
+          if (tokenIssue.previousTokenId) {
+            await tx
+              .update(passwordResetTokens)
+              .set({ usedAt: null })
+              .where(eq(passwordResetTokens.id, tokenIssue.previousTokenId));
+          }
+        });
         console.error("Password reset email delivery error:", error);
       }
     }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -49,7 +49,8 @@ export const passwordResetTokens = pgTable("password_reset_tokens", {
 }, (table) => ({
   userIdx: index("idx_password_reset_tokens_user").on(table.userId),
   tokenHashIdx: uniqueIndex("password_reset_tokens_token_hash_unique").on(table.tokenHash),
-  activeUserIdx: index("idx_password_reset_tokens_active_user").on(table.userId, table.expiresAt)
+  /** Keep one unused reset token per user; expiresAt remains data, not uniqueness scope. */
+  activeUserIdx: uniqueIndex("password_reset_tokens_active_user_unique").on(table.userId)
     .where(sql`${table.usedAt} is null`),
 }));
 


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Align `password_reset_tokens.activeUserIdx` with the deployed unique partial index on `user_id` where `used_at is null`.
- Add a one-line schema comment documenting why `expires_at` is not part of the uniqueness scope.
- Clear stale unused reset tokens after the five-minute resend check and before inserting a new token, preserving the DB-level single-active-token invariant.
- Restore the prior unused token if replacement email delivery fails, and mark the unsent replacement token used.
- Capture the prior token id from the atomic update result before any compensating restore.

## Testing
- `npx drizzle-kit generate` (emitted an untracked initial baseline because the repo has no Drizzle journal; generated index shape matches the deployed unique partial index and does not emit an alter/drop migration for this index)
- `npx tsc --noEmit`
- `npm run build`
- `coderabbit review --prompt-only` (blocked: CLI not installed in the cloud image)
- `npx coderabbit review --prompt-only` (blocked: npm could not determine executable)
- `npm run test:unit` (existing Vitest collection issue in `src/lib/thoughtSaving.test.ts`)
- Vercel preview deployed; direct Preview API/DB row-count check blocked by Vercel authentication/secret access in this agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c8cb888-07f7-4909-8ec4-b77b84625c90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c8cb888-07f7-4909-8ec4-b77b84625c90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Prevent duplicate password reset tokens and keep email retries reliable**

### What Changed
- Requesting a password reset now removes any older unused token before creating a new one, so each user keeps only one active reset link at a time.
- If sending the reset email fails, the new token is marked unusable and the previous token is restored, so the last working link still works.
- The reset token rule now matches the live database setup, avoiding drift between the app and the stored data.

### Impact
`✅ Fewer broken password reset links`
`✅ Safer resend flow for password resets`
`✅ Less mismatch between app behavior and stored reset-token rules`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=_TycL4T8-HDqAWIhA9QApci6peOE66O1EAXYAjfO4Ks&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
