### PR TITLE
Enforce case-insensitive uniqueness on users.email and users.username

### DIFF
--- a/drizzle/users_uniqueness_incremental.sql
+++ b/drizzle/users_uniqueness_incremental.sql
@@ -1,0 +1,29 @@
+-- Incremental DDL for case-insensitive uniqueness on users.username (issue #8).
+-- Preferred: apply schema with `npx drizzle-kit push` (see README).
+-- This file is the manual-apply reference for existing databases (prod / preview branches).
+--
+-- Scope: username only.
+--   * Email: the existing column-level unique constraint (`users_email_unique`) is
+--     kept as-is. The signup route normalizes email to lowercase on insert and
+--     every lookup uses the lowercased value, so the case-sensitive btree is
+--     effectively case-insensitive AND backs the equality lookups in
+--     login / password-reset / signup pre-check (no sequential scan regression).
+--   * Username: display case is preserved in storage; uniqueness is enforced
+--     case-insensitively via a functional `lower(username)` index.
+--
+-- Pre-flight (RUN FIRST against the target DB; must return 0 rows):
+--   SELECT lower(username) AS dup, count(*) FROM users GROUP BY 1 HAVING count(*) > 1;
+-- If rows are returned, resolve the duplicates out-of-band before continuing —
+-- the index build below will fail on conflicting rows and roll back the txn.
+--
+-- This script is idempotent (IF EXISTS / IF NOT EXISTS) and atomic (BEGIN/COMMIT
+-- so a failure mid-flight rolls the legacy constraint back into place).
+
+BEGIN;
+
+ALTER TABLE "users" DROP CONSTRAINT IF EXISTS "users_username_unique";
+
+CREATE UNIQUE INDEX IF NOT EXISTS "users_username_lower_unique"
+  ON "users" (lower("username"));
+
+COMMIT;

--- a/drizzle/users_uniqueness_incremental.sql
+++ b/drizzle/users_uniqueness_incremental.sql
@@ -18,6 +18,18 @@
 --
 -- This script is idempotent (IF EXISTS / IF NOT EXISTS) and atomic (BEGIN/COMMIT
 -- so a failure mid-flight rolls the legacy constraint back into place).
+--
+-- Lock note: CREATE UNIQUE INDEX (non-CONCURRENTLY) takes ACCESS EXCLUSIVE on
+-- `users` for the duration of the build, blocking concurrent writes. This is
+-- fine on a small `users` table (sub-second build), which is the current shape.
+-- For a large table, prefer this two-step alternative run OUTSIDE the
+-- BEGIN/COMMIT block — it does not block writes, but cannot run inside a
+-- transaction so the DROP CONSTRAINT and CREATE INDEX are no longer atomic
+-- (the order below puts CREATE first to keep uniqueness enforced throughout):
+--
+--   CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "users_username_lower_unique"
+--     ON "users" (lower("username"));
+--   ALTER TABLE "users" DROP CONSTRAINT IF EXISTS "users_username_unique";
 
 BEGIN;
 

--- a/src/app/api/auth/signup/route.test.ts
+++ b/src/app/api/auth/signup/route.test.ts
@@ -1,0 +1,160 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const selectLimit = vi.fn();
+const selectWhere = vi.fn(() => ({ limit: selectLimit }));
+const selectFrom = vi.fn(() => ({ where: selectWhere }));
+const dbSelect = vi.fn(() => ({ from: selectFrom }));
+
+const insertReturning = vi.fn();
+const insertValues = vi.fn(() => ({ returning: insertReturning }));
+const dbInsert = vi.fn(() => ({ values: insertValues }));
+
+const hashPassword = vi.fn();
+const createToken = vi.fn();
+const setAuthCookie = vi.fn();
+
+vi.mock("@/db", () => ({
+  db: {
+    select: dbSelect,
+    insert: dbInsert,
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  users: {
+    email: "email",
+    username: "username",
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  hashPassword,
+  createToken,
+  setAuthCookie,
+}));
+
+vi.mock("@/lib/dbErrors", () => ({
+  uniqueViolationConstraint: (e: unknown): string | null => {
+    if (!e || typeof e !== "object") return null;
+    const o = e as { code?: string; constraint?: string; constraint_name?: string; cause?: unknown };
+    if (o.code === "23505") return o.constraint ?? o.constraint_name ?? "";
+    if (o.cause) return null;
+    return null;
+  },
+}));
+
+vi.mock("@/lib/username", () => ({
+  USERNAME_ERROR: "Username must be 3-30 characters (letters, numbers, underscores)",
+  isValidUsername: (u: unknown): boolean =>
+    typeof u === "string" && u.length >= 3 && u.length <= 30 && /^[a-zA-Z0-9_]+$/.test(u),
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((left, right) => ({ kind: "eq", left, right })),
+  sql: Object.assign(
+    (strings: TemplateStringsArray, ...values: unknown[]) => ({ kind: "sql", strings, values }),
+    {},
+  ),
+}));
+
+function makeRequest(body: Record<string, unknown>, headers?: Record<string, string>): NextRequest {
+  return new Request("http://test.local/api/auth/signup", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}
+
+describe("POST /api/auth/signup uniqueness handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectLimit.mockResolvedValue([]);
+    hashPassword.mockResolvedValue("hashed");
+    createToken.mockResolvedValue("token");
+    insertReturning.mockResolvedValue([
+      { id: "u1", email: "alice@example.com", username: "alice", isPublic: false, currentDay: 1 },
+    ]);
+  });
+
+  test("rejects duplicate email at the pre-check (case-normalized)", async () => {
+    selectLimit.mockResolvedValueOnce([{ id: "u-existing" }]);
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      makeRequest({ email: "Alice@Example.com", username: "alice", password: "password123" }),
+    );
+
+    await expect(response.json()).resolves.toEqual({ error: "Email already in use" });
+    expect(response.status).toBe(409);
+    expect(dbInsert).not.toHaveBeenCalled();
+  });
+
+  test("rejects duplicate username at the pre-check (case-insensitive)", async () => {
+    selectLimit.mockResolvedValueOnce([]).mockResolvedValueOnce([{ id: "u-existing" }]);
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      makeRequest({ email: "new@example.com", username: "Alice", password: "password123" }),
+    );
+
+    await expect(response.json()).resolves.toEqual({ error: "Username already taken" });
+    expect(response.status).toBe(409);
+    expect(dbInsert).not.toHaveBeenCalled();
+  });
+
+  test("maps Postgres 23505 on email constraint to 'Email already in use' (race fallback)", async () => {
+    insertReturning.mockRejectedValueOnce(
+      Object.assign(new Error("dup"), { code: "23505", constraint: "users_email_lower_unique" }),
+    );
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      makeRequest({ email: "alice@example.com", username: "alice", password: "password123" }),
+    );
+
+    await expect(response.json()).resolves.toEqual({ error: "Email already in use" });
+    expect(response.status).toBe(409);
+    expect(setAuthCookie).not.toHaveBeenCalled();
+  });
+
+  test("maps Postgres 23505 on username constraint to 'Username already taken' (race fallback)", async () => {
+    insertReturning.mockRejectedValueOnce(
+      Object.assign(new Error("dup"), { code: "23505", constraint: "users_username_lower_unique" }),
+    );
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      makeRequest({ email: "alice@example.com", username: "alice", password: "password123" }),
+    );
+
+    await expect(response.json()).resolves.toEqual({ error: "Username already taken" });
+    expect(response.status).toBe(409);
+  });
+
+  test("falls back to a generic 409 when the unique-violation constraint is unrecognized", async () => {
+    insertReturning.mockRejectedValueOnce(
+      Object.assign(new Error("dup"), { code: "23505", constraint: "" }),
+    );
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      makeRequest({ email: "alice@example.com", username: "alice", password: "password123" }),
+    );
+
+    await expect(response.json()).resolves.toEqual({ error: "Email or username already in use" });
+    expect(response.status).toBe(409);
+  });
+
+  test("non-23505 errors still surface as 500 (no false uniqueness signal)", async () => {
+    insertReturning.mockRejectedValueOnce(Object.assign(new Error("boom"), { code: "08006" }));
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      makeRequest({ email: "alice@example.com", username: "alice", password: "password123" }),
+    );
+
+    await expect(response.json()).resolves.toEqual({ error: "Internal server error" });
+    expect(response.status).toBe(500);
+  });
+});

