### PR TITLE
feat(db): partial indexes for pending friend request inbox/outbox (#146)

### DIFF
--- a/drizzle/friend_requests_pending_indexes_incremental.sql
+++ b/drizzle/friend_requests_pending_indexes_incremental.sql
@@ -1,0 +1,5 @@
+-- #146: Partial btree indexes for pending friend request inbox/outbox.
+-- Idempotent; safe to re-apply. Does not alter friend_requests_pending_user_pair uniqueness.
+
+CREATE INDEX IF NOT EXISTS "idx_friend_requests_to_pending_created" ON "friend_requests" USING btree ("to_user_id", "created_at" DESC) WHERE "status" = 'pending';
+CREATE INDEX IF NOT EXISTS "idx_friend_requests_from_pending_created" ON "friend_requests" USING btree ("from_user_id", "created_at" DESC) WHERE "status" = 'pending';

--- a/scripts/explain-friend-request-pending-indexes.sql
+++ b/scripts/explain-friend-request-pending-indexes.sql
@@ -1,0 +1,27 @@
+-- Issue #146: verify partial indexes with EXPLAIN (ANALYZE, BUFFERS).
+-- 1. Replace the two UUID literals below with a user id that has several pending rows (or any user).
+-- 2. Run twice: once before applying drizzle/friend_requests_pending_indexes_incremental.sql, once after.
+--    psql "$POSTGRES_URL" -f scripts/explain-friend-request-pending-indexes.sql
+--
+-- Expect after migration: Bitmap Index Scan or Index Scan on
+-- idx_friend_requests_to_pending_created / idx_friend_requests_from_pending_created
+-- for the friend_requests leg (no large Seq Scan on friend_requests).
+
+PREPARE friend_requests_incoming_pending AS
+SELECT fr.id, fr.created_at, u.id, u.username
+FROM friend_requests fr
+INNER JOIN users u ON u.id = fr.from_user_id
+WHERE fr.to_user_id = $1 AND fr.status = 'pending';
+
+PREPARE friend_requests_outgoing_pending AS
+SELECT fr.id, fr.created_at, u.id, u.username
+FROM friend_requests fr
+INNER JOIN users u ON u.id = fr.to_user_id
+WHERE fr.from_user_id = $1 AND fr.status = 'pending';
+
+-- >>> Replace with a real user UUID from your database <<<
+EXPLAIN (ANALYZE, BUFFERS) EXECUTE friend_requests_incoming_pending('00000000-0000-0000-0000-000000000000'::uuid);
+EXPLAIN (ANALYZE, BUFFERS) EXECUTE friend_requests_outgoing_pending('00000000-0000-0000-0000-000000000000'::uuid);
+
+DEALLOCATE friend_requests_incoming_pending;
+DEALLOCATE friend_requests_outgoing_pending;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -251,6 +251,13 @@ export const friendRequests = pgTable("friend_requests", {
   ).where(sql`${table.status} = 'pending'`),
   fromIdx: index("idx_friend_requests_from").on(table.fromUserId),
   toIdx: index("idx_friend_requests_to").on(table.toUserId),
+  /** #146: pending inbox/outbox list — match API filters + created_at for ordering. */
+  toPendingCreatedIdx: index("idx_friend_requests_to_pending_created")
+    .on(table.toUserId, table.createdAt.desc())
+    .where(sql`${table.status} = 'pending'`),
+  fromPendingCreatedIdx: index("idx_friend_requests_from_pending_created")
+    .on(table.fromUserId, table.createdAt.desc())
+    .where(sql`${table.status} = 'pending'`),
 }));
 
 export const friendships = pgTable("friendships", {


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #146

## Summary

Adds two idempotent partial btree indexes on `friend_requests` for pending-only inbox and outbox list patterns (`to_user_id` / `from_user_id` plus `created_at DESC`), matching the GET handler in `src/app/api/friends/requests/route.ts`. Declares the same indexes in `src/db/schema.ts` for Drizzle parity.

## Unchanged semantics

- `friend_requests_pending_user_pair` (unique partial on `LEAST`/`GREATEST` where `status = 'pending'`) is untouched — at most one pending row per unordered pair remains enforced.

## Migration

- New file: `drizzle/friend_requests_pending_indexes_incremental.sql` (both `CREATE INDEX IF NOT EXISTS`).

Deploy applies this automatically via `npm run db:migrate` in the Vercel build (`vercel.json`). No ad-hoc production DDL.

## EXPLAIN verification

This agent environment had no `node`/`psql`, so **before/after `EXPLAIN (ANALYZE, BUFFERS)` output was not captured here**.

**How to verify (local + preview Neon):**

1. Apply migrations: `npm run db:migrate` with `POSTGRES_URL` pointing at the target DB (or run the SQL file contents manually once).
2. Edit `scripts/explain-friend-request-pending-indexes.sql`: replace the placeholder UUID with a user who has several pending friend requests (for a visible plan).
3. Run **before** migration (optional baseline): `psql "$POSTGRES_URL" -f scripts/explain-friend-request-pending-indexes.sql`
4. Apply the migration, run again **after**.
5. Expect for the `friend_requests` side: **Index Scan** or **Bitmap Index Scan** on `idx_friend_requests_to_pending_created` / `idx_friend_requests_from_pending_created`, not a large **Seq Scan** on `friend_requests` (row counts and planner stats may still choose seq scan on tiny tables — use enough pending rows or `SET enable_seqscan = off` only for local diagnosis).

Please paste the two “after” EXPLAIN outputs into a PR comment when validated on preview Neon.

## Production rollout

Same as any incremental migration: merge to default branch, let Vercel build run `db:migrate` against production `POSTGRES_URL`, confirm deploy logs show `friend_requests_pending_indexes_incremental.sql` applied once. Rollback: `DROP INDEX CONCURRENTLY` is optional if ever needed; indexes are additive only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2725a094-a1db-4612-b709-cea6afb517fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2725a094-a1db-4612-b709-cea6afb517fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Speed up pending friend request inbox and outbox lists**

### What Changed
- Added indexes so pending incoming and outgoing friend request lists can load using the user id and newest-first order
- Kept the existing one-pending-request-per-user-pair rule unchanged
- Added a repeatable database migration and a query check script to verify the new indexes

### Impact
`✅ Faster pending friend request lists`
`✅ Fewer slow scans on large request tables`
`✅ Easier verification after deployment`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=QZ3tO7pPHfcqctkgc7QJWlI0zRcwkFfIG6FDieNqDQU&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
