### PR TITLE
iOS: keep screen awake during session (opt-in)

### DIFF
--- a/ios/StillPoint.xcodeproj/project.pbxproj
+++ b/ios/StillPoint.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		16697A0A2D8E95D300EEA791 /* BuddyVideoWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0F8BA13F32BC68EEA0198C /* BuddyVideoWebView.swift */; };
 		17A248000000000000000001 /* AppBlockingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A248000000000000000002 /* AppBlockingManager.swift */; };
 		17A248000000000000000003 /* AppBlockingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A248000000000000000004 /* AppBlockingSettingsView.swift */; };
+		17A248000000000000000007 /* SessionIdleTimerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A248000000000000000008 /* SessionIdleTimerController.swift */; };
 		1BE60070F826B7B31DFAB315 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FA6DAE71EE23FAF8EE0F12 /* HomeView.swift */; };
 		25295F15540B9986B15EB839 /* BuddySessionContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D8D4FA0580148DEAB74CC3 /* BuddySessionContainerView.swift */; };
 		2E31C1B6A86E612EF7171348 /* ThoughtJournalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44912B427658554F984CCC3A /* ThoughtJournalView.swift */; };
@@ -49,6 +50,7 @@
 		14CEC6DBFFB1C10CFDDA8424 /* StillPointApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StillPointApp.swift; sourceTree = "<group>"; };
 		17A248000000000000000002 /* AppBlockingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBlockingManager.swift; sourceTree = "<group>"; };
 		17A248000000000000000004 /* AppBlockingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBlockingSettingsView.swift; sourceTree = "<group>"; };
+		17A248000000000000000008 /* SessionIdleTimerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIdleTimerController.swift; sourceTree = "<group>"; };
 		17A248000000000000000005 /* StillPoint.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StillPoint.entitlements; sourceTree = "<group>"; };
 		1F75039BBEED880C73680860 /* HistoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewModel.swift; sourceTree = "<group>"; };
 		218693B76FDAF56B6E0321DE /* AppViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppViewModel.swift; sourceTree = "<group>"; };
@@ -171,6 +173,7 @@
 			isa = PBXGroup;
 			children = (
 				17A248000000000000000002 /* AppBlockingManager.swift */,
+				17A248000000000000000008 /* SessionIdleTimerController.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -316,6 +319,7 @@
 				55CB825BEE151D314A4DD2FA /* AppViewModel.swift in Sources */,
 				17A248000000000000000001 /* AppBlockingManager.swift in Sources */,
 				17A248000000000000000003 /* AppBlockingSettingsView.swift in Sources */,
+				17A248000000000000000007 /* SessionIdleTimerController.swift in Sources */,
 				5EA3E8C9B84298DE1F37251F /* AuthView.swift in Sources */,
 				8A9734076E9FB3D5477913A0 /* AuthViewModel.swift in Sources */,
 				F370AA8F6AA102355FC599C9 /* BlockGridView.swift in Sources */,

--- a/ios/StillPoint.xcodeproj/project.pbxproj
+++ b/ios/StillPoint.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		16697A0A2D8E95D300EEA791 /* BuddyVideoWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0F8BA13F32BC68EEA0198C /* BuddyVideoWebView.swift */; };
 		17A248000000000000000001 /* AppBlockingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A248000000000000000002 /* AppBlockingManager.swift */; };
 		17A248000000000000000003 /* AppBlockingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A248000000000000000004 /* AppBlockingSettingsView.swift */; };
-		17A248000000000000000007 /* SessionIdleTimerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A248000000000000000008 /* SessionIdleTimerController.swift */; };
 		1BE60070F826B7B31DFAB315 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FA6DAE71EE23FAF8EE0F12 /* HomeView.swift */; };
 		25295F15540B9986B15EB839 /* BuddySessionContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D8D4FA0580148DEAB74CC3 /* BuddySessionContainerView.swift */; };
 		2E31C1B6A86E612EF7171348 /* ThoughtJournalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44912B427658554F984CCC3A /* ThoughtJournalView.swift */; };
