### PR TITLE
Keep capture note visible but dimmed during active session (#111)

### DIFF
--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -2,8 +2,8 @@ import SwiftUI
 import StillPointShared
 
 struct SessionView: View {
-    /// Space reserved when both distraction hold bar and controls are visible.
-    private static let bottomOverlayReserveWithControls: CGFloat = 268
+    /// Space reserved when both distraction hold bar and controls are visible (includes persistent Capture row).
+    private static let bottomOverlayReserveWithControls: CGFloat = 324
 
     let appVM: AppViewModel
     @State private var vm: SessionViewModel
@@ -248,6 +248,26 @@ struct SessionView: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, SPSpacing.s4)
 
+            if !vm.showPostDistractionCapture, vm.isActive || vm.isPaused {
+                Button {
+                    vm.openThoughtCapture()
+                } label: {
+                    Text("Capture")
+                        .font(SPFont.mono(12, weight: .medium))
+                        .foregroundStyle(SPColor.amberText)
+                        .padding(.horizontal, SPSpacing.s3)
+                        .padding(.vertical, SPSpacing.s1)
+                        .frame(minHeight: 44)
+                        .background(SPColor.amberBgFaint)
+                        .clipShape(Capsule())
+                        .overlay(Capsule().stroke(SPColor.amberBorderSubtle))
+                }
+                .accessibilityIdentifier("session.captureButton")
+                .opacity(vm.isActive && !vm.controlsVisible ? 0.48 : 0.88)
+                .animation(.easeInOut(duration: 0.3), value: vm.controlsVisible)
+                .padding(.top, SPSpacing.s1)
+            }
+
             HStack(spacing: SPSpacing.s2) {
                 Text("Hold — light distraction")
                     .font(SPFont.serifItalic(15))
@@ -367,21 +387,23 @@ struct SessionView: View {
                 }
                 .accessibilityIdentifier("session.endEarlyButton")
 
-                Button {
-                    vm.openThoughtCapture()
-                } label: {
-                    Text("Capture")
-                        .font(SPFont.mono(12, weight: .medium))
-                        .foregroundStyle(SPColor.amberText)
-                        .padding(.horizontal, SPSpacing.s3)
-                        .padding(.vertical, SPSpacing.s1)
-                        .background(SPColor.amberBgFaint)
-                        .clipShape(Capsule())
-                        .overlay(Capsule().stroke(SPColor.amberBorderSubtle))
+                if !(sessionInProgress && !vm.showPostDistractionCapture && (vm.isActive || vm.isPaused)) {
+                    Button {
+                        vm.openThoughtCapture()
+                    } label: {
+                        Text("Capture")
+                            .font(SPFont.mono(12, weight: .medium))
+                            .foregroundStyle(SPColor.amberText)
+                            .padding(.horizontal, SPSpacing.s3)
+                            .padding(.vertical, SPSpacing.s1)
+                            .background(SPColor.amberBgFaint)
+                            .clipShape(Capsule())
+                            .overlay(Capsule().stroke(SPColor.amberBorderSubtle))
+                    }
+                    .accessibilityIdentifier("session.captureButton")
+                    .disabled(!vm.isActive)
+                    .opacity(vm.isActive ? 1 : 0.45)
                 }
-                .accessibilityIdentifier("session.captureButton")
-                .disabled(!vm.isActive)
-                .opacity(vm.isActive ? 1 : 0.45)
 
                 // Abandon
                 Button {

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -20,7 +20,7 @@ struct SessionView: View {
             SPColor.bg.ignoresSafeArea()
 
             GeometryReader { geo in
-                let contentHeight = geo.size.height - bottomOverlayReserve
+                let contentHeight = max(0, geo.size.height - bottomOverlayReserve)
 
                 VStack(spacing: 0) {
                     // Main content — fits in viewport above controls

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -262,6 +262,22 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
     mindState === "thinking" ? "Distracted" : mindState === "hyperfocus" ? "Hyperfocus" : "Aware";
   const capturedCount = sessionThoughts.length;
   const sessionChromeDimmed = isActive && !controlsVisible;
+  /** Capture stays in the persistent tracking layer while running so it is never hidden with secondary chrome. */
+  const captureNoteButtonStyle: CSSProperties = {
+    background: "none",
+    border: "1px solid var(--accent-amber-border)",
+    color: "var(--accent-amber-border)",
+    ...mono,
+    fontSize: "11px",
+    letterSpacing: "0.15em",
+    textTransform: "uppercase",
+    padding: "14px 24px",
+    minHeight: "44px",
+    minWidth: "44px",
+    borderRadius: "20px",
+    cursor: "pointer",
+    transition: "opacity 0.5s ease",
+  };
 
   const holdButtonBase: CSSProperties = {
     ...mono,
@@ -461,6 +477,22 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
             <span style={{ color: "var(--accent-amber-border)" }}>{distractionPercent}% distraction</span>
           </div>
 
+          {!showPostDistractionCapture && (
+            <div style={{ marginTop: "18px", display: "flex", justifyContent: "center", width: "100%" }}>
+              <button
+                type="button"
+                onClick={handleOpenThoughtCapture}
+                aria-label="Capture note"
+                style={{
+                  ...captureNoteButtonStyle,
+                  opacity: sessionChromeDimmed ? 0.48 : 0.88,
+                }}
+              >
+                capture note
+              </button>
+            </div>
+          )}
+
           {showPostDistractionCapture && (
             <div
               data-no-space-distraction
@@ -502,25 +534,16 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
             >
               {isActive ? "pause" : "resume"}
             </button>
-            <button
-              type="button"
-              onClick={handleOpenThoughtCapture}
-              style={{
-                background: "none",
-                border: "1px solid var(--accent-amber-border)",
-                color: "var(--accent-amber-border)",
-                ...mono,
-                fontSize: "11px",
-                letterSpacing: "0.15em",
-                textTransform: "uppercase",
-                padding: "14px 24px",
-                minHeight: "44px",
-                borderRadius: "20px",
-                cursor: "pointer",
-              }}
-            >
-              capture note
-            </button>
+            {!isActive && (
+              <button
+                type="button"
+                onClick={handleOpenThoughtCapture}
+                aria-label="Capture note"
+                style={captureNoteButtonStyle}
+              >
+                capture note
+              </button>
+            )}
             <button
               type="button"
               onClick={handleEndEarly}

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -63,6 +63,8 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
   const [soundPrefs, setSoundPrefs] = useState<SoundPrefs>(() => loadSoundPrefs());
   const [controlsVisible, setControlsVisible] = useState(true);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** True after user pauses once this sit — keeps tracking UI (and ThoughtCapture) mounted while paused. */
+  const [wasPausedInSession, setWasPausedInSession] = useState(false);
 
   useEffect(() => {
     const resetTimer = () => {
@@ -154,6 +156,7 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
 
   const handleComplete = useCallback(() => {
     const resolvedLog = snapshotForComplete();
+    setWasPausedInSession(false);
     setIsActive(false);
     const actualTime = Math.round((Date.now() - wallStartRef.current) / 1000);
     const endT = elapsedRef.current || todayDuration;
@@ -210,6 +213,7 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
 
   const handleEndEarly = () => {
     const resolvedLog = snapshotForComplete();
+    setWasPausedInSession(false);
     setIsActive(false);
     const actualTime = Math.round((Date.now() - wallStartRef.current) / 1000);
     const endT = elapsedRef.current || todayDuration;
@@ -228,6 +232,7 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
 
   const handleAbandon = () => {
     const resolvedLog = snapshotForComplete();
+    setWasPausedInSession(false);
     setIsActive(false);
     const actualTime = Math.round((Date.now() - wallStartRef.current) / 1000);
     const endT = elapsedRef.current || todayDuration;
@@ -253,6 +258,9 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
     if (isActive) {
       resetHoldTracking();
       finalizeActiveHold(elapsedRef.current);
+      setWasPausedInSession(true);
+    } else {
+      setWasPausedInSession(false);
     }
     setIsActive(a => !a);
   };
@@ -262,6 +270,7 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
     mindState === "thinking" ? "Distracted" : mindState === "hyperfocus" ? "Hyperfocus" : "Aware";
   const capturedCount = sessionThoughts.length;
   const sessionChromeDimmed = isActive && !controlsVisible;
+  const showSessionTrackingLayer = isActive || wasPausedInSession;
   /** Capture stays in the persistent tracking layer while running so it is never hidden with secondary chrome. */
   const captureNoteButtonStyle: CSSProperties = {
     background: "none",
@@ -313,7 +322,7 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
         soundPrefs={soundPrefs}
       />
 
-      {isActive && (
+      {showSessionTrackingLayer && (
         <div
           data-session-tracking-layer="persistent"
           style={{ width: "100%", maxWidth: "min(440px, calc(100vw - 40px))", marginTop: "12px" }}
@@ -534,16 +543,6 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
             >
               {isActive ? "pause" : "resume"}
             </button>
-            {!isActive && (
-              <button
-                type="button"
-                onClick={handleOpenThoughtCapture}
-                aria-label="Capture note"
-                style={captureNoteButtonStyle}
-              >
-                capture note
-              </button>
-            )}
             <button
               type="button"
               onClick={handleEndEarly}


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements issue #111: the thought/capture control stays visible during an active sit (no need to move the pointer to “wake” secondary chrome), while staying visually softer than the primary hold controls.

## Follow-up (babysitter commit `d1ae492`)

- **Web:** Fixed a **paused “capture note” stuck state** (Cursor Bugbot): the secondary-only button could open capture while `ThoughtCapture` lived inside `{isActive && …}`. Added `wasPausedInSession` so the persistent layer (including `ThoughtCapture`) stays mounted whenever the user has paused during that sit; removed the duplicate paused-only button. Flag resets on resume and when the sit completes / ends early / abandon.
- **iOS:** **Clamp** `contentHeight` with `max(0, …)` so short viewports never get negative layout height (CodeAnt feedback).

## Testing

CI on the latest push: Web build, E2E web/mobile, and iOS E2E critical + smoke are **green**.

Closes #111
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16000851-5bd5-4f5f-80b2-1bd0299327e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16000851-5bd5-4f5f-80b2-1bd0299327e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Keep Capture note available during a session and prevent paused-session capture issues**

### What Changed
- The Capture note now stays visible during an active session instead of disappearing with the secondary controls, and it appears dimmed when those controls auto-hide.
- If a session is paused, the Capture UI stays available until the session resumes or ends, avoiding a stuck state after pausing.
- On iPhone/iPad, the session layout now reserves room for the new Capture row and avoids cramped content on very short screens.

### Impact
`✅ Faster access to note capture during a session`
`✅ Fewer missing capture buttons after pausing`
`✅ Fewer layout issues on short mobile screens`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=aWzn59_xVngUHuLYJzmpszDFQLQiDI4knNLoXwZOcro&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
