### PR TITLE
fix(e2e): provision fixture user before mobile web Playwright (closes #435)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ POSTGRES_URL=postgresql://user:password@host/database?sslmode=require
 # E2E test credentials (placeholders only; real values live in CI/local secret stores)
 # E2E_TEST_USER_EMAIL=test+<run-id>@stillpoint.local
 # E2E_TEST_USER_PASSWORD=changeme
+# Credentialed mobile web E2E against a remote app (optional; see e2e/README.md):
+# E2E_WEB_EMAIL=fixture@stillpoint.local
+# E2E_WEB_PASSWORD=at-least-8-chars
+# E2E_WEB_SETUP_USER=true
 # E2E_BASE_URL=http://127.0.0.1:3000
 
 # JWT secret for auth tokens (generate with: openssl rand -base64 32)

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -10,6 +10,13 @@ jobs:
   e2e-mobile:
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    env:
+      E2E_WEB_SETUP_USER: "true"
+      POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
+      E2E_WEB_EMAIL: ${{ secrets.E2E_WEB_EMAIL }}
+      E2E_WEB_PASSWORD: ${{ secrets.E2E_WEB_PASSWORD }}
+      E2E_TEST_USER_EMAIL: ${{ secrets.E2E_TEST_USER_EMAIL }}
+      E2E_TEST_USER_PASSWORD: ${{ secrets.E2E_TEST_USER_PASSWORD }}
     strategy:
       fail-fast: false
       matrix:
@@ -34,11 +41,6 @@ jobs:
         run: npx playwright install --with-deps chromium webkit
 
       - name: Run mobile e2e project
-        env:
-          E2E_WEB_SETUP_USER: "true"
-          POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
-          E2E_WEB_EMAIL: ${{ secrets.E2E_WEB_EMAIL }}
-          E2E_WEB_PASSWORD: ${{ secrets.E2E_WEB_PASSWORD }}
         run: npx playwright test --project ${{ matrix.project }}
 
       - name: Upload Playwright report

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -34,6 +34,11 @@ jobs:
         run: npx playwright install --with-deps chromium webkit
 
       - name: Run mobile e2e project
+        env:
+          E2E_WEB_SETUP_USER: "true"
+          POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
+          E2E_WEB_EMAIL: ${{ secrets.E2E_WEB_EMAIL }}
+          E2E_WEB_PASSWORD: ${{ secrets.E2E_WEB_PASSWORD }}
         run: npx playwright test --project ${{ matrix.project }}
 
       - name: Upload Playwright report

--- a/docs/testing/e2e-policy.md
+++ b/docs/testing/e2e-policy.md
@@ -69,7 +69,7 @@ Checks:
 - `npm run e2e:policy:secrets`
 - `scripts/e2e/run-ios-tests.sh` rejects production-looking user emails when credentials are provided.
 - For credentialed flows, CI jobs should provide `E2E_TEST_USER_EMAIL` and `E2E_TEST_USER_PASSWORD` via secrets.
-- Mobile web Playwright against a real backend: use `E2E_WEB_EMAIL` / `E2E_WEB_PASSWORD` plus `POSTGRES_URL` (non-production Neon only) and `E2E_WEB_SETUP_USER=true` so `e2e/global-setup.ts` upserts the fixture user before tests (`e2e/README.md`).
+- Mobile web Playwright against a real backend: use `E2E_WEB_EMAIL` / `E2E_WEB_PASSWORD` plus `POSTGRES_URL` (non-production Neon only) and `E2E_WEB_SETUP_USER=true` so `e2e/global-setup.ts` upserts the fixture user before tests (`e2e/README.md`). When those values are missing in CI (for example fork PRs without secrets), setup is skipped and tests continue with mocked APIs until real-auth coverage is added.
 
 ## 5) Environment guardrails
 

--- a/docs/testing/e2e-policy.md
+++ b/docs/testing/e2e-policy.md
@@ -69,6 +69,7 @@ Checks:
 - `npm run e2e:policy:secrets`
 - `scripts/e2e/run-ios-tests.sh` rejects production-looking user emails when credentials are provided.
 - For credentialed flows, CI jobs should provide `E2E_TEST_USER_EMAIL` and `E2E_TEST_USER_PASSWORD` via secrets.
+- Mobile web Playwright against a real backend: use `E2E_WEB_EMAIL` / `E2E_WEB_PASSWORD` plus `POSTGRES_URL` (non-production Neon only) and `E2E_WEB_SETUP_USER=true` so `e2e/global-setup.ts` upserts the fixture user before tests (`e2e/README.md`).
 
 ## 5) Environment guardrails
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -26,13 +26,13 @@ Configure these in **GitHub Actions secrets** (and the same values in your non-p
 | `E2E_WEB_PASSWORD` | Password that must match the hash stored for that email. |
 | `POSTGRES_URL` | Neon **non-production** connection string used to upsert the fixture user before tests. |
 
-Optional aliases: `E2E_TEST_USER_EMAIL` / `E2E_TEST_USER_PASSWORD` are read if the `E2E_WEB_*` names are unset.
+Aliases: if `E2E_WEB_EMAIL` or `E2E_WEB_PASSWORD` is unset **or empty** (GitHub Actions resolves missing secrets to `""`), `E2E_TEST_USER_EMAIL` / `E2E_TEST_USER_PASSWORD` are used instead. The fixture username is always `e2e_` plus 12 hex chars derived from the email so it stays within the app’s 3–30 character username rules and avoids collisions on `email` vs `username` uniqueness.
 
 **Never** commit real values, paste them into issues or PRs, or print them in logs.
 
 ### Automatic provisioning (recommended for CI)
 
-The workflow `.github/workflows/e2e-mobile.yml` sets `E2E_WEB_SETUP_USER=true` and runs Playwright `globalSetup`, which upserts the fixture user via `scripts/e2e/provision-e2e-web-user.ts` (same Neon guard as `scripts/seed.ts`: hostname must be `*.neon.tech`). The hash is derived from `E2E_WEB_PASSWORD`, so it stays aligned with GitHub secrets after deploys, manual DB wipes, or password rotation.
+The workflow `.github/workflows/e2e-mobile.yml` sets `E2E_WEB_SETUP_USER=true` and runs Playwright `globalSetup`, which upserts the fixture user via `scripts/e2e/provision-e2e-web-user.ts` when `POSTGRES_URL` and credentials are all non-empty (same Neon guard as `scripts/seed.ts`: hostname must be `*.neon.tech`). If any of those are missing, global setup **skips** provisioning so the default mock-based suite still passes; configure secrets to enable real DB alignment. The password hash follows whichever non-empty password env pair is selected.
 
 Manual one-off (same as CI global setup):
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,67 @@
+# Mobile web E2E (Playwright)
+
+Playwright config lives at the repo root (`playwright.config.ts`). Tests are under `e2e/` and use the `mobile-chromium-narrow`, `mobile-chromium-wide`, and `mobile-webkit-iphone` projects by default.
+
+## Local run (mock API)
+
+By default, `e2e/fixtures/auth.fixture.ts` mocks `/api/**` so no database or credentials are required:
+
+```bash
+npm ci
+npx playwright install --with-deps chromium webkit
+npm run test:e2e
+```
+
+## Credentialed run against a remote app (CI / preview)
+
+When tests call the real backend (for example after adding real-auth flows), login returns **401** if the fixture user row is missing or if the password hash in the database no longer matches the secret used in CI.
+
+### Fixture user and secrets
+
+Configure these in **GitHub Actions secrets** (and the same values in your non-production database policy):
+
+| Variable | Purpose |
+|----------|---------|
+| `E2E_WEB_EMAIL` | Fixture account email (stored lowercased by the app). |
+| `E2E_WEB_PASSWORD` | Password that must match the hash stored for that email. |
+| `POSTGRES_URL` | Neon **non-production** connection string used to upsert the fixture user before tests. |
+
+Optional aliases: `E2E_TEST_USER_EMAIL` / `E2E_TEST_USER_PASSWORD` are read if the `E2E_WEB_*` names are unset.
+
+**Never** commit real values, paste them into issues or PRs, or print them in logs.
+
+### Automatic provisioning (recommended for CI)
+
+The workflow `.github/workflows/e2e-mobile.yml` sets `E2E_WEB_SETUP_USER=true` and runs Playwright `globalSetup`, which upserts the fixture user via `scripts/e2e/provision-e2e-web-user.ts` (same Neon guard as `scripts/seed.ts`: hostname must be `*.neon.tech`). The hash is derived from `E2E_WEB_PASSWORD`, so it stays aligned with GitHub secrets after deploys, manual DB wipes, or password rotation.
+
+Manual one-off (same as CI global setup):
+
+```bash
+export SEED_CONFIRM=still-point-nonprod  # not used by setup-web-user; optional context
+export POSTGRES_URL="postgresql://..."   # Neon non-prod only
+export E2E_WEB_EMAIL="..."               # from secret store
+export E2E_WEB_PASSWORD="..."            # from secret store
+export E2E_WEB_SETUP_USER=true           # fail if creds/db missing
+npm run e2e:setup-web-user
+```
+
+Without `E2E_WEB_SETUP_USER=true`, the script skips if creds or `POSTGRES_URL` are missing (safe for local mock runs).
+
+### Re-seed / diagnostics (operators)
+
+**Root-cause triage** (run against the dev/staging DB; replace the email placeholder with the value from `E2E_WEB_EMAIL` **only in your shell**, never in the issue or git):
+
+```bash
+psql "$POSTGRES_URL" -c "SELECT email, created_at, updated_at FROM users WHERE email = '<use-secret-from-E2E_WEB_EMAIL>'"
+psql "$POSTGRES_URL" -c "SELECT email, created_at FROM users ORDER BY created_at DESC LIMIT 10"
+```
+
+Interpretation (see issue #435):
+
+- No row for the fixture + other recent rows exist → likely post-deploy or automated wipe; rely on **automatic provisioning** above or re-run `npm run e2e:setup-web-user`.
+- Row exists but login still 401 → password hash mismatch; confirm `E2E_WEB_PASSWORD` matches what was written (re-run provisioning with the current secret).
+- Row exists and local login works with the same secrets → inspect CI env wiring (wrong secret name, wrong workflow, or missing `POSTGRES_URL`).
+
+### Policy alignment
+
+Cross-cutting policy: `docs/testing/e2e-policy.md`. Full app seed for demo data remains `SEED_CONFIRM=still-point-nonprod npm run db:seed` (`scripts/seed.ts`); that is separate from the **single-user** E2E fixture upsert described here.

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,23 +1,30 @@
 import type { FullConfig } from "@playwright/test";
 import { provisionE2EWebUser, readE2EWebCredentials } from "../scripts/e2e/provision-e2e-web-user";
 
+function trimEnv(key: string): string {
+  return (process.env[key] ?? "").trim();
+}
+
 /**
  * Ensures the credentialed E2E user exists in Neon before tests hit `/api/auth/login`.
  * Aligns DB password hash with `E2E_WEB_PASSWORD` / `E2E_TEST_USER_PASSWORD` from CI.
+ *
+ * When `E2E_WEB_SETUP_USER=true` but secrets are not configured (empty in GitHub Actions),
+ * skips so default mock-based mobile E2E keeps passing until operators add secrets.
  */
 export default async function globalSetup(_config: FullConfig) {
   if (process.env.E2E_WEB_SETUP_USER !== "true") {
     return;
   }
 
+  const postgresUrl = trimEnv("POSTGRES_URL");
   const creds = readE2EWebCredentials();
-  if (!creds) {
-    throw new Error(
-      "E2E_WEB_SETUP_USER=true requires E2E_WEB_EMAIL and E2E_WEB_PASSWORD (or E2E_TEST_USER_*).",
+
+  if (!postgresUrl || !creds) {
+    console.warn(
+      "[e2e:global-setup] E2E_WEB_SETUP_USER=true but POSTGRES_URL or fixture credentials are missing — skipping DB provisioning (mock API tests will still run).",
     );
-  }
-  if (!process.env.POSTGRES_URL) {
-    throw new Error("E2E_WEB_SETUP_USER=true requires POSTGRES_URL.");
+    return;
   }
 
   await provisionE2EWebUser(creds);

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,24 @@
+import type { FullConfig } from "@playwright/test";
+import { provisionE2EWebUser, readE2EWebCredentials } from "../scripts/e2e/provision-e2e-web-user";
+
+/**
+ * Ensures the credentialed E2E user exists in Neon before tests hit `/api/auth/login`.
+ * Aligns DB password hash with `E2E_WEB_PASSWORD` / `E2E_TEST_USER_PASSWORD` from CI.
+ */
+export default async function globalSetup(_config: FullConfig) {
+  if (process.env.E2E_WEB_SETUP_USER !== "true") {
+    return;
+  }
+
+  const creds = readE2EWebCredentials();
+  if (!creds) {
+    throw new Error(
+      "E2E_WEB_SETUP_USER=true requires E2E_WEB_EMAIL and E2E_WEB_PASSWORD (or E2E_TEST_USER_*).",
+    );
+  }
+  if (!process.env.POSTGRES_URL) {
+    throw new Error("E2E_WEB_SETUP_USER=true requires POSTGRES_URL.");
+  }
+
+  await provisionE2EWebUser(creds);
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "e2e:policy:no-sleep": "node scripts/e2e/check-no-naked-sleep.mjs",
     "e2e:policy:secrets": "node scripts/e2e/check-test-secrets.mjs",
     "e2e:policy": "E2E_BASE_URL=${E2E_BASE_URL:-http://127.0.0.1:3000} npm run e2e:policy:no-sleep && npm run e2e:policy:secrets && E2E_BASE_URL=${E2E_BASE_URL:-http://127.0.0.1:3000} npm run e2e:guard",
+    "e2e:setup-web-user": "tsx scripts/e2e/setup-web-user.ts",
     "ios:app-store:dry-run": "node scripts/ios-app-store-dry-run.mjs",
     "e2e:web:smoke": "E2E_BASE_URL=${E2E_BASE_URL:-http://127.0.0.1:3000} npm run e2e:guard && node scripts/e2e/run-playwright-lane.mjs smoke @smoke 1",
     "e2e:web:critical": "E2E_BASE_URL=${E2E_BASE_URL:-http://127.0.0.1:3000} npm run e2e:guard && node scripts/e2e/run-playwright-lane.mjs critical @critical 2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,7 @@ const shouldReuseExternalServer = process.env.E2E_REUSE_SERVER === "true" || Boo
 
 export default defineConfig({
   testDir: "./e2e",
+  globalSetup: process.env.E2E_WEB_SETUP_USER === "true" ? "./e2e/global-setup.ts" : undefined,
   timeout: 45_000,
   expect: {
     timeout: 8_000,

--- a/scripts/e2e/provision-e2e-web-user.ts
+++ b/scripts/e2e/provision-e2e-web-user.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { loadEnvConfig } from "@next/env";
 import bcrypt from "bcryptjs";
-import { eq, sql } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 import { closePoolDb, poolDb } from "../../src/db/pool";
 import { users } from "../../src/db/schema";
 import { MAX_USERNAME_LENGTH, MIN_USERNAME_LENGTH, USERNAME_REGEX } from "../../src/lib/username";
@@ -62,50 +62,37 @@ export async function provisionE2EWebUser(options: ProvisionE2EWebUserOptions): 
   const username = deriveUsername(email);
 
   try {
-    const [existing] = await poolDb.select({ id: users.id }).from(users).where(eq(users.email, email)).limit(1);
+    // Another account owning this derived username blocks provisioning (rare; hash is unique per email).
+    const [nameClash] = await poolDb
+      .select({ id: users.id })
+      .from(users)
+      .where(sql`lower(${users.username}) = ${username.toLowerCase()} and lower(${users.email}) <> ${email}`)
+      .limit(1);
 
-    if (existing) {
-      const [nameClash] = await poolDb
-        .select({ id: users.id })
-        .from(users)
-        .where(sql`lower(${users.username}) = ${username.toLowerCase()} and ${users.id} <> ${existing.id}`)
-        .limit(1);
+    if (nameClash) {
+      throw new Error(
+        "E2E fixture username collides with another account; remove the conflicting user or change E2E_WEB_EMAIL.",
+      );
+    }
 
-      if (nameClash) {
-        throw new Error(
-          "E2E fixture username collides with another account; remove the conflicting user or change E2E_WEB_EMAIL.",
-        );
-      }
-
-      await poolDb
-        .update(users)
-        .set({
-          passwordHash,
-          username,
-          updatedAt: new Date(),
-        })
-        .where(eq(users.id, existing.id));
-    } else {
-      const [clash] = await poolDb
-        .select({ id: users.id })
-        .from(users)
-        .where(sql`lower(${users.username}) = ${username.toLowerCase()}`)
-        .limit(1);
-
-      if (clash) {
-        throw new Error(
-          "E2E fixture username is taken by another account; free the derived username or use a different E2E_WEB_EMAIL.",
-        );
-      }
-
-      await poolDb.insert(users).values({
+    // Single atomic upsert on email so parallel Playwright matrix jobs do not race on INSERT.
+    await poolDb
+      .insert(users)
+      .values({
         email,
         username,
         passwordHash,
         currentDay: 1,
         isPublic: false,
+      })
+      .onConflictDoUpdate({
+        target: users.email,
+        set: {
+          passwordHash,
+          username,
+          updatedAt: new Date(),
+        },
       });
-    }
   } finally {
     await closePoolDb();
   }

--- a/scripts/e2e/provision-e2e-web-user.ts
+++ b/scripts/e2e/provision-e2e-web-user.ts
@@ -1,0 +1,95 @@
+import { loadEnvConfig } from "@next/env";
+import bcrypt from "bcryptjs";
+import { poolDb } from "../../src/db/pool";
+import { users } from "../../src/db/schema";
+
+loadEnvConfig(process.cwd());
+
+/** Rejects non-Neon or malformed URLs (same guard as `scripts/seed.ts`). */
+function assertNeonNonProdPostgresUrl(rawUrl: string) {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error("POSTGRES_URL is not a valid URL.");
+  }
+
+  if (parsed.protocol !== "postgres:" && parsed.protocol !== "postgresql:") {
+    throw new Error("POSTGRES_URL must use postgres:// or postgresql://.");
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  if (!host.endsWith(".neon.tech") && host !== "neon.tech") {
+    throw new Error(
+      "Refusing to provision E2E user: POSTGRES_URL hostname must be a Neon host (*.neon.tech).",
+    );
+  }
+}
+
+function deriveUsername(email: string): string {
+  const local = (email.split("@")[0] ?? "user").replace(/[^a-z0-9]/gi, "_").replace(/_+/g, "_");
+  const base = `e2e_${local}`.toLowerCase();
+  return base.slice(0, 50);
+}
+
+export type ProvisionE2EWebUserOptions = {
+  email: string;
+  password: string;
+};
+
+/**
+ * Upserts the credentialed E2E web user so its password hash matches CI secrets
+ * (survives empty DB, manual wipes, or secret rotation without a manual re-seed).
+ */
+export async function provisionE2EWebUser(options: ProvisionE2EWebUserOptions): Promise<void> {
+  if (process.env.NODE_ENV === "production") {
+    throw new Error("Refusing to provision E2E user with NODE_ENV=production.");
+  }
+
+  const postgresUrl = process.env.POSTGRES_URL;
+  if (!postgresUrl) {
+    throw new Error("POSTGRES_URL is required to provision the E2E web user.");
+  }
+
+  assertNeonNonProdPostgresUrl(postgresUrl);
+
+  const email = options.email.trim().toLowerCase();
+  const password = options.password;
+  if (!email || !email.includes("@")) {
+    throw new Error("E2E email must be a non-empty address.");
+  }
+  if (password.length < 8) {
+    throw new Error("E2E password must be at least 8 characters.");
+  }
+
+  const passwordHash = await bcrypt.hash(password, 12);
+  const username = deriveUsername(email);
+
+  await poolDb
+    .insert(users)
+    .values({
+      email,
+      username,
+      passwordHash,
+      currentDay: 1,
+      isPublic: false,
+    })
+    .onConflictDoUpdate({
+      target: users.email,
+      set: {
+        passwordHash,
+        updatedAt: new Date(),
+      },
+    });
+
+  console.log("[e2e:setup-web-user] Upserted fixture user (email redacted).");
+}
+
+export function readE2EWebCredentials(): { email: string; password: string } | null {
+  const email = (process.env.E2E_WEB_EMAIL ?? process.env.E2E_TEST_USER_EMAIL ?? "").trim();
+  const password = process.env.E2E_WEB_PASSWORD ?? process.env.E2E_TEST_USER_PASSWORD ?? "";
+  if (!email || !password) {
+    return null;
+  }
+  return { email, password };
+}

--- a/scripts/e2e/provision-e2e-web-user.ts
+++ b/scripts/e2e/provision-e2e-web-user.ts
@@ -5,7 +5,7 @@ import { sql } from "drizzle-orm";
 import { closePoolDb, poolDb } from "../../src/db/pool";
 import { users } from "../../src/db/schema";
 import { MAX_USERNAME_LENGTH, MIN_USERNAME_LENGTH, USERNAME_REGEX } from "../../src/lib/username";
-import { assertNeonNonProdPostgresUrl } from "../lib/assert-neon-postgres-url";
+import { assertNeonHostedPostgresUrl } from "../lib/assert-neon-postgres-url";
 
 loadEnvConfig(process.cwd());
 
@@ -42,12 +42,13 @@ export async function provisionE2EWebUser(options: ProvisionE2EWebUserOptions): 
     throw new Error("Refusing to provision E2E user with NODE_ENV=production.");
   }
 
-  const postgresUrl = process.env.POSTGRES_URL;
+  const postgresUrl = (process.env.POSTGRES_URL ?? "").trim();
   if (!postgresUrl) {
     throw new Error("POSTGRES_URL is required to provision the E2E web user.");
   }
 
-  assertNeonNonProdPostgresUrl(postgresUrl);
+  assertNeonHostedPostgresUrl(postgresUrl);
+  process.env.POSTGRES_URL = postgresUrl;
 
   const email = options.email.trim().toLowerCase();
   const password = options.password;

--- a/scripts/e2e/provision-e2e-web-user.ts
+++ b/scripts/e2e/provision-e2e-web-user.ts
@@ -1,35 +1,31 @@
+import { createHash } from "node:crypto";
 import { loadEnvConfig } from "@next/env";
 import bcrypt from "bcryptjs";
-import { poolDb } from "../../src/db/pool";
+import { eq, sql } from "drizzle-orm";
+import { closePoolDb, poolDb } from "../../src/db/pool";
 import { users } from "../../src/db/schema";
+import { MAX_USERNAME_LENGTH, MIN_USERNAME_LENGTH, USERNAME_REGEX } from "../../src/lib/username";
+import { assertNeonNonProdPostgresUrl } from "../lib/assert-neon-postgres-url";
 
 loadEnvConfig(process.cwd());
 
-/** Rejects non-Neon or malformed URLs (same guard as `scripts/seed.ts`). */
-function assertNeonNonProdPostgresUrl(rawUrl: string) {
-  let parsed: URL;
-  try {
-    parsed = new URL(rawUrl);
-  } catch {
-    throw new Error("POSTGRES_URL is not a valid URL.");
-  }
-
-  if (parsed.protocol !== "postgres:" && parsed.protocol !== "postgresql:") {
-    throw new Error("POSTGRES_URL must use postgres:// or postgresql://.");
-  }
-
-  const host = parsed.hostname.toLowerCase();
-  if (!host.endsWith(".neon.tech") && host !== "neon.tech") {
-    throw new Error(
-      "Refusing to provision E2E user: POSTGRES_URL hostname must be a Neon host (*.neon.tech).",
-    );
-  }
+function trimEnv(key: string): string {
+  return (process.env[key] ?? "").trim();
 }
 
+/** Username derived from email hash so it stays unique and within app contract (3–30 chars). */
 function deriveUsername(email: string): string {
-  const local = (email.split("@")[0] ?? "user").replace(/[^a-z0-9]/gi, "_").replace(/_+/g, "_");
-  const base = `e2e_${local}`.toLowerCase();
-  return base.slice(0, 50);
+  const normalized = email.trim().toLowerCase();
+  const suffix = createHash("sha256").update(normalized).digest("hex").slice(0, 12);
+  const candidate = `e2e_${suffix}`;
+  if (
+    candidate.length < MIN_USERNAME_LENGTH ||
+    candidate.length > MAX_USERNAME_LENGTH ||
+    !USERNAME_REGEX.test(candidate)
+  ) {
+    throw new Error("Internal error: derived E2E username does not satisfy app contract.");
+  }
+  return candidate;
 }
 
 export type ProvisionE2EWebUserOptions = {
@@ -65,31 +61,70 @@ export async function provisionE2EWebUser(options: ProvisionE2EWebUserOptions): 
   const passwordHash = await bcrypt.hash(password, 12);
   const username = deriveUsername(email);
 
-  await poolDb
-    .insert(users)
-    .values({
-      email,
-      username,
-      passwordHash,
-      currentDay: 1,
-      isPublic: false,
-    })
-    .onConflictDoUpdate({
-      target: users.email,
-      set: {
+  try {
+    const [existing] = await poolDb.select({ id: users.id }).from(users).where(eq(users.email, email)).limit(1);
+
+    if (existing) {
+      const [nameClash] = await poolDb
+        .select({ id: users.id })
+        .from(users)
+        .where(sql`lower(${users.username}) = ${username.toLowerCase()} and ${users.id} <> ${existing.id}`)
+        .limit(1);
+
+      if (nameClash) {
+        throw new Error(
+          "E2E fixture username collides with another account; remove the conflicting user or change E2E_WEB_EMAIL.",
+        );
+      }
+
+      await poolDb
+        .update(users)
+        .set({
+          passwordHash,
+          username,
+          updatedAt: new Date(),
+        })
+        .where(eq(users.id, existing.id));
+    } else {
+      const [clash] = await poolDb
+        .select({ id: users.id })
+        .from(users)
+        .where(sql`lower(${users.username}) = ${username.toLowerCase()}`)
+        .limit(1);
+
+      if (clash) {
+        throw new Error(
+          "E2E fixture username is taken by another account; free the derived username or use a different E2E_WEB_EMAIL.",
+        );
+      }
+
+      await poolDb.insert(users).values({
+        email,
+        username,
         passwordHash,
-        updatedAt: new Date(),
-      },
-    });
+        currentDay: 1,
+        isPublic: false,
+      });
+    }
+  } finally {
+    await closePoolDb();
+  }
 
   console.log("[e2e:setup-web-user] Upserted fixture user (email redacted).");
 }
 
 export function readE2EWebCredentials(): { email: string; password: string } | null {
-  const email = (process.env.E2E_WEB_EMAIL ?? process.env.E2E_TEST_USER_EMAIL ?? "").trim();
-  const password = process.env.E2E_WEB_PASSWORD ?? process.env.E2E_TEST_USER_PASSWORD ?? "";
-  if (!email || !password) {
-    return null;
+  const webEmail = trimEnv("E2E_WEB_EMAIL");
+  const webPassword = trimEnv("E2E_WEB_PASSWORD");
+  if (webEmail && webPassword) {
+    return { email: webEmail, password: webPassword };
   }
-  return { email, password };
+
+  const testEmail = trimEnv("E2E_TEST_USER_EMAIL");
+  const testPassword = trimEnv("E2E_TEST_USER_PASSWORD");
+  if (testEmail && testPassword) {
+    return { email: testEmail, password: testPassword };
+  }
+
+  return null;
 }

--- a/scripts/e2e/setup-web-user.ts
+++ b/scripts/e2e/setup-web-user.ts
@@ -1,23 +1,21 @@
 import { provisionE2EWebUser, readE2EWebCredentials } from "./provision-e2e-web-user";
 
+function trimEnv(key: string): string {
+  return (process.env[key] ?? "").trim();
+}
+
 async function main() {
   const force = process.env.E2E_WEB_SETUP_USER === "true";
   const creds = readE2EWebCredentials();
-  if (!creds) {
+  const postgresUrl = trimEnv("POSTGRES_URL");
+
+  if (!creds || !postgresUrl) {
     if (force) {
       throw new Error(
-        "E2E_WEB_SETUP_USER=true requires E2E_WEB_EMAIL and E2E_WEB_PASSWORD (or E2E_TEST_USER_EMAIL / E2E_TEST_USER_PASSWORD).",
+        "E2E_WEB_SETUP_USER=true requires POSTGRES_URL plus E2E_WEB_EMAIL/E2E_WEB_PASSWORD or E2E_TEST_USER_EMAIL/E2E_TEST_USER_PASSWORD (non-empty after trim).",
       );
     }
-    console.log("[e2e:setup-web-user] Skipping: no E2E_WEB_* or E2E_TEST_USER_* credentials set.");
-    return;
-  }
-
-  if (!process.env.POSTGRES_URL) {
-    if (force) {
-      throw new Error("E2E_WEB_SETUP_USER=true requires POSTGRES_URL.");
-    }
-    console.log("[e2e:setup-web-user] Skipping: POSTGRES_URL not set.");
+    console.log("[e2e:setup-web-user] Skipping: POSTGRES_URL or fixture credentials not set.");
     return;
   }
 

--- a/scripts/e2e/setup-web-user.ts
+++ b/scripts/e2e/setup-web-user.ts
@@ -1,0 +1,30 @@
+import { provisionE2EWebUser, readE2EWebCredentials } from "./provision-e2e-web-user";
+
+async function main() {
+  const force = process.env.E2E_WEB_SETUP_USER === "true";
+  const creds = readE2EWebCredentials();
+  if (!creds) {
+    if (force) {
+      throw new Error(
+        "E2E_WEB_SETUP_USER=true requires E2E_WEB_EMAIL and E2E_WEB_PASSWORD (or E2E_TEST_USER_EMAIL / E2E_TEST_USER_PASSWORD).",
+      );
+    }
+    console.log("[e2e:setup-web-user] Skipping: no E2E_WEB_* or E2E_TEST_USER_* credentials set.");
+    return;
+  }
+
+  if (!process.env.POSTGRES_URL) {
+    if (force) {
+      throw new Error("E2E_WEB_SETUP_USER=true requires POSTGRES_URL.");
+    }
+    console.log("[e2e:setup-web-user] Skipping: POSTGRES_URL not set.");
+    return;
+  }
+
+  await provisionE2EWebUser(creds);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/lib/assert-neon-postgres-url.ts
+++ b/scripts/lib/assert-neon-postgres-url.ts
@@ -1,0 +1,20 @@
+/** Rejects non-Neon or malformed URLs so scripts cannot target arbitrary hosts by mistake. */
+export function assertNeonNonProdPostgresUrl(rawUrl: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error("POSTGRES_URL is not a valid URL.");
+  }
+
+  if (parsed.protocol !== "postgres:" && parsed.protocol !== "postgresql:") {
+    throw new Error("POSTGRES_URL must use postgres:// or postgresql://.");
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  if (!host.endsWith(".neon.tech") && host !== "neon.tech") {
+    throw new Error(
+      "Refusing to use POSTGRES_URL: hostname must be a Neon host (*.neon.tech). Point POSTGRES_URL at your non-production Neon branch.",
+    );
+  }
+}

--- a/scripts/lib/assert-neon-postgres-url.ts
+++ b/scripts/lib/assert-neon-postgres-url.ts
@@ -1,5 +1,9 @@
-/** Rejects non-Neon or malformed URLs so scripts cannot target arbitrary hosts by mistake. */
-export function assertNeonNonProdPostgresUrl(rawUrl: string): void {
+/**
+ * Ensures `POSTGRES_URL` is a well-formed `postgres(s)` URL whose host is on Neon
+ * (`*.neon.tech`). This does **not** detect production vs non-production: use separate
+ * credentials per environment and/or operator confirmation (e.g. `SEED_CONFIRM` on seed).
+ */
+export function assertNeonHostedPostgresUrl(rawUrl: string): void {
   let parsed: URL;
   try {
     parsed = new URL(rawUrl);
@@ -14,7 +18,7 @@ export function assertNeonNonProdPostgresUrl(rawUrl: string): void {
   const host = parsed.hostname.toLowerCase();
   if (!host.endsWith(".neon.tech") && host !== "neon.tech") {
     throw new Error(
-      "Refusing to use POSTGRES_URL: hostname must be a Neon host (*.neon.tech). Point POSTGRES_URL at your non-production Neon branch.",
+      "Refusing to use POSTGRES_URL: hostname must be a Neon host (*.neon.tech).",
     );
   }
 }

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -5,6 +5,7 @@ import type { NeonDatabase } from "drizzle-orm/neon-serverless";
 import { poolDb } from "../src/db/pool";
 import * as schema from "../src/db/schema";
 import { friendships, sessions, thoughts, users } from "../src/db/schema";
+import { assertNeonNonProdPostgresUrl } from "./lib/assert-neon-postgres-url";
 
 loadEnvConfig(process.cwd());
 
@@ -48,27 +49,6 @@ function buildSeedUsers(runId: string): SeedUser[] {
 }
 
 type AppDb = NeonDatabase<typeof schema>;
-
-/** Rejects non-Neon or malformed URLs so the seed script cannot target arbitrary hosts by mistake. */
-function assertNeonNonProdPostgresUrl(rawUrl: string) {
-  let parsed: URL;
-  try {
-    parsed = new URL(rawUrl);
-  } catch {
-    throw new Error("POSTGRES_URL is not a valid URL.");
-  }
-
-  if (parsed.protocol !== "postgres:" && parsed.protocol !== "postgresql:") {
-    throw new Error("POSTGRES_URL must use postgres:// or postgresql://.");
-  }
-
-  const host = parsed.hostname.toLowerCase();
-  if (!host.endsWith(".neon.tech") && host !== "neon.tech") {
-    throw new Error(
-      "Refusing to seed: POSTGRES_URL hostname must be a Neon host (*.neon.tech). Point POSTGRES_URL at your non-production Neon branch.",
-    );
-  }
-}
 
 /** Idempotent non-production seed: replaces fixture users by email, then inserts sessions, thoughts, and friendship. */
 async function main() {

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -5,7 +5,7 @@ import type { NeonDatabase } from "drizzle-orm/neon-serverless";
 import { poolDb } from "../src/db/pool";
 import * as schema from "../src/db/schema";
 import { friendships, sessions, thoughts, users } from "../src/db/schema";
-import { assertNeonNonProdPostgresUrl } from "./lib/assert-neon-postgres-url";
+import { assertNeonHostedPostgresUrl } from "./lib/assert-neon-postgres-url";
 
 loadEnvConfig(process.cwd());
 
@@ -62,12 +62,13 @@ async function main() {
     );
   }
 
-  const postgresUrl = process.env.POSTGRES_URL;
+  const postgresUrl = (process.env.POSTGRES_URL ?? "").trim();
   if (!postgresUrl) {
     throw new Error("POSTGRES_URL is required.");
   }
 
-  assertNeonNonProdPostgresUrl(postgresUrl);
+  assertNeonHostedPostgresUrl(postgresUrl);
+  process.env.POSTGRES_URL = postgresUrl;
 
   const runId = (process.env.E2E_RUN_ID ?? "").trim().toLowerCase().replace(/[^a-z0-9_-]/g, "");
   const seedUsers = buildSeedUsers(runId);

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -45,3 +45,12 @@ export const poolDb = new Proxy({} as PoolDb, {
     return (getPoolDb() as unknown as Record<string | symbol, unknown>)[prop as string];
   },
 });
+
+/** End WebSocket pool (scripts / Playwright globalSetup only; not used in serverless). */
+export async function closePoolDb(): Promise<void> {
+  if (globalForPool.__drizzlePool) {
+    await globalForPool.__drizzlePool.end();
+    globalForPool.__drizzlePool = undefined;
+    globalForPool.__poolDb = undefined;
+  }
+}


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses long-standing **401 on login** for credentialed mobile web E2E when the fixture user row is missing from Neon or the stored password hash no longer matches GitHub Actions secrets.

## Babysitter follow-up (commit cc7d5c0)

- **CI:** `E2E_WEB_SETUP_USER=true` no longer fails when `secrets.E2E_WEB_*` / `POSTGRES_URL` resolve to empty strings. `globalSetup` logs a warning and skips DB provisioning so mock-based mobile E2E stays green until secrets exist.
- **Workflow:** Job-level `env` includes `E2E_TEST_USER_EMAIL` / `E2E_TEST_USER_PASSWORD` fallbacks (Bugbot: empty-string `E2E_WEB_*` no longer blocks `E2E_TEST_USER_*`).
- **Review fixes:** `closePoolDb()` after provision; shared `scripts/lib/assert-neon-postgres-url.ts`; fixture username `e2e_` + 12 hex (fits app 3–30 rule); update path checks username collision with another row.

## Operator / issue #435

Post diagnostic comment on #435 without pasting secrets. Add repo secrets when ready for real DB alignment.

Closes #435.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d30ba210-83b5-4370-8154-eddcb721bb9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d30ba210-83b5-4370-8154-eddcb721bb9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Set up the mobile web E2E login user before Playwright runs**

### What Changed
- Mobile web E2E can now create or refresh the fixture login user before tests start, preventing 401 login failures when the database row is missing or the saved password no longer matches CI secrets.
- When the required database URL or secrets are not present, setup now skips instead of failing, so mock-based E2E runs keep working.
- Added a setup command, workflow wiring, and documentation for running credentialed mobile web E2E tests against a remote non-production database.

### Impact
`✅ Fewer mobile web login failures in E2E`
`✅ Reliable Playwright runs after DB wipes or secret rotation`
`✅ Clearer setup for credentialed CI test runs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=xIgK5I91sNkQ1zNzzw7ASmtYbVc_tO6pRWSA2n4_UQo&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
