### PR TITLE
Add Google OAuth sign-in via Auth.js (#136)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,41 @@ DAILY_API_KEY=
 # Must decode to exactly 32 bytes; base64 preferred (`openssl rand -base64 32`) or 64-char hex.
 # GOOGLE_TOKEN_ENCRYPTION_KEY=
 
+# Auth.js (NextAuth v5) sign-in provider OAuth (#136). Distinct from the
+# Google Calendar OAuth above — different redirect URIs, different secrets.
+# Generate with: openssl rand -base64 32
+AUTH_SECRET=your-authjs-secret-here
+
+# Google sign-in (#136). Console: https://console.cloud.google.com/
+# Authorized redirect URIs to register:
+#   https://www.still-point.me/api/auth/callback/google
+#   http://localhost:3000/api/auth/callback/google
+AUTH_GOOGLE_ID=
+AUTH_GOOGLE_SECRET=
+
+# Microsoft sign-in (deferred to #284). Console: https://entra.microsoft.com/
+# Authorized redirect URIs:
+#   https://www.still-point.me/api/auth/callback/microsoft-entra-id
+#   http://localhost:3000/api/auth/callback/microsoft-entra-id
+# AUTH_MICROSOFT_ENTRA_ID_ID=
+# AUTH_MICROSOFT_ENTRA_ID_SECRET=
+# AUTH_MICROSOFT_ENTRA_ID_ISSUER=https://login.microsoftonline.com/common/v2.0
+
+# Facebook sign-in (deferred to #285). Console: https://developers.facebook.com/
+# Authorized redirect URIs:
+#   https://www.still-point.me/api/auth/callback/facebook
+#   http://localhost:3000/api/auth/callback/facebook
+# AUTH_FACEBOOK_ID=
+# AUTH_FACEBOOK_SECRET=
+
+# Apple sign-in (deferred to #286). Console: https://developer.apple.com/account/
+# Apple does NOT allow localhost. Local dev requires a tunnel.
+# Services ID Return URL: https://www.still-point.me/api/auth/callback/apple
+# AUTH_APPLE_ID=                      # Services ID identifier (e.g. com.brettonauerbach.stillpoint.web.signin)
+# APPLE_TEAM_ID=                      # 10-char Team ID
+# APPLE_KEY_ID=                       # 10-char Key ID from Sign in with Apple key
+# APPLE_PRIVATE_KEY=                  # Full .p8 contents incl. BEGIN/END lines (escape newlines as \n in single-line .env)
+
 # Optional: set to exactly "true" to require friendship before buddy join (see README)
 # BUDDY_REQUIRE_FRIENDSHIP=
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ npm run build:turbo
 | `POSTGRES_URL` | Runtime DB connection string used by the app (`src/db/index.ts`, `drizzle.config.ts`). In local dev, point at non-production Neon. | [Neon console](https://console.neon.tech) → project/branch → connection string |
 | `POSTGRES_URL_TEST` | **Not read by the app** — optional team alias for the non-production URL when documenting or mirroring Vercel Preview envs. | Same as non-prod `POSTGRES_URL` |
 | `JWT_SECRET` | Secret for signing auth tokens (`src/lib/auth.ts`, `src/middleware.ts`) | `openssl rand -base64 32` |
-| `NEXT_PUBLIC_APP_URL` | Public absolute URL used when generating password reset links. Defaults to `https://still-point.me` when unset. | Deployment URL such as `https://still-point.me` or local `http://127.0.0.1:3000` |
+| `NEXT_PUBLIC_APP_URL` | Public absolute URL used when generating password reset links. Defaults to `https://www.still-point.me` when unset. | Deployment URL such as `https://www.still-point.me` or local `http://127.0.0.1:3000` |
 | `EMAIL_FROM` | Sender address for password reset email. Required with `RESEND_API_KEY` for password reset email delivery. | Verified sender/domain in the email provider |
 | `RESEND_API_KEY` | Server-only Resend API key for password reset email delivery. Never expose to the client. | Resend dashboard → API Keys |
 | `DAILY_API_KEY` | [Daily.co](https://www.daily.co/) REST API key — buddy video rooms and meeting tokens (`src/lib/daily.ts`). Server-only; never expose to the client. | Daily dashboard → Developers → API key |
@@ -205,7 +205,7 @@ echo "your_test_db_url" | npx vercel env add POSTGRES_URL_TEST preview
 
 Production should continue to use the production Neon URL for `POSTGRES_URL`.
 
-The app is live at [still-point.me](https://still-point.me).
+The app is live at [www.still-point.me](https://www.still-point.me/).
 
 ## Release operations
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Still Point
 
-**The app is live at [still-point.me](https://still-point.me)**
+**The app is live at [www.still-point.me](https://www.still-point.me/)** (production canonical URL — use this for OAuth redirect URIs, third-party developer console domain config, marketing links, and any external integration that needs the prod origin).
 
 Practice focus by watching the clock without thinking for fixed blocks of time.
 

--- a/docs/mobile-oauth-integration.md
+++ b/docs/mobile-oauth-integration.md
@@ -85,7 +85,6 @@ than carrying provider SDKs. The flow:
 
    ```text
    https://www.still-point.me/api/auth/signin/<provider>
-       ?callbackUrl=stillpoint%3A%2F%2Foauth-complete
    ```
 
    For `<provider>` use the Auth.js id: `google`, `microsoft-entra-id`, or
@@ -101,10 +100,23 @@ than carrying provider SDKs. The flow:
    the HttpOnly cookie scoped to `still-point.me`, then redirects to
    `/app`.
 
-4. `ASWebAuthenticationSession`'s callback URL scheme (registered in
-   `Info.plist` under `CFBundleURLTypes`, e.g. `stillpoint://oauth-complete`)
-   is invoked once the redirect chain reaches `/app`. iOS reads
-   `HTTPCookieStorage.shared` for the `sp_token` cookie and proceeds.
+4. **Detecting completion on iOS.** The redirect chain ends on `/app` —
+   the server does not redirect to a custom URL scheme today, so
+   `ASWebAuthenticationSession`'s `callbackURLScheme` completion handler
+   does NOT fire automatically. The iOS-side issue (separate from #136)
+   will choose one of:
+   - **(a)** Have the server redirect to `stillpoint://oauth-complete`
+     after `oauth-complete` instead of `/app`, with a server-side
+     allow-list keyed off a request marker (e.g. `?ios=1` propagated
+     from `signin/<provider>?callbackUrl=...`). This requires a small
+     extension to the `redirect` callback in `src/lib/auth-config.ts` so
+     known custom schemes survive.
+   - **(b)** Poll the session's current URL on a timer; when it reaches
+     `https://www.still-point.me/app`, dismiss the session and read
+     `sp_token` from `HTTPCookieStorage.shared`.
+   Until that decision lands, treat the existing custom-scheme
+   registration in `Info.plist` as scaffolding — it does not yet
+   round-trip end-to-end.
 
 Caveats for Pattern B:
 

--- a/docs/mobile-oauth-integration.md
+++ b/docs/mobile-oauth-integration.md
@@ -47,14 +47,16 @@ when the platform supports it. The native flow returns an `identityToken`
 Endpoint (to be implemented under issue
 [#286](https://github.com/auerbachb/still-point/issues/286)):
 
-```
+```http
 POST /api/auth/apple-native
 Content-Type: application/json
+```
 
+```json
 {
   "identityToken": "<JWS from ASAuthorizationCredential.identityToken>",
   "authorizationCode": "<from ASAuthorizationCredential.authorizationCode>",
-  "fullName": { "givenName": "Ada", "familyName": "Lovelace" }   // optional, first sign-in only
+  "fullName": { "givenName": "Ada", "familyName": "Lovelace" }
 }
 ```
 
@@ -81,7 +83,7 @@ than carrying provider SDKs. The flow:
 
 1. iOS opens `ASWebAuthenticationSession` pointed at:
 
-   ```
+   ```text
    https://www.still-point.me/api/auth/signin/<provider>
        ?callbackUrl=stillpoint%3A%2F%2Foauth-complete
    ```

--- a/docs/mobile-oauth-integration.md
+++ b/docs/mobile-oauth-integration.md
@@ -1,0 +1,146 @@
+# Mobile OAuth Integration (iOS)
+
+This document defines the architecture and API contract the iOS app uses to
+sign in users via the same OAuth providers offered on the web. It is the
+companion spec for issue #136 (web Google sign-in) and follow-ups
+[#284](https://github.com/auerbachb/still-point/issues/284) (Microsoft),
+[#285](https://github.com/auerbachb/still-point/issues/285) (Facebook), and
+[#286](https://github.com/auerbachb/still-point/issues/286) (Apple).
+
+The iOS implementation itself ships in a separate iOS-side issue. This file
+describes only what the web backend already supports today and what each
+provider expects from the client.
+
+---
+
+## Account model
+
+A single Still Point user account can have:
+
+- An optional password (stored as a bcrypt hash in `users.password_hash`,
+  nullable as of #136).
+- Zero or more linked OAuth identities, recorded in `oauth_accounts` as
+  `(provider, provider_account_id) -> user_id`.
+
+Linking rule: when a sign-in provider returns a verified email that matches
+an existing `users.email` (case-insensitively), the new
+`(provider, provider_account_id)` is attached to that user. Otherwise a new
+user is created with a null `password_hash`.
+
+The session token format is unchanged. The web backend mints the same
+HttpOnly `sp_token` JWT it has always used; iOS continues to read
+`sp_token` from `HTTPCookieStorage.shared` and attach it to subsequent
+requests.
+
+---
+
+## Provider integration patterns
+
+There are two patterns iOS uses depending on the provider:
+
+### Pattern A: Native SDK + dedicated server endpoint (Apple only)
+
+Apple requires Sign in with Apple to use `ASAuthorizationController` on iOS
+when the platform supports it. The native flow returns an `identityToken`
+(JWT signed by Apple) and an `authorizationCode` to the app, not a redirect.
+
+Endpoint (to be implemented under issue
+[#286](https://github.com/auerbachb/still-point/issues/286)):
+
+```
+POST /api/auth/apple-native
+Content-Type: application/json
+
+{
+  "identityToken": "<JWS from ASAuthorizationCredential.identityToken>",
+  "authorizationCode": "<from ASAuthorizationCredential.authorizationCode>",
+  "fullName": { "givenName": "Ada", "familyName": "Lovelace" }   // optional, first sign-in only
+}
+```
+
+Server responsibilities:
+
+1. Verify `identityToken` against Apple's JWKS
+   (`https://appleid.apple.com/auth/keys`) using the `jose` library that is
+   already in the project; check `iss == "https://appleid.apple.com"`,
+   `aud == AUTH_APPLE_ID` (the Services ID), and `exp`.
+2. Extract `sub` (Apple user id, stable across sign-ins) and `email`.
+3. Apply the same find/create-and-link logic as the web `signIn` callback,
+   keyed on email when present (Apple may return a relay address) and on
+   `(provider='apple', provider_account_id=sub)` for re-sign-in.
+4. Mint `sp_token`, set the cookie, and return the same response shape as
+   `POST /api/auth/login`.
+
+This endpoint does not exist yet. It is gated on
+[#286](https://github.com/auerbachb/still-point/issues/286).
+
+### Pattern B: `ASWebAuthenticationSession` over the web flow (Google, Microsoft, Facebook)
+
+For all non-Apple providers, iOS reuses the existing web OAuth flow rather
+than carrying provider SDKs. The flow:
+
+1. iOS opens `ASWebAuthenticationSession` pointed at:
+
+   ```
+   https://www.still-point.me/api/auth/signin/<provider>
+       ?callbackUrl=stillpoint%3A%2F%2Foauth-complete
+   ```
+
+   For `<provider>` use the Auth.js id: `google`, `microsoft-entra-id`, or
+   `facebook`.
+
+2. The user authenticates with the provider in a system-managed browser tab
+   that shares cookies with Safari (set
+   `prefersEphemeralWebBrowserSession: false` so returning users do not
+   re-enter their password).
+
+3. Auth.js (server) handles `/api/auth/callback/<provider>` and redirects
+   to `/api/auth/oauth-complete`. `oauth-complete` mints `sp_token`, sets
+   the HttpOnly cookie scoped to `still-point.me`, then redirects to
+   `/app`.
+
+4. `ASWebAuthenticationSession`'s callback URL scheme (registered in
+   `Info.plist` under `CFBundleURLTypes`, e.g. `stillpoint://oauth-complete`)
+   is invoked once the redirect chain reaches `/app`. iOS reads
+   `HTTPCookieStorage.shared` for the `sp_token` cookie and proceeds.
+
+Caveats for Pattern B:
+
+- The redirect URI registered with each provider must be the **server**
+  callback (`https://www.still-point.me/api/auth/callback/<provider>`),
+  not the iOS custom scheme. Auth.js owns the OAuth handshake; iOS only
+  cares about the final `sp_token` cookie.
+- iOS must use `HTTPCookieStorage.shared` (the default) so cookies set
+  by the system browser are visible to the app's `URLSession`. Custom
+  cookie stores will miss `sp_token`.
+- If `sp_token` is unexpectedly absent after the session callback, the
+  app should call `GET /api/auth/me` once. If it returns 401, treat the
+  attempt as a failed sign-in and surface a retry UI.
+
+---
+
+## Provider-specific notes
+
+| Provider | Pattern | iOS framework | Status |
+|---|---|---|---|
+| Google | B (web flow) | `ASWebAuthenticationSession` | Web available today (#136). iOS-side issue not yet filed. |
+| Apple | A (native) | `ASAuthorizationController` | Web Auth.js + native endpoint deferred to [#286](https://github.com/auerbachb/still-point/issues/286). |
+| Facebook | B (web flow) | `ASWebAuthenticationSession` | Deferred to [#285](https://github.com/auerbachb/still-point/issues/285). |
+| Microsoft | B (web flow) | `ASWebAuthenticationSession` | Deferred to [#284](https://github.com/auerbachb/still-point/issues/284). |
+
+---
+
+## Security expectations (all providers)
+
+- Verify provider tokens server-side; never trust client-supplied user
+  identifiers.
+- Provider tokens (`identityToken`, OAuth access tokens, refresh tokens)
+  must not appear in application logs. Auth.js does not log them by default;
+  custom server code (e.g., `/api/auth/apple-native`) must follow the same
+  rule.
+- `sp_token` remains the only credential the iOS app sees and stores. It is
+  HttpOnly on web; on iOS it lives in `HTTPCookieStorage.shared` and is
+  attached automatically by `URLSession`.
+- CSRF/state for the OAuth handshake is owned by Auth.js for Pattern B;
+  Pattern A endpoints (`/api/auth/apple-native`) do not need CSRF protection
+  because the request is a one-shot exchange of a provider-issued JWT.

--- a/drizzle/oauth_accounts_incremental.sql
+++ b/drizzle/oauth_accounts_incremental.sql
@@ -1,0 +1,34 @@
+-- Incremental DDL for OAuth provider account linking (issue #136).
+-- Preferred: apply schema with `npx drizzle-kit push` (see README).
+-- This file is the manual-apply reference for existing databases (prod / preview branches).
+--
+-- Stores one row per (provider, provider_account_id) pair, linking it to a
+-- users.id. A single user may have multiple oauth_accounts rows (one per
+-- provider). The unique index on (provider, provider_account_id) prevents
+-- the same external identity from being linked to two different local users.
+--
+-- Provider check covers the four providers planned for #136 + follow-up
+-- issues #284 (microsoft), #285 (facebook), #286 (apple). Today only
+-- 'google' is wired in product code; the other values are reserved.
+--
+-- Idempotent (IF NOT EXISTS) and atomic (BEGIN/COMMIT).
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS "oauth_accounts" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "user_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "provider" varchar(32) NOT NULL,
+  "provider_account_id" varchar(255) NOT NULL,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT "oauth_accounts_provider_allowed"
+    CHECK ("provider" IN ('google', 'apple', 'facebook', 'microsoft'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "oauth_accounts_provider_account_unique"
+  ON "oauth_accounts" ("provider", "provider_account_id");
+
+CREATE INDEX IF NOT EXISTS "idx_oauth_accounts_user"
+  ON "oauth_accounts" ("user_id");
+
+COMMIT;

--- a/drizzle/oauth_accounts_incremental.sql
+++ b/drizzle/oauth_accounts_incremental.sql
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS "oauth_accounts" (
   "provider_account_id" varchar(255) NOT NULL,
   "created_at" timestamp with time zone NOT NULL DEFAULT now(),
   CONSTRAINT "oauth_accounts_provider_allowed"
-    CHECK ("provider" IN ('google', 'apple', 'facebook', 'microsoft'))
+    CHECK ("provider" IN ('google', 'apple', 'facebook', 'microsoft-entra-id'))
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS "oauth_accounts_provider_account_unique"

--- a/drizzle/users_nullable_password_incremental.sql
+++ b/drizzle/users_nullable_password_incremental.sql
@@ -1,0 +1,12 @@
+-- Incremental DDL: make users.password_hash nullable (issue #136).
+-- OAuth-only accounts (e.g., Google sign-in with no password ever set) need
+-- the column to be NULL. The login route refuses logins for users with a
+-- NULL password_hash and prompts them to use OAuth instead.
+--
+-- Idempotent: DROP NOT NULL is a no-op if already nullable.
+
+BEGIN;
+
+ALTER TABLE "users" ALTER COLUMN "password_hash" DROP NOT NULL;
+
+COMMIT;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "jose": "^6.1.3",
         "jotai": "^2.19.1",
         "next": "15.5.12",
+        "next-auth": "5.0.0-beta.31",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "server-only": "^0.0.1",
@@ -92,6 +93,35 @@
       "license": "MIT",
       "optional": true,
       "peer": true
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
+      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
@@ -1911,6 +1941,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@playwright/test": {
@@ -3962,6 +4001,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.31.tgz",
+      "integrity": "sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.2"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
@@ -3973,6 +4039,15 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/obuf": {
@@ -4194,6 +4269,25 @@
       "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
       "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
       "license": "MIT"
+    },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "jose": "^6.1.3",
     "jotai": "^2.19.1",
     "next": "15.5.12",
+    "next-auth": "5.0.0-beta.31",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "server-only": "^0.0.1",

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/lib/auth-config";
+
+export const { GET, POST } = handlers;

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -33,14 +33,13 @@ export async function POST(request: NextRequest) {
     }
 
     if (!user.passwordHash) {
-      // OAuth-only account (#136): no password ever set. Run a dummy compare
-      // so timing matches the password-set path, then reject with a hint
-      // pointing at the available OAuth provider(s).
+      // OAuth-only account (#136): no password ever set. Run a dummy
+      // compare so timing matches the password-set path, then reject with
+      // the same generic message as wrong-password / unknown-email — a
+      // distinct message would let attackers enumerate which emails exist
+      // AND which auth method they use.
       await verifyPassword(password, DUMMY_PASSWORD_HASH);
-      return NextResponse.json(
-        { error: "This account uses single sign-on. Use 'Continue with Google' to log in." },
-        { status: 401 },
-      );
+      return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
     }
 
     const valid = await verifyPassword(password, user.passwordHash);

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -32,6 +32,17 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
     }
 
+    if (!user.passwordHash) {
+      // OAuth-only account (#136): no password ever set. Run a dummy compare
+      // so timing matches the password-set path, then reject with a hint
+      // pointing at the available OAuth provider(s).
+      await verifyPassword(password, DUMMY_PASSWORD_HASH);
+      return NextResponse.json(
+        { error: "This account uses single sign-on. Use 'Continue with Google' to log in." },
+        { status: 401 },
+      );
+    }
+
     const valid = await verifyPassword(password, user.passwordHash);
     if (!valid) {
       return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -7,7 +7,13 @@ export async function POST() {
   // Belt-and-suspenders: clear any lingering Auth.js cookies (#136). Most
   // OAuth users only carry sp_token because oauth-complete drops the
   // Auth.js cookies on hand-off, but if the user never made it through
-  // oauth-complete the session cookie can still be present here.
-  await clearAuthJsCookies();
+  // oauth-complete the session cookie can still be present here. This is
+  // best-effort cleanup — a throw here should not turn a successful sp_token
+  // clear into a 500 to the client.
+  try {
+    await clearAuthJsCookies();
+  } catch (err) {
+    console.error("logout cookie cleanup failed:", err);
+  }
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,16 +1,6 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
 import { clearAuthCookie } from "@/lib/auth";
-
-// Auth.js v5 sets a varying set of cookies (session-token, csrf-token,
-// callback-url, pkce.code_verifier, state, nonce, plus chunked variants
-// like session-token.0, .1) under three name prefixes. Match by prefix so
-// future cookies and chunked variants are wiped without code changes.
-const AUTHJS_COOKIE_PREFIXES = [
-  "authjs.",
-  "__Secure-authjs.",
-  "__Host-authjs.",
-];
+import { clearAuthJsCookies } from "@/lib/authJsCookies";
 
 export async function POST() {
   await clearAuthCookie();
@@ -18,11 +8,6 @@ export async function POST() {
   // OAuth users only carry sp_token because oauth-complete drops the
   // Auth.js cookies on hand-off, but if the user never made it through
   // oauth-complete the session cookie can still be present here.
-  const store = await cookies();
-  for (const cookie of store.getAll()) {
-    if (AUTHJS_COOKIE_PREFIXES.some((p) => cookie.name.startsWith(p))) {
-      store.delete(cookie.name);
-    }
-  }
+  await clearAuthJsCookies();
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,7 +1,28 @@
 import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
 import { clearAuthCookie } from "@/lib/auth";
+
+// Auth.js v5 sets a varying set of cookies (session-token, csrf-token,
+// callback-url, pkce.code_verifier, state, nonce, plus chunked variants
+// like session-token.0, .1) under three name prefixes. Match by prefix so
+// future cookies and chunked variants are wiped without code changes.
+const AUTHJS_COOKIE_PREFIXES = [
+  "authjs.",
+  "__Secure-authjs.",
+  "__Host-authjs.",
+];
 
 export async function POST() {
   await clearAuthCookie();
+  // Belt-and-suspenders: clear any lingering Auth.js cookies (#136). Most
+  // OAuth users only carry sp_token because oauth-complete drops the
+  // Auth.js cookies on hand-off, but if the user never made it through
+  // oauth-complete the session cookie can still be present here.
+  const store = await cookies();
+  for (const cookie of store.getAll()) {
+    if (AUTHJS_COOKIE_PREFIXES.some((p) => cookie.name.startsWith(p))) {
+      store.delete(cookie.name);
+    }
+  }
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/auth/oauth-complete/route.ts
+++ b/src/app/api/auth/oauth-complete/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { auth } from "@/lib/auth-config";
 import { clearAuthJsCookies } from "@/lib/authJsCookies";
@@ -6,25 +6,39 @@ import { db } from "@/db";
 import { users } from "@/db/schema";
 import { createToken, setAuthCookie } from "@/lib/auth";
 
-const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://www.still-point.me";
+/** Sanitize a `?return=` param into a same-origin path. Anything other
+ *  than a leading single `/` (no protocol-relative `//`, no full URL) is
+ *  rejected to prevent open-redirect via the bridge. */
+function sanitizeReturnTarget(raw: string | null): string {
+  if (!raw) return "/app";
+  if (!raw.startsWith("/") || raw.startsWith("//")) return "/app";
+  return raw;
+}
 
 /** Bridge from an Auth.js OAuth session to our long-lived sp_token cookie.
  *  After Auth.js completes the provider callback, the redirect callback in
  *  auth-config sends the user here; we mint sp_token and drop the Auth.js
- *  session so the SPA's existing /api/auth/me path is the only auth source. */
-export async function GET() {
-  let redirectPath = "/app";
+ *  session so the SPA's existing /api/auth/me path is the only auth source.
+ *
+ *  Redirects use the inbound `request.url` as the base so the sp_token
+ *  cookie (set on the request host) is sent on the redirect — using a
+ *  fixed canonical APP_URL would cross hosts on previews/localhost and
+ *  drop the cookie. */
+export async function GET(request: NextRequest) {
+  const requestUrl = new URL(request.url);
+  const successTarget = sanitizeReturnTarget(requestUrl.searchParams.get("return"));
+  let errorPath: string | null = null;
 
   try {
     const session = await auth();
     const userId = session?.userId;
 
     if (!userId) {
-      redirectPath = "/app?error=oauth_session_missing";
+      errorPath = "/app?error=oauth_session_missing";
     } else {
       const [user] = await db.select().from(users).where(eq(users.id, userId)).limit(1);
       if (!user) {
-        redirectPath = "/app?error=oauth_user_missing";
+        errorPath = "/app?error=oauth_user_missing";
       } else {
         const token = await createToken({ userId: user.id, email: user.email });
         await setAuthCookie(token);
@@ -32,14 +46,13 @@ export async function GET() {
     }
   } catch (error) {
     console.error("oauth-complete bridge error:", error);
-    redirectPath = "/app?error=oauth_internal_error";
+    errorPath = "/app?error=oauth_internal_error";
   } finally {
-    // Always clear Auth.js cookies — on success because sp_token is now the
-    // canonical session, on failure to avoid leaving the user pinned to a
-    // half-completed Auth.js session that would loop them through the
-    // bridge again. Best-effort: a thrown error here must not prevent the
-    // redirect below from running, otherwise we'd serve a 500 and the user
-    // would have no path forward.
+    // Always clear Auth.js cookies — on success because sp_token is now
+    // the canonical session, on failure to avoid leaving the user pinned
+    // to a half-completed Auth.js session that would loop them through
+    // the bridge again. Best-effort: a thrown error here must not prevent
+    // the redirect below from running.
     try {
       await clearAuthJsCookies();
     } catch (cookieError) {
@@ -47,5 +60,6 @@ export async function GET() {
     }
   }
 
-  return NextResponse.redirect(new URL(redirectPath, APP_URL));
+  const finalPath = errorPath ?? successTarget;
+  return NextResponse.redirect(new URL(finalPath, request.url));
 }

--- a/src/app/api/auth/oauth-complete/route.ts
+++ b/src/app/api/auth/oauth-complete/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { eq } from "drizzle-orm";
+import { auth } from "@/lib/auth-config";
+import { db } from "@/db";
+import { users } from "@/db/schema";
+import { createToken, setAuthCookie } from "@/lib/auth";
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://www.still-point.me";
+
+// Auth.js v5 sets a varying set of cookies (session-token, csrf-token,
+// callback-url, pkce.code_verifier, state, nonce, plus chunked variants
+// like session-token.0, .1) under three name prefixes. Match by prefix so
+// future cookies and chunked variants are wiped without code changes.
+const AUTHJS_COOKIE_PREFIXES = [
+  "authjs.",
+  "__Secure-authjs.",
+  "__Host-authjs.",
+];
+
+async function clearAuthJsCookies() {
+  const store = await cookies();
+  for (const cookie of store.getAll()) {
+    if (AUTHJS_COOKIE_PREFIXES.some((p) => cookie.name.startsWith(p))) {
+      store.delete(cookie.name);
+    }
+  }
+}
+
+/** Bridge from an Auth.js OAuth session to our long-lived sp_token cookie.
+ *  After Auth.js completes the provider callback, redirect callback in
+ *  auth-config sends the user here; we mint sp_token and drop the Auth.js
+ *  session so the SPA's existing /api/auth/me path is the only auth source. */
+export async function GET() {
+  let redirectPath = "/app";
+
+  try {
+    const session = await auth();
+    const userId = session?.userId;
+
+    if (!userId) {
+      redirectPath = "/app?error=oauth_session_missing";
+    } else {
+      const [user] = await db.select().from(users).where(eq(users.id, userId)).limit(1);
+      if (!user) {
+        redirectPath = "/app?error=oauth_user_missing";
+      } else {
+        const token = await createToken({ userId: user.id, email: user.email });
+        await setAuthCookie(token);
+      }
+    }
+  } catch (error) {
+    console.error("oauth-complete bridge error:", error);
+    redirectPath = "/app?error=oauth_internal_error";
+  } finally {
+    // Always clear Auth.js cookies — on success because sp_token is now the
+    // canonical session, on failure to avoid leaving the user pinned to a
+    // half-completed Auth.js session that would loop them through the
+    // bridge again.
+    await clearAuthJsCookies();
+  }
+
+  return NextResponse.redirect(new URL(redirectPath, APP_URL));
+}

--- a/src/app/api/auth/oauth-complete/route.ts
+++ b/src/app/api/auth/oauth-complete/route.ts
@@ -1,34 +1,15 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
 import { eq } from "drizzle-orm";
 import { auth } from "@/lib/auth-config";
+import { clearAuthJsCookies } from "@/lib/authJsCookies";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { createToken, setAuthCookie } from "@/lib/auth";
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://www.still-point.me";
 
-// Auth.js v5 sets a varying set of cookies (session-token, csrf-token,
-// callback-url, pkce.code_verifier, state, nonce, plus chunked variants
-// like session-token.0, .1) under three name prefixes. Match by prefix so
-// future cookies and chunked variants are wiped without code changes.
-const AUTHJS_COOKIE_PREFIXES = [
-  "authjs.",
-  "__Secure-authjs.",
-  "__Host-authjs.",
-];
-
-async function clearAuthJsCookies() {
-  const store = await cookies();
-  for (const cookie of store.getAll()) {
-    if (AUTHJS_COOKIE_PREFIXES.some((p) => cookie.name.startsWith(p))) {
-      store.delete(cookie.name);
-    }
-  }
-}
-
 /** Bridge from an Auth.js OAuth session to our long-lived sp_token cookie.
- *  After Auth.js completes the provider callback, redirect callback in
+ *  After Auth.js completes the provider callback, the redirect callback in
  *  auth-config sends the user here; we mint sp_token and drop the Auth.js
  *  session so the SPA's existing /api/auth/me path is the only auth source. */
 export async function GET() {

--- a/src/app/api/auth/oauth-complete/route.ts
+++ b/src/app/api/auth/oauth-complete/route.ts
@@ -37,8 +37,14 @@ export async function GET() {
     // Always clear Auth.js cookies — on success because sp_token is now the
     // canonical session, on failure to avoid leaving the user pinned to a
     // half-completed Auth.js session that would loop them through the
-    // bridge again.
-    await clearAuthJsCookies();
+    // bridge again. Best-effort: a thrown error here must not prevent the
+    // redirect below from running, otherwise we'd serve a 500 and the user
+    // would have no path forward.
+    try {
+      await clearAuthJsCookies();
+    } catch (cookieError) {
+      console.error("oauth-complete cookie cleanup failed:", cookieError);
+    }
   }
 
   return NextResponse.redirect(new URL(redirectPath, APP_URL));

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   description:
     "How Still Point collects, uses, stores, and protects your information when you use our website and apps.",
   alternates: {
-    canonical: "https://still-point.me/privacy",
+    canonical: "https://www.still-point.me/privacy",
   },
 };
 
@@ -104,8 +104,8 @@ export default function PrivacyPolicyPage() {
         <p style={{ ...body, color: "var(--fg-3)", fontSize: "15px", marginBottom: "var(--s5)" }}>
           Effective date: April 10, 2026. This policy describes how Still Point (“we,” “us”) handles
           information when you use the website and services available at{" "}
-          <a href="https://still-point.me" style={{ color: "var(--accent-green-text)", textDecoration: "underline" }}>
-            https://still-point.me
+          <a href="https://www.still-point.me" style={{ color: "var(--accent-green-text)", textDecoration: "underline" }}>
+            https://www.still-point.me
           </a>{" "}
           (the “Service”).
         </p>
@@ -190,12 +190,12 @@ export default function PrivacyPolicyPage() {
         <h2 style={sectionTitle}>Third-party sign-in</h2>
         <p style={body}>
           You can sign in to Still Point with a third-party identity provider in addition to (or
-          instead of) creating a password. When you choose a provider, we receive your verified email
-          address, your name (when available), and a stable provider account identifier so we can
-          link the provider to your Still Point account on subsequent sign-ins. We do not store your
-          provider password and we do not request access to your contacts, calendar, files, or other
-          provider data through sign-in. The provider's own privacy practices apply to anything you
-          do on their site.
+          instead of) creating a password. When you choose a provider, we receive an email address
+          (which the provider verifies where supported), your name when available, and a stable
+          provider account identifier so we can link the provider to your Still Point account on
+          subsequent sign-ins. We do not store your provider password and we do not request access
+          to your contacts, calendar, files, or other provider data through sign-in. The provider's
+          own privacy practices apply to anything you do on their site.
         </p>
         <ul style={list}>
           <li>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -117,7 +117,8 @@ export default function PrivacyPolicyPage() {
         <ul style={list}>
           <li>
             <strong style={{ color: "var(--fg)" }}>Account and profile.</strong> Email address,
-            username, and a password hash (we do not store your password in plain text).
+            username, and either a password hash (we do not store your password in plain text) or a
+            link to a single sign-on provider you used to register.
           </li>
           <li>
             <strong style={{ color: "var(--fg)" }}>Session and practice data.</strong> Meditation
@@ -185,6 +186,31 @@ export default function PrivacyPolicyPage() {
           law, legal process, or to protect the rights, safety, or integrity of our users or the
           Service.
         </p>
+
+        <h2 style={sectionTitle}>Third-party sign-in</h2>
+        <p style={body}>
+          You can sign in to Still Point with a third-party identity provider in addition to (or
+          instead of) creating a password. When you choose a provider, we receive your verified email
+          address, your name (when available), and a stable provider account identifier so we can
+          link the provider to your Still Point account on subsequent sign-ins. We do not store your
+          provider password and we do not request access to your contacts, calendar, files, or other
+          provider data through sign-in. The provider's own privacy practices apply to anything you
+          do on their site.
+        </p>
+        <ul style={list}>
+          <li>
+            <strong style={{ color: "var(--fg)" }}>Google:</strong>{" "}
+            <a
+              href="https://policies.google.com/privacy"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: "var(--accent-green-text)", textDecoration: "underline" }}
+            >
+              Google Privacy Policy
+            </a>
+            .
+          </li>
+        </ul>
 
         <h2 style={sectionTitle}>Retention and your choices</h2>
         <p style={body}>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -117,8 +117,8 @@ export default function PrivacyPolicyPage() {
         <ul style={list}>
           <li>
             <strong style={{ color: "var(--fg)" }}>Account and profile.</strong> Email address,
-            username, and either a password hash (we do not store your password in plain text) or a
-            link to a single sign-on provider you used to register.
+            username, and any combination of a password hash (we do not store your password in plain
+            text) and links to single sign-on providers you have used to sign in.
           </li>
           <li>
             <strong style={{ color: "var(--fg)" }}>Session and practice data.</strong> Meditation

--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -118,10 +118,16 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
           onClick={() => {
             // Carry the current page (path + query) as callbackUrl so any
             // deep-link state (invite links, ?buddy=..., etc.) survives the
-            // OAuth round-trip. The redirect callback in auth-config wraps
-            // this into ?return= for the sp_token bridge.
+            // OAuth round-trip. Strip `error` first — if the user is
+            // retrying from /app?error=OAuthCallback, forwarding `error`
+            // back into callbackUrl would round-trip through the redirect
+            // callback in auth-config, which treats any /app?...error=...
+            // URL as a failure target and skips the sp_token bridge.
+            const params = new URLSearchParams(window.location.search);
+            params.delete("error");
+            const search = params.toString();
             const callbackUrl = encodeURIComponent(
-              window.location.pathname + window.location.search,
+              `${window.location.pathname}${search ? `?${search}` : ""}`,
             );
             window.location.href = `/api/auth/signin/google?callbackUrl=${callbackUrl}`;
           }}

--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -1,9 +1,21 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 type AuthScreenProps = {
   onLogin: (user: { id: string; email: string; username: string; isPublic: boolean; currentDay: number }) => void;
+};
+
+const OAUTH_ERROR_MESSAGES: Record<string, string> = {
+  oauth_session_missing: "Sign-in didn't complete. Please try again.",
+  oauth_user_missing: "We couldn't find your account. Please try again.",
+  oauth_internal_error: "Something went wrong on our end. Please try again.",
+  OAuthSignin: "Couldn't start Google sign-in. Please try again.",
+  OAuthCallback: "Google sign-in was cancelled or failed.",
+  OAuthCreateAccount: "Couldn't create your account. Please try again.",
+  AccessDenied: "Access denied. Please try again.",
+  Verification: "We couldn't verify your Google account.",
+  Configuration: "Sign-in is temporarily unavailable.",
 };
 
 export function AuthScreen({ onLogin }: AuthScreenProps) {
@@ -13,6 +25,19 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    const oauthError = params.get("error");
+    if (!oauthError) return;
+    setError(OAUTH_ERROR_MESSAGES[oauthError] ?? "Sign-in failed. Please try again.");
+    // Strip the query param so a refresh doesn't re-show the error.
+    params.delete("error");
+    const next = params.toString();
+    const url = `${window.location.pathname}${next ? `?${next}` : ""}`;
+    window.history.replaceState({}, "", url);
+  }, []);
 
   const handleSubmit = async () => {
     const trimmedEmail = email.trim().toLowerCase();
@@ -85,6 +110,79 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
         }}>
           attention training
         </p>
+      </div>
+
+      <div style={{ width: "100%", display: "flex", flexDirection: "column", gap: "12px" }}>
+        <button
+          type="button"
+          onClick={() => {
+            window.location.href = "/api/auth/signin/google";
+          }}
+          style={{
+            background: "var(--surface-1)",
+            border: "1px solid var(--border-2)",
+            color: "var(--fg)",
+            fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+            fontSize: "15px",
+            padding: "12px 16px",
+            borderRadius: "30px",
+            cursor: "pointer",
+            transition: "all 0.3s",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "10px",
+          }}
+          onMouseEnter={e => {
+            e.currentTarget.style.borderColor = "var(--border-3)";
+            e.currentTarget.style.background = "var(--surface-2)";
+          }}
+          onMouseLeave={e => {
+            e.currentTarget.style.borderColor = "var(--border-2)";
+            e.currentTarget.style.background = "var(--surface-1)";
+          }}
+          aria-label="Continue with Google"
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
+            <path fill="#4285F4" d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z"/>
+            <path fill="#34A853" d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z"/>
+            <path fill="#FBBC05" d="M3.964 10.706A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.706V4.962H.957A8.997 8.997 0 0 0 0 9c0 1.452.348 2.827.957 4.038l3.007-2.332z"/>
+            <path fill="#EA4335" d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.962L3.964 7.294C4.672 5.167 6.656 3.58 9 3.58z"/>
+          </svg>
+          Continue with Google
+        </button>
+
+        <p style={{
+          fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+          fontSize: "10px",
+          color: "var(--fg-4)",
+          textAlign: "center",
+          letterSpacing: "0.05em",
+          lineHeight: 1.5,
+          margin: 0,
+        }}>
+          By continuing you agree to our{" "}
+          <a href="/privacy" style={{ color: "var(--fg-3)", textDecoration: "underline", textUnderlineOffset: "2px" }}>
+            privacy policy
+          </a>
+          .
+        </p>
+      </div>
+
+      <div style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "12px",
+        width: "100%",
+        color: "var(--fg-4)",
+        fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+        fontSize: "10px",
+        letterSpacing: "0.15em",
+        textTransform: "uppercase",
+      }}>
+        <div style={{ flex: 1, height: "1px", background: "var(--border-1)" }} />
+        or
+        <div style={{ flex: 1, height: "1px", background: "var(--border-1)" }} />
       </div>
 
       <div style={{

--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -116,7 +116,14 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
         <button
           type="button"
           onClick={() => {
-            window.location.href = "/api/auth/signin/google";
+            // Carry the current page (path + query) as callbackUrl so any
+            // deep-link state (invite links, ?buddy=..., etc.) survives the
+            // OAuth round-trip. The redirect callback in auth-config wraps
+            // this into ?return= for the sp_token bridge.
+            const callbackUrl = encodeURIComponent(
+              window.location.pathname + window.location.search,
+            );
+            window.location.href = `/api/auth/signin/google?callbackUrl=${callbackUrl}`;
           }}
           style={{
             background: "var(--surface-1)",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -22,7 +22,8 @@ export const users = pgTable("users", {
    *  `eq(users.email, ...)` lookups. */
   email: varchar("email", { length: 255 }).unique().notNull(),
   username: varchar("username", { length: 50 }).notNull(),
-  passwordHash: varchar("password_hash", { length: 255 }).notNull(),
+  /** Nullable: OAuth-only accounts (#136) never have a password. */
+  passwordHash: varchar("password_hash", { length: 255 }),
   isPublic: boolean("is_public").default(false).notNull(),
   currentDay: integer("current_day").default(1).notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
@@ -66,6 +67,28 @@ export const accountDeletionLog = pgTable("account_deletion_log", {
 }, (table) => ({
   emailHashIdx: index("idx_account_deletion_log_email_hash").on(table.emailHash),
   userIdx: index("idx_account_deletion_log_user").on(table.userId),
+}));
+
+/** OAuth provider identities linked to a user (#136).
+ *  One row per (provider, providerAccountId); a single user may have
+ *  multiple rows (one per provider). Email-match account linking is
+ *  performed in `src/lib/auth-config.ts` signIn callback. */
+export const oauthAccounts = pgTable("oauth_accounts", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  userId: uuid("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
+  provider: varchar("provider", { length: 32 }).notNull(),
+  providerAccountId: varchar("provider_account_id", { length: 255 }).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  providerAccountUnique: uniqueIndex("oauth_accounts_provider_account_unique").on(
+    table.provider,
+    table.providerAccountId,
+  ),
+  userIdx: index("idx_oauth_accounts_user").on(table.userId),
+  providerCheck: check(
+    "oauth_accounts_provider_allowed",
+    sql`${table.provider} in ('google', 'apple', 'facebook', 'microsoft')`,
+  ),
 }));
 
 export const passwordResetTokens = pgTable("password_reset_tokens", {
@@ -246,11 +269,16 @@ export const usersRelations = relations(users, ({ one, many }) => ({
   thoughts: many(thoughts),
   passwordResetTokens: many(passwordResetTokens),
   deviceTokens: many(deviceTokens),
+  oauthAccounts: many(oauthAccounts),
   googleOAuthToken: one(googleOAuthTokens, {
     fields: [users.id],
     references: [googleOAuthTokens.userId],
   }),
   buddyCalendarEvents: many(buddySessionCalendarEvents),
+}));
+
+export const oauthAccountsRelations = relations(oauthAccounts, ({ one }) => ({
+  user: one(users, { fields: [oauthAccounts.userId], references: [users.id] }),
 }));
 
 export const deviceTokensRelations = relations(deviceTokens, ({ one }) => ({

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -87,7 +87,7 @@ export const oauthAccounts = pgTable("oauth_accounts", {
   userIdx: index("idx_oauth_accounts_user").on(table.userId),
   providerCheck: check(
     "oauth_accounts_provider_allowed",
-    sql`${table.provider} in ('google', 'apple', 'facebook', 'microsoft')`,
+    sql`${table.provider} in ('google', 'apple', 'facebook', 'microsoft-entra-id')`,
   ),
 }));
 

--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -245,6 +245,14 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       return session;
     },
     async redirect({ url, baseUrl }) {
+      // Auth.js may invoke this callback with a relative same-origin path
+      // (e.g. "/app?error=AccessDenied" or a relative `callbackUrl`).
+      // Normalise to an absolute URL up front so the comparisons below
+      // match both relative and absolute forms — without this, relative
+      // values fell through to the final fallback and lost their error /
+      // deep-link state.
+      const normalizedUrl = url.startsWith("/") ? `${baseUrl}${url}` : url;
+
       // Auth.js error redirects (e.g. /app?error=AccessDenied,
       // /app?error=OAuthCallback) come through here when sign-in fails or
       // is cancelled. Identify them by the explicit ?error= query param
@@ -252,19 +260,24 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       // The earlier broader rule (any /app URL) was too wide — the default
       // post-sign-in callbackUrl is also /app, which would bypass the
       // sp_token bridge entirely.
-      if (url.startsWith(`${baseUrl}/app`) && /[?&]error=/.test(url)) {
-        return url;
+      if (
+        normalizedUrl.startsWith(`${baseUrl}/app`) &&
+        /[?&]error=/.test(normalizedUrl)
+      ) {
+        return normalizedUrl;
       }
 
       // Already in our sp_token bridge. Pass through.
-      if (url.startsWith(`${baseUrl}/api/auth/oauth-complete`)) return url;
+      if (normalizedUrl.startsWith(`${baseUrl}/api/auth/oauth-complete`)) {
+        return normalizedUrl;
+      }
 
       // Successful sign-in (or any other same-origin destination): route
       // through the bridge so sp_token is minted before the user lands on
       // the SPA. Encode the original target as ?return= so the bridge can
       // honour deep-link/callbackUrl state after minting the cookie.
-      if (url.startsWith(baseUrl)) {
-        const target = url.slice(baseUrl.length) || "/app";
+      if (normalizedUrl.startsWith(baseUrl)) {
+        const target = normalizedUrl.slice(baseUrl.length) || "/app";
         return `${baseUrl}/api/auth/oauth-complete?return=${encodeURIComponent(target)}`;
       }
 

--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -123,12 +123,20 @@ async function createUserWithUsernameRetry(email: string, seed: string): Promise
       return racedRow.id;
     } catch (err) {
       const constraint = uniqueViolationConstraint(err);
-      if (
-        constraint &&
-        constraint.toLowerCase().includes("username") &&
-        attempt < MAX_USERNAME_RETRIES
-      ) {
-        // Username unique index race — regenerate and retry.
+      // uniqueViolationConstraint returns:
+      //   - null  → not a unique_violation, do not retry
+      //   - ""    → unique_violation but driver did not surface the
+      //             constraint name (Neon HTTP can do this)
+      //   - "..." → constraint name string
+      // The email conflict path is handled by onConflictDoNothing above
+      // (no throw), so any unique_violation that reaches here must be on
+      // the username index. Treat empty/unknown names as retryable too,
+      // otherwise an empty-string constraint silently falls through and
+      // the truthy check on `constraint &&` would skip the retry.
+      if (constraint === null) throw err;
+      const isLikelyUsernameConstraint =
+        constraint === "" || constraint.toLowerCase().includes("username");
+      if (isLikelyUsernameConstraint && attempt < MAX_USERNAME_RETRIES) {
         continue;
       }
       throw err;

--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -12,11 +12,15 @@ import {
 /** Sanitize a Google profile field into a username candidate that satisfies
  *  the existing users.username constraints (#136 + #8 case-insensitive
  *  uniqueness). The function may still return a colliding name; the
- *  surrounding loop appends numeric suffixes until a free slot is found. */
+ *  surrounding loop appends random suffixes until a free slot is found. */
 function sanitizeUsernameSeed(seed: string): string {
   const cleaned = seed.replace(/[^A-Za-z0-9_]/g, "");
   if (cleaned.length === 0) return "user";
   return cleaned.slice(0, MAX_USERNAME_LENGTH);
+}
+
+function randomSuffix(length: number): string {
+  return crypto.randomUUID().replace(/-/g, "").slice(0, length);
 }
 
 async function generateUniqueUsername(seed: string): Promise<string> {
@@ -24,7 +28,7 @@ async function generateUniqueUsername(seed: string): Promise<string> {
   const padded = base.length < MIN_USERNAME_LENGTH ? `${base}user`.slice(0, MAX_USERNAME_LENGTH) : base;
 
   for (let attempt = 0; attempt < 8; attempt++) {
-    const suffix = attempt === 0 ? "" : `_${Math.random().toString(36).slice(2, 6)}`;
+    const suffix = attempt === 0 ? "" : `_${randomSuffix(4)}`;
     const candidate = `${padded.slice(0, MAX_USERNAME_LENGTH - suffix.length)}${suffix}`;
 
     if (!USERNAME_REGEX.test(candidate)) continue;
@@ -38,11 +42,47 @@ async function generateUniqueUsername(seed: string): Promise<string> {
     if (!collision) return candidate;
   }
 
-  // Last resort: random suffix from crypto.randomUUID() so the probability
-  // of collision is negligible even under contention. Math.random() is not
-  // cryptographically secure and would not give the same guarantee.
-  const random = crypto.randomUUID().replace(/-/g, "").slice(0, 10);
-  return `user_${random}`;
+  // Last resort: 10-char random suffix. Crypto-RNG keeps the probability of
+  // collision negligible even under contention.
+  return `user_${randomSuffix(10)}`;
+}
+
+/** Insert a (provider, providerAccountId) -> userId link, returning the
+ *  userId that ends up owning the link. If a link already exists (race or
+ *  re-sign-in), the existing row's userId wins via ON CONFLICT DO NOTHING +
+ *  fallback lookup. This guarantees the link/userId mapping is unique. */
+async function linkProviderToUser(
+  provider: string,
+  providerAccountId: string,
+  userId: string,
+): Promise<string> {
+  const inserted = await db
+    .insert(oauthAccounts)
+    .values({ userId, provider, providerAccountId })
+    .onConflictDoNothing({
+      target: [oauthAccounts.provider, oauthAccounts.providerAccountId],
+    })
+    .returning({ userId: oauthAccounts.userId });
+
+  if (inserted.length > 0) return inserted[0].userId;
+
+  // Race: another callback inserted the same link. Use whichever userId
+  // ended up owning it. (Cannot be `userId` we passed in if we lost the
+  // race for an already-linked-to-different-user row.)
+  const [existing] = await db
+    .select({ userId: oauthAccounts.userId })
+    .from(oauthAccounts)
+    .where(
+      and(
+        eq(oauthAccounts.provider, provider),
+        eq(oauthAccounts.providerAccountId, providerAccountId),
+      ),
+    )
+    .limit(1);
+  if (!existing) {
+    throw new Error("oauth_accounts insert returned no rows and no existing link");
+  }
+  return existing.userId;
 }
 
 declare module "next-auth" {
@@ -104,21 +144,19 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       if (existingLink) {
         userId = existingLink.userId;
       } else {
+        // No link yet → resolve target user (existing email match or
+        // freshly created), then link the provider identity to them
+        // atomically. ON CONFLICT collapses concurrent callbacks into a
+        // single row.
         const [emailMatch] = await db
           .select({ id: users.id })
           .from(users)
           .where(eq(users.email, email))
           .limit(1);
 
+        let targetUserId: string;
         if (emailMatch) {
-          // Email match without an existing link → attach this provider
-          // identity to the email-owning user.
-          userId = emailMatch.id;
-          await db.insert(oauthAccounts).values({
-            userId,
-            provider,
-            providerAccountId,
-          });
+          targetUserId = emailMatch.id;
         } else {
           const seed =
             (typeof profile.name === "string" && profile.name) ||
@@ -126,18 +164,30 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
             "user";
           const username = await generateUniqueUsername(seed);
 
-          const [created] = await db
+          const inserted = await db
             .insert(users)
             .values({ email, username })
+            .onConflictDoNothing({ target: users.email })
             .returning({ id: users.id });
-          userId = created.id;
 
-          await db.insert(oauthAccounts).values({
-            userId,
-            provider,
-            providerAccountId,
-          });
+          if (inserted.length > 0) {
+            targetUserId = inserted[0].id;
+          } else {
+            // Race: another callback created a user with this email
+            // between our SELECT and INSERT. Look it up.
+            const [racedRow] = await db
+              .select({ id: users.id })
+              .from(users)
+              .where(eq(users.email, email))
+              .limit(1);
+            if (!racedRow) {
+              throw new Error("users insert raced and lookup returned no row");
+            }
+            targetUserId = racedRow.id;
+          }
         }
+
+        userId = await linkProviderToUser(provider, providerAccountId, targetUserId);
       }
 
       // Auth.js passes `user` into the jwt callback only on initial sign-in;
@@ -157,9 +207,18 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       return session;
     },
     async redirect({ url, baseUrl }) {
-      // After OAuth completes, route through /api/auth/oauth-complete so the
-      // server can mint our sp_token cookie before the user lands on /app.
+      // Auth.js error redirects (e.g. /app?error=AccessDenied,
+      // /app?error=OAuthCallback) come through here when sign-in fails or
+      // is cancelled. Pass them through unchanged so AuthScreen can render
+      // the inline error — do NOT overwrite with the success bridge.
+      if (url.startsWith(`${baseUrl}/app`)) return url;
+
+      // Already in our sp_token bridge. Pass through.
       if (url.startsWith(`${baseUrl}/api/auth/oauth-complete`)) return url;
+
+      // Same-origin success URL → route through the bridge to mint sp_token.
+      // Anything off-origin (defensive) also goes through the bridge, which
+      // ends on /app.
       return `${baseUrl}/api/auth/oauth-complete`;
     },
   },

--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -8,6 +8,7 @@ import {
   MIN_USERNAME_LENGTH,
   USERNAME_REGEX,
 } from "@/lib/username";
+import { uniqueViolationConstraint } from "@/lib/dbErrors";
 
 /** Sanitize a Google profile field into a username candidate that satisfies
  *  the existing users.username constraints (#136 + #8 case-insensitive
@@ -83,6 +84,57 @@ async function linkProviderToUser(
     throw new Error("oauth_accounts insert returned no rows and no existing link");
   }
   return existing.userId;
+}
+
+/** Insert a new user, retrying with a fresh username if the
+ *  case-insensitive username unique index races. The pre-check in
+ *  `generateUniqueUsername()` reduces but does not eliminate the race —
+ *  two concurrent first-time OAuth sign-ins with the same name seed could
+ *  both pre-check, both pick the same candidate, and both attempt the
+ *  same insert. The first wins; the loser regenerates and retries.
+ *
+ *  Email conflicts collapse via ON CONFLICT DO NOTHING (we re-look-up the
+ *  row a sibling callback inserted). Username conflicts cannot be handled
+ *  with a single ON CONFLICT clause alongside email, so they're caught as
+ *  a Postgres unique_violation and re-attempted with a new candidate. */
+const MAX_USERNAME_RETRIES = 5;
+
+async function createUserWithUsernameRetry(email: string, seed: string): Promise<string> {
+  for (let attempt = 0; attempt <= MAX_USERNAME_RETRIES; attempt++) {
+    const username = await generateUniqueUsername(seed);
+    try {
+      const inserted = await db
+        .insert(users)
+        .values({ email, username })
+        .onConflictDoNothing({ target: users.email })
+        .returning({ id: users.id });
+
+      if (inserted.length > 0) return inserted[0].id;
+
+      // Email conflict — another callback created this user. Look up.
+      const [racedRow] = await db
+        .select({ id: users.id })
+        .from(users)
+        .where(eq(users.email, email))
+        .limit(1);
+      if (!racedRow) {
+        throw new Error("users insert raced and lookup returned no row");
+      }
+      return racedRow.id;
+    } catch (err) {
+      const constraint = uniqueViolationConstraint(err);
+      if (
+        constraint &&
+        constraint.toLowerCase().includes("username") &&
+        attempt < MAX_USERNAME_RETRIES
+      ) {
+        // Username unique index race — regenerate and retry.
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw new Error("Failed to allocate a unique username after retries");
 }
 
 declare module "next-auth" {
@@ -162,29 +214,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
             (typeof profile.name === "string" && profile.name) ||
             email.split("@")[0] ||
             "user";
-          const username = await generateUniqueUsername(seed);
-
-          const inserted = await db
-            .insert(users)
-            .values({ email, username })
-            .onConflictDoNothing({ target: users.email })
-            .returning({ id: users.id });
-
-          if (inserted.length > 0) {
-            targetUserId = inserted[0].id;
-          } else {
-            // Race: another callback created a user with this email
-            // between our SELECT and INSERT. Look it up.
-            const [racedRow] = await db
-              .select({ id: users.id })
-              .from(users)
-              .where(eq(users.email, email))
-              .limit(1);
-            if (!racedRow) {
-              throw new Error("users insert raced and lookup returned no row");
-            }
-            targetUserId = racedRow.id;
-          }
+          targetUserId = await createUserWithUsernameRetry(email, seed);
         }
 
         userId = await linkProviderToUser(provider, providerAccountId, targetUserId);

--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -239,16 +239,28 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     async redirect({ url, baseUrl }) {
       // Auth.js error redirects (e.g. /app?error=AccessDenied,
       // /app?error=OAuthCallback) come through here when sign-in fails or
-      // is cancelled. Pass them through unchanged so AuthScreen can render
-      // the inline error — do NOT overwrite with the success bridge.
-      if (url.startsWith(`${baseUrl}/app`)) return url;
+      // is cancelled. Identify them by the explicit ?error= query param
+      // and pass through unchanged so AuthScreen renders the inline error.
+      // The earlier broader rule (any /app URL) was too wide — the default
+      // post-sign-in callbackUrl is also /app, which would bypass the
+      // sp_token bridge entirely.
+      if (url.startsWith(`${baseUrl}/app`) && /[?&]error=/.test(url)) {
+        return url;
+      }
 
       // Already in our sp_token bridge. Pass through.
       if (url.startsWith(`${baseUrl}/api/auth/oauth-complete`)) return url;
 
-      // Same-origin success URL → route through the bridge to mint sp_token.
-      // Anything off-origin (defensive) also goes through the bridge, which
-      // ends on /app.
+      // Successful sign-in (or any other same-origin destination): route
+      // through the bridge so sp_token is minted before the user lands on
+      // the SPA. Encode the original target as ?return= so the bridge can
+      // honour deep-link/callbackUrl state after minting the cookie.
+      if (url.startsWith(baseUrl)) {
+        const target = url.slice(baseUrl.length) || "/app";
+        return `${baseUrl}/api/auth/oauth-complete?return=${encodeURIComponent(target)}`;
+      }
+
+      // Off-origin URL (defensive). Drop and use the bridge default.
       return `${baseUrl}/api/auth/oauth-complete`;
     },
   },

--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -1,0 +1,166 @@
+import NextAuth from "next-auth";
+import Google from "next-auth/providers/google";
+import { db } from "@/db";
+import { users, oauthAccounts } from "@/db/schema";
+import { and, eq, sql } from "drizzle-orm";
+import {
+  MAX_USERNAME_LENGTH,
+  MIN_USERNAME_LENGTH,
+  USERNAME_REGEX,
+} from "@/lib/username";
+
+/** Sanitize a Google profile field into a username candidate that satisfies
+ *  the existing users.username constraints (#136 + #8 case-insensitive
+ *  uniqueness). The function may still return a colliding name; the
+ *  surrounding loop appends numeric suffixes until a free slot is found. */
+function sanitizeUsernameSeed(seed: string): string {
+  const cleaned = seed.replace(/[^A-Za-z0-9_]/g, "");
+  if (cleaned.length === 0) return "user";
+  return cleaned.slice(0, MAX_USERNAME_LENGTH);
+}
+
+async function generateUniqueUsername(seed: string): Promise<string> {
+  const base = sanitizeUsernameSeed(seed);
+  const padded = base.length < MIN_USERNAME_LENGTH ? `${base}user`.slice(0, MAX_USERNAME_LENGTH) : base;
+
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const suffix = attempt === 0 ? "" : `_${Math.random().toString(36).slice(2, 6)}`;
+    const candidate = `${padded.slice(0, MAX_USERNAME_LENGTH - suffix.length)}${suffix}`;
+
+    if (!USERNAME_REGEX.test(candidate)) continue;
+    if (candidate.length < MIN_USERNAME_LENGTH || candidate.length > MAX_USERNAME_LENGTH) continue;
+
+    const [collision] = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(sql`lower(${users.username}) = lower(${candidate})`)
+      .limit(1);
+    if (!collision) return candidate;
+  }
+
+  // Last resort: random suffix from crypto.randomUUID() so the probability
+  // of collision is negligible even under contention. Math.random() is not
+  // cryptographically secure and would not give the same guarantee.
+  const random = crypto.randomUUID().replace(/-/g, "").slice(0, 10);
+  return `user_${random}`;
+}
+
+declare module "next-auth" {
+  interface Session {
+    userId?: string;
+  }
+}
+
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  trustHost: true,
+  providers: [
+    Google({
+      clientId: process.env.AUTH_GOOGLE_ID,
+      clientSecret: process.env.AUTH_GOOGLE_SECRET,
+      authorization: { params: { scope: "openid email profile" } },
+    }),
+  ],
+  pages: {
+    signIn: "/app",
+    error: "/app",
+  },
+  callbacks: {
+    async signIn({ user, account, profile }) {
+      if (!account || !profile) return false;
+      const rawEmail = typeof profile.email === "string" ? profile.email : null;
+      // Default to false when email_verified is absent: an unknown
+      // verification state must NOT be treated as verified. Google always
+      // sets email_verified for OIDC userinfo, so the only path that hits
+      // the false default is a provider that doesn't surface the claim —
+      // which we should reject rather than implicitly trust.
+      const emailVerified =
+        (profile as { email_verified?: boolean }).email_verified ?? false;
+      if (!rawEmail || !emailVerified) return false;
+
+      const email = rawEmail.trim().toLowerCase();
+      const provider = account.provider;
+      const providerAccountId = account.providerAccountId;
+      if (!provider || !providerAccountId) return false;
+
+      // Resolve provider identity FIRST: if (provider, providerAccountId)
+      // is already linked to a user, that's the owner — full stop. Email
+      // matching is only used to attach a *new* provider identity to an
+      // existing email-only account; we must never let an email match
+      // hijack a provider identity that already belongs to a different
+      // user (account-takeover guard).
+      const [existingLink] = await db
+        .select({ userId: oauthAccounts.userId })
+        .from(oauthAccounts)
+        .where(
+          and(
+            eq(oauthAccounts.provider, provider),
+            eq(oauthAccounts.providerAccountId, providerAccountId),
+          ),
+        )
+        .limit(1);
+
+      let userId: string;
+
+      if (existingLink) {
+        userId = existingLink.userId;
+      } else {
+        const [emailMatch] = await db
+          .select({ id: users.id })
+          .from(users)
+          .where(eq(users.email, email))
+          .limit(1);
+
+        if (emailMatch) {
+          // Email match without an existing link → attach this provider
+          // identity to the email-owning user.
+          userId = emailMatch.id;
+          await db.insert(oauthAccounts).values({
+            userId,
+            provider,
+            providerAccountId,
+          });
+        } else {
+          const seed =
+            (typeof profile.name === "string" && profile.name) ||
+            email.split("@")[0] ||
+            "user";
+          const username = await generateUniqueUsername(seed);
+
+          const [created] = await db
+            .insert(users)
+            .values({ email, username })
+            .returning({ id: users.id });
+          userId = created.id;
+
+          await db.insert(oauthAccounts).values({
+            userId,
+            provider,
+            providerAccountId,
+          });
+        }
+      }
+
+      // Auth.js passes `user` into the jwt callback only on initial sign-in;
+      // overwriting `user.id` here is how we hand the database id to the JWT.
+      user.id = userId;
+      return true;
+    },
+    async jwt({ token, user }) {
+      if (user?.id) token.userId = user.id;
+      return token;
+    },
+    async session({ session, token }) {
+      const tokenUserId = (token as { userId?: unknown }).userId;
+      if (typeof tokenUserId === "string") {
+        session.userId = tokenUserId;
+      }
+      return session;
+    },
+    async redirect({ url, baseUrl }) {
+      // After OAuth completes, route through /api/auth/oauth-complete so the
+      // server can mint our sp_token cookie before the user lands on /app.
+      if (url.startsWith(`${baseUrl}/api/auth/oauth-complete`)) return url;
+      return `${baseUrl}/api/auth/oauth-complete`;
+    },
+  },
+});

--- a/src/lib/authJsCookies.ts
+++ b/src/lib/authJsCookies.ts
@@ -1,0 +1,22 @@
+import { cookies } from "next/headers";
+
+// Auth.js v5 sets a varying set of cookies (session-token, csrf-token,
+// callback-url, pkce.code_verifier, state, nonce, plus chunked variants
+// like session-token.0, .1) under three name prefixes. Match by prefix so
+// future cookies and chunked variants are wiped without code changes.
+const AUTHJS_COOKIE_PREFIXES = [
+  "authjs.",
+  "__Secure-authjs.",
+  "__Host-authjs.",
+];
+
+/** Clear every Auth.js cookie set on the current request. Used by both
+ *  `oauth-complete` (after sp_token is minted) and `/api/auth/logout`. */
+export async function clearAuthJsCookies(): Promise<void> {
+  const store = await cookies();
+  for (const cookie of store.getAll()) {
+    if (AUTHJS_COOKIE_PREFIXES.some((p) => cookie.name.startsWith(p))) {
+      store.delete(cookie.name);
+    }
+  }
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -12,7 +12,9 @@ type SendEmailParams = {
 
 const fromAddress = process.env.EMAIL_FROM;
 const resendApiKey = process.env.RESEND_API_KEY;
-const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://www.still-point.me";
+// `??` would let an empty NEXT_PUBLIC_APP_URL through and `new URL()` below
+// would throw at runtime; trim + truthy check protects against that.
+const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim() || "https://www.still-point.me";
 
 function escapeHtml(value: string) {
   return value

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -12,7 +12,7 @@ type SendEmailParams = {
 
 const fromAddress = process.env.EMAIL_FROM;
 const resendApiKey = process.env.RESEND_API_KEY;
-const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://still-point.me";
+const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://www.still-point.me";
 
 function escapeHtml(value: string) {
   return value

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,23 +9,26 @@ const publicExactPaths = [
   "/api/auth/logout",
   "/api/auth/google/callback",
   "/api/auth/oauth-complete",
-];
-
-const publicPrefixPaths = [
-  "/api/board",
-  "/api/auth/password-reset",
-  // Auth.js v5 catch-all routes (#136). The catch-all lives at
-  // /api/auth/[...nextauth], so /api/auth/signin, /api/auth/callback/*,
-  // /api/auth/csrf, /api/auth/session, /api/auth/providers, and
-  // /api/auth/error all need to bypass sp_token verification — Auth.js
-  // manages its own short-lived session cookie during the OAuth dance,
-  // and oauth-complete (above) hands off to sp_token afterwards.
+  // Auth.js v5 catch-all routes (#136) — bare endpoints. The catch-all
+  // lives at /api/auth/[...nextauth]; these and the prefixed variants
+  // below need to bypass sp_token verification because Auth.js manages
+  // its own short-lived session cookie during the OAuth dance, and
+  // oauth-complete (above) hands off to sp_token afterwards.
   "/api/auth/signin",
   "/api/auth/callback",
   "/api/auth/csrf",
   "/api/auth/session",
   "/api/auth/providers",
   "/api/auth/error",
+];
+
+const publicPrefixPaths = [
+  "/api/board",
+  "/api/auth/password-reset",
+  // Auth.js sub-paths (provider variants). Use trailing `/` so a future
+  // route like /api/auth/signin-admin would NOT silently bypass auth.
+  "/api/auth/signin/",
+  "/api/auth/callback/",
 ];
 
 export async function middleware(request: NextRequest) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,11 +8,24 @@ const publicExactPaths = [
   "/api/auth/login",
   "/api/auth/logout",
   "/api/auth/google/callback",
+  "/api/auth/oauth-complete",
 ];
 
 const publicPrefixPaths = [
   "/api/board",
   "/api/auth/password-reset",
+  // Auth.js v5 catch-all routes (#136). The catch-all lives at
+  // /api/auth/[...nextauth], so /api/auth/signin, /api/auth/callback/*,
+  // /api/auth/csrf, /api/auth/session, /api/auth/providers, and
+  // /api/auth/error all need to bypass sp_token verification — Auth.js
+  // manages its own short-lived session cookie during the OAuth dance,
+  // and oauth-complete (above) hands off to sp_token afterwards.
+  "/api/auth/signin",
+  "/api/auth/callback",
+  "/api/auth/csrf",
+  "/api/auth/session",
+  "/api/auth/providers",
+  "/api/auth/error",
 ];
 
 export async function middleware(request: NextRequest) {


### PR DESCRIPTION
## **User description**
## Summary

Wires up Google as a first OAuth sign-in provider, using Auth.js v5 for the OAuth handshake and bridging into the existing `sp_token` JWT cookie so the rest of the auth model is unchanged. Account linking by verified email; `oauth_accounts` table records `(provider, provider_account_id) -> user_id`. `users.password_hash` is now nullable so OAuth-only accounts are valid.

Microsoft, Facebook, and Apple are deferred to #284 / #285 / #286 — this PR exercises the phased-rollout exception in #136's AC. Architecture for all four providers (web + iOS) is documented in `docs/mobile-oauth-integration.md` so the follow-ups have a single spec to land against.

### Architecture

- **DB**: new `oauth_accounts` table; nullable `users.password_hash`. Two `*_incremental.sql` files for manual apply on existing branches.
- **Auth.js v5** (`src/lib/auth-config.ts`): Google provider only, `signIn` callback does the find-or-create + link, with an explicit account-takeover guard (provider identity is resolved BEFORE email match — an existing `(provider, providerAccountId)` link wins, never gets re-linked to a different user).
- **`/api/auth/[...nextauth]`**: Auth.js catch-all (signin / callback / csrf / providers / session / error).
- **`/api/auth/oauth-complete`**: Auth.js redirects here after a successful OAuth callback. Reads the Auth.js session, mints an `sp_token` JWT (same shape as password login), drops the Auth.js cookies, redirects to `/app`. Wrapped in try/catch/finally so transient errors redirect to `/app?error=...` and Auth.js cookies are always cleared (no half-completed sessions).
- **Cookie cleanup**: prefix-based filter (`authjs.` / `__Secure-authjs.` / `__Host-authjs.`) covers session-token, csrf, callback-url, pkce, state, nonce, and chunked variants in one shot. Used by both oauth-complete and logout.
- **Middleware**: whitelisted Auth.js public paths and `/api/auth/oauth-complete` (sp_token doesn't exist yet at hand-off time). The existing `/api/auth/google/*` Calendar-OAuth routes (#204) are NOT touched — different URL segments, no collision.
- **Login route**: existing email/password login refuses with a friendly "this account uses single sign-on" message when `password_hash` is null, instead of 500-ing on bcrypt-of-null.
- **AuthScreen UI**: "Continue with Google" button above the password form, brand-compliant 4-color Google glyph, "or" divider, privacy policy link below the OAuth button. URL `?error=...` params (e.g. `oauth_session_missing`) are mapped to friendly inline messages and stripped from the URL after display.
- **Privacy page**: new "Third-party sign-in" section with Google's privacy policy link; existing "Account and profile" bullet updated to mention OAuth-only accounts.
- **README**: production canonical URL line updated to `https://www.still-point.me/` so future OAuth/integration work has one canonical reference.

### Security

- `email_verified` defaults to **false** when absent on the OIDC profile (Google always sets it; any future provider that omits it will be rejected rather than implicitly trusted).
- Account-takeover guard: `(provider, providerAccountId)` is resolved before email match.
- Username generation falls back to `crypto.randomUUID()` (not `Math.random()`) for collision resistance.
- `next-auth` pinned to exact `5.0.0-beta.31` (no caret on beta).
- No provider tokens logged.
- `sp_token` is HttpOnly + Secure (in prod) — same posture as before.
- CSRF/state for OAuth handshake handled by Auth.js.

### Phased rollout

Per #136 AC: only Google ships in this PR. The other three providers are filed as #284 (Microsoft), #285 (Facebook), #286 (Apple). `.env.example` documents env var names + redirect URIs for all four so the follow-ups are mostly credential-wiring + UI buttons.

Closes #136

## Test plan

- [x] `npm run build` passes
- [x] `coderabbit review --prompt-only` passes with no findings
- [x] `oauth_accounts` migration applies cleanly on a fresh DB (idempotent IF NOT EXISTS)
- [x] `users_nullable_password` migration applies cleanly (idempotent DROP NOT NULL)
- [x] `npx drizzle-kit push` produces no schema drift after the migrations are applied
- [x] Visiting `/app` while logged out shows the new "Continue with Google" button above the email/password form
- [x] "Continue with Google" navigates to `/api/auth/signin/google`, then to Google's consent screen
- [x] After consent, redirect chain reaches `/api/auth/callback/google` → `/api/auth/oauth-complete` → `/app` with `sp_token` cookie set
- [x] `GET /api/auth/me` returns the user record after the redirect
- [x] Signing in with a Google account whose email matches an existing email/password user adds an `oauth_accounts` row linking that provider identity to the existing user (no duplicate user created)
- [x] Signing in with a Google account whose email does NOT match any existing user creates a new user with `password_hash` IS NULL and one matching `oauth_accounts` row
- [x] Returning Google sign-in resolves to the same user (link is hit, no duplicate row)
- [x] Account-takeover guard: a Google account whose `(provider, providerAccountId)` is already linked to user A but whose email matches user B resolves to user A (existing link wins; no new row is inserted)
- [x] Email/password login on an OAuth-only account (null `password_hash`) returns generic 401 `Invalid credentials` (no crash; message hardened during review to avoid enumeration leak)
- [x] `POST /api/auth/logout` clears both `sp_token` and any Auth.js cookies (verify in browser devtools)
- [x] Cancelling Google consent or hitting an Auth.js error redirects to `/app?error=...` with a friendly message rendered inline by `AuthScreen`
- [x] `/api/auth/google/callback` (Google Calendar OAuth, #204) still works for already-connected users — no regression from the catch-all
- [x] Privacy page renders the new "Third-party sign-in" section with a working Google policy link
- [x] `docs/mobile-oauth-integration.md` describes both Pattern A (Apple native) and Pattern B (web flow over `ASWebAuthenticationSession`) and links to the four issues
- [x] No provider tokens or `identityToken` values appear in production logs after a sign-in attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add Google sign-in and handle OAuth-only accounts safely**

### What Changed
- Added a Google sign-in button and OAuth sign-in flow alongside the existing email/password login
- Users who sign in with Google are linked to their account by verified email, and new accounts can be created without a password
- Password login now rejects OAuth-only accounts with the same generic invalid-credentials message as other failed logins
- Sign-in and logout now clear leftover OAuth cookies, and OAuth failures show inline messages instead of leaving users stuck in a half-finished session
- Updated privacy and project links to use the `www.still-point.me` canonical domain, and documented OAuth usage for the web and iOS

### Impact
`✅ Shorter sign-in for Google users`
`✅ Fewer account-enumeration leaks`
`✅ Clearer OAuth failure messages`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=doRXjhGw8i55uxs8MNrI0J-9BlR9qRliPFazsNo_clI&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
