### PR TITLE
Display app version and build SHA in Settings (#294)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,3 +72,9 @@ AUTH_GOOGLE_SECRET=
 
 # Optional: public App Store URL for landing page badge (#199). Unset or empty = no badge shown.
 # NEXT_PUBLIC_APP_STORE_URL=
+
+# Optional: git commit SHA (short form) shown in Settings next to app version (#294).
+# Vercel sets VERCEL_GIT_COMMIT_SHA automatically. If unset, local `next dev` / `next build`
+# may resolve HEAD via `git rev-parse` when building from a git checkout. You can override, e.g.:
+# NEXT_PUBLIC_BUILD_SHA=$(git rev-parse --short=7 HEAD)
+# NEXT_PUBLIC_BUILD_SHA=

--- a/.env.example
+++ b/.env.example
@@ -74,7 +74,7 @@ AUTH_GOOGLE_SECRET=
 # NEXT_PUBLIC_APP_STORE_URL=
 
 # Optional: git commit SHA (short form) shown in Settings next to app version (#294).
-# Vercel sets VERCEL_GIT_COMMIT_SHA automatically. If unset, local `next dev` / `next build`
-# may resolve HEAD via `git rev-parse` when building from a git checkout. You can override, e.g.:
+# If set (non-empty), overrides VERCEL_GIT_COMMIT_SHA. Vercel sets VERCEL_GIT_COMMIT_SHA automatically.
+# If unset, local `next dev` / `next build` may resolve HEAD via `git rev-parse` when building from a git checkout. You can override, e.g.:
 # NEXT_PUBLIC_BUILD_SHA=$(git rev-parse --short=7 HEAD)
 # NEXT_PUBLIC_BUILD_SHA=

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,51 @@
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { NextConfig } from "next";
+
+function readPackageVersion(): string {
+  try {
+    const raw = readFileSync(join(process.cwd(), "package.json"), "utf8");
+    const parsed = JSON.parse(raw) as { version?: string };
+    return typeof parsed.version === "string" ? parsed.version : "";
+  } catch {
+    return "";
+  }
+}
+
+function shortGitSha(full: string | undefined): string {
+  if (!full) return "";
+  const t = full.trim();
+  if (!t) return "";
+  return t.length > 7 ? t.slice(0, 7) : t;
+}
+
+function tryGitHead(): string {
+  try {
+    return execSync("git rev-parse HEAD", {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+const buildShaFull =
+  process.env.VERCEL_GIT_COMMIT_SHA ??
+  process.env.NEXT_PUBLIC_BUILD_SHA ??
+  process.env.SOURCE_VERSION ??
+  tryGitHead();
 
 const nextConfig: NextConfig = {
   // Externalize Neon's WS driver and `ws` so Next does not bundle them.
   // Bundling tree-shakes `ws`'s mask path on Vercel and crashes every
   // `poolDb.transaction()` with `b.mask is not a function`. See #246.
   serverExternalPackages: ["@neondatabase/serverless", "ws"],
+  env: {
+    NEXT_PUBLIC_APP_VERSION: readPackageVersion(),
+    NEXT_PUBLIC_BUILD_SHA: shortGitSha(buildShaFull),
+  },
 };
 
 export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,6 +13,11 @@ function readPackageVersion(): string {
   }
 }
 
+function nonBlankEnv(v: string | undefined): string | undefined {
+  const t = (v ?? "").trim();
+  return t.length > 0 ? t : undefined;
+}
+
 function shortGitSha(full: string | undefined): string {
   if (!full) return "";
   const t = full.trim();
@@ -32,10 +37,11 @@ function tryGitHead(): string {
 }
 
 const buildShaFull =
-  process.env.VERCEL_GIT_COMMIT_SHA ??
-  process.env.NEXT_PUBLIC_BUILD_SHA ??
-  process.env.SOURCE_VERSION ??
-  tryGitHead();
+  nonBlankEnv(process.env.VERCEL_GIT_COMMIT_SHA) ??
+  nonBlankEnv(process.env.NEXT_PUBLIC_BUILD_SHA) ??
+  nonBlankEnv(process.env.SOURCE_VERSION) ??
+  nonBlankEnv(tryGitHead()) ??
+  "";
 
 const nextConfig: NextConfig = {
   // Externalize Neon's WS driver and `ws` so Next does not bundle them.

--- a/next.config.ts
+++ b/next.config.ts
@@ -37,8 +37,8 @@ function tryGitHead(): string {
 }
 
 const buildShaFull =
-  nonBlankEnv(process.env.VERCEL_GIT_COMMIT_SHA) ??
   nonBlankEnv(process.env.NEXT_PUBLIC_BUILD_SHA) ??
+  nonBlankEnv(process.env.VERCEL_GIT_COMMIT_SHA) ??
   nonBlankEnv(process.env.SOURCE_VERSION) ??
   nonBlankEnv(tryGitHead()) ??
   "";

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -337,7 +337,39 @@ export function SettingsView({
             onLogout();
           }}
         />
+
+        <AppVersionFooter />
       </div>
     </div>
+  );
+}
+
+function AppVersionFooter() {
+  const version = process.env.NEXT_PUBLIC_APP_VERSION?.trim() ?? "";
+  const buildSha = process.env.NEXT_PUBLIC_BUILD_SHA?.trim() ?? "";
+  if (!version && !buildSha) return null;
+
+  const label =
+    version && buildSha
+      ? `v${version} (${buildSha})`
+      : version
+        ? `v${version}`
+        : buildSha;
+
+  return (
+    <p
+      style={{
+        margin: "24px 0 0",
+        padding: 0,
+        textAlign: "center",
+        fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+        fontSize: "10px",
+        letterSpacing: "0.04em",
+        color: "var(--fg-4)",
+        userSelect: "none",
+      }}
+    >
+      {label}
+    </p>
   );
 }


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Settings footer:** Small muted monospace line at the bottom of Settings shows `v{version} ({shortSha})` when both are available, matching existing `--fg-4` / JetBrains styling.
- **Build-time values:** `next.config.ts` sets `NEXT_PUBLIC_APP_VERSION` from `package.json` and `NEXT_PUBLIC_BUILD_SHA` as a 7-character prefix. Resolution order: non-empty `NEXT_PUBLIC_BUILD_SHA` (explicit override), then `VERCEL_GIT_COMMIT_SHA`, `SOURCE_VERSION`, then `git rev-parse HEAD` when building from a git checkout. Empty/whitespace env values are treated as unset so fallbacks still apply.
- **Docs:** `.env.example` documents optional `NEXT_PUBLIC_BUILD_SHA` and override semantics.

## Testing

- CI: Web build, E2E policy/smoke/critical, mobile E2E, Vercel preview — all passing on latest push.

## Review follow-ups (addressed)

- **Bugbot / CodeAnt:** Empty-string env values no longer block the SHA fallback (`nonBlankEnv` + `??` chain).
- **CodeRabbit:** `NEXT_PUBLIC_BUILD_SHA` is evaluated before `VERCEL_GIT_COMMIT_SHA` so local/CI overrides win over the provider default.

Closes #294
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e766d778-3a57-4d0b-b1f2-31377c29a0d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e766d778-3a57-4d0b-b1f2-31377c29a0d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
Show the app version and build SHA in Settings, and make the build SHA fallback rules clearer

### What Changed
- Settings now shows a small footer with the app version, build SHA, or both when available
- The app version is pulled from the app’s package version, so the displayed version matches the build
- The build SHA now follows a clear order: an explicit override first, then the Vercel commit SHA, then another provided source, and finally the current git commit when building from a repo
- Empty build SHA values no longer block fallback values from being used
- The example env file now documents how to set or override the displayed build SHA

### Impact
`✅ Easier build verification`
`✅ Clearer app version display in Settings`
`✅ Fewer missing build SHA values`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=8v2kq1IkFR8fHN9EhXE9JdAjXiw7FDSJf151UGmbDd8&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