@@ -50,7 +49,6 @@
 		14CEC6DBFFB1C10CFDDA8424 /* StillPointApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StillPointApp.swift; sourceTree = "<group>"; };
 		17A248000000000000000002 /* AppBlockingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBlockingManager.swift; sourceTree = "<group>"; };
 		17A248000000000000000004 /* AppBlockingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBlockingSettingsView.swift; sourceTree = "<group>"; };
-		17A248000000000000000008 /* SessionIdleTimerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIdleTimerController.swift; sourceTree = "<group>"; };
 		17A248000000000000000005 /* StillPoint.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StillPoint.entitlements; sourceTree = "<group>"; };
 		1F75039BBEED880C73680860 /* HistoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewModel.swift; sourceTree = "<group>"; };
 		218693B76FDAF56B6E0321DE /* AppViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppViewModel.swift; sourceTree = "<group>"; };
@@ -173,7 +171,6 @@
 			isa = PBXGroup;
 			children = (
 				17A248000000000000000002 /* AppBlockingManager.swift */,
-				17A248000000000000000008 /* SessionIdleTimerController.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -319,7 +316,6 @@
 				55CB825BEE151D314A4DD2FA /* AppViewModel.swift in Sources */,
 				17A248000000000000000001 /* AppBlockingManager.swift in Sources */,
 				17A248000000000000000003 /* AppBlockingSettingsView.swift in Sources */,
-				17A248000000000000000007 /* SessionIdleTimerController.swift in Sources */,
 				5EA3E8C9B84298DE1F37251F /* AuthView.swift in Sources */,
 				8A9734076E9FB3D5477913A0 /* AuthViewModel.swift in Sources */,
 				F370AA8F6AA102355FC599C9 /* BlockGridView.swift in Sources */,

--- a/ios/StillPointApp/Managers/SessionIdleTimerController.swift
+++ b/ios/StillPointApp/Managers/SessionIdleTimerController.swift
@@ -2,9 +2,15 @@ import UIKit
 
 /// Central place to apply `UIApplication.shared.isIdleTimerDisabled` for active sits.
 /// When the preference is off, or no sit timer is running, the system idle timer stays enabled.
