### PR TITLE
fix(ios): UITest tapAndType waits for keyboard focus (#288)

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -52,6 +52,9 @@ jobs:
         working-directory: ios
         run: xcodegen generate
 
+      # iOS UITest retries are controlled by `scripts/e2e/run-ios-tests.sh` (2nd arg =
+      # MAX_RETRIES). `package.json` passes `1` for both smoke and critical (`e2e:ios:*`),
+      # so each lane runs a single xcodebuild attempt unless that script is changed.
       - name: Run iOS ${{ matrix.lane }} lane
         env:
           E2E_ENV: ci

--- a/ios/StillPointAppUITests/Helpers/XCUIElement+TapAndType.swift
+++ b/ios/StillPointAppUITests/Helpers/XCUIElement+TapAndType.swift
@@ -1,9 +1,10 @@
 import XCTest
 
 extension XCUIElement {
-    /// Taps the element, waits for the software keyboard and keyboard focus on this element, then types.
+    /// Taps the element, waits for keyboard focus on this element, then types.
     ///
-    /// Avoids `typeText` failures when CI is slow to promote the field to first responder
+    /// Does not require the software keyboard to be visible (hardware keyboard / CI variants).
+    /// Avoids `typeText` failures when the field is not yet first responder
     /// (“Neither element nor any descendant has keyboard focus”).
     func tapAndType(
         _ text: String,
@@ -14,20 +15,26 @@ extension XCUIElement {
     ) {
         tap()
 
-        let keyboard = app.keyboards.firstMatch
-        XCTAssertTrue(
-            keyboard.waitForExistence(timeout: timeout),
-            "Keyboard did not appear after tapping text field",
-            file: file,
-            line: line
-        )
-
         let focusPredicate = NSPredicate(format: "hasKeyboardFocus == true")
-        let focusExpectation = XCTNSPredicateExpectation(predicate: focusPredicate, object: self)
-        let outcome = XCTWaiter.wait(for: [focusExpectation], timeout: timeout)
+        // Instance waiter (no delegate) so timeouts return `.timedOut` instead of XCTest auto-failing,
+        // allowing a single descriptive `XCTFail` below.
+        let waiter = XCTWaiter(delegate: nil, delegateQueue: nil)
+        let primaryFocus = XCTNSPredicateExpectation(predicate: focusPredicate, object: self)
+        var outcome = waiter.wait(for: [primaryFocus], timeout: timeout)
+
+        if outcome != .completed {
+            // Keyboard can appear slightly after focus on some simulator builds; optional short wait
+            // then re-check focus without requiring `keyboards` to exist (hardware keyboard).
+            let keyboard = app.keyboards.firstMatch
+            if keyboard.waitForExistence(timeout: min(2.0, timeout)) {
+                let retryFocus = XCTNSPredicateExpectation(predicate: focusPredicate, object: self)
+                outcome = waiter.wait(for: [retryFocus], timeout: min(3.0, timeout))
+            }
+        }
+
         guard outcome == .completed else {
             XCTFail(
-                "Field did not become keyboard first responder (wait outcome: \(outcome.rawValue))",
+                "Field did not become keyboard first responder within \(timeout)s (wait outcome: \(outcome.rawValue))",
                 file: file,
                 line: line
             )

--- a/ios/StillPointAppUITests/Helpers/XCUIElement+TapAndType.swift
+++ b/ios/StillPointAppUITests/Helpers/XCUIElement+TapAndType.swift
@@ -16,9 +16,9 @@ extension XCUIElement {
         tap()
 
         let focusPredicate = NSPredicate(format: "hasKeyboardFocus == true")
-        // Instance waiter (no delegate) so timeouts return `.timedOut` instead of XCTest auto-failing,
-        // allowing a single descriptive `XCTFail` below.
-        let waiter = XCTWaiter(delegate: nil, delegateQueue: nil)
+        // Fresh waiter instance so predicate timeouts return `.timedOut` instead of XCTest auto-failing
+        // via the default XCTestCase delegate (allows one descriptive `XCTFail` below).
+        let waiter = XCTWaiter()
         let primaryFocus = XCTNSPredicateExpectation(predicate: focusPredicate, object: self)
         var outcome = waiter.wait(for: [primaryFocus], timeout: timeout)
 

--- a/ios/StillPointAppUITests/Helpers/XCUIElement+TapAndType.swift
+++ b/ios/StillPointAppUITests/Helpers/XCUIElement+TapAndType.swift
@@ -1,0 +1,39 @@
+import XCTest
+
+extension XCUIElement {
+    /// Taps the element, waits for the software keyboard and keyboard focus on this element, then types.
+    ///
+    /// Avoids `typeText` failures when CI is slow to promote the field to first responder
+    /// (“Neither element nor any descendant has keyboard focus”).
+    func tapAndType(
+        _ text: String,
+        in app: XCUIApplication,
+        timeout: TimeInterval = 10,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        tap()
+
+        let keyboard = app.keyboards.firstMatch
+        XCTAssertTrue(
+            keyboard.waitForExistence(timeout: timeout),
+            "Keyboard did not appear after tapping text field",
+            file: file,
+            line: line
+        )
+
+        let focusPredicate = NSPredicate(format: "hasKeyboardFocus == true")
+        let focusExpectation = XCTNSPredicateExpectation(predicate: focusPredicate, object: self)
+        let outcome = XCTWaiter.wait(for: [focusExpectation], timeout: timeout)
+        guard outcome == .completed else {
+            XCTFail(
+                "Field did not become keyboard first responder (wait outcome: \(outcome.rawValue))",
+                file: file,
+                line: line
+            )
+            return
+        }
+
+        typeText(text)
+    }
+}

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -27,8 +27,7 @@ final class StillPointAppUITests: XCTestCase {
 
         let emailField = app.textFields["auth.emailField"]
         XCTAssertTrue(emailField.waitForExistence(timeout: 5))
-        emailField.tap()
-        emailField.typeText("ios.fixture@stillpoint.test")
+        emailField.tapAndType("ios.fixture@stillpoint.test", in: app)
 
         let forgotPasswordButton = app.buttons["auth.forgotPasswordButton"]
         XCTAssertTrue(forgotPasswordButton.waitForExistence(timeout: 5))
@@ -55,13 +54,11 @@ final class StillPointAppUITests: XCTestCase {
 
         let emailField = app.textFields["auth.emailField"]
         XCTAssertTrue(emailField.waitForExistence(timeout: 5))
-        emailField.tap()
-        emailField.typeText("ios.fixture@stillpoint.test")
+        emailField.tapAndType("ios.fixture@stillpoint.test", in: app)
 
         let passwordField = app.secureTextFields["auth.passwordField"]
         XCTAssertTrue(passwordField.waitForExistence(timeout: 5))
-        passwordField.tap()
-        passwordField.typeText("stillpoint-pass")
+        passwordField.tapAndType("stillpoint-pass", in: app)
 
         let submitButton = app.buttons["auth.submitButton"]
         tapByStableCenter(submitButton, in: app)
@@ -174,10 +171,8 @@ final class StillPointAppUITests: XCTestCase {
         XCTAssertTrue(passwordField.waitForExistence(timeout: 5))
         XCTAssertTrue(submitButton.waitForExistence(timeout: 5))
 
-        emailField.tap()
-        emailField.typeText("ios.fixture@stillpoint.test")
-        passwordField.tap()
-        passwordField.typeText("stillpoint-pass")
+        emailField.tapAndType("ios.fixture@stillpoint.test", in: app)
+        passwordField.tapAndType("stillpoint-pass", in: app)
         let keyboard = app.keyboards.firstMatch
         XCTAssertTrue(keyboard.waitForExistence(timeout: 5), "Keyboard should be visible for overlap reachability check")
         XCTAssertTrue(submitButton.isHittable, "Submit should remain reachable with keyboard visible")

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -68,12 +68,12 @@ final class StillPointAppUITests: XCTestCase {
         XCTAssertTrue(beginButton.waitForExistence(timeout: 5))
         beginButton.tap()
         app.launchEnvironment["SP_UI_TEST_SEED_AUTH"] = "1"
-        app.terminate()
+        terminateAppReliably(app)
         app.launch()
         waitForRoot("home", in: app, failureMessage: "Home screen did not survive relaunch before session", assertColdStart: false)
         app.launchEnvironment["SP_UI_TEST_SEED_AUTH"] = "1"
         app.launchEnvironment["SP_UI_TEST_FORCE_START_SESSION"] = "1"
-        app.terminate()
+        terminateAppReliably(app)
         app.launch()
         waitForRoot("session", in: app, failureMessage: "Session screen did not appear", assertColdStart: false)
 
@@ -111,7 +111,7 @@ final class StillPointAppUITests: XCTestCase {
         tapByStableCenter(returnButton, in: app)
         XCTAssertTrue(app.otherElements["root.currentView.home"].waitForExistence(timeout: 8))
 
-        app.terminate()
+        terminateAppReliably(app)
 
         let relaunch = makeApp(
             seedAuthenticated: true,
@@ -250,7 +250,8 @@ final class StillPointAppUITests: XCTestCase {
 
     @MainActor
     func testVoiceOverLabelsForTimerAndPrimaryButton() throws {
-        let app = makeApp(seedAuthenticated: true, resetStore: true, sessionSeconds: 30, timerMultiplier: 1.0)
+        // Long wall-clock budget so completion cannot beat the timer assertion on slow CI navigations.
+        let app = makeApp(seedAuthenticated: true, resetStore: true, sessionSeconds: 600, timerMultiplier: 0.05)
         app.launch()
 
         waitForRoot("home", in: app, failureMessage: "Home screen did not appear")
@@ -435,6 +436,21 @@ final class StillPointAppUITests: XCTestCase {
 
         XCTFail("Element existed but never had a stable tappable frame: \(element.debugDescription)", file: file, line: line)
         return nil
+    }
+
+    /// Retries `terminate()` since XCTest occasionally reports "Failed to terminate … :0" on loaded CI simulators.
+    private func terminateAppReliably(_ app: XCUIApplication, attempts: Int = 4) {
+        for _ in 1...attempts {
+            app.terminate()
+            let deadline = Date().addingTimeInterval(15)
+            while Date() < deadline {
+                if app.state == .notRunning {
+                    return
+                }
+                RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+            }
+        }
+        XCTFail("App did not reach notRunning after \(attempts) terminate attempts")
     }
 
     private func dismissKeyboardIfPresent(in app: XCUIApplication) {

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -29,13 +29,15 @@ final class StillPointAppUITests: XCTestCase {
         XCTAssertTrue(emailField.waitForExistence(timeout: 5))
         emailField.tapAndType("ios.fixture@stillpoint.test", in: app)
 
+        dismissKeyboardIfPresent(in: app)
+
         let forgotPasswordButton = app.buttons["auth.forgotPasswordButton"]
         XCTAssertTrue(forgotPasswordButton.waitForExistence(timeout: 5))
         XCTAssertTrue(forgotPasswordButton.isHittable)
-        forgotPasswordButton.tap()
+        XCTAssertTrue(tapByStableCenter(forgotPasswordButton, in: app))
 
         XCTAssertTrue(
-            app.staticTexts["auth.passwordResetMessage"].waitForExistence(timeout: 5),
+            app.staticTexts["auth.passwordResetMessage"].waitForExistence(timeout: 20),
             "Password reset request confirmation should be visible"
         )
     }


### PR DESCRIPTION
## **User description**
## Test plan

- [x] `ios-e2e-smoke` CI lane passes (smoke auth + basic navigation)
- [x] `ios-e2e-critical` CI lane passes (VoiceOver timer, password reset flow)
- [x] `tapAndType` waits for keyboard focus before typing — no "neither element nor any descendant has keyboard focus" failures
- [x] App relaunch via `terminateAppReliably` is stable under repeat runs
- [x] `XCTWaiter()` instance init compiles on Xcode 26

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

UITest keyboard/focus helper and CI hardening for PR #288 / #300.

## Recent fixes

- **Compile:** `XCTWaiter()` default init on Xcode 26.
- **Smoke:** `terminateAppReliably` for flaky `terminate()`.
- **Critical VoiceOver:** Long virtual session + slow multiplier so navigation cannot finish before timer assertion.
- **Critical password reset:** Dismiss keyboard after typing email, `tapByStableCenter` on forgot-password, 20s wait for confirmation.

Closes #288
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebe826bf-b13a-4a3f-b4c7-3bdca1e24943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebe826bf-b13a-4a3f-b4c7-3bdca1e24943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved iOS test stability: more reliable keyboard interactions for auth flows, more robust app relaunch handling, and extended timing for VoiceOver/timer checks to reduce CI flakiness.

* **Chores**
  * Added documentation for iOS E2E retry behavior configuration.
  * Consolidated repeated test interaction patterns for cleaner, more consistent UI tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Make iOS UI tests wait for focus and handle flaky CI runs**

### What Changed
- Text fields now wait until they have keyboard focus before typing, which prevents auth screen test failures during fast or hardware-keyboard simulator runs
- Password reset and login flows now dismiss the keyboard, tap the forgot-password button more reliably, and wait longer for the confirmation message
- App relaunch checks now retry termination until the app fully closes, reducing launch-related test flakes
- The VoiceOver timer test now uses a longer session window so slow CI runs cannot finish the session before the accessibility checks run
- The iOS CI workflow now documents that each e2e lane runs with a single retry attempt

### Impact
`✅ Fewer auth test failures`
`✅ More stable iOS CI runs`
`✅ Clearer password reset verification`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=5cgEiBEXgSDYMIspjOx3VvIVmGqNDMrz2HN0pyWPC0g&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
