### PR TITLE
Hotfix: Google OAuth signin uses signIn() helper for Auth.js v5 (#287)

### DIFF
--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { signIn } from "next-auth/react";
 
 type AuthScreenProps = {
   onLogin: (user: { id: string; email: string; username: string; isPublic: boolean; currentDay: number }) => void;
@@ -118,18 +119,21 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
           onClick={() => {
             // Carry the current page (path + query) as callbackUrl so any
             // deep-link state (invite links, ?buddy=..., etc.) survives the
-            // OAuth round-trip. Strip `error` first — if the user is
-            // retrying from /app?error=OAuthCallback, forwarding `error`
-            // back into callbackUrl would round-trip through the redirect
-            // callback in auth-config, which treats any /app?...error=...
-            // URL as a failure target and skips the sp_token bridge.
+            // OAuth round-trip. Strip `error` first — forwarding it back
+            // would land the user on /app?error=... after sign-in, which
+            // the redirect callback in auth-config treats as a failure
+            // target and bypasses the sp_token bridge.
             const params = new URLSearchParams(window.location.search);
             params.delete("error");
             const search = params.toString();
-            const callbackUrl = encodeURIComponent(
-              `${window.location.pathname}${search ? `?${search}` : ""}`,
-            );
-            window.location.href = `/api/auth/signin/google?callbackUrl=${callbackUrl}`;
+            const callbackUrl = `${window.location.pathname}${search ? `?${search}` : ""}`;
+            // Auth.js v5 changed the contract: GET /api/auth/signin/<provider>
+            // is rejected with UnknownAction. Signin requires POST + CSRF.
+            // The signIn() helper from next-auth/react fetches the CSRF
+            // token, posts the form, and navigates the browser to Google's
+            // authorize URL — same UX as the previous direct navigation,
+            // correct v5 contract.
+            void signIn("google", { callbackUrl });
           }}
           style={{
             background: "var(--surface-1)",

--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -160,8 +160,14 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       authorization: { params: { scope: "openid email profile" } },
     }),
   ],
+  // Only override `error`. Setting `pages.signIn` to a custom path tells
+  // Auth.js v5 that we render our own signin UI on that path, which
+  // changes the routing — the built-in `/api/auth/signin/<provider>`
+  // route then expects to be reached only via POST+CSRF from that page.
+  // We don't need a custom signin page: AuthScreen renders at /app
+  // whenever sp_token is missing, completely outside Auth.js's flow. The
+  // `signIn()` helper in AuthScreen handles POST+CSRF automatically.
   pages: {
-    signIn: "/app",
     error: "/app",
   },
   callbacks: {


### PR DESCRIPTION
## Summary

Production-blocking hotfix for [#287](https://github.com/auerbachb/still-point/pull/287). Google sign-in shows \"Sign-in is temporarily unavailable\" because Auth.js v5 changed the signin contract: a top-level `GET /api/auth/signin/<provider>` is rejected with `UnknownAction` (surfaces to the browser as `Configuration`). Signin requires POST + CSRF, which `signIn()` from `next-auth/react` handles automatically.

## Root cause

The shipped AuthScreen does:

```js
window.location.href = "/api/auth/signin/google?callbackUrl=..."
```

That's a GET navigation. Auth.js v4 accepted it; **Auth.js v5 does not**.

Confirmed by promoting a temporary debug branch (env probe + `debug: true`) to prod and capturing runtime logs. POST + CSRF flow returned the proper `https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=...&code_challenge=...` URL with valid PKCE — Auth.js is healthy, only the client-side initiation was wrong.

## Changes

- `src/components/AuthScreen.tsx`: import `signIn` from `next-auth/react`, replace `window.location.href = "/api/auth/signin/google?..."` with `void signIn("google", { callbackUrl })`. Same end-user UX, correct v5 contract.
- `src/lib/auth-config.ts`: drop `pages.signIn: "/app"` override. We never used a custom signin UI — AuthScreen renders at `/app` only when `sp_token` is missing, completely outside Auth.js. Setting `pages.signIn` to a custom path changes the routing such that the built-in `/api/auth/signin/<provider>` expects POST+CSRF from that page, which conflicts with the `signIn()` helper. Kept `pages.error: "/app"` so error redirects still land where AuthScreen renders them inline.

## Test plan

- [ ] Visit https://www.still-point.me/app while logged out, click \"Continue with Google\"
- [ ] Browser navigates to `accounts.google.com` consent screen (not `/app?error=Configuration`)
- [ ] After picking an account, browser redirects through `/api/auth/callback/google` → `/api/auth/oauth-complete` → `/app` with `sp_token` cookie set
- [ ] `GET /api/auth/me` returns the user record
- [ ] Existing email/password login is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)