### PR TITLE
Drop redundant idx_friendships_user1 (closes #148)

### DIFF
--- a/drizzle/friendships_drop_user1_index_incremental.sql
+++ b/drizzle/friendships_drop_user1_index_incremental.sql
@@ -1,0 +1,6 @@
+-- Issue #148: idx_friendships_user1 is redundant with PK (user1_id, user2_id).
+-- B-tree PK is usable for predicates on user1_id alone (left-prefix); app queries
+-- use user1_id = ? with or without user2_id = ? — both match the PK.
+-- Capture pg_stat_user_indexes (idx_scan, idx_tup_fetch) over a window before prod;
+-- expect idx_friendships_user1 ~0 scans if redundant. Apply via npm run db:migrate only.
+DROP INDEX IF EXISTS "idx_friendships_user1";

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -260,7 +260,6 @@ export const friendships = pgTable("friendships", {
 }, (table) => ({
   pk: primaryKey({ columns: [table.user1Id, table.user2Id] }),
   ordered: check("friendships_user_order", sql`${table.user1Id} < ${table.user2Id}`),
-  user1Idx: index("idx_friendships_user1").on(table.user1Id),
   user2Idx: index("idx_friendships_user2").on(table.user2Id),
 }));
 


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes `idx_friendships_user1` from the Drizzle schema and adds incremental SQL so `npm run db:migrate` drops the index in deploy environments.

Closes #148.

## Evidence and decision (representative window)

**This agent environment had no `POSTGRES_URL`**, so live `pg_stat_user_indexes` / `pg_stat_statements` snapshots from prod or preview could not be attached here. The PR documents the intended evidence capture for whoever merges.

### Index usage over a window (run on prod or prod-like Neon)

1. **Reset counters** (optional but gives a clean window; coordinate with ops):

   ```sql
   SELECT pg_stat_reset_single_table_counters('public.friendships'::regclass);
   ```

   If your Postgres version supports it, reset index stats for this table only:

   ```sql
   SELECT pg_stat_reset_single_table_counters('public.friendships'::regclass);
   ```

   (On older versions, use a documented maintenance window or compare two snapshots of `pg_stat_user_indexes` taken days apart without resetting.)

2. **After the window**, compare `idx_friendships_user1` vs PK `friendships_user1_id_user2_id_pk`:

   ```sql
   SELECT indexrelname,
          idx_scan,
          idx_tup_read,
          idx_tup_fetch
   FROM pg_stat_user_indexes
   WHERE relname = 'friendships'
   ORDER BY indexrelname;
   ```

   **Expectation:** `idx_scan` for `idx_friendships_user1` stays at or near **zero** while the PK serves `WHERE user1_id = $1` (and composite lookups), because the PK is a B-tree on `(user1_id, user2_id)` and is valid for left-prefix predicates on `user1_id`.

3. **Optional — planner proof** on preview after the migration (or in a branch DB):

   ```sql
   EXPLAIN (ANALYZE, BUFFERS)
   SELECT * FROM friendships WHERE user1_id = $1::uuid;
   ```

   Confirm an **Index Scan** using `friendships_user1_id_user2_id_pk` (not a sequential scan at expected row counts).

### `pg_stat_statements` (if enabled)

Filter for statements touching `friendships` and confirm no plan regression; compare mean time before/after on preview.

### Decision

**Drop**, contingent on the windowed stats above showing no meaningful use of `idx_friendships_user1`. Rationale: duplicate btree structure on the leading PK column adds write overhead and maintenance surface without a distinct access path the planner needs.

## What changed

- `src/db/schema.ts`: removed `user1Idx` so Drizzle-generated migrations stay aligned.
- `drizzle/friendships_drop_user1_index_incremental.sql`: `DROP INDEX IF EXISTS "idx_friendships_user1";` — only this index; `idx_friendships_user2` unchanged.

## Prod rollout

- Apply **only** via the existing migration path (`npm run db:migrate` in Vercel / CI with `POSTGRES_URL` set). No ad-hoc DDL.
- **Preview first:** merge to default preview branch, run migrate, run `EXPLAIN (ANALYZE)` on friend-list paths and spot-check latency.
- **Production:** deploy with migration; `DROP INDEX` is quick on `friendships` at typical sizes.

## Verification

- [x] `npm run test:unit` (48 tests) — pass locally after `npm ci` on Node 22.

## Code review

`coderabbit review --prompt-only` was **not** run here (CLI not present in this environment). Maintainer can run per repo checklist before merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3841de7-cbc6-4506-9db0-e8832371c90a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3841de7-cbc6-4506-9db0-e8832371c90a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Remove a redundant friendships index**

### What Changed
- Removed the extra index on friendships by user 1, since the existing primary key already covers the same lookups
- Added a migration that drops the unused index during deployment
- Kept the remaining friendships index for user 2

### Impact
`✅ Lower database storage for friendships`
`✅ Less write overhead when saving friendships`
`✅ Fewer slowdowns from duplicate indexes`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=EddfZn0FfeopU0Avw_INuUB--nGFbk1NbgzZa6GuEJI&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
