### PR TITLE
Add scheduled buddy sessions with Google Calendar sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,12 @@ JWT_SECRET=your-secret-here
 # Daily.co — server-only REST API key for creating/deleting buddy video rooms (#105). Never expose to the client.
 DAILY_API_KEY=
 
+# Google Calendar OAuth for scheduled buddy sessions (#204). Never expose client secret or token key.
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
+# GOOGLE_REDIRECT_URI=https://still-point.me/api/auth/google/callback
+# GOOGLE_TOKEN_ENCRYPTION_KEY=
+
 # Optional: set to exactly "true" to require friendship before buddy join (see README)
 # BUDDY_REQUIRE_FRIENDSHIP=
 

--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,7 @@ DAILY_API_KEY=
 # GOOGLE_CLIENT_ID=
 # GOOGLE_CLIENT_SECRET=
 # GOOGLE_REDIRECT_URI=https://still-point.me/api/auth/google/callback
+# Must decode to exactly 32 bytes; base64 preferred (`openssl rand -base64 32`) or 64-char hex.
 # GOOGLE_TOKEN_ENCRYPTION_KEY=
 
 # Optional: set to exactly "true" to require friendship before buddy join (see README)

--- a/drizzle/partner_scheduling_google_calendar_incremental.sql
+++ b/drizzle/partner_scheduling_google_calendar_incremental.sql
@@ -1,0 +1,44 @@
+-- Partner scheduling + Google Calendar sync (#204).
+-- Preferred: apply schema with `npx drizzle-kit push` (see README).
+-- This file is a reference for existing databases if you apply SQL manually.
+
+ALTER TABLE "buddy_sessions"
+  ADD COLUMN IF NOT EXISTS "scheduled_start_at" timestamptz;
+
+CREATE TABLE IF NOT EXISTS "google_oauth_tokens" (
+  "user_id" uuid PRIMARY KEY REFERENCES "users"("id") ON DELETE CASCADE,
+  "google_sub" varchar(255),
+  "google_email" varchar(255),
+  "access_token_encrypted" text NOT NULL,
+  "refresh_token_encrypted" text,
+  "scope" text NOT NULL,
+  "token_type" varchar(32) NOT NULL DEFAULT 'Bearer',
+  "expiry_date" timestamptz NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "idx_google_oauth_tokens_email"
+  ON "google_oauth_tokens"("google_email");
+
+CREATE TABLE IF NOT EXISTS "buddy_session_calendar_events" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "buddy_session_id" uuid NOT NULL REFERENCES "buddy_sessions"("id") ON DELETE CASCADE,
+  "user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "google_event_id" varchar(255),
+  "html_link" text,
+  "status" varchar(20) NOT NULL DEFAULT 'created',
+  "error" text,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "buddy_session_calendar_events_session_user"
+    UNIQUE ("buddy_session_id", "user_id"),
+  CONSTRAINT "buddy_session_calendar_events_status_allowed"
+    CHECK ("status" IN ('created', 'failed', 'deleted'))
+);
+
+CREATE INDEX IF NOT EXISTS "idx_buddy_session_calendar_events_session"
+  ON "buddy_session_calendar_events"("buddy_session_id");
+
+CREATE INDEX IF NOT EXISTS "idx_buddy_session_calendar_events_user"
+  ON "buddy_session_calendar_events"("user_id");

--- a/drizzle/partner_scheduling_google_calendar_incremental.sql
+++ b/drizzle/partner_scheduling_google_calendar_incremental.sql
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS "buddy_session_calendar_events" (
   "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   "buddy_session_id" uuid NOT NULL REFERENCES "buddy_sessions"("id") ON DELETE CASCADE,
   "user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
-  "google_event_id" varchar(255),
+  "google_event_id" text,
   "html_link" text,
   "status" varchar(20) NOT NULL DEFAULT 'created',
   "error" text,

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -7,9 +7,9 @@ import {
 } from "@/lib/google";
 
 export async function GET(request: NextRequest) {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim()?.replace(/\/+$/, "") ?? request.nextUrl.origin;
   try {
     const auth = await getCurrentUser();
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim()?.replace(/\/+$/, "") ?? request.nextUrl.origin;
     const doneUrl = new URL("/app", appUrl);
 
     if (!auth) {
@@ -38,7 +38,6 @@ export async function GET(request: NextRequest) {
     return response;
   } catch (error) {
     console.error("Google OAuth callback error:", error);
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim()?.replace(/\/+$/, "") ?? request.nextUrl.origin;
     const failedUrl = new URL("/app", appUrl);
     failedUrl.searchParams.set("googleCalendar", "failed");
     return NextResponse.redirect(failedUrl);

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth";
+import {
+  exchangeGoogleCodeForTokens,
+  getGoogleStateCookieName,
+  verifyGoogleOAuthState,
+} from "@/lib/google";
+
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await getCurrentUser();
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim()?.replace(/\/+$/, "") ?? request.nextUrl.origin;
+    const doneUrl = new URL("/app", appUrl);
+
+    if (!auth) {
+      doneUrl.searchParams.set("googleCalendar", "unauthorized");
+      return NextResponse.redirect(doneUrl);
+    }
+
+    const code = request.nextUrl.searchParams.get("code");
+    const state = request.nextUrl.searchParams.get("state");
+    const error = request.nextUrl.searchParams.get("error");
+    const nonceCookie = request.cookies.get(getGoogleStateCookieName())?.value;
+
+    if (error) {
+      doneUrl.searchParams.set("googleCalendar", "denied");
+      return NextResponse.redirect(doneUrl);
+    }
+    if (!code || !verifyGoogleOAuthState(state, nonceCookie, auth.userId)) {
+      doneUrl.searchParams.set("googleCalendar", "invalid");
+      return NextResponse.redirect(doneUrl);
+    }
+
+    await exchangeGoogleCodeForTokens(code, auth.userId);
+    doneUrl.searchParams.set("googleCalendar", "connected");
+    const response = NextResponse.redirect(doneUrl);
+    response.cookies.delete(getGoogleStateCookieName());
+    return response;
+  } catch (error) {
+    console.error("Google OAuth callback error:", error);
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim()?.replace(/\/+$/, "") ?? request.nextUrl.origin;
+    const failedUrl = new URL("/app", appUrl);
+    failedUrl.searchParams.set("googleCalendar", "failed");
+    return NextResponse.redirect(failedUrl);
+  }
+}

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -7,14 +7,19 @@ import {
 } from "@/lib/google";
 
 export async function GET(request: NextRequest) {
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim()?.replace(/\/+$/, "") ?? request.nextUrl.origin;
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim()?.replace(/\/+$/, "") ?? "https://still-point.me";
+  const redirectAndClearState = (url: URL) => {
+    const response = NextResponse.redirect(url);
+    response.cookies.delete(getGoogleStateCookieName());
+    return response;
+  };
   try {
     const auth = await getCurrentUser();
     const doneUrl = new URL("/app", appUrl);
 
     if (!auth) {
       doneUrl.searchParams.set("googleCalendar", "unauthorized");
-      return NextResponse.redirect(doneUrl);
+      return redirectAndClearState(doneUrl);
     }
 
     const code = request.nextUrl.searchParams.get("code");
@@ -24,22 +29,20 @@ export async function GET(request: NextRequest) {
 
     if (error) {
       doneUrl.searchParams.set("googleCalendar", "denied");
-      return NextResponse.redirect(doneUrl);
+      return redirectAndClearState(doneUrl);
     }
     if (!code || !verifyGoogleOAuthState(state, nonceCookie, auth.userId)) {
       doneUrl.searchParams.set("googleCalendar", "invalid");
-      return NextResponse.redirect(doneUrl);
+      return redirectAndClearState(doneUrl);
     }
 
     await exchangeGoogleCodeForTokens(code, auth.userId);
     doneUrl.searchParams.set("googleCalendar", "connected");
-    const response = NextResponse.redirect(doneUrl);
-    response.cookies.delete(getGoogleStateCookieName());
-    return response;
+    return redirectAndClearState(doneUrl);
   } catch (error) {
     console.error("Google OAuth callback error:", error);
     const failedUrl = new URL("/app", appUrl);
     failedUrl.searchParams.set("googleCalendar", "failed");
-    return NextResponse.redirect(failedUrl);
+    return redirectAndClearState(failedUrl);
   }
 }

--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth";
+import {
+  GoogleCalendarUnavailableError,
+  buildGoogleAuthUrl,
+  makeGoogleOAuthState,
+} from "@/lib/google";
+
+export async function GET() {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const oauthState = makeGoogleOAuthState(auth.userId);
+    const response = NextResponse.redirect(buildGoogleAuthUrl(oauthState.state));
+    response.cookies.set(oauthState.cookie);
+    return response;
+  } catch (error) {
+    if (error instanceof GoogleCalendarUnavailableError) {
+      return NextResponse.json({ error: error.message }, { status: 503 });
+    }
+    console.error("Google OAuth start error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/auth/google/status/route.ts
+++ b/src/app/api/auth/google/status/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth";
+import { loadGoogleCalendarStatus } from "@/lib/google";
+
+export async function GET() {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    return NextResponse.json({ google: await loadGoogleCalendarStatus(auth.userId) });
+  } catch (error) {
+    console.error("Google status error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/buddy/sessions/[id]/start/route.ts
+++ b/src/app/api/buddy/sessions/[id]/start/route.ts
@@ -60,6 +60,13 @@ export async function POST(_request: Request, context: Params) {
 
     const phaseErr = requireReadyCheckForStart(session);
     if (phaseErr) return phaseErr;
+    if (session.scheduledStartAt && session.scheduledStartAt.getTime() > Date.now()) {
+      return buddyPolicyJson(
+        409,
+        "This session is scheduled for later.",
+        BUDDY_POLICY_CODES.START_WRONG_PHASE,
+      );
+    }
 
     const roomName = `buddy-${sessionId}`;
     let dailyRoom: { name: string; url: string };

--- a/src/app/api/buddy/sessions/[id]/start/route.ts
+++ b/src/app/api/buddy/sessions/[id]/start/route.ts
@@ -61,10 +61,9 @@ export async function POST(_request: Request, context: Params) {
     const phaseErr = requireReadyCheckForStart(session);
     if (phaseErr) return phaseErr;
     if (session.scheduledStartAt && session.scheduledStartAt.getTime() > Date.now()) {
-      return buddyPolicyJson(
-        409,
-        "This session is scheduled for later.",
-        BUDDY_POLICY_CODES.START_WRONG_PHASE,
+      return NextResponse.json(
+        { error: "This session is scheduled for later." },
+        { status: 409 },
       );
     }
 

--- a/src/app/api/buddy/sessions/join/route.ts
+++ b/src/app/api/buddy/sessions/join/route.ts
@@ -7,6 +7,7 @@ import {
   bumpBuddyRevision,
   reconcileBuddySession,
 } from "@/lib/buddySession";
+import { syncBuddySessionCalendarForUser } from "@/lib/google";
 import { and, eq } from "drizzle-orm";
 import { readJsonObject } from "@/lib/readJsonObject";
 
@@ -79,7 +80,14 @@ export async function POST(request: NextRequest) {
         .where(eq(buddySessionParticipants.id, existing.id));
       await bumpBuddyRevision(session.id);
       await reconcileBuddySession(session.id);
-      return NextResponse.json({ sessionId: session.id });
+      const calendarSync = session.scheduledStartAt
+        ? [await syncBuddySessionCalendarForUser(session, auth.userId)]
+        : [];
+      return NextResponse.json({
+        sessionId: session.id,
+        scheduledStartAt: session.scheduledStartAt?.toISOString() ?? null,
+        calendarSync,
+      });
     }
 
     if (session.state === "waiting" || session.state === "ready_check") {
@@ -104,7 +112,14 @@ export async function POST(request: NextRequest) {
       }
       await bumpBuddyRevision(session.id);
       await reconcileBuddySession(session.id);
-      return NextResponse.json({ sessionId: session.id });
+      const calendarSync = session.scheduledStartAt
+        ? [await syncBuddySessionCalendarForUser(session, auth.userId)]
+        : [];
+      return NextResponse.json({
+        sessionId: session.id,
+        scheduledStartAt: session.scheduledStartAt?.toISOString() ?? null,
+        calendarSync,
+      });
     }
 
     return NextResponse.json({ error: "Cannot join this session" }, { status: 409 });

--- a/src/app/api/buddy/sessions/join/route.ts
+++ b/src/app/api/buddy/sessions/join/route.ts
@@ -7,7 +7,10 @@ import {
   bumpBuddyRevision,
   reconcileBuddySession,
 } from "@/lib/buddySession";
-import { syncBuddySessionCalendarForUser } from "@/lib/google";
+import {
+  GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE,
+  syncBuddySessionCalendarForUser,
+} from "@/lib/google";
 import { and, eq } from "drizzle-orm";
 import { readJsonObject } from "@/lib/readJsonObject";
 import type { CalendarSyncResult } from "@/lib/google";
@@ -25,10 +28,7 @@ async function syncCalendarBestEffort(
       {
         status: "failed" as const,
         userId,
-        error:
-          error instanceof Error
-            ? error.message
-            : "Could not sync Google Calendar",
+        error: GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE,
       },
     ];
   }

--- a/src/app/api/buddy/sessions/join/route.ts
+++ b/src/app/api/buddy/sessions/join/route.ts
@@ -10,6 +10,29 @@ import {
 import { syncBuddySessionCalendarForUser } from "@/lib/google";
 import { and, eq } from "drizzle-orm";
 import { readJsonObject } from "@/lib/readJsonObject";
+import type { CalendarSyncResult } from "@/lib/google";
+
+async function syncCalendarBestEffort(
+  session: typeof buddySessions.$inferSelect,
+  userId: string,
+): Promise<CalendarSyncResult[]> {
+  if (!session.scheduledStartAt) return [];
+  try {
+    return [await syncBuddySessionCalendarForUser(session, userId)];
+  } catch (error) {
+    console.error("Buddy join Google Calendar sync error:", error);
+    return [
+      {
+        status: "failed" as const,
+        userId,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Could not sync Google Calendar",
+      },
+    ];
+  }
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -80,9 +103,7 @@ export async function POST(request: NextRequest) {
         .where(eq(buddySessionParticipants.id, existing.id));
       await bumpBuddyRevision(session.id);
       await reconcileBuddySession(session.id);
-      const calendarSync = session.scheduledStartAt
-        ? [await syncBuddySessionCalendarForUser(session, auth.userId)]
-        : [];
+      const calendarSync = await syncCalendarBestEffort(session, auth.userId);
       return NextResponse.json({
         sessionId: session.id,
         scheduledStartAt: session.scheduledStartAt?.toISOString() ?? null,
@@ -112,9 +133,7 @@ export async function POST(request: NextRequest) {
       }
       await bumpBuddyRevision(session.id);
       await reconcileBuddySession(session.id);
-      const calendarSync = session.scheduledStartAt
-        ? [await syncBuddySessionCalendarForUser(session, auth.userId)]
-        : [];
+      const calendarSync = await syncCalendarBestEffort(session, auth.userId);
       return NextResponse.json({
         sessionId: session.id,
         scheduledStartAt: session.scheduledStartAt?.toISOString() ?? null,

--- a/src/app/api/buddy/sessions/route.test.ts
+++ b/src/app/api/buddy/sessions/route.test.ts
@@ -1,4 +1,4 @@
-import type { NextRequest } from "next/server";
+import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const getCurrentUser = vi.fn();
@@ -43,6 +43,13 @@ vi.mock("drizzle-orm", () => ({
   eq: vi.fn((left, right) => ({ left, right })),
 }));
 
+function buddyCreateRequest(body?: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://test.local/api/buddy/sessions", {
+    method: "POST",
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
 describe("POST /api/buddy/sessions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -66,12 +73,9 @@ describe("POST /api/buddy/sessions", () => {
   test("rejects a scheduled start in the past", async () => {
     const { POST } = await import("./route");
 
-    const response = await POST(
-      new Request("http://test.local/api/buddy/sessions", {
-        method: "POST",
-        body: JSON.stringify({ scheduledStartAt: "2000-01-01T00:00:00.000Z" }),
-      }) as NextRequest,
-    );
+    const response = await POST(buddyCreateRequest({
+      scheduledStartAt: "2000-01-01T00:00:00.000Z",
+    }));
 
     await expect(response.json()).resolves.toEqual({
       error: "scheduledStartAt must be in the future",
@@ -92,12 +96,7 @@ describe("POST /api/buddy/sessions", () => {
     ]);
     const { POST } = await import("./route");
 
-    const response = await POST(
-      new Request("http://test.local/api/buddy/sessions", {
-        method: "POST",
-        body: JSON.stringify({ scheduledStartAt: future }),
-      }) as NextRequest,
-    );
+    const response = await POST(buddyCreateRequest({ scheduledStartAt: future }));
 
     const body = await response.json();
     expect(response.status).toBe(200);
@@ -113,5 +112,55 @@ describe("POST /api/buddy/sessions", () => {
     );
     expect(body.session.scheduledStartAt).toBe(future);
     expect(body.session.calendarSync).toHaveLength(1);
+  });
+
+  test("creates an immediate session without calendar sync", async () => {
+    const { POST } = await import("./route");
+
+    const response = await POST(buddyCreateRequest());
+
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scheduledStartAt: null,
+        state: "waiting",
+      }),
+    );
+    expect(syncBuddySessionCalendarForUser).not.toHaveBeenCalled();
+    expect(body.session.scheduledStartAt).toBeNull();
+    expect(body.session.calendarSync).toEqual([]);
+  });
+
+  test("keeps scheduled session creation successful when calendar sync throws", async () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    insertReturning.mockResolvedValue([
+      {
+        id: "session-1",
+        shareToken: "share-token",
+        durationSeconds: 600,
+        scheduledStartAt: new Date(future),
+      },
+    ]);
+    syncBuddySessionCalendarForUser.mockRejectedValue(new Error("calendar unavailable"));
+    const { POST } = await import("./route");
+
+    const response = await POST(buddyCreateRequest({ scheduledStartAt: future }));
+
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scheduledStartAt: expect.any(Date),
+        state: "waiting",
+      }),
+    );
+    expect(body.session.calendarSync).toEqual([
+      {
+        status: "failed",
+        userId: "user-1",
+        error: "calendar unavailable",
+      },
+    ]);
   });
 });

--- a/src/app/api/buddy/sessions/route.test.ts
+++ b/src/app/api/buddy/sessions/route.test.ts
@@ -36,6 +36,7 @@ vi.mock("@/lib/buddySession", () => ({
 }));
 
 vi.mock("@/lib/google", () => ({
+  GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE: "Could not sync Google Calendar",
   syncBuddySessionCalendarForUser,
 }));
 
@@ -159,7 +160,7 @@ describe("POST /api/buddy/sessions", () => {
       {
         status: "failed",
         userId: "user-1",
-        error: "calendar unavailable",
+        error: "Could not sync Google Calendar",
       },
     ]);
   });

--- a/src/app/api/buddy/sessions/route.test.ts
+++ b/src/app/api/buddy/sessions/route.test.ts
@@ -1,0 +1,117 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const getCurrentUser = vi.fn();
+const syncBuddySessionCalendarForUser = vi.fn();
+const selectLimit = vi.fn();
+const selectWhere = vi.fn(() => ({ limit: selectLimit }));
+const selectFrom = vi.fn(() => ({ where: selectWhere }));
+const dbSelect = vi.fn(() => ({ from: selectFrom }));
+const insertReturning = vi.fn();
+const insertValues = vi.fn(() => ({ returning: insertReturning }));
+const dbInsert = vi.fn(() => ({ values: insertValues }));
+
+vi.mock("@/db", () => ({
+  db: {
+    select: dbSelect,
+    insert: dbInsert,
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  buddySessions: {},
+  buddySessionParticipants: {},
+  users: {
+    id: "users.id",
+    currentDay: "users.currentDay",
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentUser,
+}));
+
+vi.mock("@/lib/buddySession", () => ({
+  buddyDurationForDay: vi.fn(() => 600),
+}));
+
+vi.mock("@/lib/google", () => ({
+  syncBuddySessionCalendarForUser,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((left, right) => ({ left, right })),
+}));
+
+describe("POST /api/buddy/sessions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCurrentUser.mockResolvedValue({ userId: "user-1", email: "user@example.com" });
+    selectLimit.mockResolvedValue([{ currentDay: 1 }]);
+    insertReturning.mockResolvedValue([
+      {
+        id: "session-1",
+        shareToken: "share-token",
+        durationSeconds: 600,
+        scheduledStartAt: null,
+      },
+    ]);
+    syncBuddySessionCalendarForUser.mockResolvedValue({
+      status: "skipped",
+      userId: "user-1",
+      reason: "not_connected",
+    });
+  });
+
+  test("rejects a scheduled start in the past", async () => {
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      new Request("http://test.local/api/buddy/sessions", {
+        method: "POST",
+        body: JSON.stringify({ scheduledStartAt: "2000-01-01T00:00:00.000Z" }),
+      }) as NextRequest,
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      error: "scheduledStartAt must be in the future",
+    });
+    expect(response.status).toBe(400);
+    expect(dbInsert).not.toHaveBeenCalled();
+  });
+
+  test("stores a future scheduled start and syncs the host calendar", async () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    insertReturning.mockResolvedValue([
+      {
+        id: "session-1",
+        shareToken: "share-token",
+        durationSeconds: 600,
+        scheduledStartAt: new Date(future),
+      },
+    ]);
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      new Request("http://test.local/api/buddy/sessions", {
+        method: "POST",
+        body: JSON.stringify({ scheduledStartAt: future }),
+      }) as NextRequest,
+    );
+
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scheduledStartAt: expect.any(Date),
+        state: "waiting",
+      }),
+    );
+    expect(syncBuddySessionCalendarForUser).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "session-1" }),
+      "user-1",
+    );
+    expect(body.session.scheduledStartAt).toBe(future);
+    expect(body.session.calendarSync).toHaveLength(1);
+  });
+});

--- a/src/app/api/buddy/sessions/route.ts
+++ b/src/app/api/buddy/sessions/route.ts
@@ -1,17 +1,47 @@
 import { randomBytes } from "crypto";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { buddySessions, buddySessionParticipants, users } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
 import { buddyDurationForDay } from "@/lib/buddySession";
+import { syncBuddySessionCalendarForUser } from "@/lib/google";
 import { eq } from "drizzle-orm";
 
-export async function POST() {
+async function readOptionalScheduledStartAt(request: NextRequest): Promise<Date | null | NextResponse> {
+  const text = await request.text();
+  if (!text.trim()) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const raw = (parsed as Record<string, unknown>).scheduledStartAt;
+  if (raw == null || raw === "") return null;
+  if (typeof raw !== "string") {
+    return NextResponse.json({ error: "scheduledStartAt must be an ISO timestamp" }, { status: 400 });
+  }
+  const scheduledStartAt = new Date(raw);
+  if (Number.isNaN(scheduledStartAt.getTime())) {
+    return NextResponse.json({ error: "scheduledStartAt must be a valid timestamp" }, { status: 400 });
+  }
+  if (scheduledStartAt.getTime() <= Date.now()) {
+    return NextResponse.json({ error: "scheduledStartAt must be in the future" }, { status: 400 });
+  }
+  return scheduledStartAt;
+}
+
+export async function POST(request: NextRequest) {
   try {
     const auth = await getCurrentUser();
     if (!auth) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
+    const scheduledStartAt = await readOptionalScheduledStartAt(request);
+    if (scheduledStartAt instanceof NextResponse) return scheduledStartAt;
 
     const [host] = await db
       .select({ currentDay: users.currentDay })
@@ -31,6 +61,7 @@ export async function POST() {
         shareToken,
         hostUserId: auth.userId,
         durationSeconds,
+        scheduledStartAt,
         state: "waiting",
       })
       .returning();
@@ -47,6 +78,24 @@ export async function POST() {
     });
 
     const sharePath = `/app?buddy=${encodeURIComponent(shareToken)}`;
+    let calendarSync: Awaited<ReturnType<typeof syncBuddySessionCalendarForUser>>[] = [];
+    if (session.scheduledStartAt) {
+      try {
+        calendarSync = [await syncBuddySessionCalendarForUser(session, auth.userId)];
+      } catch (syncError) {
+        console.error("Buddy create Google Calendar sync error:", syncError);
+        calendarSync = [
+          {
+            status: "failed",
+            userId: auth.userId,
+            error:
+              syncError instanceof Error
+                ? syncError.message
+                : "Could not sync Google Calendar",
+          },
+        ];
+      }
+    }
 
     return NextResponse.json({
       session: {
@@ -54,6 +103,8 @@ export async function POST() {
         shareToken: session.shareToken,
         sharePath,
         durationSeconds: session.durationSeconds,
+        scheduledStartAt: session.scheduledStartAt?.toISOString() ?? null,
+        calendarSync,
       },
     });
   } catch (error) {

--- a/src/app/api/buddy/sessions/route.ts
+++ b/src/app/api/buddy/sessions/route.ts
@@ -4,7 +4,7 @@ import { db } from "@/db";
 import { buddySessions, buddySessionParticipants, users } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
 import { buddyDurationForDay } from "@/lib/buddySession";
-import { syncBuddySessionCalendarForUser } from "@/lib/google";
+import { GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE, syncBuddySessionCalendarForUser } from "@/lib/google";
 import { eq } from "drizzle-orm";
 
 async function readOptionalScheduledStartAt(request: NextRequest): Promise<Date | null | NextResponse> {
@@ -88,10 +88,7 @@ export async function POST(request: NextRequest) {
           {
             status: "failed",
             userId: auth.userId,
-            error:
-              syncError instanceof Error
-                ? syncError.message
-                : "Could not sync Google Calendar",
+            error: GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE,
           },
         ];
       }

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import type { User } from "@/lib/api";
+import type { CalendarSyncResult, User } from "@/lib/api";
 import { AuthScreen } from "@/components/AuthScreen";
 import { HomeView } from "@/components/HomeView";
 import { SessionView } from "@/components/SessionView";
@@ -44,6 +44,14 @@ function getLocalIsoDate(): string {
   return `${year}-${month}-${day}`;
 }
 
+function calendarSyncMessageFromResult(sync: CalendarSyncResult[] | undefined): string | null {
+  const item = sync?.[0];
+  if (!item) return null;
+  if (item.status === "created") return "Added this scheduled sit to your Google Calendar.";
+  if (item.status === "skipped") return "Google Calendar is not connected on this account.";
+  return "Could not add this sit to Google Calendar, but you joined successfully.";
+}
+
 export default function StillPoint() {
   const [user, setUser] = useState<User | null>(null);
   const [view, setView] = useState<View>("home");
@@ -53,6 +61,7 @@ export default function StillPoint() {
   const [completionData, setCompletionData] = useState<CompletionData | null>(null);
   const [buddySessionId, setBuddySessionId] = useState<string | null>(null);
   const [buddyInviteError, setBuddyInviteError] = useState<string | null>(null);
+  const [buddyCalendarMessage, setBuddyCalendarMessage] = useState<string | null>(null);
   const buddyInviteInFlight = useRef(false);
   const isMobile = useIsMobile();
 
@@ -114,9 +123,10 @@ export default function StillPoint() {
 
     (async () => {
       try {
-        const { sessionId } = await api.joinBuddySession(raw);
+        const { sessionId, calendarSync } = await api.joinBuddySession(raw);
         if (cancelled) return;
         setBuddyInviteError(null);
+        setBuddyCalendarMessage(calendarSyncMessageFromResult(calendarSync));
         setBuddySessionId(sessionId);
         setView("buddy");
         window.history.replaceState({}, "", "/app");
@@ -144,6 +154,7 @@ export default function StillPoint() {
   const handleLogout = () => {
     buddyInviteInFlight.current = false;
     setBuddySessionId(null);
+    setBuddyCalendarMessage(null);
     setUser(null);
     setView("home");
   };
@@ -154,12 +165,14 @@ export default function StillPoint() {
 
   const handleBuddyExit = useCallback(() => {
     setBuddySessionId(null);
+    setBuddyCalendarMessage(null);
     setBuddyInviteError(null);
     setView("home");
   }, []);
 
   const handleBuddyPersonalRecordComplete = useCallback((data: BuddyPersonalRecordPayload) => {
     setBuddySessionId(null);
+    setBuddyCalendarMessage(null);
     setCompletionData({
       sessionId: data.sessionId,
       dayNumber: data.dayNumber,
@@ -495,6 +508,7 @@ export default function StillPoint() {
           onBegin={handleBegin}
           onBuddy={() => {
             setBuddySessionId(null);
+            setBuddyCalendarMessage(null);
             setBuddyInviteError(null);
             setView("buddy");
           }}
@@ -503,7 +517,10 @@ export default function StillPoint() {
 
       {view === "buddy" && !buddySessionId && (
         <BuddySessionHub
-          onEnterSession={(id) => setBuddySessionId(id)}
+          onEnterSession={(id, calendarSync) => {
+            setBuddyCalendarMessage(calendarSyncMessageFromResult(calendarSync ?? undefined));
+            setBuddySessionId(id);
+          }}
           onBack={handleBuddyExit}
         />
       )}
@@ -512,6 +529,7 @@ export default function StillPoint() {
         <BuddySessionRoom
           sessionId={buddySessionId}
           currentUserId={user.id}
+          calendarMessage={buddyCalendarMessage}
           onExit={handleBuddyExit}
           onPersonalRecordComplete={handleBuddyPersonalRecordComplete}
         />

--- a/src/components/BuddySessionHub.tsx
+++ b/src/components/BuddySessionHub.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { api, ApiError } from "@/lib/api";
 
 function extractBuddyToken(input: string): string {
@@ -26,20 +26,80 @@ type BuddySessionHubProps = {
   onBack: () => void;
 };
 
+type CalendarSync = NonNullable<Awaited<ReturnType<typeof api.joinBuddySession>>["calendarSync"]>;
+
 export function BuddySessionHub({ onEnterSession, onBack }: BuddySessionHubProps) {
   const [joinToken, setJoinToken] = useState("");
   const [createdPath, setCreatedPath] = useState<string | null>(null);
   const [createdId, setCreatedId] = useState<string | null>(null);
+  const [scheduledLocal, setScheduledLocal] = useState("");
+  const [createdScheduledStartAt, setCreatedScheduledStartAt] = useState<string | null>(null);
+  const [googleStatus, setGoogleStatus] = useState<{
+    connected: boolean;
+    email: string | null;
+  } | null>(null);
+  const [calendarMessage, setCalendarMessage] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  useEffect(() => {
+    let cancelled = false;
+    void api.getGoogleCalendarStatus().then(
+      ({ google }) => {
+        if (!cancelled) setGoogleStatus(google);
+      },
+      () => {
+        if (!cancelled) setGoogleStatus({ connected: false, email: null });
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  function localDateTimeToIso(value: string): { ok: true; value: string | null } | { ok: false } {
+    if (!value.trim()) return { ok: true, value: null };
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      setError("Pick a valid date and time");
+      return { ok: false };
+    }
+    if (date.getTime() <= Date.now()) {
+      setError("Pick a future time for a scheduled session");
+      return { ok: false };
+    }
+    return { ok: true, value: date.toISOString() };
+  }
+
+  function formatScheduled(value: string | null): string | null {
+    if (!value) return null;
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date(value));
+  }
+
+  function calendarSyncMessage(sync: CalendarSync) {
+    if (sync.length === 0) return null;
+    const item = sync[0];
+    if (!item) return null;
+    if (item.status === "created") return "Added to your Google Calendar.";
+    if (item.status === "skipped") return "Google Calendar is not connected on this account.";
+    return "Could not add to Google Calendar, but the invite was created.";
+  }
+
   async function handleCreate() {
     setError(null);
+    setCalendarMessage(null);
+    const scheduledStartAt = localDateTimeToIso(scheduledLocal);
+    if (!scheduledStartAt.ok) return;
     setBusy(true);
     try {
-      const { session } = await api.createBuddySession();
+      const { session } = await api.createBuddySession({ scheduledStartAt: scheduledStartAt.value });
       setCreatedPath(session.sharePath);
       setCreatedId(session.id);
+      setCreatedScheduledStartAt(session.scheduledStartAt);
+      setCalendarMessage(calendarSyncMessage(session.calendarSync));
     } catch (e) {
       setError(e instanceof ApiError ? e.message : "Could not create session");
     } finally {
@@ -49,6 +109,7 @@ export function BuddySessionHub({ onEnterSession, onBack }: BuddySessionHubProps
 
   async function handleJoin() {
     setError(null);
+    setCalendarMessage(null);
     const t = extractBuddyToken(joinToken);
     if (!t) {
       setError("Paste a join link or token");
@@ -56,7 +117,8 @@ export function BuddySessionHub({ onEnterSession, onBack }: BuddySessionHubProps
     }
     setBusy(true);
     try {
-      const { sessionId } = await api.joinBuddySession(t);
+      const { sessionId, calendarSync } = await api.joinBuddySession(t);
+      if (calendarSync) setCalendarMessage(calendarSyncMessage(calendarSync));
       onEnterSession(sessionId);
     } catch (e) {
       setError(e instanceof ApiError ? e.message : "Could not join");
@@ -103,8 +165,47 @@ export function BuddySessionHub({ onEnterSession, onBack }: BuddySessionHubProps
           margin: 0,
         }}
       >
-        Create a room, share the link, mark ready when you are set, then the host starts one shared timer for everyone.
+        Create a room now, or schedule a shared sit and let each connected Google Calendar add the agreed time.
       </p>
+
+      <div
+        style={{
+          width: "100%",
+          border: "1px solid var(--border-2)",
+          borderRadius: "12px",
+          padding: "14px",
+          background: "var(--surface-1)",
+          boxSizing: "border-box",
+          display: "grid",
+          gap: "var(--s2)",
+        }}
+      >
+        <p style={{ margin: 0, fontSize: "13px", color: "var(--fg-2)", lineHeight: 1.45 }}>
+          Google Calendar:{" "}
+          {googleStatus?.connected
+            ? `connected${googleStatus.email ? ` as ${googleStatus.email}` : ""}`
+            : "not connected"}
+        </p>
+        {!googleStatus?.connected && (
+          <a
+            href="/api/auth/google"
+            style={{
+              color: "var(--fg)",
+              fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+              fontSize: "11px",
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+            }}
+          >
+            Connect Google Calendar
+          </a>
+        )}
+        {calendarMessage && (
+          <p style={{ margin: 0, fontSize: "12px", color: "var(--fg-3)", lineHeight: 1.45 }}>
+            {calendarMessage}
+          </p>
+        )}
+      </div>
 
       {error && (
         <p
@@ -126,6 +227,36 @@ export function BuddySessionHub({ onEnterSession, onBack }: BuddySessionHubProps
 
       {!createdPath ? (
         <>
+          <label
+            htmlFor="buddy-scheduled-start"
+            style={{
+              width: "100%",
+              display: "grid",
+              gap: "var(--s2)",
+              color: "var(--fg-2)",
+              fontSize: "13px",
+            }}
+          >
+            Schedule for later (optional)
+            <input
+              id="buddy-scheduled-start"
+              type="datetime-local"
+              value={scheduledLocal}
+              onChange={(e) => setScheduledLocal(e.target.value)}
+              disabled={busy}
+              style={{
+                width: "100%",
+                boxSizing: "border-box",
+                background: "var(--surface-1)",
+                border: "1px solid var(--border-2)",
+                color: "var(--fg)",
+                borderRadius: "8px",
+                padding: "10px 12px",
+                fontSize: "13px",
+                fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+              }}
+            />
+          </label>
           <button
             type="button"
             disabled={busy}
@@ -143,7 +274,7 @@ export function BuddySessionHub({ onEnterSession, onBack }: BuddySessionHubProps
               width: "100%",
             }}
           >
-            Start shared session
+            {scheduledLocal ? "Create scheduled invite" : "Start shared session"}
           </button>
 
           <div
@@ -214,6 +345,11 @@ export function BuddySessionHub({ onEnterSession, onBack }: BuddySessionHubProps
           <p style={{ margin: 0, fontSize: "14px", color: "var(--fg-2)" }}>
             Share this link with your friend (they must be signed in):
           </p>
+          {createdScheduledStartAt && (
+            <p style={{ margin: 0, fontSize: "14px", color: "var(--fg-2)", lineHeight: 1.45 }}>
+              Scheduled for {formatScheduled(createdScheduledStartAt)}. They accept by joining; Google Calendar sync runs for each connected account.
+            </p>
+          )}
           <code
             style={{
               display: "block",

--- a/src/components/BuddySessionHub.tsx
+++ b/src/components/BuddySessionHub.tsx
@@ -22,7 +22,7 @@ function extractBuddyToken(input: string): string {
 }
 
 type BuddySessionHubProps = {
-  onEnterSession: (sessionId: string) => void;
+  onEnterSession: (sessionId: string, calendarSync?: CalendarSync | null) => void;
   onBack: () => void;
 };
 
@@ -38,6 +38,7 @@ export function BuddySessionHub({ onEnterSession, onBack }: BuddySessionHubProps
     connected: boolean;
     email: string | null;
   } | null>(null);
+  const [googleStatusLoading, setGoogleStatusLoading] = useState(true);
   const [calendarMessage, setCalendarMessage] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -46,10 +47,16 @@ export function BuddySessionHub({ onEnterSession, onBack }: BuddySessionHubProps
     let cancelled = false;
     void api.getGoogleCalendarStatus().then(
       ({ google }) => {
-        if (!cancelled) setGoogleStatus(google);
+        if (!cancelled) {
+          setGoogleStatus(google);
+          setGoogleStatusLoading(false);
+        }
       },
       () => {
-        if (!cancelled) setGoogleStatus({ connected: false, email: null });
+        if (!cancelled) {
+          setGoogleStatus({ connected: false, email: null });
+          setGoogleStatusLoading(false);
+        }
       },
     );
     return () => {
@@ -57,16 +64,14 @@ export function BuddySessionHub({ onEnterSession, onBack }: BuddySessionHubProps
     };
   }, []);
 
-  function localDateTimeToIso(value: string): { ok: true; value: string | null } | { ok: false } {
+  function localDateTimeToIso(value: string): { ok: true; value: string | null } | { ok: false; error: string } {
     if (!value.trim()) return { ok: true, value: null };
     const date = new Date(value);
     if (Number.isNaN(date.getTime())) {
-      setError("Pick a valid date and time");
-      return { ok: false };
+      return { ok: false, error: "Pick a valid date and time" };
     }
     if (date.getTime() <= Date.now()) {
-      setError("Pick a future time for a scheduled session");
-      return { ok: false };
+      return { ok: false, error: "Pick a future time for a scheduled session" };
     }
     return { ok: true, value: date.toISOString() };
   }
@@ -92,7 +97,10 @@ export function BuddySessionHub({ onEnterSession, onBack }: BuddySessionHubProps
     setError(null);
     setCalendarMessage(null);
     const scheduledStartAt = localDateTimeToIso(scheduledLocal);
-    if (!scheduledStartAt.ok) return;
+    if (!scheduledStartAt.ok) {
+      setError(scheduledStartAt.error);
+      return;
+    }
     setBusy(true);
     try {
       const { session } = await api.createBuddySession({ scheduledStartAt: scheduledStartAt.value });
@@ -118,8 +126,7 @@ export function BuddySessionHub({ onEnterSession, onBack }: BuddySessionHubProps
     setBusy(true);
     try {
       const { sessionId, calendarSync } = await api.joinBuddySession(t);
-      if (calendarSync) setCalendarMessage(calendarSyncMessage(calendarSync));
-      onEnterSession(sessionId);
+      onEnterSession(sessionId, calendarSync ?? null);
     } catch (e) {
       setError(e instanceof ApiError ? e.message : "Could not join");
     } finally {
@@ -182,11 +189,13 @@ export function BuddySessionHub({ onEnterSession, onBack }: BuddySessionHubProps
       >
         <p style={{ margin: 0, fontSize: "13px", color: "var(--fg-2)", lineHeight: 1.45 }}>
           Google Calendar:{" "}
-          {googleStatus?.connected
+          {googleStatusLoading
+            ? "checking..."
+            : googleStatus?.connected
             ? `connected${googleStatus.email ? ` as ${googleStatus.email}` : ""}`
             : "not connected"}
         </p>
-        {!googleStatus?.connected && (
+        {!googleStatusLoading && !googleStatus?.connected && (
           <a
             href="/api/auth/google"
             style={{

--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -65,6 +65,13 @@ function BuddyRoomErrorBanner({ message }: { message: string }) {
   );
 }
 
+function formatScheduledStart(value: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
 export function BuddySessionRoom({
   sessionId,
   currentUserId,
@@ -635,6 +642,22 @@ export function BuddySessionRoom({
       >
         Shared session
       </h2>
+
+      {snap.scheduledStartAt && inLobby && (
+        <p
+          role="note"
+          style={{
+            margin: 0,
+            fontSize: "13px",
+            color: "var(--fg-2)",
+            textAlign: "center",
+            lineHeight: 1.45,
+          }}
+        >
+          Scheduled for {formatScheduledStart(snap.scheduledStartAt)}. Joining confirms the shared
+          time; connected Google Calendars add it automatically.
+        </p>
+      )}
 
       {inLobby && (
         <>

--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -25,6 +25,7 @@ export type BuddyPersonalRecordPayload = {
 type BuddySessionRoomProps = {
   sessionId: string;
   currentUserId: string;
+  calendarMessage?: string | null;
   onExit: () => void;
   /** When set, a finished shared timer saves a personal session row then opens the normal completion flow. */
   onPersonalRecordComplete?: (data: BuddyPersonalRecordPayload) => void;
@@ -75,6 +76,7 @@ function formatScheduledStart(value: string): string {
 export function BuddySessionRoom({
   sessionId,
   currentUserId,
+  calendarMessage,
   onExit,
   onPersonalRecordComplete,
 }: BuddySessionRoomProps) {
@@ -656,6 +658,21 @@ export function BuddySessionRoom({
         >
           Scheduled for {formatScheduledStart(snap.scheduledStartAt)}. Joining confirms the shared
           time; connected Google Calendars add it automatically.
+        </p>
+      )}
+
+      {calendarMessage && inLobby && (
+        <p
+          role="status"
+          style={{
+            margin: 0,
+            fontSize: "12px",
+            color: "var(--fg-3)",
+            textAlign: "center",
+            lineHeight: 1.45,
+          }}
+        >
+          {calendarMessage}
         </p>
       )}
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -60,6 +60,7 @@ export const buddySessions = pgTable("buddy_sessions", {
   hostUserId: uuid("host_user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
   state: varchar("state", { length: 20 }).notNull().default("waiting"),
   durationSeconds: integer("duration_seconds").notNull(),
+  scheduledStartAt: timestamp("scheduled_start_at", { withTimezone: true }),
   startedAt: timestamp("started_at", { withTimezone: true }),
   /** Daily.co room name (for DELETE); set when the shared sit starts (#106). */
   dailyRoomName: varchar("daily_room_name", { length: 128 }),
@@ -91,6 +92,46 @@ export const buddySessionParticipants = pgTable("buddy_session_participants", {
   sessionUserUnique: uniqueIndex("buddy_session_participants_session_user").on(
     table.buddySessionId,
     table.userId,
+  ),
+}));
+
+/** Google Calendar OAuth connection per app user (#204). Tokens are encrypted server-side. */
+export const googleOAuthTokens = pgTable("google_oauth_tokens", {
+  userId: uuid("user_id").primaryKey().references(() => users.id, { onDelete: "cascade" }),
+  googleSub: varchar("google_sub", { length: 255 }),
+  googleEmail: varchar("google_email", { length: 255 }),
+  accessTokenEncrypted: text("access_token_encrypted").notNull(),
+  refreshTokenEncrypted: text("refresh_token_encrypted"),
+  scope: text("scope").notNull(),
+  tokenType: varchar("token_type", { length: 32 }).notNull().default("Bearer"),
+  expiryDate: timestamp("expiry_date", { withTimezone: true }).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  emailIdx: index("idx_google_oauth_tokens_email").on(table.googleEmail),
+}));
+
+/** Per-user Google Calendar event sync state for scheduled buddy sessions (#204). */
+export const buddySessionCalendarEvents = pgTable("buddy_session_calendar_events", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  buddySessionId: uuid("buddy_session_id").references(() => buddySessions.id, { onDelete: "cascade" }).notNull(),
+  userId: uuid("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
+  googleEventId: varchar("google_event_id", { length: 255 }),
+  htmlLink: text("html_link"),
+  status: varchar("status", { length: 20 }).notNull().default("created"),
+  error: text("error"),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  sessionUserUnique: uniqueIndex("buddy_session_calendar_events_session_user").on(
+    table.buddySessionId,
+    table.userId,
+  ),
+  sessionIdx: index("idx_buddy_session_calendar_events_session").on(table.buddySessionId),
+  userIdx: index("idx_buddy_session_calendar_events_user").on(table.userId),
+  statusCheck: check(
+    "buddy_session_calendar_events_status_allowed",
+    sql`${table.status} in ('created', 'failed', 'deleted')`,
   ),
 }));
 
@@ -164,10 +205,15 @@ export const friendships = pgTable("friendships", {
   user2Idx: index("idx_friendships_user2").on(table.user2Id),
 }));
 
-export const usersRelations = relations(users, ({ many }) => ({
+export const usersRelations = relations(users, ({ one, many }) => ({
   sessions: many(sessions),
   thoughts: many(thoughts),
   passwordResetTokens: many(passwordResetTokens),
+  googleOAuthToken: one(googleOAuthTokens, {
+    fields: [users.id],
+    references: [googleOAuthTokens.userId],
+  }),
+  buddyCalendarEvents: many(buddySessionCalendarEvents),
 }));
 
 export const passwordResetTokensRelations = relations(passwordResetTokens, ({ one }) => ({
@@ -178,6 +224,7 @@ export const buddySessionsRelations = relations(buddySessions, ({ one, many }) =
   host: one(users, { fields: [buddySessions.hostUserId], references: [users.id] }),
   participants: many(buddySessionParticipants),
   personalSessions: many(sessions),
+  calendarEvents: many(buddySessionCalendarEvents),
 }));
 
 export const buddySessionParticipantsRelations = relations(buddySessionParticipants, ({ one }) => ({
@@ -187,6 +234,21 @@ export const buddySessionParticipantsRelations = relations(buddySessionParticipa
   }),
   user: one(users, { fields: [buddySessionParticipants.userId], references: [users.id] }),
 }));
+
+export const googleOAuthTokensRelations = relations(googleOAuthTokens, ({ one }) => ({
+  user: one(users, { fields: [googleOAuthTokens.userId], references: [users.id] }),
+}));
+
+export const buddySessionCalendarEventsRelations = relations(
+  buddySessionCalendarEvents,
+  ({ one }) => ({
+    session: one(buddySessions, {
+      fields: [buddySessionCalendarEvents.buddySessionId],
+      references: [buddySessions.id],
+    }),
+    user: one(users, { fields: [buddySessionCalendarEvents.userId], references: [users.id] }),
+  }),
+);
 
 export const sessionsRelations = relations(sessions, ({ one, many }) => ({
   user: one(users, { fields: [sessions.userId], references: [users.id] }),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -116,7 +116,7 @@ export const buddySessionCalendarEvents = pgTable("buddy_session_calendar_events
   id: uuid("id").primaryKey().defaultRandom(),
   buddySessionId: uuid("buddy_session_id").references(() => buddySessions.id, { onDelete: "cascade" }).notNull(),
   userId: uuid("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
-  googleEventId: varchar("google_event_id", { length: 255 }),
+  googleEventId: text("google_event_id"),
   htmlLink: text("html_link"),
   status: varchar("status", { length: 20 }).notNull().default("created"),
   error: text("error"),

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -105,6 +105,7 @@ export type BuddySnapshot = {
   state: string;
   revision: number;
   durationSeconds: number;
+  scheduledStartAt: string | null;
   startedAt: string | null;
   serverNow: string;
   endsAt: string | null;
@@ -116,6 +117,11 @@ export type BuddySnapshot = {
   isHost: boolean;
   participants: BuddyParticipantSnap[];
 };
+
+export type CalendarSyncResult =
+  | { status: "created"; userId: string; eventId: string; htmlLink: string | null }
+  | { status: "skipped"; userId: string; reason: string }
+  | { status: "failed"; userId: string; error: string };
 
 export const api = {
   signup: (data: { email: string; username: string; password: string }) =>
@@ -198,13 +204,30 @@ export const api = {
   removeFriend: (friendUserId: string) =>
     request<{ ok: boolean }>(`/api/friends/${friendUserId}`, { method: "DELETE" }),
 
-  createBuddySession: () =>
+  getGoogleCalendarStatus: () =>
+    request<{ google: { connected: boolean; email: string | null } }>("/api/auth/google/status"),
+
+  createBuddySession: (data?: { scheduledStartAt?: string | null }) =>
     request<{
-      session: { id: string; shareToken: string; sharePath: string; durationSeconds: number };
-    }>("/api/buddy/sessions", { method: "POST" }),
+      session: {
+        id: string;
+        shareToken: string;
+        sharePath: string;
+        durationSeconds: number;
+        scheduledStartAt: string | null;
+        calendarSync: CalendarSyncResult[];
+      };
+    }>("/api/buddy/sessions", {
+      method: "POST",
+      body: JSON.stringify(data ?? {}),
+    }),
 
   joinBuddySession: (token: string) =>
-    request<{ sessionId: string }>("/api/buddy/sessions/join", {
+    request<{
+      sessionId: string;
+      scheduledStartAt?: string | null;
+      calendarSync?: CalendarSyncResult[];
+    }>("/api/buddy/sessions/join", {
       method: "POST",
       body: JSON.stringify({ token }),
     }),

--- a/src/lib/buddySession.ts
+++ b/src/lib/buddySession.ts
@@ -169,6 +169,7 @@ export function buildBuddySnapshot(
     state: session.state as BuddySessionState,
     revision: session.revision,
     durationSeconds: session.durationSeconds,
+    scheduledStartAt: session.scheduledStartAt?.toISOString() ?? null,
     startedAt: session.startedAt?.toISOString() ?? null,
     serverNow: serverNow.toISOString(),
     endsAt,

--- a/src/lib/google.ts
+++ b/src/lib/google.ts
@@ -1,0 +1,478 @@
+import "server-only";
+
+import crypto from "crypto";
+import { db } from "@/db";
+import {
+  buddySessionCalendarEvents,
+  buddySessionParticipants,
+  buddySessions,
+  googleOAuthTokens,
+  users,
+} from "@/db/schema";
+import { and, eq, isNull } from "drizzle-orm";
+
+const GOOGLE_AUTH_BASE = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const GOOGLE_USERINFO_URL = "https://openidconnect.googleapis.com/v1/userinfo";
+const GOOGLE_CALENDAR_EVENTS_URL =
+  "https://www.googleapis.com/calendar/v3/calendars/primary/events";
+const GOOGLE_SCOPES = [
+  "openid",
+  "email",
+  "https://www.googleapis.com/auth/calendar.events",
+];
+const GOOGLE_STATE_COOKIE = "sp_google_oauth_state";
+const TOKEN_REFRESH_SKEW_MS = 60_000;
+
+export class GoogleCalendarUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GoogleCalendarUnavailableError";
+  }
+}
+
+export class GoogleCalendarApiError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = "GoogleCalendarApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export type GoogleOAuthState = {
+  state: string;
+  cookie: {
+    name: string;
+    value: string;
+    maxAge: number;
+    path: string;
+    httpOnly: true;
+    secure: boolean;
+    sameSite: "lax";
+  };
+};
+
+export type CalendarSyncResult =
+  | { status: "created"; userId: string; eventId: string; htmlLink: string | null }
+  | { status: "skipped"; userId: string; reason: "not_connected" | "not_scheduled" }
+  | { status: "failed"; userId: string; error: string };
+
+export type GoogleCalendarStatus = {
+  connected: boolean;
+  email: string | null;
+};
+
+type GoogleTokenResponse = {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+  scope?: string;
+  token_type?: string;
+  error?: string;
+  error_description?: string;
+};
+
+type GoogleCalendarEventResponse = {
+  id?: string;
+  htmlLink?: string;
+};
+
+function requireGoogleClientConfig() {
+  const clientId = process.env.GOOGLE_CLIENT_ID?.trim();
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET?.trim();
+  const redirectUri = getGoogleRedirectUri();
+  if (!clientId || !clientSecret || !redirectUri) {
+    throw new GoogleCalendarUnavailableError(
+      "Google Calendar is not configured. Add GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and GOOGLE_REDIRECT_URI.",
+    );
+  }
+  return { clientId, clientSecret, redirectUri };
+}
+
+function getGoogleRedirectUri(): string | null {
+  const explicit = process.env.GOOGLE_REDIRECT_URI?.trim();
+  if (explicit) return explicit;
+  const origin = process.env.NEXT_PUBLIC_APP_URL?.trim();
+  if (!origin) return null;
+  return `${origin.replace(/\/+$/, "")}/api/auth/google/callback`;
+}
+
+function requireEncryptionKey(): Buffer {
+  const raw = process.env.GOOGLE_TOKEN_ENCRYPTION_KEY?.trim();
+  if (!raw) {
+    throw new GoogleCalendarUnavailableError(
+      "GOOGLE_TOKEN_ENCRYPTION_KEY is not set. Generate 32 bytes with `openssl rand -base64 32`.",
+    );
+  }
+  const fromBase64 = Buffer.from(raw, "base64");
+  if (fromBase64.length === 32) return fromBase64;
+  const fromHex = Buffer.from(raw, "hex");
+  if (fromHex.length === 32) return fromHex;
+  throw new GoogleCalendarUnavailableError(
+    "GOOGLE_TOKEN_ENCRYPTION_KEY must decode to 32 bytes (base64 or hex).",
+  );
+}
+
+export function makeGoogleOAuthState(userId: string): GoogleOAuthState {
+  const nonce = crypto.randomBytes(16).toString("base64url");
+  const state = Buffer.from(JSON.stringify({ userId, nonce }), "utf8").toString("base64url");
+  return {
+    state,
+    cookie: {
+      name: GOOGLE_STATE_COOKIE,
+      value: nonce,
+      maxAge: 10 * 60,
+      path: "/",
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+    },
+  };
+}
+
+export function verifyGoogleOAuthState(
+  state: string | null,
+  nonceCookie: string | undefined,
+  expectedUserId: string,
+): boolean {
+  if (!state || !nonceCookie) return false;
+  try {
+    const parsed = JSON.parse(Buffer.from(state, "base64url").toString("utf8")) as {
+      userId?: unknown;
+      nonce?: unknown;
+    };
+    return parsed.userId === expectedUserId && parsed.nonce === nonceCookie;
+  } catch {
+    return false;
+  }
+}
+
+export function getGoogleStateCookieName(): string {
+  return GOOGLE_STATE_COOKIE;
+}
+
+export function buildGoogleAuthUrl(state: string): string {
+  const { clientId, redirectUri } = requireGoogleClientConfig();
+  const url = new URL(GOOGLE_AUTH_BASE);
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", GOOGLE_SCOPES.join(" "));
+  url.searchParams.set("access_type", "offline");
+  url.searchParams.set("prompt", "consent");
+  url.searchParams.set("state", state);
+  return url.toString();
+}
+
+function encryptToken(token: string): string {
+  const key = requireEncryptionKey();
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  const ciphertext = Buffer.concat([cipher.update(token, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return [iv, tag, ciphertext].map((part) => part.toString("base64url")).join(".");
+}
+
+function decryptToken(payload: string): string {
+  const key = requireEncryptionKey();
+  const [ivRaw, tagRaw, ciphertextRaw] = payload.split(".");
+  if (!ivRaw || !tagRaw || !ciphertextRaw) {
+    throw new GoogleCalendarUnavailableError("Stored Google token is malformed.");
+  }
+  const decipher = crypto.createDecipheriv(
+    "aes-256-gcm",
+    key,
+    Buffer.from(ivRaw, "base64url"),
+  );
+  decipher.setAuthTag(Buffer.from(tagRaw, "base64url"));
+  return Buffer.concat([
+    decipher.update(Buffer.from(ciphertextRaw, "base64url")),
+    decipher.final(),
+  ]).toString("utf8");
+}
+
+async function parseGoogleError(res: Response): Promise<unknown> {
+  const text = await res.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function googleErrorMessage(body: unknown, fallback: string): string {
+  if (body && typeof body === "object") {
+    const o = body as Record<string, unknown>;
+    const errorDescription = o.error_description;
+    if (typeof errorDescription === "string" && errorDescription.trim()) {
+      return errorDescription;
+    }
+    const error = o.error;
+    if (typeof error === "string" && error.trim()) return error;
+    const message = o.message;
+    if (typeof message === "string" && message.trim()) return message;
+  }
+  if (typeof body === "string" && body.trim()) return body;
+  return fallback;
+}
+
+async function googleJsonFetch<T>(url: string, init: RequestInit): Promise<T> {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    const body = await parseGoogleError(res);
+    throw new GoogleCalendarApiError(googleErrorMessage(body, `Google API failed (${res.status})`), res.status, body);
+  }
+  return (await res.json()) as T;
+}
+
+export async function exchangeGoogleCodeForTokens(
+  code: string,
+  userId: string,
+): Promise<void> {
+  const { clientId, clientSecret, redirectUri } = requireGoogleClientConfig();
+  const body = new URLSearchParams({
+    code,
+    client_id: clientId,
+    client_secret: clientSecret,
+    redirect_uri: redirectUri,
+    grant_type: "authorization_code",
+  });
+
+  const token = await googleJsonFetch<GoogleTokenResponse>(GOOGLE_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  if (!token.access_token || !token.expires_in) {
+    throw new GoogleCalendarApiError("Google token response was incomplete", 200, token);
+  }
+
+  const userInfo = await googleJsonFetch<{ sub?: string; email?: string }>(GOOGLE_USERINFO_URL, {
+    headers: { Authorization: `Bearer ${token.access_token}` },
+  });
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + token.expires_in * 1000);
+  const existing = await getGoogleOAuthToken(userId);
+  await db
+    .insert(googleOAuthTokens)
+    .values({
+      userId,
+      googleSub: typeof userInfo.sub === "string" ? userInfo.sub : null,
+      googleEmail: typeof userInfo.email === "string" ? userInfo.email : null,
+      accessTokenEncrypted: encryptToken(token.access_token),
+      refreshTokenEncrypted: token.refresh_token
+        ? encryptToken(token.refresh_token)
+        : existing?.refreshTokenEncrypted ?? null,
+      scope: token.scope ?? GOOGLE_SCOPES.join(" "),
+      tokenType: token.token_type ?? "Bearer",
+      expiryDate: expiresAt,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: googleOAuthTokens.userId,
+      set: {
+        googleSub: typeof userInfo.sub === "string" ? userInfo.sub : null,
+        googleEmail: typeof userInfo.email === "string" ? userInfo.email : null,
+        accessTokenEncrypted: encryptToken(token.access_token),
+        refreshTokenEncrypted: token.refresh_token
+          ? encryptToken(token.refresh_token)
+          : existing?.refreshTokenEncrypted ?? null,
+        scope: token.scope ?? GOOGLE_SCOPES.join(" "),
+        tokenType: token.token_type ?? "Bearer",
+        expiryDate: expiresAt,
+        updatedAt: now,
+      },
+    });
+}
+
+export async function getGoogleOAuthToken(userId: string) {
+  const [token] = await db
+    .select()
+    .from(googleOAuthTokens)
+    .where(eq(googleOAuthTokens.userId, userId))
+    .limit(1);
+  return token ?? null;
+}
+
+async function refreshAccessToken(userId: string, refreshTokenEncrypted: string): Promise<string> {
+  const { clientId, clientSecret } = requireGoogleClientConfig();
+  const refreshToken = decryptToken(refreshTokenEncrypted);
+  const token = await googleJsonFetch<GoogleTokenResponse>(GOOGLE_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: refreshToken,
+      grant_type: "refresh_token",
+    }),
+  });
+  if (!token.access_token || !token.expires_in) {
+    throw new GoogleCalendarApiError("Google refresh response was incomplete", 200, token);
+  }
+  const now = new Date();
+  await db
+    .update(googleOAuthTokens)
+    .set({
+      accessTokenEncrypted: encryptToken(token.access_token),
+      scope: token.scope ?? GOOGLE_SCOPES.join(" "),
+      tokenType: token.token_type ?? "Bearer",
+      expiryDate: new Date(now.getTime() + token.expires_in * 1000),
+      updatedAt: now,
+    })
+    .where(eq(googleOAuthTokens.userId, userId));
+  return token.access_token;
+}
+
+async function getValidAccessToken(userId: string): Promise<string | null> {
+  const token = await getGoogleOAuthToken(userId);
+  if (!token) return null;
+  if (token.expiryDate.getTime() > Date.now() + TOKEN_REFRESH_SKEW_MS) {
+    return decryptToken(token.accessTokenEncrypted);
+  }
+  if (!token.refreshTokenEncrypted) return decryptToken(token.accessTokenEncrypted);
+  return refreshAccessToken(userId, token.refreshTokenEncrypted);
+}
+
+function eventDescription(shareToken: string): string {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim()?.replace(/\/+$/, "");
+  const joinLine = appUrl ? `Join: ${appUrl}/app?buddy=${encodeURIComponent(shareToken)}` : "";
+  return [
+    "Still Point shared buddy meditation.",
+    joinLine,
+    "Open Still Point at the scheduled time, join the room, and mark ready.",
+  ].filter(Boolean).join("\n\n");
+}
+
+async function insertCalendarEvent(
+  userId: string,
+  session: typeof buddySessions.$inferSelect,
+  accessToken: string,
+): Promise<GoogleCalendarEventResponse> {
+  if (!session.scheduledStartAt) {
+    throw new GoogleCalendarUnavailableError("Cannot create a calendar event without scheduledStartAt.");
+  }
+  const start = session.scheduledStartAt;
+  const end = new Date(start.getTime() + session.durationSeconds * 1000);
+  return googleJsonFetch<GoogleCalendarEventResponse>(GOOGLE_CALENDAR_EVENTS_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      summary: "Still Point buddy session",
+      description: eventDescription(session.shareToken),
+      start: { dateTime: start.toISOString() },
+      end: { dateTime: end.toISOString() },
+      reminders: { useDefault: true },
+      extendedProperties: {
+        private: {
+          stillPointBuddySessionId: session.id,
+          stillPointUserId: userId,
+        },
+      },
+    }),
+  });
+}
+
+export async function syncBuddySessionCalendarForUser(
+  session: typeof buddySessions.$inferSelect,
+  userId: string,
+): Promise<CalendarSyncResult> {
+  if (!session.scheduledStartAt) {
+    return { status: "skipped", userId, reason: "not_scheduled" };
+  }
+  try {
+    const accessToken = await getValidAccessToken(userId);
+    if (!accessToken) return { status: "skipped", userId, reason: "not_connected" };
+    const event = await insertCalendarEvent(userId, session, accessToken);
+    if (!event.id) {
+      throw new GoogleCalendarApiError("Google Calendar event response was incomplete", 200, event);
+    }
+    await db
+      .insert(buddySessionCalendarEvents)
+      .values({
+        buddySessionId: session.id,
+        userId,
+        googleEventId: event.id,
+        htmlLink: event.htmlLink ?? null,
+        status: "created",
+        error: null,
+        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: [
+          buddySessionCalendarEvents.buddySessionId,
+          buddySessionCalendarEvents.userId,
+        ],
+        set: {
+          googleEventId: event.id,
+          htmlLink: event.htmlLink ?? null,
+          status: "created",
+          error: null,
+          updatedAt: new Date(),
+        },
+      });
+    return { status: "created", userId, eventId: event.id, htmlLink: event.htmlLink ?? null };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Could not create Google Calendar event";
+    await db
+      .insert(buddySessionCalendarEvents)
+      .values({
+        buddySessionId: session.id,
+        userId,
+        status: "failed",
+        error: message,
+        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: [
+          buddySessionCalendarEvents.buddySessionId,
+          buddySessionCalendarEvents.userId,
+        ],
+        set: {
+          status: "failed",
+          error: message,
+          updatedAt: new Date(),
+        },
+      });
+    return { status: "failed", userId, error: message };
+  }
+}
+
+export async function syncBuddySessionCalendars(
+  session: typeof buddySessions.$inferSelect,
+): Promise<CalendarSyncResult[]> {
+  if (!session.scheduledStartAt) return [];
+  const participants = await db
+    .select({ userId: buddySessionParticipants.userId })
+    .from(buddySessionParticipants)
+    .where(
+      and(
+        eq(buddySessionParticipants.buddySessionId, session.id),
+        isNull(buddySessionParticipants.leftAt),
+      ),
+    );
+  return Promise.all(
+    participants.map((participant) =>
+      syncBuddySessionCalendarForUser(session, participant.userId),
+    ),
+  );
+}
+
+export async function loadGoogleCalendarStatus(userId: string) {
+  const token = await getGoogleOAuthToken(userId);
+  return token
+    ? {
+        connected: true,
+        email: token.googleEmail,
+      }
+    : { connected: false, email: null };
+}
+

--- a/src/lib/google.ts
+++ b/src/lib/google.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import crypto from "crypto";
 import { db } from "@/db";
+import { poolDb } from "@/db/pool";
 import {
   buddySessionCalendarEvents,
   buddySessions,
@@ -413,59 +414,65 @@ export async function syncBuddySessionCalendarForUser(
     return { status: "skipped", userId, reason: "not_scheduled" };
   }
   try {
-    const [existingEvent] = await db
-      .select({
-        googleEventId: buddySessionCalendarEvents.googleEventId,
-        htmlLink: buddySessionCalendarEvents.htmlLink,
-      })
-      .from(buddySessionCalendarEvents)
-      .where(
-        and(
-          eq(buddySessionCalendarEvents.buddySessionId, session.id),
-          eq(buddySessionCalendarEvents.userId, userId),
-          eq(buddySessionCalendarEvents.status, "created"),
-        ),
-      )
-      .limit(1);
-    if (existingEvent?.googleEventId) {
-      return {
-        status: "created",
-        userId,
-        eventId: existingEvent.googleEventId,
-        htmlLink: existingEvent.htmlLink ?? null,
-      };
-    }
-    const accessToken = await getValidAccessToken(userId);
-    if (!accessToken) return { status: "skipped", userId, reason: "not_connected" };
-    const event = await insertCalendarEvent(userId, session, accessToken);
-    if (!event.id) {
-      throw new GoogleCalendarApiError("Google Calendar event response was incomplete", 200, event);
-    }
-    await db
-      .insert(buddySessionCalendarEvents)
-      .values({
-        buddySessionId: session.id,
-        userId,
-        googleEventId: event.id,
-        htmlLink: event.htmlLink ?? null,
-        status: "created",
-        error: null,
-        updatedAt: new Date(),
-      })
-      .onConflictDoUpdate({
-        target: [
-          buddySessionCalendarEvents.buddySessionId,
-          buddySessionCalendarEvents.userId,
-        ],
-        set: {
+    return await poolDb.transaction(async (tx) => {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtext(${`buddy-calendar:${session.id}:${userId}`}))`,
+      );
+
+      const [existingEvent] = await tx
+        .select({
+          googleEventId: buddySessionCalendarEvents.googleEventId,
+          htmlLink: buddySessionCalendarEvents.htmlLink,
+        })
+        .from(buddySessionCalendarEvents)
+        .where(
+          and(
+            eq(buddySessionCalendarEvents.buddySessionId, session.id),
+            eq(buddySessionCalendarEvents.userId, userId),
+            eq(buddySessionCalendarEvents.status, "created"),
+          ),
+        )
+        .limit(1);
+      if (existingEvent?.googleEventId) {
+        return {
+          status: "created",
+          userId,
+          eventId: existingEvent.googleEventId,
+          htmlLink: existingEvent.htmlLink ?? null,
+        };
+      }
+      const accessToken = await getValidAccessToken(userId);
+      if (!accessToken) return { status: "skipped", userId, reason: "not_connected" };
+      const event = await insertCalendarEvent(userId, session, accessToken);
+      if (!event.id) {
+        throw new GoogleCalendarApiError("Google Calendar event response was incomplete", 200, event);
+      }
+      await tx
+        .insert(buddySessionCalendarEvents)
+        .values({
+          buddySessionId: session.id,
+          userId,
           googleEventId: event.id,
           htmlLink: event.htmlLink ?? null,
           status: "created",
           error: null,
           updatedAt: new Date(),
-        },
-      });
-    return { status: "created", userId, eventId: event.id, htmlLink: event.htmlLink ?? null };
+        })
+        .onConflictDoUpdate({
+          target: [
+            buddySessionCalendarEvents.buddySessionId,
+            buddySessionCalendarEvents.userId,
+          ],
+          set: {
+            googleEventId: event.id,
+            htmlLink: event.htmlLink ?? null,
+            status: "created",
+            error: null,
+            updatedAt: new Date(),
+          },
+        });
+      return { status: "created", userId, eventId: event.id, htmlLink: event.htmlLink ?? null };
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Could not create Google Calendar event";
     await db

--- a/src/lib/google.ts
+++ b/src/lib/google.ts
@@ -4,12 +4,11 @@ import crypto from "crypto";
 import { db } from "@/db";
 import {
   buddySessionCalendarEvents,
-  buddySessionParticipants,
   buddySessions,
   googleOAuthTokens,
   users,
 } from "@/db/schema";
-import { and, eq, isNull } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 
 const GOOGLE_AUTH_BASE = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
@@ -335,7 +334,7 @@ async function getValidAccessToken(userId: string): Promise<string | null> {
   if (token.expiryDate.getTime() > Date.now() + TOKEN_REFRESH_SKEW_MS) {
     return decryptToken(token.accessTokenEncrypted);
   }
-  if (!token.refreshTokenEncrypted) return decryptToken(token.accessTokenEncrypted);
+  if (!token.refreshTokenEncrypted) return null;
   return refreshAccessToken(userId, token.refreshTokenEncrypted);
 }
 
@@ -444,26 +443,6 @@ export async function syncBuddySessionCalendarForUser(
       });
     return { status: "failed", userId, error: message };
   }
-}
-
-export async function syncBuddySessionCalendars(
-  session: typeof buddySessions.$inferSelect,
-): Promise<CalendarSyncResult[]> {
-  if (!session.scheduledStartAt) return [];
-  const participants = await db
-    .select({ userId: buddySessionParticipants.userId })
-    .from(buddySessionParticipants)
-    .where(
-      and(
-        eq(buddySessionParticipants.buddySessionId, session.id),
-        isNull(buddySessionParticipants.leftAt),
-      ),
-    );
-  return Promise.all(
-    participants.map((participant) =>
-      syncBuddySessionCalendarForUser(session, participant.userId),
-    ),
-  );
 }
 
 export async function loadGoogleCalendarStatus(userId: string) {

--- a/src/lib/google.ts
+++ b/src/lib/google.ts
@@ -83,6 +83,10 @@ type GoogleCalendarEventResponse = {
   htmlLink?: string;
 };
 
+function isGoogleCalendarEventConflict(error: unknown): error is GoogleCalendarApiError {
+  return error instanceof GoogleCalendarApiError && error.status === 409;
+}
+
 function requireGoogleClientConfig() {
   const clientId = process.env.GOOGLE_CLIENT_ID?.trim();
   const clientSecret = process.env.GOOGLE_CLIENT_SECRET?.trim();
@@ -369,14 +373,14 @@ async function insertCalendarEvent(
   const start = session.scheduledStartAt;
   const end = new Date(start.getTime() + session.durationSeconds * 1000);
   const eventId = googleCalendarEventId(session.id, userId);
-  return googleJsonFetch<GoogleCalendarEventResponse>(
-    `${GOOGLE_CALENDAR_EVENTS_URL}/${encodeURIComponent(eventId)}`,
-    {
-      method: "PUT",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "Content-Type": "application/json",
-      },
+  const headers = {
+    Authorization: `Bearer ${accessToken}`,
+    "Content-Type": "application/json",
+  };
+  try {
+    return await googleJsonFetch<GoogleCalendarEventResponse>(GOOGLE_CALENDAR_EVENTS_URL, {
+      method: "POST",
+      headers,
       body: JSON.stringify({
         id: eventId,
         summary: "Still Point buddy session",
@@ -391,8 +395,14 @@ async function insertCalendarEvent(
           },
         },
       }),
-    },
-  );
+    });
+  } catch (error) {
+    if (!isGoogleCalendarEventConflict(error)) throw error;
+    return googleJsonFetch<GoogleCalendarEventResponse>(
+      `${GOOGLE_CALENDAR_EVENTS_URL}/${encodeURIComponent(eventId)}`,
+      { headers },
+    );
+  }
 }
 
 export async function syncBuddySessionCalendarForUser(

--- a/src/lib/google.ts
+++ b/src/lib/google.ts
@@ -8,7 +8,7 @@ import {
   googleOAuthTokens,
   users,
 } from "@/db/schema";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 const GOOGLE_AUTH_BASE = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
@@ -390,6 +390,28 @@ export async function syncBuddySessionCalendarForUser(
   try {
     const accessToken = await getValidAccessToken(userId);
     if (!accessToken) return { status: "skipped", userId, reason: "not_connected" };
+    const [existingEvent] = await db
+      .select({
+        googleEventId: buddySessionCalendarEvents.googleEventId,
+        htmlLink: buddySessionCalendarEvents.htmlLink,
+      })
+      .from(buddySessionCalendarEvents)
+      .where(
+        and(
+          eq(buddySessionCalendarEvents.buddySessionId, session.id),
+          eq(buddySessionCalendarEvents.userId, userId),
+          eq(buddySessionCalendarEvents.status, "created"),
+        ),
+      )
+      .limit(1);
+    if (existingEvent?.googleEventId) {
+      return {
+        status: "created",
+        userId,
+        eventId: existingEvent.googleEventId,
+        htmlLink: existingEvent.htmlLink ?? null,
+      };
+    }
     const event = await insertCalendarEvent(userId, session, accessToken);
     if (!event.id) {
       throw new GoogleCalendarApiError("Google Calendar event response was incomplete", 200, event);

--- a/src/lib/google.ts
+++ b/src/lib/google.ts
@@ -60,6 +60,8 @@ export type CalendarSyncResult =
   | { status: "skipped"; userId: string; reason: "not_connected" | "not_scheduled" }
   | { status: "failed"; userId: string; error: string };
 
+export const GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE = "Could not sync Google Calendar";
+
 export type GoogleCalendarStatus = {
   connected: boolean;
   email: string | null;
@@ -463,7 +465,7 @@ export async function syncBuddySessionCalendarForUser(
           updatedAt: new Date(),
         },
       });
-    return { status: "failed", userId, error: message };
+    return { status: "failed", userId, error: GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE };
   }
 }
 

--- a/src/lib/google.ts
+++ b/src/lib/google.ts
@@ -8,7 +8,7 @@ import {
   googleOAuthTokens,
   users,
 } from "@/db/schema";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 const GOOGLE_AUTH_BASE = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
@@ -266,7 +266,9 @@ export async function exchangeGoogleCodeForTokens(
   });
   const now = new Date();
   const expiresAt = new Date(now.getTime() + token.expires_in * 1000);
-  const existing = await getGoogleOAuthToken(userId);
+  const encryptedRefreshToken = token.refresh_token
+    ? encryptToken(token.refresh_token)
+    : null;
   await db
     .insert(googleOAuthTokens)
     .values({
@@ -274,9 +276,7 @@ export async function exchangeGoogleCodeForTokens(
       googleSub: typeof userInfo.sub === "string" ? userInfo.sub : null,
       googleEmail: typeof userInfo.email === "string" ? userInfo.email : null,
       accessTokenEncrypted: encryptToken(token.access_token),
-      refreshTokenEncrypted: token.refresh_token
-        ? encryptToken(token.refresh_token)
-        : existing?.refreshTokenEncrypted ?? null,
+      refreshTokenEncrypted: encryptedRefreshToken,
       scope: token.scope ?? GOOGLE_SCOPES.join(" "),
       tokenType: token.token_type ?? "Bearer",
       expiryDate: expiresAt,
@@ -288,9 +288,9 @@ export async function exchangeGoogleCodeForTokens(
         googleSub: typeof userInfo.sub === "string" ? userInfo.sub : null,
         googleEmail: typeof userInfo.email === "string" ? userInfo.email : null,
         accessTokenEncrypted: encryptToken(token.access_token),
-        refreshTokenEncrypted: token.refresh_token
-          ? encryptToken(token.refresh_token)
-          : existing?.refreshTokenEncrypted ?? null,
+        refreshTokenEncrypted: encryptedRefreshToken === null
+          ? sql`coalesce(excluded.refresh_token_encrypted, ${googleOAuthTokens.refreshTokenEncrypted})`
+          : encryptedRefreshToken,
         scope: token.scope ?? GOOGLE_SCOPES.join(" "),
         tokenType: token.token_type ?? "Bearer",
         expiryDate: expiresAt,
@@ -359,7 +359,7 @@ function eventDescription(shareToken: string): string {
 }
 
 function googleCalendarEventId(sessionId: string, userId: string): string {
-  return `sp_${crypto.createHash("sha256").update(`${sessionId}:${userId}`).digest("hex")}`;
+  return `sp${crypto.createHash("sha256").update(`${sessionId}:${userId}`).digest("hex")}`;
 }
 
 async function insertCalendarEvent(
@@ -413,8 +413,6 @@ export async function syncBuddySessionCalendarForUser(
     return { status: "skipped", userId, reason: "not_scheduled" };
   }
   try {
-    const accessToken = await getValidAccessToken(userId);
-    if (!accessToken) return { status: "skipped", userId, reason: "not_connected" };
     const [existingEvent] = await db
       .select({
         googleEventId: buddySessionCalendarEvents.googleEventId,
@@ -437,6 +435,8 @@ export async function syncBuddySessionCalendarForUser(
         htmlLink: existingEvent.htmlLink ?? null,
       };
     }
+    const accessToken = await getValidAccessToken(userId);
+    if (!accessToken) return { status: "skipped", userId, reason: "not_connected" };
     const event = await insertCalendarEvent(userId, session, accessToken);
     if (!event.id) {
       throw new GoogleCalendarApiError("Google Calendar event response was incomplete", 200, event);

--- a/src/lib/google.ts
+++ b/src/lib/google.ts
@@ -22,6 +22,7 @@ const GOOGLE_SCOPES = [
 ];
 const GOOGLE_STATE_COOKIE = "sp_google_oauth_state";
 const TOKEN_REFRESH_SKEW_MS = 60_000;
+const GOOGLE_HTTP_TIMEOUT_MS = 10_000;
 
 export class GoogleCalendarUnavailableError extends Error {
   constructor(message: string) {
@@ -223,7 +224,10 @@ function googleErrorMessage(body: unknown, fallback: string): string {
 }
 
 async function googleJsonFetch<T>(url: string, init: RequestInit): Promise<T> {
-  const res = await fetch(url, init);
+  const res = await fetch(url, {
+    ...init,
+    signal: init.signal ?? AbortSignal.timeout(GOOGLE_HTTP_TIMEOUT_MS),
+  });
   if (!res.ok) {
     const body = await parseGoogleError(res);
     throw new GoogleCalendarApiError(googleErrorMessage(body, `Google API failed (${res.status})`), res.status, body);
@@ -350,6 +354,10 @@ function eventDescription(shareToken: string): string {
   ].filter(Boolean).join("\n\n");
 }
 
+function googleCalendarEventId(sessionId: string, userId: string): string {
+  return `sp_${crypto.createHash("sha256").update(`${sessionId}:${userId}`).digest("hex")}`;
+}
+
 async function insertCalendarEvent(
   userId: string,
   session: typeof buddySessions.$inferSelect,
@@ -360,26 +368,31 @@ async function insertCalendarEvent(
   }
   const start = session.scheduledStartAt;
   const end = new Date(start.getTime() + session.durationSeconds * 1000);
-  return googleJsonFetch<GoogleCalendarEventResponse>(GOOGLE_CALENDAR_EVENTS_URL, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      summary: "Still Point buddy session",
-      description: eventDescription(session.shareToken),
-      start: { dateTime: start.toISOString() },
-      end: { dateTime: end.toISOString() },
-      reminders: { useDefault: true },
-      extendedProperties: {
-        private: {
-          stillPointBuddySessionId: session.id,
-          stillPointUserId: userId,
-        },
+  const eventId = googleCalendarEventId(session.id, userId);
+  return googleJsonFetch<GoogleCalendarEventResponse>(
+    `${GOOGLE_CALENDAR_EVENTS_URL}/${encodeURIComponent(eventId)}`,
+    {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
       },
-    }),
-  });
+      body: JSON.stringify({
+        id: eventId,
+        summary: "Still Point buddy session",
+        description: eventDescription(session.shareToken),
+        start: { dateTime: start.toISOString() },
+        end: { dateTime: end.toISOString() },
+        reminders: { useDefault: true },
+        extendedProperties: {
+          private: {
+            stillPointBuddySessionId: session.id,
+            stillPointUserId: userId,
+          },
+        },
+      }),
+    },
+  );
 }
 
 export async function syncBuddySessionCalendarForUser(
@@ -471,11 +484,11 @@ export async function syncBuddySessionCalendarForUser(
 
 export async function loadGoogleCalendarStatus(userId: string) {
   const token = await getGoogleOAuthToken(userId);
-  return token
-    ? {
-        connected: true,
-        email: token.googleEmail,
-      }
-    : { connected: false, email: null };
+  if (!token) return { connected: false, email: null };
+  const hasUsableAccessToken = token.expiryDate.getTime() > Date.now() + TOKEN_REFRESH_SKEW_MS;
+  return {
+    connected: hasUsableAccessToken || Boolean(token.refreshTokenEncrypted),
+    email: token.googleEmail,
+  };
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,6 +7,7 @@ const publicPaths = [
   "/api/auth/signup",
   "/api/auth/login",
   "/api/auth/logout",
+  "/api/auth/google/callback",
   "/api/auth/password-reset",
   "/api/board",
 ];

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,13 +3,16 @@ import { jwtVerify } from "jose";
 
 const COOKIE_NAME = "sp_token";
 
-const publicPaths = [
+const publicExactPaths = [
   "/api/auth/signup",
   "/api/auth/login",
   "/api/auth/logout",
   "/api/auth/google/callback",
-  "/api/auth/password-reset",
+];
+
+const publicPrefixPaths = [
   "/api/board",
+  "/api/auth/password-reset",
 ];
 
 export async function middleware(request: NextRequest) {
@@ -21,7 +24,10 @@ export async function middleware(request: NextRequest) {
   }
 
   // Allow public routes
-  if (publicPaths.some((p) => pathname.startsWith(p))) {
+  if (
+    publicExactPaths.includes(pathname) ||
+    publicPrefixPaths.some((p) => pathname.startsWith(p))
+  ) {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add scheduled start support to buddy sessions, including API validation, snapshots, lobby display, and start-time guard.
- Add Google OAuth routes, encrypted token storage, and best-effort per-participant Calendar event sync.
- Add Drizzle schema/migration entries and focused route tests for scheduled buddy creation.
- Address review feedback: timing-specific start errors, guarded join sync, exact OAuth callback allowlisting, expired-token handling, visible join sync feedback, expanded tests, unbounded Google event IDs, idempotent calendar sync, user-safe sync failure messages, trusted OAuth redirects/state cleanup, request timeouts, accurate connection status, deterministic event conflict handling, valid Calendar event IDs, refresh-token preserving upserts, and DB advisory-lock serialization around calendar event sync.

## Walkthrough
[scheduled_buddy_invite_google_fallback.mp4](https://cursor.com/agents/bc-449bc6ad-d927-4aac-abe5-4e2139e5f643/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscheduled_buddy_invite_google_fallback.mp4)

## Testing
- `npx vitest run src/app/api/buddy/sessions/route.test.ts`
- `npm run build`
- Manual browser walkthrough against local Postgres: sign up, open buddy flow, create scheduled invite, confirm share link and Google Calendar fallback.
- `gh pr view 272 --json statusCheckRollup` confirmed all reported PR checks were green before the final serialized-sync follow-up commit; new checks were re-triggered after the final push.
- `coderabbit review --prompt-only` could not run because the `coderabbit` CLI is not installed in this environment.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-449bc6ad-d927-4aac-abe5-4e2139e5f643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-449bc6ad-d927-4aac-abe5-4e2139e5f643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connect Google Calendar, view connection status, and sync scheduled buddy sessions; calendar sync results are returned to the client and shown in the UI
  * Create scheduled buddy sessions (future date/time) and display scheduled start times; per-user calendar events are created/updated

* **Behavior Changes**
  * Prevent starting a session before its scheduled start (409 scheduling error)
  * Join/start flows include calendar sync outcomes in responses and UI

* **Documentation**
  * Added .env.example placeholders and note requiring a 32-byte encryption key

* **Tests**
  * New tests covering scheduled-session creation and calendar sync outcomes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add scheduled buddy sessions with Google Calendar sync**

### What Changed
- Buddy sessions can now be scheduled for a future time instead of starting immediately.
- Scheduled sessions now show the planned start time in the lobby and room, and the app blocks starting a session before that time.
- Users can connect Google Calendar, and scheduled buddy sessions are added to each connected participant’s calendar with clear success, skipped, or failure feedback.
- Google sign-in and calendar syncing now use safer redirect handling, token storage, and request handling so failed syncs do not block session creation or joining.

### Impact
`✅ Scheduled buddy invites`
`✅ Fewer early session starts`
`✅ Clearer Google Calendar setup`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=GUQa9Djsg2BW9pHoH6-mQpBfE6WFQBx6KAIyeFb5CBs&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