--- a/src/app/api/auth/signup/route.test.ts
+++ b/src/app/api/auth/signup/route.test.ts
@@ -101,6 +101,11 @@ describe("POST /api/auth/signup uniqueness handling", () => {
     await expect(response.json()).resolves.toEqual({ error: "Username already taken" });
     expect(response.status).toBe(409);
     expect(dbInsert).not.toHaveBeenCalled();
+    // Pin the predicate shape so a regression to plain eq(users.username, ...)
+    // (which would be case-sensitive) fails this test instead of silently passing.
+    expect(selectWhere).toHaveBeenCalledTimes(2);
+    const usernamePredicate = selectWhere.mock.calls[1][0] as { kind?: string };
+    expect(usernamePredicate?.kind).toBe("sql");
   });
 
   test("maps Postgres 23505 on email constraint to 'Email already in use' (race fallback)", async () => {

--- a/src/app/api/auth/signup/route.test.ts
+++ b/src/app/api/auth/signup/route.test.ts
@@ -105,7 +105,7 @@ describe("POST /api/auth/signup uniqueness handling", () => {
 
   test("maps Postgres 23505 on email constraint to 'Email already in use' (race fallback)", async () => {
     insertReturning.mockRejectedValueOnce(
-      Object.assign(new Error("dup"), { code: "23505", constraint: "users_email_lower_unique" }),
+      Object.assign(new Error("dup"), { code: "23505", constraint: "users_email_unique" }),
     );
     const { POST } = await import("./route");
 

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { hashPassword, createToken, setAuthCookie } from "@/lib/auth";
+import { uniqueViolationConstraint } from "@/lib/dbErrors";
 import { USERNAME_ERROR, isValidUsername } from "@/lib/username";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 
 export async function POST(request: NextRequest) {
   try {
@@ -27,23 +28,44 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Password must be at least 8 characters" }, { status: 400 });
     }
 
-    const existingEmail = await db.select().from(users).where(eq(users.email, email.toLowerCase())).limit(1);
+    const normalizedEmail = email.toLowerCase();
+
+    const existingEmail = await db.select().from(users).where(eq(users.email, normalizedEmail)).limit(1);
     if (existingEmail.length > 0) {
       return NextResponse.json({ error: "Email already in use" }, { status: 409 });
     }
 
-    const existingUsername = await db.select().from(users).where(eq(users.username, username)).limit(1);
+    const existingUsername = await db
+      .select()
+      .from(users)
+      .where(sql`lower(${users.username}) = lower(${username})`)
+      .limit(1);
     if (existingUsername.length > 0) {
       return NextResponse.json({ error: "Username already taken" }, { status: 409 });
     }
 
     const passwordHash = await hashPassword(password);
 
-    const [newUser] = await db.insert(users).values({
-      email: email.toLowerCase(),
-      username,
-      passwordHash,
-    }).returning();
+    let newUser;
+    try {
+      [newUser] = await db.insert(users).values({
+        email: normalizedEmail,
+        username,
+        passwordHash,
+      }).returning();
+    } catch (err) {
+      const constraint = uniqueViolationConstraint(err);
+      if (constraint !== null) {
+        if (constraint.includes("email")) {
+          return NextResponse.json({ error: "Email already in use" }, { status: 409 });
+        }
+        if (constraint.includes("username")) {
+          return NextResponse.json({ error: "Username already taken" }, { status: 409 });
+        }
+        return NextResponse.json({ error: "Email or username already in use" }, { status: 409 });
+      }
+      throw err;
+    }
 
     const token = await createToken({ userId: newUser.id, email: newUser.email });
     await setAuthCookie(token);

--- a/src/app/api/buddy/sessions/[id]/record-personal-session/route.ts
+++ b/src/app/api/buddy/sessions/[id]/record-personal-session/route.ts
@@ -16,17 +16,10 @@ import {
   requireBuddySessionCompletedForPersonalRecord,
 } from "@/lib/buddySessionControlsPolicy";
 import { hasRejectedSubmittedThoughts, normalizeThoughtInputs } from "@/lib/thoughtSaving";
+import { isUniqueViolation } from "@/lib/dbErrors";
 import { and, eq, sql } from "drizzle-orm";
 
 type Params = { params: Promise<{ id: string }> };
-
-function isUniqueViolation(e: unknown): boolean {
-  if (!e || typeof e !== "object") return false;
-  const o = e as { code?: string; cause?: unknown };
-  if (o.code === "23505") return true;
-  if (o.cause) return isUniqueViolation(o.cause);
-  return false;
-}
 
 function parseMindStateLog(raw: unknown): Array<{ time: number; state: string }> {
   if (!Array.isArray(raw)) return [];

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -17,8 +17,11 @@ import { relations, sql } from "drizzle-orm";
 
 export const users = pgTable("users", {
   id: uuid("id").primaryKey().defaultRandom(),
+  /** Stored lowercased by the signup route, so the column-level unique constraint
+   *  is effectively case-insensitive and its btree backs login/password-reset
+   *  `eq(users.email, ...)` lookups. */
   email: varchar("email", { length: 255 }).unique().notNull(),
-  username: varchar("username", { length: 50 }).unique().notNull(),
+  username: varchar("username", { length: 50 }).notNull(),
   passwordHash: varchar("password_hash", { length: 255 }).notNull(),
   isPublic: boolean("is_public").default(false).notNull(),
   currentDay: integer("current_day").default(1).notNull(),
@@ -26,6 +29,8 @@ export const users = pgTable("users", {
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 }, (table) => ({
   publicIdx: index("idx_users_public").on(table.isPublic),
+  /** #8: Case-insensitive uniqueness for username; display case preserved in column. */
+  usernameLowerUnique: uniqueIndex("users_username_lower_unique").on(sql`lower(${table.username})`),
 }));
 
 export const deviceTokens = pgTable("device_tokens", {

--- a/src/lib/dbErrors.ts
+++ b/src/lib/dbErrors.ts
@@ -1,0 +1,23 @@
+/** Postgres SQLSTATE for unique_violation. */
+const UNIQUE_VIOLATION = "23505";
+
+/**
+ * Returns the failed constraint name when `e` is a Postgres unique_violation
+ * (SQLSTATE 23505), or `null` otherwise. The constraint name may be an empty
+ * string if the driver did not surface it.
+ *
+ * Recursively unwraps `cause` so wrapped errors (e.g., from drizzle / neon
+ * adapters) are still detected.
+ */
+export function uniqueViolationConstraint(e: unknown): string | null {
+  if (!e || typeof e !== "object") return null;
+  const o = e as { code?: string; constraint?: string; constraint_name?: string; cause?: unknown };
+  if (o.code === UNIQUE_VIOLATION) return o.constraint ?? o.constraint_name ?? "";
+  if (o.cause) return uniqueViolationConstraint(o.cause);
+  return null;
+}
+
+/** Convenience boolean check around `uniqueViolationConstraint`. */
+export function isUniqueViolation(e: unknown): boolean {
+  return uniqueViolationConstraint(e) !== null;
+}


### PR DESCRIPTION
## **User description**
Closes #8.

## Summary

Add DB-level, **case-insensitive** uniqueness enforcement for `users.username`, plus race-safe signup error handling.

- Schema: keep the existing column-level `.unique()` on `users.email` (its btree backs equality lookups in login / password-reset / signup pre-check); for `users.username`, drop the column-level `.unique()` and add a functional `uniqueIndex` on `lower(username)`. Display case is preserved in the column; uniqueness is enforced on the lowercased value.
- Migration: new `drizzle/users_uniqueness_incremental.sql` wrapped in `BEGIN/COMMIT` so the legacy constraint drop and the new index creation are atomic — a failure mid-flight rolls the original constraint back into place. Idempotent (`DROP ... IF EXISTS` + `CREATE UNIQUE INDEX IF NOT EXISTS`).
- Signup: existing pre-check for username is now case-insensitive (`lower(username) = lower(input)`); a `23505` (unique_violation) fallback maps the rare race-condition error to a user-safe 409 ("Email already in use" / "Username already taken") instead of leaking a Postgres error or returning 500.
- Shared helper: extracted `uniqueViolationConstraint` + `isUniqueViolation` to `src/lib/dbErrors.ts`; `signup/route.ts` and `record-personal-session/route.ts` both import from it so the recursive cause-unwrapping logic cannot drift.
- Settings route is unchanged. It does not currently support username updates, so there is no uniqueness path to guard there. If username changes are added later, the new DB constraint will protect them at the layer below.

## Case-sensitivity policy

- **Email** — case-sensitive at the DB layer via the existing column-level `.unique()` constraint, but the signup route normalizes to lowercase on insert and on every lookup (`email.toLowerCase()`), so all stored values are pre-normalized and the column-level unique is functionally case-insensitive. Adding a separate `lower(email)` functional index would shadow the column btree and force `eq(users.email, ...)` lookups in login/password-reset onto a sequential scan, so it is intentionally **not** added.
- **Username** — display case **preserved** in storage (Twitter/Reddit-style); uniqueness enforced via `lower(username)` index. No equality lookups on username rely on a plain btree (signup pre-check uses `lower(...)`, friends/search uses `ilike`).

## Production rollout

`npx drizzle-kit push` is the project's apply mechanism (per `README.md`); the SQL file is the manual-apply reference for environments where push is not run.

Pre-flight (run against the target DB before applying — must return 0 rows):

```sql
SELECT lower(username) AS dup, count(*) FROM users GROUP BY 1 HAVING count(*) > 1;
```

If the query returns rows, resolve duplicates out-of-band before applying — index creation will fail mid-flight on conflicting data and the BEGIN/COMMIT will roll back, leaving the original `users_username_unique` constraint in place. The DDL itself takes a brief `ACCESS EXCLUSIVE` on `users` while the index builds (small table, expected sub-second). Rollback if needed: drop the new index; the legacy `.unique()` constraint is recreatable from the prior schema commit.

## Test plan

- [x] `npx vitest run src/app/api/auth/signup/route.test.ts` — 6 tests pass (pre-check rejects duplicate email; pre-check rejects duplicate username case-insensitively; 23505 on email constraint maps to "Email already in use"; 23505 on username constraint maps to "Username already taken"; unrecognized 23505 constraint name maps to a generic 409; non-23505 errors still surface as 500).
- [x] `npx vitest run src` — full unit suite stays green (40/40).
- [x] `npx tsc --noEmit` — no new errors in `src/` source files (pre-existing test/e2e errors unaffected).
- [ ] Pre-flight dedup query above returns 0 rows on the local/preview DB before applying the migration.
- [ ] After applying the migration, `\d users` (or Drizzle introspection) shows `users_email_unique` (kept) and `users_username_lower_unique` (new), and the legacy `users_username_unique` constraint is gone.
- [ ] Manual: signup with `Alice@Example.com` then `alice@example.com` — second attempt returns 409 "Email already in use" (covered by app-layer normalization).
- [ ] Manual: signup with username `Alice` then `alice` — second attempt returns 409 "Username already taken" (covered by the new `lower(username)` index).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make username uniqueness case-insensitive and return clear signup conflicts**

### What Changed
- Usernames are now treated as taken even when they only differ by letter case, while the saved display case stays unchanged.
- Signup now catches duplicate-email and duplicate-username races and returns a clear 409 error instead of a server failure.
- Email checks continue to use the normalized email value, so login and reset flows are unaffected.

### Impact
`✅ Fewer duplicate usernames`
`✅ Clearer signup conflict messages`
`✅ Fewer signup server errors`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=S-t1PWCssZxUmhKtwlW-dacj0o296kivB5OQyhIS-bI&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
