### PR TITLE
Allow editing username from settings

### DIFF
--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { hashPassword, createToken, setAuthCookie } from "@/lib/auth";
+import { USERNAME_ERROR, isValidUsername } from "@/lib/username";
 import { eq } from "drizzle-orm";
 
 export async function POST(request: NextRequest) {
@@ -18,8 +19,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Invalid email format" }, { status: 400 });
     }
 
-    if (username.length < 3 || username.length > 30 || !/^[a-zA-Z0-9_]+$/.test(username)) {
-      return NextResponse.json({ error: "Username must be 3-30 characters (letters, numbers, underscores)" }, { status: 400 });
+    if (!isValidUsername(username)) {
+      return NextResponse.json({ error: USERNAME_ERROR }, { status: 400 });
     }
 
     if (password.length < 8) {

--- a/src/app/api/settings/route.test.ts
+++ b/src/app/api/settings/route.test.ts
@@ -1,24 +1,32 @@
 import type { NextRequest } from "next/server";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-const updateReturning = vi.fn();
-const updateWhere = vi.fn(() => ({ returning: updateReturning }));
-const updateSet = vi.fn((_values: Record<string, unknown>) => ({ where: updateWhere }));
-const dbUpdate = vi.fn(() => ({ set: updateSet }));
+// HTTP-driver path (no username): db.update(...).set(...).where(...).returning(...)
+const dbUpdateReturning = vi.fn();
+const dbUpdateWhere = vi.fn(() => ({ returning: dbUpdateReturning }));
+const dbUpdateSet = vi.fn((_values: Record<string, unknown>) => ({ where: dbUpdateWhere }));
+const dbUpdate = vi.fn(() => ({ set: dbUpdateSet }));
 
-const selectLimit = vi.fn();
-const selectWhere = vi.fn(() => ({ limit: selectLimit }));
-const selectFrom = vi.fn(() => ({ where: selectWhere }));
-const dbSelect = vi.fn(() => ({ from: selectFrom }));
+// Transactional path (username present): poolDb.transaction(async (tx) => ...)
+const txExecute = vi.fn();
+const txSelectLimit = vi.fn();
+const txSelectWhere = vi.fn(() => ({ limit: txSelectLimit }));
+const txSelectFrom = vi.fn(() => ({ where: txSelectWhere }));
+const txSelect = vi.fn(() => ({ from: txSelectFrom }));
+const txUpdateReturning = vi.fn();
+const txUpdateWhere = vi.fn(() => ({ returning: txUpdateReturning }));
+const txUpdateSet = vi.fn((_values: Record<string, unknown>) => ({ where: txUpdateWhere }));
+const txUpdate = vi.fn(() => ({ set: txUpdateSet }));
+
+const poolTransaction = vi.fn(
+  async (cb: (tx: { execute: typeof txExecute; select: typeof txSelect; update: typeof txUpdate }) => unknown) =>
+    cb({ execute: txExecute, select: txSelect, update: txUpdate }),
+);
 
 const getCurrentUser = vi.fn();
 
-vi.mock("@/db", () => ({
-  db: {
-    update: dbUpdate,
-    select: dbSelect,
-  },
-}));
+vi.mock("@/db", () => ({ db: { update: dbUpdate } }));
+vi.mock("@/db/pool", () => ({ poolDb: { transaction: poolTransaction } }));
 
 vi.mock("@/db/schema", () => ({
   users: {
@@ -55,13 +63,23 @@ describe("PATCH /api/settings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getCurrentUser.mockResolvedValue({ userId, email: "user@example.com" });
-    selectLimit.mockResolvedValue([]);
-    updateReturning.mockResolvedValue([
+    txSelectLimit.mockResolvedValue([]);
+    txExecute.mockResolvedValue(undefined);
+    txUpdateReturning.mockResolvedValue([
       {
         id: userId,
         email: "user@example.com",
         username: "newname",
         isPublic: false,
+        currentDay: 1,
+      },
+    ]);
+    dbUpdateReturning.mockResolvedValue([
+      {
+        id: userId,
+        email: "user@example.com",
+        username: "existing",
+        isPublic: true,
         currentDay: 1,
       },
     ]);
@@ -74,6 +92,7 @@ describe("PATCH /api/settings", () => {
     const res = await PATCH(buildRequest({ username: "newname" }));
 
     expect(res.status).toBe(401);
+    expect(poolTransaction).not.toHaveBeenCalled();
     expect(dbUpdate).not.toHaveBeenCalled();
   });
 
@@ -86,21 +105,28 @@ describe("PATCH /api/settings", () => {
     await expect(res.json()).resolves.toEqual({
       error: "Username must be 3-30 characters (letters, numbers, underscores)",
     });
+    expect(poolTransaction).not.toHaveBeenCalled();
     expect(dbUpdate).not.toHaveBeenCalled();
   });
 
-  test("rejects usernames that another user already holds", async () => {
-    selectLimit.mockResolvedValue([{ id: "other-user" }]);
+  test("acquires advisory lock and rejects when another user holds the username", async () => {
+    txSelectLimit.mockResolvedValue([{ id: "other-user" }]);
     const { PATCH } = await import("./route");
 
-    const res = await PATCH(buildRequest({ username: "taken" }));
+    const res = await PATCH(buildRequest({ username: "Taken" }));
 
     expect(res.status).toBe(409);
     await expect(res.json()).resolves.toEqual({ error: "Username already taken" });
-    expect(dbUpdate).not.toHaveBeenCalled();
+
+    expect(poolTransaction).toHaveBeenCalledTimes(1);
+    expect(txExecute).toHaveBeenCalledTimes(1);
+    const lockArg = txExecute.mock.calls[0]![0] as { sql: { values: unknown[] } };
+    // Lock key is hashtext("username:" + lower(username)) — verify case is folded.
+    expect(lockArg.sql.values).toContain("username:taken");
+    expect(txUpdate).not.toHaveBeenCalled();
   });
 
-  test("updates the username when valid and unique", async () => {
+  test("updates the username inside the transaction when valid and unique", async () => {
     const { PATCH } = await import("./route");
 
     const res = await PATCH(buildRequest({ username: "  newname  " }));
@@ -115,14 +141,18 @@ describe("PATCH /api/settings", () => {
         currentDay: 1,
       },
     });
-    expect(updateSet).toHaveBeenCalledTimes(1);
-    const updates = updateSet.mock.calls[0]![0];
+    expect(poolTransaction).toHaveBeenCalledTimes(1);
+    expect(txExecute).toHaveBeenCalledTimes(1);
+    expect(txUpdateSet).toHaveBeenCalledTimes(1);
+    const updates = txUpdateSet.mock.calls[0]![0];
     expect(updates.username).toBe("newname");
     expect(updates.updatedAt).toBeInstanceOf(Date);
+    // The HTTP-driver fall-through must not fire when username is being updated.
+    expect(dbUpdate).not.toHaveBeenCalled();
   });
 
   test("translates Postgres unique-violation races into 409", async () => {
-    updateReturning.mockRejectedValue(Object.assign(new Error("dup"), { code: "23505" }));
+    txUpdateReturning.mockRejectedValue(Object.assign(new Error("dup"), { code: "23505" }));
     const { PATCH } = await import("./route");
 
     const res = await PATCH(buildRequest({ username: "racy" }));
@@ -131,23 +161,15 @@ describe("PATCH /api/settings", () => {
     await expect(res.json()).resolves.toEqual({ error: "Username already taken" });
   });
 
-  test("still supports the existing isPublic toggle without touching username", async () => {
-    updateReturning.mockResolvedValue([
-      {
-        id: userId,
-        email: "user@example.com",
-        username: "existing",
-        isPublic: true,
-        currentDay: 1,
-      },
-    ]);
+  test("isPublic-only updates skip the transaction and use the HTTP driver", async () => {
     const { PATCH } = await import("./route");
 
     const res = await PATCH(buildRequest({ isPublic: true }));
 
     expect(res.status).toBe(200);
-    expect(dbSelect).not.toHaveBeenCalled();
-    const updates = updateSet.mock.calls[0]![0];
+    expect(poolTransaction).not.toHaveBeenCalled();
+    expect(dbUpdate).toHaveBeenCalledTimes(1);
+    const updates = dbUpdateSet.mock.calls[0]![0];
     expect(updates.isPublic).toBe(true);
     expect(updates).not.toHaveProperty("username");
   });

--- a/src/app/api/settings/route.test.ts
+++ b/src/app/api/settings/route.test.ts
@@ -42,6 +42,16 @@ vi.mock("@/lib/auth", () => ({
   getCurrentUser,
 }));
 
+vi.mock("@/lib/username", () => ({
+  USERNAME_ERROR:
+    "Username must be 3-30 characters (letters, numbers, underscores)",
+  MIN_USERNAME_LENGTH: 3,
+  MAX_USERNAME_LENGTH: 30,
+  USERNAME_REGEX: /^[a-zA-Z0-9_]+$/,
+  isValidUsername: (value: string) =>
+    value.length >= 3 && value.length <= 30 && /^[a-zA-Z0-9_]+$/.test(value),
+}));
+
 vi.mock("drizzle-orm", () => ({
   and: (...args: unknown[]) => ({ and: args }),
   eq: (left: unknown, right: unknown) => ({ eq: [left, right] }),

--- a/src/app/api/settings/route.test.ts
+++ b/src/app/api/settings/route.test.ts
@@ -161,6 +161,19 @@ describe("PATCH /api/settings", () => {
     await expect(res.json()).resolves.toEqual({ error: "Username already taken" });
   });
 
+  test("rejects PATCH bodies without any supported settings", async () => {
+    const { PATCH } = await import("./route");
+
+    const res = await PATCH(buildRequest({ unrelated: "noise" }));
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "No supported settings provided",
+    });
+    expect(poolTransaction).not.toHaveBeenCalled();
+    expect(dbUpdate).not.toHaveBeenCalled();
+  });
+
   test("isPublic-only updates skip the transaction and use the HTTP driver", async () => {
     const { PATCH } = await import("./route");
 

--- a/src/app/api/settings/route.test.ts
+++ b/src/app/api/settings/route.test.ts
@@ -1,0 +1,154 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const updateReturning = vi.fn();
+const updateWhere = vi.fn(() => ({ returning: updateReturning }));
+const updateSet = vi.fn((_values: Record<string, unknown>) => ({ where: updateWhere }));
+const dbUpdate = vi.fn(() => ({ set: updateSet }));
+
+const selectLimit = vi.fn();
+const selectWhere = vi.fn(() => ({ limit: selectLimit }));
+const selectFrom = vi.fn(() => ({ where: selectWhere }));
+const dbSelect = vi.fn(() => ({ from: selectFrom }));
+
+const getCurrentUser = vi.fn();
+
+vi.mock("@/db", () => ({
+  db: {
+    update: dbUpdate,
+    select: dbSelect,
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  users: {
+    id: "id",
+    email: "email",
+    username: "username",
+    isPublic: "isPublic",
+    currentDay: "currentDay",
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentUser,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: (...args: unknown[]) => ({ and: args }),
+  eq: (left: unknown, right: unknown) => ({ eq: [left, right] }),
+  ne: (left: unknown, right: unknown) => ({ ne: [left, right] }),
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    sql: { strings: Array.from(strings), values },
+  }),
+}));
+
+const userId = "user-1";
+
+const buildRequest = (body: unknown) =>
+  new Request("http://test.local/api/settings", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  }) as NextRequest;
+
+describe("PATCH /api/settings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCurrentUser.mockResolvedValue({ userId, email: "user@example.com" });
+    selectLimit.mockResolvedValue([]);
+    updateReturning.mockResolvedValue([
+      {
+        id: userId,
+        email: "user@example.com",
+        username: "newname",
+        isPublic: false,
+        currentDay: 1,
+      },
+    ]);
+  });
+
+  test("rejects unauthenticated callers", async () => {
+    getCurrentUser.mockResolvedValue(null);
+    const { PATCH } = await import("./route");
+
+    const res = await PATCH(buildRequest({ username: "newname" }));
+
+    expect(res.status).toBe(401);
+    expect(dbUpdate).not.toHaveBeenCalled();
+  });
+
+  test("rejects usernames that violate the format rules", async () => {
+    const { PATCH } = await import("./route");
+
+    const res = await PATCH(buildRequest({ username: "no" }));
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "Username must be 3-30 characters (letters, numbers, underscores)",
+    });
+    expect(dbUpdate).not.toHaveBeenCalled();
+  });
+
+  test("rejects usernames that another user already holds", async () => {
+    selectLimit.mockResolvedValue([{ id: "other-user" }]);
+    const { PATCH } = await import("./route");
+
+    const res = await PATCH(buildRequest({ username: "taken" }));
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({ error: "Username already taken" });
+    expect(dbUpdate).not.toHaveBeenCalled();
+  });
+
+  test("updates the username when valid and unique", async () => {
+    const { PATCH } = await import("./route");
+
+    const res = await PATCH(buildRequest({ username: "  newname  " }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      user: {
+        id: userId,
+        email: "user@example.com",
+        username: "newname",
+        isPublic: false,
+        currentDay: 1,
+      },
+    });
+    expect(updateSet).toHaveBeenCalledTimes(1);
+    const updates = updateSet.mock.calls[0]![0];
+    expect(updates.username).toBe("newname");
+    expect(updates.updatedAt).toBeInstanceOf(Date);
+  });
+
+  test("translates Postgres unique-violation races into 409", async () => {
+    updateReturning.mockRejectedValue(Object.assign(new Error("dup"), { code: "23505" }));
+    const { PATCH } = await import("./route");
+
+    const res = await PATCH(buildRequest({ username: "racy" }));
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({ error: "Username already taken" });
+  });
+
+  test("still supports the existing isPublic toggle without touching username", async () => {
+    updateReturning.mockResolvedValue([
+      {
+        id: userId,
+        email: "user@example.com",
+        username: "existing",
+        isPublic: true,
+        currentDay: 1,
+      },
+    ]);
+    const { PATCH } = await import("./route");
+
+    const res = await PATCH(buildRequest({ isPublic: true }));
+
+    expect(res.status).toBe(200);
+    expect(dbSelect).not.toHaveBeenCalled();
+    const updates = updateSet.mock.calls[0]![0];
+    expect(updates.isPublic).toBe(true);
+    expect(updates).not.toHaveProperty("username");
+  });
+});

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -3,11 +3,9 @@ import { db } from "@/db";
 import { poolDb } from "@/db/pool";
 import { users } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
+import { USERNAME_ERROR, isValidUsername } from "@/lib/username";
 import { and, eq, ne, sql } from "drizzle-orm";
 
-const USERNAME_REGEX = /^[a-zA-Z0-9_]+$/;
-const USERNAME_ERROR =
-  "Username must be 3-30 characters (letters, numbers, underscores)";
 const USERNAME_TAKEN_ERROR = "Username already taken";
 
 const RETURN_FIELDS = {
@@ -37,11 +35,7 @@ export async function PATCH(request: NextRequest) {
     if (typeof body.username === "string") {
       hasSupportedUpdate = true;
       const username = body.username.trim();
-      if (
-        username.length < 3 ||
-        username.length > 30 ||
-        !USERNAME_REGEX.test(username)
-      ) {
+      if (!isValidUsername(username)) {
         return NextResponse.json({ error: USERNAME_ERROR }, { status: 400 });
       }
 

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
+import { poolDb } from "@/db/pool";
 import { users } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
 import { and, eq, ne, sql } from "drizzle-orm";
@@ -8,6 +9,14 @@ const USERNAME_REGEX = /^[a-zA-Z0-9_]+$/;
 const USERNAME_ERROR =
   "Username must be 3-30 characters (letters, numbers, underscores)";
 const USERNAME_TAKEN_ERROR = "Username already taken";
+
+const RETURN_FIELDS = {
+  id: users.id,
+  email: users.email,
+  username: users.username,
+  isPublic: users.isPublic,
+  currentDay: users.currentDay,
+};
 
 export async function PATCH(request: NextRequest) {
   try {
@@ -33,39 +42,57 @@ export async function PATCH(request: NextRequest) {
         return NextResponse.json({ error: USERNAME_ERROR }, { status: 400 });
       }
 
-      const existing = await db
-        .select({ id: users.id })
-        .from(users)
-        .where(
-          and(
-            sql`lower(${users.username}) = lower(${username})`,
-            ne(users.id, auth.userId),
-          ),
-        )
-        .limit(1);
+      // Serialize concurrent username PATCHes targeting the same case-insensitive
+      // value: Postgres' unique index on `username` is case-sensitive, so without
+      // this advisory lock two requests setting "John" / "john" could both pass
+      // the SELECT and both succeed at UPDATE. (Cross-route races with signup are
+      // tracked in #8 alongside the case-insensitive unique index.)
+      const result = await poolDb.transaction(async (tx) => {
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtext(${`username:${username.toLowerCase()}`}))`,
+        );
 
-      if (existing.length > 0) {
+        const existing = await tx
+          .select({ id: users.id })
+          .from(users)
+          .where(
+            and(
+              sql`lower(${users.username}) = lower(${username})`,
+              ne(users.id, auth.userId),
+            ),
+          )
+          .limit(1);
+
+        if (existing.length > 0) {
+          return { taken: true as const };
+        }
+
+        updates.username = username;
+        const [updated] = await tx
+          .update(users)
+          .set(updates)
+          .where(eq(users.id, auth.userId))
+          .returning(RETURN_FIELDS);
+        return { taken: false as const, user: updated };
+      });
+
+      if (result.taken) {
         return NextResponse.json({ error: USERNAME_TAKEN_ERROR }, { status: 409 });
       }
-
-      updates.username = username;
+      return NextResponse.json({ user: result.user });
     }
 
-    const [updated] = await db.update(users)
+    const [updated] = await db
+      .update(users)
       .set(updates)
       .where(eq(users.id, auth.userId))
-      .returning({
-        id: users.id,
-        email: users.email,
-        username: users.username,
-        isPublic: users.isPublic,
-        currentDay: users.currentDay,
-      });
+      .returning(RETURN_FIELDS);
 
     return NextResponse.json({ user: updated });
   } catch (error) {
-    // Backstop in case a concurrent insert/update wins the race after the
-    // explicit uniqueness check — Postgres unique-violation is SQLSTATE 23505.
+    // Defensive: if a concurrent signup commits the case-EXACT username between
+    // the SELECT inside the transaction and the UPDATE, Postgres' case-sensitive
+    // unique index will raise SQLSTATE 23505. Surface as 409 rather than 500.
     if (
       error &&
       typeof error === "object" &&

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -2,7 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
-import { eq } from "drizzle-orm";
+import { and, eq, ne, sql } from "drizzle-orm";
+
+const USERNAME_REGEX = /^[a-zA-Z0-9_]+$/;
+const USERNAME_ERROR =
+  "Username must be 3-30 characters (letters, numbers, underscores)";
+const USERNAME_TAKEN_ERROR = "Username already taken";
 
 export async function PATCH(request: NextRequest) {
   try {
@@ -12,10 +17,38 @@ export async function PATCH(request: NextRequest) {
     }
 
     const body = await request.json();
-    const updates: Record<string, any> = { updatedAt: new Date() };
+    const updates: Record<string, unknown> = { updatedAt: new Date() };
 
     if (typeof body.isPublic === "boolean") {
       updates.isPublic = body.isPublic;
+    }
+
+    if (typeof body.username === "string") {
+      const username = body.username.trim();
+      if (
+        username.length < 3 ||
+        username.length > 30 ||
+        !USERNAME_REGEX.test(username)
+      ) {
+        return NextResponse.json({ error: USERNAME_ERROR }, { status: 400 });
+      }
+
+      const existing = await db
+        .select({ id: users.id })
+        .from(users)
+        .where(
+          and(
+            sql`lower(${users.username}) = lower(${username})`,
+            ne(users.id, auth.userId),
+          ),
+        )
+        .limit(1);
+
+      if (existing.length > 0) {
+        return NextResponse.json({ error: USERNAME_TAKEN_ERROR }, { status: 409 });
+      }
+
+      updates.username = username;
     }
 
     const [updated] = await db.update(users)
@@ -31,6 +64,16 @@ export async function PATCH(request: NextRequest) {
 
     return NextResponse.json({ user: updated });
   } catch (error) {
+    // Backstop in case a concurrent insert/update wins the race after the
+    // explicit uniqueness check — Postgres unique-violation is SQLSTATE 23505.
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      (error as { code: unknown }).code === "23505"
+    ) {
+      return NextResponse.json({ error: USERNAME_TAKEN_ERROR }, { status: 409 });
+    }
     console.error("Settings error:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -27,12 +27,15 @@ export async function PATCH(request: NextRequest) {
 
     const body = await request.json();
     const updates: Record<string, unknown> = { updatedAt: new Date() };
+    let hasSupportedUpdate = false;
 
     if (typeof body.isPublic === "boolean") {
       updates.isPublic = body.isPublic;
+      hasSupportedUpdate = true;
     }
 
     if (typeof body.username === "string") {
+      hasSupportedUpdate = true;
       const username = body.username.trim();
       if (
         username.length < 3 ||
@@ -80,6 +83,13 @@ export async function PATCH(request: NextRequest) {
         return NextResponse.json({ error: USERNAME_TAKEN_ERROR }, { status: 409 });
       }
       return NextResponse.json({ user: result.user });
+    }
+
+    if (!hasSupportedUpdate) {
+      return NextResponse.json(
+        { error: "No supported settings provided" },
+        { status: 400 },
+      );
     }
 
     const [updated] = await db

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -605,6 +605,7 @@ export default function StillPoint() {
         <SettingsView
           user={user}
           onTogglePublic={(isPublic) => setUser({ ...user, isPublic })}
+          onUsernameChange={(username) => setUser({ ...user, username })}
           onLogout={handleLogout}
         />
       )}

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -604,8 +604,12 @@ export default function StillPoint() {
       {view === "settings" && (
         <SettingsView
           user={user}
-          onTogglePublic={(isPublic) => setUser({ ...user, isPublic })}
-          onUsernameChange={(username) => setUser({ ...user, username })}
+          onTogglePublic={(isPublic) =>
+            setUser((prev) => (prev ? { ...prev, isPublic } : prev))
+          }
+          onUsernameChange={(username) =>
+            setUser((prev) => (prev ? { ...prev, username } : prev))
+          }
           onLogout={handleLogout}
         />
       )}

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -15,11 +15,81 @@ type User = {
 type SettingsViewProps = {
   user: User;
   onTogglePublic: (isPublic: boolean) => void;
+  onUsernameChange: (username: string) => void;
   onLogout: () => void;
 };
 
-export function SettingsView({ user, onTogglePublic, onLogout }: SettingsViewProps) {
+const USERNAME_REGEX = /^[a-zA-Z0-9_]+$/;
+const USERNAME_FORMAT_ERROR =
+  "Username must be 3-30 characters (letters, numbers, underscores)";
+
+export function SettingsView({
+  user,
+  onTogglePublic,
+  onUsernameChange,
+  onLogout,
+}: SettingsViewProps) {
   const [toggling, setToggling] = useState(false);
+  const [editingUsername, setEditingUsername] = useState(false);
+  const [usernameInput, setUsernameInput] = useState(user.username);
+  const [savingUsername, setSavingUsername] = useState(false);
+  const [usernameError, setUsernameError] = useState<string | null>(null);
+  const [usernameSuccess, setUsernameSuccess] = useState<string | null>(null);
+
+  const beginEditUsername = () => {
+    setUsernameInput(user.username);
+    setUsernameError(null);
+    setUsernameSuccess(null);
+    setEditingUsername(true);
+  };
+
+  const cancelEditUsername = () => {
+    setEditingUsername(false);
+    setUsernameError(null);
+    setUsernameInput(user.username);
+  };
+
+  const handleSaveUsername = async () => {
+    const trimmed = usernameInput.trim();
+    setUsernameError(null);
+    setUsernameSuccess(null);
+
+    if (trimmed === user.username) {
+      setEditingUsername(false);
+      return;
+    }
+    if (
+      trimmed.length < 3 ||
+      trimmed.length > 30 ||
+      !USERNAME_REGEX.test(trimmed)
+    ) {
+      setUsernameError(USERNAME_FORMAT_ERROR);
+      return;
+    }
+
+    setSavingUsername(true);
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username: trimmed }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setUsernameError(data?.error ?? "Could not update username");
+        return;
+      }
+      const updated = data?.user?.username ?? trimmed;
+      onUsernameChange(updated);
+      setUsernameInput(updated);
+      setEditingUsername(false);
+      setUsernameSuccess("Username updated");
+    } catch {
+      setUsernameError("Could not update username");
+    } finally {
+      setSavingUsername(false);
+    }
+  };
 
   const handleToggle = async () => {
     setToggling(true);
@@ -73,12 +143,117 @@ export function SettingsView({ user, onTogglePublic, onLogout }: SettingsViewPro
           }}>
             ACCOUNT
           </div>
-          <div style={{
-            fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
-            fontSize: "16px", color: "var(--fg)",
-          }}>
-            {user.username}
-          </div>
+          {editingUsername ? (
+            <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+              <input
+                type="text"
+                value={usernameInput}
+                onChange={(e) => setUsernameInput(e.target.value)}
+                disabled={savingUsername}
+                autoFocus
+                aria-label="Username"
+                aria-invalid={usernameError !== null}
+                maxLength={30}
+                style={{
+                  fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+                  fontSize: "16px", color: "var(--fg)",
+                  background: "var(--surface-2)",
+                  border: "1px solid var(--border-3)",
+                  borderRadius: "6px",
+                  padding: "6px 10px",
+                  outline: "none",
+                }}
+              />
+              <div style={{ display: "flex", gap: "8px" }}>
+                <button
+                  type="button"
+                  onClick={handleSaveUsername}
+                  disabled={savingUsername}
+                  style={{
+                    background: "none",
+                    border: "1px solid var(--border-3)",
+                    color: "var(--fg)",
+                    fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                    fontSize: "11px", letterSpacing: "0.12em",
+                    textTransform: "uppercase", padding: "6px 12px",
+                    borderRadius: "6px",
+                    cursor: savingUsername ? "not-allowed" : "pointer",
+                  }}
+                >
+                  {savingUsername ? "saving…" : "save"}
+                </button>
+                <button
+                  type="button"
+                  onClick={cancelEditUsername}
+                  disabled={savingUsername}
+                  style={{
+                    background: "none",
+                    border: "1px solid var(--border-3)",
+                    color: "var(--fg-3)",
+                    fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                    fontSize: "11px", letterSpacing: "0.12em",
+                    textTransform: "uppercase", padding: "6px 12px",
+                    borderRadius: "6px",
+                    cursor: savingUsername ? "not-allowed" : "pointer",
+                  }}
+                >
+                  cancel
+                </button>
+              </div>
+              {usernameError && (
+                <div
+                  role="alert"
+                  style={{
+                    fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                    fontSize: "11px",
+                    color: "var(--accent-danger-muted)",
+                  }}
+                >
+                  {usernameError}
+                </div>
+              )}
+            </div>
+          ) : (
+            <div style={{
+              display: "flex", alignItems: "center", justifyContent: "space-between",
+              gap: "12px",
+            }}>
+              <div style={{
+                fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+                fontSize: "16px", color: "var(--fg)",
+              }}>
+                {user.username}
+              </div>
+              <button
+                type="button"
+                onClick={beginEditUsername}
+                aria-label="Edit username"
+                style={{
+                  background: "none",
+                  border: "1px solid var(--border-3)",
+                  color: "var(--fg-3)",
+                  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                  fontSize: "10px", letterSpacing: "0.12em",
+                  textTransform: "uppercase", padding: "4px 10px",
+                  borderRadius: "6px", cursor: "pointer",
+                }}
+              >
+                edit
+              </button>
+            </div>
+          )}
+          {usernameSuccess && !editingUsername && (
+            <div
+              role="status"
+              style={{
+                fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                fontSize: "11px",
+                color: "var(--accent-green)",
+              }}
+            >
+              {usernameSuccess}
+            </div>
+          )}
           <div style={{
             fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
             fontSize: "12px", color: "var(--fg-3)",

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -3,6 +3,11 @@
 import { useState } from "react";
 import { DeleteAccountSection } from "@/components/DeleteAccountSection";
 import { api } from "@/lib/api";
+import {
+  MAX_USERNAME_LENGTH,
+  USERNAME_ERROR,
+  isValidUsername,
+} from "@/lib/username";
 
 type User = {
   id: string;
@@ -18,10 +23,6 @@ type SettingsViewProps = {
   onUsernameChange: (username: string) => void;
   onLogout: () => void;
 };
-
-const USERNAME_REGEX = /^[a-zA-Z0-9_]+$/;
-const USERNAME_FORMAT_ERROR =
-  "Username must be 3-30 characters (letters, numbers, underscores)";
 
 export function SettingsView({
   user,
@@ -58,12 +59,8 @@ export function SettingsView({
       setEditingUsername(false);
       return;
     }
-    if (
-      trimmed.length < 3 ||
-      trimmed.length > 30 ||
-      !USERNAME_REGEX.test(trimmed)
-    ) {
-      setUsernameError(USERNAME_FORMAT_ERROR);
+    if (!isValidUsername(trimmed)) {
+      setUsernameError(USERNAME_ERROR);
       return;
     }
 
@@ -153,7 +150,7 @@ export function SettingsView({
                 autoFocus
                 aria-label="Username"
                 aria-invalid={usernameError !== null}
-                maxLength={30}
+                maxLength={MAX_USERNAME_LENGTH}
                 style={{
                   fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
                   fontSize: "16px", color: "var(--fg)",

--- a/src/lib/username.ts
+++ b/src/lib/username.ts
@@ -1,0 +1,13 @@
+export const USERNAME_REGEX = /^[a-zA-Z0-9_]+$/;
+export const MIN_USERNAME_LENGTH = 3;
+export const MAX_USERNAME_LENGTH = 30;
+export const USERNAME_ERROR =
+  "Username must be 3-30 characters (letters, numbers, underscores)";
+
+export function isValidUsername(value: string): boolean {
+  return (
+    value.length >= MIN_USERNAME_LENGTH &&
+    value.length <= MAX_USERNAME_LENGTH &&
+    USERNAME_REGEX.test(value)
+  );
+}


### PR DESCRIPTION
## **User description**
## Summary
- Adds inline username editing to `SettingsView` with client-side validation (3-30 chars, `[a-zA-Z0-9_]`).
- Extends `PATCH /api/settings` to accept `username`, validating format and enforcing case-insensitive uniqueness via `lower()`.
- Catches Postgres unique-violation (`23505`) as a 409 backstop in case a concurrent insert races the explicit uniqueness check.
- Wires `onUsernameChange` from `app/page.tsx` so the parent's user state updates without a round-trip refresh.

Closes #7

## Test plan
- [x] Username field in Settings renders the current username and reveals an inline editor when "edit" is pressed
- [x] Submitting an invalid format (too short / disallowed chars) shows the validation error and does not call the API
- [x] Submitting a username already used by another user (case-insensitive) returns 409 and surfaces "Username already taken"
- [x] Submitting a valid, unused username persists, shows "Username updated", and the new value is reflected wherever `user.username` is used (header, public board, journal)
- [x] `PATCH /api/settings` with `{isPublic: true/false}` still toggles the public-board setting unchanged
- [x] `npx vitest run src` is green (41 tests, 8 files — including 7 new settings route tests)
- [x] `npx tsc --noEmit` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Edit your username from settings and get clearer save errors**

### What Changed
- Settings now lets you edit your username inline, with save and cancel actions, validation, and a success message after a successful change.
- Username changes update the rest of the app immediately, so the new name appears without a refresh.
- Username rules are now the same in sign-up and settings: 3–30 characters, letters/numbers/underscores only.
- Saving a username now rejects names already in use, including case-insensitive matches, and returns a clear “Username already taken” error.
- Settings PATCH now rejects requests that do not include a supported change, instead of silently succeeding.

### Impact
`✅ Shorter username changes`
`✅ Clearer username conflict errors`
`✅ Fewer accidental no-op settings saves`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=SSEMZdUMS1qDSBgn8jnJfCwqDIHHn31gub2l5vF16eU&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