+///
+/// Last-known local/buddy activity is retained so a no-argument re-apply (e.g. after
+/// `scenePhase` becomes `.active`) still matches an in-progress sit.
 @MainActor
 enum SessionIdleTimerController {
     private static let userDefaultsKey = "sp_keepScreenAwakeDuringSession"
+
+    private static var lastLocalSessionRunning = false
+    private static var lastBuddySessionActive = false
 
     static var keepScreenAwakePreferenceEnabled: Bool {
         UserDefaults.standard.bool(forKey: userDefaultsKey)
@@ -19,23 +25,34 @@ enum SessionIdleTimerController {
     static func syncLocalSession(isRunning: Bool, preferenceEnabled: Bool) {
         applyDesiredIdleTimerState(
             localSessionRunning: isRunning,
-            localSessionPreference: preferenceEnabled
+            localSessionPreference: preferenceEnabled,
+            buddySessionActive: nil
         )
     }
 
     /// Call when buddy shared sit is in the `active` server state.
     static func syncBuddySessionActive(_ active: Bool) {
-        applyDesiredIdleTimerState(buddySessionActive: active)
+        applyDesiredIdleTimerState(
+            localSessionRunning: nil,
+            localSessionPreference: nil,
+            buddySessionActive: active
+        )
     }
 
-    /// Recompute from stored preference and current flags (e.g. after foreground).
+    /// Recompute from stored session flags and UserDefaults (e.g. after foreground).
     static func applyDesiredIdleTimerState(
-        localSessionRunning: Bool = false,
+        localSessionRunning: Bool? = nil,
         localSessionPreference: Bool? = nil,
-        buddySessionActive: Bool = false
+        buddySessionActive: Bool? = nil
     ) {
+        if let localSessionRunning {
+            lastLocalSessionRunning = localSessionRunning
+        }
+        if let buddySessionActive {
+            lastBuddySessionActive = buddySessionActive
+        }
         let pref = localSessionPreference ?? keepScreenAwakePreferenceEnabled
-        let shouldDisable = (localSessionRunning && pref) || (buddySessionActive && pref)
+        let shouldDisable = (lastLocalSessionRunning && pref) || (lastBuddySessionActive && pref)
         UIApplication.shared.isIdleTimerDisabled = shouldDisable
     }
 }

--- a/ios/StillPointApp/Managers/SessionIdleTimerController.swift
+++ b/ios/StillPointApp/Managers/SessionIdleTimerController.swift
@@ -32,10 +32,10 @@ enum SessionIdleTimerController {
     }
 
     /// Call when local `SessionView` is on screen and timer state changes, or preference toggles.
-    static func syncLocalSession(appVM: AppViewModel, isRunning: Bool, preferenceEnabled: Bool) {
+    static func syncLocalSession(appVM: AppViewModel, isRunning: Bool) {
         let reg = registration(for: appVM)
         reg.localSessionRunning = isRunning
-        applyDesiredIdleTimerState(localSessionPreference: preferenceEnabled)
+        applyDesiredIdleTimerState()
     }
 
     /// Call when buddy shared sit is in the `active` server state.
@@ -53,9 +53,9 @@ enum SessionIdleTimerController {
     }
 
     /// Recompute from all registrations and UserDefaults (e.g. after foreground).
-    static func applyDesiredIdleTimerState(localSessionPreference: Bool? = nil) {
+    static func applyDesiredIdleTimerState() {
         pruneDeadRegistrations()
-        let pref = localSessionPreference ?? keepScreenAwakePreferenceEnabled
+        let pref = keepScreenAwakePreferenceEnabled
         let shouldDisable = pref && registrations.values.contains { reg in
             reg.appViewModel != nil && reg.sceneForegroundActive
                 && (reg.localSessionRunning || reg.buddySessionActive)

--- a/ios/StillPointApp/Managers/SessionIdleTimerController.swift
+++ b/ios/StillPointApp/Managers/SessionIdleTimerController.swift
@@ -3,14 +3,24 @@ import UIKit
 /// Central place to apply `UIApplication.shared.isIdleTimerDisabled` for active sits.
 /// When the preference is off, or no sit timer is running, the system idle timer stays enabled.
 ///
-/// Last-known local/buddy activity is retained so a no-argument re-apply (e.g. after
-/// `scenePhase` becomes `.active`) still matches an in-progress sit.
+/// Tracks activity per `AppViewModel` so multiple `WindowGroup` scenes do not overwrite
+/// each other. Re-applies after foreground using stored registration state.
 @MainActor
 enum SessionIdleTimerController {
     private static let userDefaultsKey = "sp_keepScreenAwakeDuringSession"
 
-    private static var lastLocalSessionRunning = false
-    private static var lastBuddySessionActive = false
+    private final class IdleRegistration {
+        weak var appViewModel: AppViewModel?
+        var sceneForegroundActive = false
+        var localSessionRunning = false
+        var buddySessionActive = false
+
+        init(appViewModel: AppViewModel) {
+            self.appViewModel = appViewModel
+        }
+    }
+
+    private static var registrations: [ObjectIdentifier: IdleRegistration] = [:]
 
     static var keepScreenAwakePreferenceEnabled: Bool {
         UserDefaults.standard.bool(forKey: userDefaultsKey)
@@ -22,37 +32,63 @@ enum SessionIdleTimerController {
     }
 
     /// Call when local `SessionView` is on screen and timer state changes, or preference toggles.
-    static func syncLocalSession(isRunning: Bool, preferenceEnabled: Bool) {
-        applyDesiredIdleTimerState(
-            localSessionRunning: isRunning,
-            localSessionPreference: preferenceEnabled,
-            buddySessionActive: nil
-        )
+    static func syncLocalSession(appVM: AppViewModel, isRunning: Bool, preferenceEnabled: Bool) {
+        let reg = registration(for: appVM)
+        reg.localSessionRunning = isRunning
+        applyDesiredIdleTimerState(localSessionPreference: preferenceEnabled)
     }
 
     /// Call when buddy shared sit is in the `active` server state.
-    static func syncBuddySessionActive(_ active: Bool) {
-        applyDesiredIdleTimerState(
-            localSessionRunning: nil,
-            localSessionPreference: nil,
-            buddySessionActive: active
-        )
+    static func syncBuddySessionActive(appVM: AppViewModel, active: Bool) {
+        let reg = registration(for: appVM)
+        reg.buddySessionActive = active
+        applyDesiredIdleTimerState()
     }
 
-    /// Recompute from stored session flags and UserDefaults (e.g. after foreground).
-    static func applyDesiredIdleTimerState(
-        localSessionRunning: Bool? = nil,
-        localSessionPreference: Bool? = nil,
-        buddySessionActive: Bool? = nil
-    ) {
-        if let localSessionRunning {
-            lastLocalSessionRunning = localSessionRunning
-        }
-        if let buddySessionActive {
-            lastBuddySessionActive = buddySessionActive
-        }
+    /// Call from each window’s `RootView` when `scenePhase` changes.
+    static func syncSceneForegroundActive(appVM: AppViewModel, isForegroundActive: Bool) {
+        let reg = registration(for: appVM)
+        reg.sceneForegroundActive = isForegroundActive
+        applyDesiredIdleTimerState()
+    }
+
+    /// Recompute from all registrations and UserDefaults (e.g. after foreground).
+    static func applyDesiredIdleTimerState(localSessionPreference: Bool? = nil) {
+        pruneDeadRegistrations()
         let pref = localSessionPreference ?? keepScreenAwakePreferenceEnabled
-        let shouldDisable = (lastLocalSessionRunning && pref) || (lastBuddySessionActive && pref)
+        let shouldDisable = pref && registrations.values.contains { reg in
+            reg.appViewModel != nil && reg.sceneForegroundActive
+                && (reg.localSessionRunning || reg.buddySessionActive)
+        }
         UIApplication.shared.isIdleTimerDisabled = shouldDisable
+    }
+
+    /// True if any connected scene is foreground-active (multi-window safe).
+    static var hasForegroundActiveScene: Bool {
+        UIApplication.shared.connectedScenes.contains { scene in
+            scene.activationState == .foregroundActive
+        }
+    }
+
+    /// When the app has no foreground-active scene, force the idle timer on so the device can lock.
+    static func applyBackgroundIdleTimerPolicyIfNoForegroundScene() {
+        guard !hasForegroundActiveScene else { return }
+        UIApplication.shared.isIdleTimerDisabled = false
+    }
+
+    private static func registration(for appVM: AppViewModel) -> IdleRegistration {
+        let id = ObjectIdentifier(appVM)
+        if let existing = registrations[id] {
+            return existing
+        }
+        let reg = IdleRegistration(appViewModel: appVM)
+        registrations[id] = reg
+        return reg
+    }
+
+    private static func pruneDeadRegistrations() {
+        registrations = registrations.filter { _, reg in
+            reg.appViewModel != nil
+        }
     }
 }

--- a/ios/StillPointApp/Managers/SessionIdleTimerController.swift
+++ b/ios/StillPointApp/Managers/SessionIdleTimerController.swift
@@ -1,0 +1,41 @@
+import UIKit
+
+/// Central place to apply `UIApplication.shared.isIdleTimerDisabled` for active sits.
+/// Resets to `false` whenever the app is not in an active session UI or the user opts out.
+@MainActor
+enum SessionIdleTimerController {
+    private static let userDefaultsKey = "sp_keepScreenAwakeDuringSession"
+
+    static var keepScreenAwakePreferenceEnabled: Bool {
+        UserDefaults.standard.bool(forKey: userDefaultsKey)
+    }
+
+    static func setKeepScreenAwakePreferenceEnabled(_ enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: userDefaultsKey)
+        applyDesiredIdleTimerState()
+    }
+
+    /// Call when local `SessionView` is on screen and timer state changes, or preference toggles.
+    static func syncLocalSession(isRunning: Bool, preferenceEnabled: Bool) {
+        applyDesiredIdleTimerState(
+            localSessionRunning: isRunning,
+            localSessionPreference: preferenceEnabled
+        )
+    }
+
+    /// Call when buddy shared sit is in the `active` server state.
+    static func syncBuddySessionActive(_ active: Bool) {
+        applyDesiredIdleTimerState(buddySessionActive: active)
+    }
+
+    /// Recompute from stored preference and current flags (e.g. after foreground).
+    static func applyDesiredIdleTimerState(
+        localSessionRunning: Bool = false,
+        localSessionPreference: Bool? = nil,
+        buddySessionActive: Bool = false
+    ) {
+        let pref = localSessionPreference ?? keepScreenAwakePreferenceEnabled
+        let shouldDisable = (localSessionRunning && pref) || (buddySessionActive && pref)
+        UIApplication.shared.isIdleTimerDisabled = shouldDisable
+    }
+}

--- a/ios/StillPointApp/Managers/SessionIdleTimerController.swift
+++ b/ios/StillPointApp/Managers/SessionIdleTimerController.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// Central place to apply `UIApplication.shared.isIdleTimerDisabled` for active sits.
-/// Resets to `false` whenever the app is not in an active session UI or the user opts out.
+/// When the preference is off, or no sit timer is running, the system idle timer stays enabled.
 @MainActor
 enum SessionIdleTimerController {
     private static let userDefaultsKey = "sp_keepScreenAwakeDuringSession"

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -72,6 +72,13 @@ final class AppViewModel {
     }
     private var pendingBuddyInviteToken: String?
 
+    /// Persisted: keep device screen awake during an active sit when enabled.
+    var keepScreenAwakeDuringSession: Bool {
+        didSet {
+            SessionIdleTimerController.setKeepScreenAwakePreferenceEnabled(keepScreenAwakeDuringSession)
+        }
+    }
+
     var currentDay: Int {
         StillPoint.clampedCurrentDay(for: currentUser)
     }
@@ -89,6 +96,10 @@ final class AppViewModel {
         if case .buddySession = currentView { return true }
         if case .completion = currentView { return true }
         return false
+    }
+
+    init() {
+        self.keepScreenAwakeDuringSession = SessionIdleTimerController.keepScreenAwakePreferenceEnabled
     }
 
     func checkAuth() async {

--- a/ios/StillPointApp/Views/BuddySession/BuddySessionContainerView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddySessionContainerView.swift
@@ -54,14 +54,17 @@ struct BuddySessionContainerView: View {
             await saveCompletionIfPossible()
         }
         .onAppear {
-            SessionIdleTimerController.syncBuddySessionActive(vm.snapshot?.state == "active")
+            SessionIdleTimerController.syncBuddySessionActive(
+                appVM: appVM,
+                active: vm.snapshot?.state == "active"
+            )
         }
         .onDisappear {
             vm.stopPolling()
-            SessionIdleTimerController.syncBuddySessionActive(false)
+            SessionIdleTimerController.syncBuddySessionActive(appVM: appVM, active: false)
         }
         .onChange(of: vm.snapshot?.state) { _, newState in
-            SessionIdleTimerController.syncBuddySessionActive(newState == "active")
+            SessionIdleTimerController.syncBuddySessionActive(appVM: appVM, active: newState == "active")
             guard newState == "completed" else { return }
             Task { await saveCompletionIfPossible() }
         }

--- a/ios/StillPointApp/Views/BuddySession/BuddySessionContainerView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddySessionContainerView.swift
@@ -53,10 +53,15 @@ struct BuddySessionContainerView: View {
             vm.startPolling()
             await saveCompletionIfPossible()
         }
+        .onAppear {
+            SessionIdleTimerController.syncBuddySessionActive(vm.snapshot?.state == "active")
+        }
         .onDisappear {
             vm.stopPolling()
+            SessionIdleTimerController.syncBuddySessionActive(false)
         }
         .onChange(of: vm.snapshot?.state) { _, newState in
+            SessionIdleTimerController.syncBuddySessionActive(newState == "active")
             guard newState == "completed" else { return }
             Task { await saveCompletionIfPossible() }
         }

--- a/ios/StillPointApp/Views/RootView.swift
+++ b/ios/StillPointApp/Views/RootView.swift
@@ -97,16 +97,26 @@ struct RootView: View {
         }
         .animation(.easeInOut(duration: 0.3), value: appVM.currentView)
         .animation(.easeInOut(duration: 0.2), value: appVM.isLoading)
+        .onAppear {
+            SessionIdleTimerController.syncSceneForegroundActive(
+                appVM: appVM,
+                isForegroundActive: scenePhase == .active
+            )
+        }
         .task {
             await appVM.checkAuth()
         }
         .onChange(of: scenePhase) { _, phase in
+            SessionIdleTimerController.syncSceneForegroundActive(
+                appVM: appVM,
+                isForegroundActive: phase == .active
+            )
             if phase == .active {
                 appVM.appBlockingManager.refreshShielding()
                 SessionIdleTimerController.applyDesiredIdleTimerState()
             } else if phase == .inactive || phase == .background {
-                // Avoid leaving the device awake when the app is not visible (issue #87).
-                UIApplication.shared.isIdleTimerDisabled = false
+                // Multi-window: only clear when no scene is foreground-active (issue #87).
+                SessionIdleTimerController.applyBackgroundIdleTimerPolicyIfNoForegroundScene()
             }
         }
         .onOpenURL { url in

--- a/ios/StillPointApp/Views/RootView.swift
+++ b/ios/StillPointApp/Views/RootView.swift
@@ -103,6 +103,10 @@ struct RootView: View {
         .onChange(of: scenePhase) { _, phase in
             if phase == .active {
                 appVM.appBlockingManager.refreshShielding()
+                SessionIdleTimerController.applyDesiredIdleTimerState()
+            } else if phase == .inactive || phase == .background {
+                // Avoid leaving the device awake when the app is not visible (issue #87).
+                UIApplication.shared.isIdleTimerDisabled = false
             }
         }
         .onOpenURL { url in

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -110,39 +110,49 @@ struct SessionView: View {
         .onAppear {
             vm.start()
             SessionIdleTimerController.syncLocalSession(
+                appVM: appVM,
                 isRunning: sessionTimerRunning,
                 preferenceEnabled: appVM.keepScreenAwakeDuringSession
             )
         }
         .onDisappear {
-            SessionIdleTimerController.syncLocalSession(isRunning: false, preferenceEnabled: appVM.keepScreenAwakeDuringSession)
+            SessionIdleTimerController.syncLocalSession(
+                appVM: appVM,
+                isRunning: false,
+                preferenceEnabled: appVM.keepScreenAwakeDuringSession
+            )
         }
         .onChange(of: appVM.keepScreenAwakeDuringSession) { _, _ in
             SessionIdleTimerController.syncLocalSession(
+                appVM: appVM,
                 isRunning: sessionTimerRunning,
                 preferenceEnabled: appVM.keepScreenAwakeDuringSession
             )
         }
         .onChange(of: vm.isActive) { _, _ in
             SessionIdleTimerController.syncLocalSession(
+                appVM: appVM,
                 isRunning: sessionTimerRunning,
                 preferenceEnabled: appVM.keepScreenAwakeDuringSession
             )
         }
         .onChange(of: vm.isPaused) { _, _ in
             SessionIdleTimerController.syncLocalSession(
+                appVM: appVM,
                 isRunning: sessionTimerRunning,
                 preferenceEnabled: appVM.keepScreenAwakeDuringSession
             )
         }
         .onChange(of: vm.isAbandoned) { _, _ in
             SessionIdleTimerController.syncLocalSession(
+                appVM: appVM,
                 isRunning: sessionTimerRunning,
                 preferenceEnabled: appVM.keepScreenAwakeDuringSession
             )
         }
         .onChange(of: vm.isComplete) { _, isComplete in
             SessionIdleTimerController.syncLocalSession(
+                appVM: appVM,
                 isRunning: sessionTimerRunning,
                 preferenceEnabled: appVM.keepScreenAwakeDuringSession
             )

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -111,50 +111,43 @@ struct SessionView: View {
             vm.start()
             SessionIdleTimerController.syncLocalSession(
                 appVM: appVM,
-                isRunning: sessionTimerRunning,
-                preferenceEnabled: appVM.keepScreenAwakeDuringSession
+                isRunning: sessionTimerRunning
             )
         }
         .onDisappear {
             SessionIdleTimerController.syncLocalSession(
                 appVM: appVM,
-                isRunning: false,
-                preferenceEnabled: appVM.keepScreenAwakeDuringSession
+                isRunning: false
             )
         }
         .onChange(of: appVM.keepScreenAwakeDuringSession) { _, _ in
             SessionIdleTimerController.syncLocalSession(
                 appVM: appVM,
-                isRunning: sessionTimerRunning,
-                preferenceEnabled: appVM.keepScreenAwakeDuringSession
+                isRunning: sessionTimerRunning
             )
         }
         .onChange(of: vm.isActive) { _, _ in
             SessionIdleTimerController.syncLocalSession(
                 appVM: appVM,
-                isRunning: sessionTimerRunning,
-                preferenceEnabled: appVM.keepScreenAwakeDuringSession
+                isRunning: sessionTimerRunning
             )
         }
         .onChange(of: vm.isPaused) { _, _ in
             SessionIdleTimerController.syncLocalSession(
                 appVM: appVM,
-                isRunning: sessionTimerRunning,
-                preferenceEnabled: appVM.keepScreenAwakeDuringSession
+                isRunning: sessionTimerRunning
             )
         }
         .onChange(of: vm.isAbandoned) { _, _ in
             SessionIdleTimerController.syncLocalSession(
                 appVM: appVM,
-                isRunning: sessionTimerRunning,
-                preferenceEnabled: appVM.keepScreenAwakeDuringSession
+                isRunning: sessionTimerRunning
             )
         }
         .onChange(of: vm.isComplete) { _, isComplete in
             SessionIdleTimerController.syncLocalSession(
                 appVM: appVM,
-                isRunning: sessionTimerRunning,
-                preferenceEnabled: appVM.keepScreenAwakeDuringSession
+                isRunning: sessionTimerRunning
             )
             if isComplete && !vm.isAbandoned {
                 handleCompletion()

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import StillPointShared
+import UIKit
 
 struct SessionView: View {
     /// Space reserved when both distraction hold bar and controls are visible.
@@ -108,8 +109,43 @@ struct SessionView: View {
         }
         .onAppear {
             vm.start()
+            SessionIdleTimerController.syncLocalSession(
+                isRunning: sessionTimerRunning,
+                preferenceEnabled: appVM.keepScreenAwakeDuringSession
+            )
+        }
+        .onDisappear {
+            SessionIdleTimerController.syncLocalSession(isRunning: false, preferenceEnabled: appVM.keepScreenAwakeDuringSession)
+        }
+        .onChange(of: appVM.keepScreenAwakeDuringSession) { _, _ in
+            SessionIdleTimerController.syncLocalSession(
+                isRunning: sessionTimerRunning,
+                preferenceEnabled: appVM.keepScreenAwakeDuringSession
+            )
+        }
+        .onChange(of: vm.isActive) { _, _ in
+            SessionIdleTimerController.syncLocalSession(
+                isRunning: sessionTimerRunning,
+                preferenceEnabled: appVM.keepScreenAwakeDuringSession
+            )
+        }
+        .onChange(of: vm.isPaused) { _, _ in
+            SessionIdleTimerController.syncLocalSession(
+                isRunning: sessionTimerRunning,
+                preferenceEnabled: appVM.keepScreenAwakeDuringSession
+            )
+        }
+        .onChange(of: vm.isAbandoned) { _, _ in
+            SessionIdleTimerController.syncLocalSession(
+                isRunning: sessionTimerRunning,
+                preferenceEnabled: appVM.keepScreenAwakeDuringSession
+            )
         }
         .onChange(of: vm.isComplete) { _, isComplete in
+            SessionIdleTimerController.syncLocalSession(
+                isRunning: sessionTimerRunning,
+                preferenceEnabled: appVM.keepScreenAwakeDuringSession
+            )
             if isComplete && !vm.isAbandoned {
                 handleCompletion()
             }
@@ -163,6 +199,11 @@ struct SessionView: View {
 
     private var sessionInProgress: Bool {
         !vm.isComplete && !vm.isAbandoned && (vm.isActive || vm.isPaused)
+    }
+
+    /// Timer is running or paused (sit not finished); used for idle-timer / screen awake.
+    private var sessionTimerRunning: Bool {
+        sessionInProgress
     }
 
     private var bottomOverlayReserve: CGFloat {

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -204,9 +204,9 @@ struct SessionView: View {
         !vm.isComplete && !vm.isAbandoned && (vm.isActive || vm.isPaused)
     }
 
-    /// Timer is running or paused (sit not finished); used for idle-timer / screen awake.
+    /// Active sit timer only (not paused); idle timer may lock while paused.
     private var sessionTimerRunning: Bool {
-        sessionInProgress
+        vm.isActive && !vm.isPaused && !vm.isComplete && !vm.isAbandoned
     }
 
     private var bottomOverlayReserve: CGFloat {

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -59,6 +59,34 @@ struct SettingsView: View {
 
                 AppBlockingSettingsView(manager: appVM.appBlockingManager)
 
+                // Session display
+                VStack(alignment: .leading, spacing: SPSpacing.s2) {
+                    Text("SESSION")
+                        .font(SPFont.mono(11, weight: .medium))
+                        .foregroundStyle(Color(SPColor.fg4))
+                        .tracking(2)
+
+                    Toggle(isOn: Bindable(appVM).keepScreenAwakeDuringSession) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Keep screen on during session")
+                                .font(SPFont.mono(13))
+                                .foregroundStyle(Color(SPColor.fg))
+                            Text("Prevents auto-lock while a sit timer is running")
+                                .font(SPFont.serif(13, weight: .light))
+                                .foregroundStyle(Color(SPColor.fg4))
+                        }
+                    }
+                    .tint(SPColor.green)
+                    .accessibilityIdentifier("settings.keepScreenAwakeDuringSessionToggle")
+                }
+                .padding(SPSpacing.s3)
+                .background(SPColor.surface1)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(SPColor.border1)
+                )
+
                 // Public board toggle
                 VStack(alignment: .leading, spacing: SPSpacing.s2) {
                     Text("VISIBILITY")


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4e298f6-bf24-4b93-8ea9-1382927de0a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4e298f6-bf24-4b93-8ea9-1382927de0a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Let users keep the iPhone screen awake during an active session**

### What Changed
- Added a Settings toggle to keep the screen on during a session, and saved that choice between app launches
- The screen stays awake only while an active sit or active shared session is running, then returns to normal auto-lock when the session ends, is dismissed, or the setting is turned off
- Paused sessions no longer prevent auto-lock
- Screen-lock behavior now stays correct when switching between windows or bringing the app back to the foreground

### Impact
`✅ Fewer interruptions during meditation sessions`
`✅ Auto-lock returns when sessions are paused or ended`
`✅ Clearer screen behavior in multi-window use`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=ItY6LMAiAtZkIh315ATOqY4AH0xZxw_aFFkmp9HJ4BY&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
