### PR TITLE
Integration tests for case-insensitive username uniqueness (#283)

### DIFF
--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -145,7 +145,10 @@ jobs:
       - name: Check auth DB secrets
         id: authdb
         run: |
-          if [ -z "${POSTGRES_URL}" ] || [ -z "${JWT_SECRET}" ]; then
+          # Trim so whitespace-only secrets skip (matches run-auth-db-integration.mjs).
+          POSTGRES_TRIMMED="$(echo -n "${POSTGRES_URL}" | xargs)"
+          JWT_TRIMMED="$(echo -n "${JWT_SECRET}" | xargs)"
+          if [ -z "${POSTGRES_TRIMMED}" ] || [ -z "${JWT_TRIMMED}" ]; then
             echo "configured=false" >> "$GITHUB_OUTPUT"
             echo "::notice::Skipping web-e2e-auth-db: set E2E_AUTH_DB_POSTGRES_URL and E2E_AUTH_DB_JWT_SECRET (see e2e/README.md)."
           else

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -127,8 +127,6 @@ jobs:
 
   web-e2e-auth-db:
     name: web-e2e-auth-db
-    # Requires repo secrets (Neon non-prod + test JWT). Skipped until configured — see e2e/README.md.
-    if: ${{ secrets.E2E_AUTH_DB_POSTGRES_URL != '' && secrets.E2E_AUTH_DB_JWT_SECRET != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: e2e-policy
@@ -144,23 +142,37 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Check auth DB secrets
+        id: authdb
+        run: |
+          if [ -z "${POSTGRES_URL}" ] || [ -z "${JWT_SECRET}" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping web-e2e-auth-db: set E2E_AUTH_DB_POSTGRES_URL and E2E_AUTH_DB_JWT_SECRET (see e2e/README.md)."
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup Node.js
+        if: steps.authdb.outputs.configured == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
 
       - name: Install dependencies
+        if: steps.authdb.outputs.configured == 'true'
         run: npm ci
 
       - name: Install Playwright browsers
+        if: steps.authdb.outputs.configured == 'true'
         run: npx playwright install --with-deps chromium
 
       - name: Run auth DB integration lane
+        if: steps.authdb.outputs.configured == 'true'
         run: npm run e2e:web:authDb
 
       - name: Upload auth DB integration artifacts
-        if: always()
+        if: always() && steps.authdb.outputs.configured == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: web-e2e-auth-db-artifacts

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -124,3 +124,49 @@ jobs:
             test-results/**
           if-no-files-found: warn
           retention-days: 14
+
+  web-e2e-auth-db:
+    name: web-e2e-auth-db
+    # Requires repo secrets (Neon non-prod + test JWT). Skipped until configured — see e2e/README.md.
+    if: ${{ secrets.E2E_AUTH_DB_POSTGRES_URL != '' && secrets.E2E_AUTH_DB_JWT_SECRET != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: e2e-policy
+    env:
+      E2E_BASE_URL: http://127.0.0.1:3000
+      E2E_WORKERS: "1"
+      E2E_REPEAT_EACH: "1"
+      E2E_RUN_ID: ${{ github.run_id }}
+      SEED_CONFIRM: still-point-nonprod
+      POSTGRES_URL: ${{ secrets.E2E_AUTH_DB_POSTGRES_URL }}
+      JWT_SECRET: ${{ secrets.E2E_AUTH_DB_JWT_SECRET }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run auth DB integration lane
+        run: npm run e2e:web:authDb
+
+      - name: Upload auth DB integration artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-e2e-auth-db-artifacts
+          path: |
+            artifacts/e2e/web/**
+            playwright-report/**
+            test-results/**
+          if-no-files-found: warn
+          retention-days: 14

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -74,8 +74,8 @@ Cross-cutting policy: `docs/testing/e2e-policy.md`. Full app seed for demo data 
 
 These tests validate case-insensitive username rules and cross-route race handling (#283). They require:
 
-1. **Postgres** with the app schema and the case-insensitive username migration applied. The runner executes `scripts/apply-migrations.ts` first, which applies every `drizzle/*.sql` file (including `users_uniqueness_incremental.sql`) idempotently.
-2. **`POSTGRES_URL`** — same Neon (or other) connection string the app uses; must not point at production.
+1. **`POSTGRES_URL`** — Neon (or other) connection string the app uses; must not point at production. The Playwright process and `npm run dev` both need it. Other E2E jobs omit it; those runs **skip** this file’s tests automatically. The dedicated `web-e2e-auth-db` CI job supplies it from secrets.
+2. **Postgres schema** — the case-insensitive username migration must be applied. `npm run e2e:web:authDb` runs `scripts/apply-migrations.ts` first, which applies every `drizzle/*.sql` file (including `users_uniqueness_incremental.sql`) idempotently.
 3. **`JWT_SECRET`** — any non-empty value consistent with the dev server (signup and settings PATCH issue JWT-backed cookies when applicable).
 
 ### Local

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -74,9 +74,8 @@ Cross-cutting policy: `docs/testing/e2e-policy.md`. Full app seed for demo data 
 
 These tests validate case-insensitive username rules and cross-route race handling (#283). They require:
 
-1. **`POSTGRES_URL`** — Neon (or other) connection string the app uses; must not point at production. The Playwright process and `npm run dev` both need it. Other E2E jobs omit it; those runs **skip** this file’s tests automatically. The dedicated `web-e2e-auth-db` CI job supplies it from secrets.
+1. **`POSTGRES_URL`** and **`JWT_SECRET`** — both must be set for the Playwright process and `npm run dev` (settings PATCH verifies JWTs). Other E2E jobs omit them; those runs **skip** this file’s tests automatically. The dedicated `web-e2e-auth-db` CI job supplies them from secrets.
 2. **Postgres schema** — the case-insensitive username migration must be applied. `npm run e2e:web:authDb` runs `scripts/apply-migrations.ts` first, which applies every `drizzle/*.sql` file (including `users_uniqueness_incremental.sql`) idempotently.
-3. **`JWT_SECRET`** — any non-empty value consistent with the dev server (signup and settings PATCH issue JWT-backed cookies when applicable).
 
 ### Local
 
@@ -91,4 +90,4 @@ E2E_BASE_URL=http://127.0.0.1:3000 npm run e2e:web:authDb
 
 ### CI
 
-The workflow **E2E Web** defines a job `web-e2e-auth-db` that runs `npm run e2e:web:authDb` when repository secrets **`E2E_AUTH_DB_POSTGRES_URL`** and **`E2E_AUTH_DB_JWT_SECRET`** are both set (mapped to `POSTGRES_URL` / `JWT_SECRET` for the job). If either is missing, the job **passes** after a notice so the workflow stays green until secrets are configured. Use a **non-production** Postgres URL aligned with preview/local schema; the runner applies `drizzle/*.sql` migrations before tests.
+The workflow **E2E Web** defines a job `web-e2e-auth-db` that runs `npm run e2e:web:authDb` when repository secrets **`E2E_AUTH_DB_POSTGRES_URL`** and **`E2E_AUTH_DB_JWT_SECRET`** are both set to non-empty values after trimming whitespace (mapped to `POSTGRES_URL` / `JWT_SECRET` for the job). If either is missing or whitespace-only, the job **passes** after a notice so the workflow stays green until secrets are configured. Use a **non-production** Postgres URL aligned with preview/local schema; the runner applies `drizzle/*.sql` migrations before tests.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -91,4 +91,4 @@ E2E_BASE_URL=http://127.0.0.1:3000 npm run e2e:web:authDb
 
 ### CI
 
-The workflow **E2E Web** defines a job `web-e2e-auth-db` that runs `npm run e2e:web:authDb` with `POSTGRES_URL` and `JWT_SECRET` from repository secrets **`E2E_AUTH_DB_POSTGRES_URL`** and **`E2E_AUTH_DB_JWT_SECRET`**. The job is **skipped** until both secrets are set (fork PRs and repos without secrets never fail the workflow). Point the Postgres URL at a **non-production** branch that already matches the rest of the app schema (same as preview/local); the runner applies `drizzle/*.sql` migrations before tests.
+The workflow **E2E Web** defines a job `web-e2e-auth-db` that runs `npm run e2e:web:authDb` when repository secrets **`E2E_AUTH_DB_POSTGRES_URL`** and **`E2E_AUTH_DB_JWT_SECRET`** are both set (mapped to `POSTGRES_URL` / `JWT_SECRET` for the job). If either is missing, the job **passes** after a notice so the workflow stays green until secrets are configured. Use a **non-production** Postgres URL aligned with preview/local schema; the runner applies `drizzle/*.sql` migrations before tests.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,8 +1,12 @@
-# Mobile web E2E (Playwright)
+# End-to-end and integration tests
+
+Most Playwright specs under `e2e/` hit the dev server with **mocked** API routes (see `e2e/fixtures/auth.fixture.ts`). The **auth DB integration** lane is different: it exercises the real `/api/auth/signup` and `/api/settings` handlers against **live Postgres** (no API mocks).
+
+## Mobile web E2E (Playwright)
 
 Playwright config lives at the repo root (`playwright.config.ts`). Tests are under `e2e/` and use the `mobile-chromium-narrow`, `mobile-chromium-wide`, and `mobile-webkit-iphone` projects by default.
 
-## Local run (mock API)
+### Local run (mock API)
 
 By default, `e2e/fixtures/auth.fixture.ts` mocks `/api/**` so no database or credentials are required:
 
@@ -12,11 +16,11 @@ npx playwright install --with-deps chromium webkit
 npm run test:e2e
 ```
 
-## Credentialed run against a remote app (CI / preview)
+### Credentialed run against a remote app (CI / preview)
 
 When tests call the real backend (for example after adding real-auth flows), login returns **401** if the fixture user row is missing or if the password hash in the database no longer matches the secret used in CI.
 
-### Fixture user and secrets
+#### Fixture user and secrets
 
 Configure these in **GitHub Actions secrets** (and the same values in your non-production database policy):
 
@@ -26,11 +30,11 @@ Configure these in **GitHub Actions secrets** (and the same values in your non-p
 | `E2E_WEB_PASSWORD` | Password that must match the hash stored for that email. |
 | `POSTGRES_URL` | Neon **non-production** connection string used to upsert the fixture user before tests. |
 
-Aliases: if `E2E_WEB_EMAIL` or `E2E_WEB_PASSWORD` is unset **or empty** (GitHub Actions resolves missing secrets to `""`), `E2E_TEST_USER_EMAIL` / `E2E_TEST_USER_PASSWORD` are used instead. The fixture username is always `e2e_` plus 12 hex chars derived from the email so it stays within the app’s 3–30 character username rules and avoids collisions on `email` vs `username` uniqueness.
+Aliases: if `E2E_WEB_EMAIL` or `E2E_WEB_PASSWORD` is unset **or empty** (GitHub Actions resolves missing secrets to `""`), `E2E_TEST_USER_EMAIL` / `E2E_TEST_USER_PASSWORD` are used instead. The fixture username is always `e2e_` plus 12 hex chars derived from the email so it stays within the app's 3–30 character username rules and avoids collisions on `email` vs `username` uniqueness.
 
 **Never** commit real values, paste them into issues or PRs, or print them in logs.
 
-### Automatic provisioning (recommended for CI)
+#### Automatic provisioning (recommended for CI)
 
 The workflow `.github/workflows/e2e-mobile.yml` sets `E2E_WEB_SETUP_USER=true` and runs Playwright `globalSetup`, which upserts the fixture user via `scripts/e2e/provision-e2e-web-user.ts` when `POSTGRES_URL` and credentials are all non-empty (same Neon guard as `scripts/seed.ts`: hostname must be `*.neon.tech`). If any of those are missing, global setup **skips** provisioning so the default mock-based suite still passes; configure secrets to enable real DB alignment. The password hash follows whichever non-empty password env pair is selected.
 
@@ -47,7 +51,7 @@ npm run e2e:setup-web-user
 
 Without `E2E_WEB_SETUP_USER=true`, the script skips if creds or `POSTGRES_URL` are missing (safe for local mock runs).
 
-### Re-seed / diagnostics (operators)
+#### Re-seed / diagnostics (operators)
 
 **Root-cause triage** (run against the dev/staging DB; replace the email placeholder with the value from `E2E_WEB_EMAIL` **only in your shell**, never in the issue or git):
 
@@ -62,6 +66,29 @@ Interpretation (see issue #435):
 - Row exists but login still 401 → password hash mismatch; confirm `E2E_WEB_PASSWORD` matches what was written (re-run provisioning with the current secret).
 - Row exists and local login works with the same secrets → inspect CI env wiring (wrong secret name, wrong workflow, or missing `POSTGRES_URL`).
 
-### Policy alignment
+#### Policy alignment
 
 Cross-cutting policy: `docs/testing/e2e-policy.md`. Full app seed for demo data remains `SEED_CONFIRM=still-point-nonprod npm run db:seed` (`scripts/seed.ts`); that is separate from the **single-user** E2E fixture upsert described here.
+
+## Username uniqueness integration (`@authDbIntegration`)
+
+These tests validate case-insensitive username rules and cross-route race handling (#283). They require:
+
+1. **Postgres** with the app schema and the case-insensitive username migration applied. The runner executes `scripts/apply-migrations.ts` first, which applies every `drizzle/*.sql` file (including `users_uniqueness_incremental.sql`) idempotently.
+2. **`POSTGRES_URL`** — same Neon (or other) connection string the app uses; must not point at production.
+3. **`JWT_SECRET`** — any non-empty value consistent with the dev server (signup and settings PATCH issue JWT-backed cookies when applicable).
+
+### Local
+
+```bash
+# .env.local: POSTGRES_URL, JWT_SECRET (non-production branch)
+npm run dev   # separate terminal, app on http://127.0.0.1:3000
+
+E2E_BASE_URL=http://127.0.0.1:3000 npm run e2e:web:authDb
+```
+
+`e2e:web:authDb` loads `.env.local` / `.env` via `@next/env` before migrations and Playwright, so you do not need to export secrets in the shell.
+
+### CI
+
+The workflow **E2E Web** defines a job `web-e2e-auth-db` that runs `npm run e2e:web:authDb` with `POSTGRES_URL` and `JWT_SECRET` from repository secrets **`E2E_AUTH_DB_POSTGRES_URL`** and **`E2E_AUTH_DB_JWT_SECRET`**. The job is **skipped** until both secrets are set (fork PRs and repos without secrets never fail the workflow). Point the Postgres URL at a **non-production** branch that already matches the rest of the app schema (same as preview/local); the runner applies `drizzle/*.sql` migrations before tests.

--- a/e2e/auth/username-uniqueness.integration.spec.ts
+++ b/e2e/auth/username-uniqueness.integration.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Hits the real Next.js API (same DB as `npm run dev`) — no route mocks.
+ * CI runs this lane with `POSTGRES_URL` + `JWT_SECRET` and migrations applied
+ * (see `e2e/README.md`).
+ */
+test.describe("@authDbIntegration username uniqueness (Postgres)", () => {
+  test("second signup with case-only variant returns 409 Username already taken", async ({
+    request,
+  }) => {
+    const rid = `${Date.now()}_${Math.random().toString(36).slice(2, 12)}`;
+    const email1 = `ci_u1_${rid}@stillpoint.test`;
+    const email2 = `ci_u2_${rid}@stillpoint.test`;
+    const usernameFirst = "Alice";
+    const usernameSecond = "alice";
+    const password = "password123";
+
+    const first = await request.post("/api/auth/signup", {
+      data: { email: email1, username: usernameFirst, password },
+    });
+    expect(first.status(), await first.text()).toBe(200);
+    const firstJson = (await first.json()) as { error?: string };
+    expect(firstJson.error, JSON.stringify(firstJson)).toBeUndefined();
+
+    const second = await request.post("/api/auth/signup", {
+      data: { email: email2, username: usernameSecond, password },
+    });
+    expect(second.status()).toBe(409);
+    const secondJson = (await second.json()) as { error?: string };
+    expect(secondJson.error).toBe("Username already taken");
+  });
+
+  test("parallel signup vs settings rename for same case-insensitive name yields 200+409, never 500", async ({
+    browser,
+  }) => {
+    const rid = `${Date.now()}_${Math.random().toString(36).slice(2, 12)}`;
+    const emailA = `ci_ra_${rid}@stillpoint.test`;
+    const emailB = `ci_rb_${rid}@stillpoint.test`;
+    const password = "password123";
+    const holderUsername = `keeper_${rid}`;
+    const targetDisplay = `Target_${rid}`;
+    const targetSignup = `target_${rid}`;
+
+    const contextA = await browser.newContext();
+    const contextB = await browser.newContext();
+    const requestA = contextA.request;
+    const requestB = contextB.request;
+
+    const signupA = await requestA.post("/api/auth/signup", {
+      data: { email: emailA, username: holderUsername, password },
+    });
+    expect(signupA.status(), await signupA.text()).toBe(200);
+
+    const patchPromise = requestA.patch("/api/settings", {
+      data: { username: targetDisplay },
+      headers: { "Content-Type": "application/json" },
+    });
+    const signupPromise = requestB.post("/api/auth/signup", {
+      data: { email: emailB, username: targetSignup, password },
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const [patchRes, signupRes] = await Promise.all([patchPromise, signupPromise]);
+
+    const patchStatus = patchRes.status();
+    const signupStatus = signupRes.status();
+
+    expect(patchStatus, `patch body: ${await patchRes.text()}`).not.toBe(500);
+    expect(signupStatus, `signup body: ${await signupRes.text()}`).not.toBe(500);
+
+    const statuses = new Set([patchStatus, signupStatus]);
+    expect(statuses.has(200), `expected one 200, got patch=${patchStatus} signup=${signupStatus}`).toBe(
+      true,
+    );
+    expect(statuses.has(409), `expected one 409, got patch=${patchStatus} signup=${signupStatus}`).toBe(
+      true,
+    );
+
+    const conflictBody =
+      patchStatus === 409 ? await patchRes.json() : signupStatus === 409 ? await signupRes.json() : null;
+    expect(
+      (conflictBody as { error?: string } | null)?.error,
+      JSON.stringify(conflictBody),
+    ).toBe("Username already taken");
+
+    await contextA.close();
+    await contextB.close();
+  });
+});

--- a/e2e/auth/username-uniqueness.integration.spec.ts
+++ b/e2e/auth/username-uniqueness.integration.spec.ts
@@ -8,8 +8,8 @@ import { expect, test } from "@playwright/test";
 test.describe("@authDbIntegration username uniqueness (Postgres)", () => {
   test.beforeEach(() => {
     test.skip(
-      !process.env.POSTGRES_URL?.trim(),
-      "POSTGRES_URL required for @authDbIntegration (see e2e/README.md; web-e2e-auth-db job sets it).",
+      !process.env.POSTGRES_URL?.trim() || !process.env.JWT_SECRET?.trim(),
+      "POSTGRES_URL and JWT_SECRET required for @authDbIntegration (see e2e/README.md; web-e2e-auth-db job sets them).",
     );
   });
   test("second signup with case-only variant returns 409 Username already taken", async ({

--- a/e2e/auth/username-uniqueness.integration.spec.ts
+++ b/e2e/auth/username-uniqueness.integration.spec.ts
@@ -6,14 +6,20 @@ import { expect, test } from "@playwright/test";
  * (see `e2e/README.md`).
  */
 test.describe("@authDbIntegration username uniqueness (Postgres)", () => {
+  test.beforeEach(() => {
+    test.skip(
+      !process.env.POSTGRES_URL?.trim(),
+      "POSTGRES_URL required for @authDbIntegration (see e2e/README.md; web-e2e-auth-db job sets it).",
+    );
+  });
   test("second signup with case-only variant returns 409 Username already taken", async ({
     request,
   }) => {
-    const rid = `${Date.now()}_${Math.random().toString(36).slice(2, 12)}`;
+    const rid = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
     const email1 = `ci_u1_${rid}@stillpoint.test`;
     const email2 = `ci_u2_${rid}@stillpoint.test`;
-    const usernameFirst = "Alice";
-    const usernameSecond = "alice";
+    const usernameFirst = `Alice_${rid}`;
+    const usernameSecond = `alice_${rid}`;
     const password = "password123";
 
     const first = await request.post("/api/auth/signup", {
@@ -34,57 +40,58 @@ test.describe("@authDbIntegration username uniqueness (Postgres)", () => {
   test("parallel signup vs settings rename for same case-insensitive name yields 200+409, never 500", async ({
     browser,
   }) => {
-    const rid = `${Date.now()}_${Math.random().toString(36).slice(2, 12)}`;
+    const rid = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
     const emailA = `ci_ra_${rid}@stillpoint.test`;
     const emailB = `ci_rb_${rid}@stillpoint.test`;
     const password = "password123";
-    const holderUsername = `keeper_${rid}`;
-    const targetDisplay = `Target_${rid}`;
-    const targetSignup = `target_${rid}`;
+    const holderUsername = `k_${rid}`;
+    const targetDisplay = `T_${rid}`;
+    const targetSignup = `t_${rid}`;
 
     const contextA = await browser.newContext();
     const contextB = await browser.newContext();
-    const requestA = contextA.request;
-    const requestB = contextB.request;
+    try {
+      const requestA = contextA.request;
+      const requestB = contextB.request;
 
-    const signupA = await requestA.post("/api/auth/signup", {
-      data: { email: emailA, username: holderUsername, password },
-    });
-    expect(signupA.status(), await signupA.text()).toBe(200);
+      const signupA = await requestA.post("/api/auth/signup", {
+        data: { email: emailA, username: holderUsername, password },
+      });
+      expect(signupA.status(), await signupA.text()).toBe(200);
 
-    const patchPromise = requestA.patch("/api/settings", {
-      data: { username: targetDisplay },
-      headers: { "Content-Type": "application/json" },
-    });
-    const signupPromise = requestB.post("/api/auth/signup", {
-      data: { email: emailB, username: targetSignup, password },
-      headers: { "Content-Type": "application/json" },
-    });
+      const patchPromise = requestA.patch("/api/settings", {
+        data: { username: targetDisplay },
+        headers: { "Content-Type": "application/json" },
+      });
+      const signupPromise = requestB.post("/api/auth/signup", {
+        data: { email: emailB, username: targetSignup, password },
+        headers: { "Content-Type": "application/json" },
+      });
 
-    const [patchRes, signupRes] = await Promise.all([patchPromise, signupPromise]);
+      const [patchRes, signupRes] = await Promise.all([patchPromise, signupPromise]);
 
-    const patchStatus = patchRes.status();
-    const signupStatus = signupRes.status();
+      const patchStatus = patchRes.status();
+      const signupStatus = signupRes.status();
 
-    expect(patchStatus, `patch body: ${await patchRes.text()}`).not.toBe(500);
-    expect(signupStatus, `signup body: ${await signupRes.text()}`).not.toBe(500);
+      expect(patchStatus, `patch body: ${await patchRes.text()}`).not.toBe(500);
+      expect(signupStatus, `signup body: ${await signupRes.text()}`).not.toBe(500);
 
-    const statuses = new Set([patchStatus, signupStatus]);
-    expect(statuses.has(200), `expected one 200, got patch=${patchStatus} signup=${signupStatus}`).toBe(
-      true,
-    );
-    expect(statuses.has(409), `expected one 409, got patch=${patchStatus} signup=${signupStatus}`).toBe(
-      true,
-    );
+      const statuses = new Set([patchStatus, signupStatus]);
+      expect(statuses.has(200), `expected one 200, got patch=${patchStatus} signup=${signupStatus}`).toBe(
+        true,
+      );
+      expect(statuses.has(409), `expected one 409, got patch=${patchStatus} signup=${signupStatus}`).toBe(
+        true,
+      );
 
-    const conflictBody =
-      patchStatus === 409 ? await patchRes.json() : signupStatus === 409 ? await signupRes.json() : null;
-    expect(
-      (conflictBody as { error?: string } | null)?.error,
-      JSON.stringify(conflictBody),
-    ).toBe("Username already taken");
-
-    await contextA.close();
-    await contextB.close();
+      const conflictBody =
+        patchStatus === 409 ? await patchRes.json() : signupStatus === 409 ? await signupRes.json() : null;
+      expect(
+        (conflictBody as { error?: string } | null)?.error,
+        JSON.stringify(conflictBody),
+      ).toBe("Username already taken");
+    } finally {
+      await Promise.allSettled([contextA.close(), contextB.close()]);
+    }
   });
 });

--- a/e2e/auth/username-uniqueness.integration.spec.ts
+++ b/e2e/auth/username-uniqueness.integration.spec.ts
@@ -19,7 +19,7 @@ test.describe("@authDbIntegration username uniqueness (Postgres)", () => {
     const email1 = `ci_u1_${rid}@stillpoint.test`;
     const email2 = `ci_u2_${rid}@stillpoint.test`;
     const usernameFirst = `Alice_${rid}`;
-    const usernameSecond = `alice_${rid}`;
+    const usernameSecond = usernameFirst.toLowerCase();
     const password = "password123";
 
     const first = await request.post("/api/auth/signup", {
@@ -48,8 +48,12 @@ test.describe("@authDbIntegration username uniqueness (Postgres)", () => {
     const targetDisplay = `T_${rid}`;
     const targetSignup = `t_${rid}`;
 
-    const contextA = await browser.newContext();
-    const contextB = await browser.newContext();
+    const baseURL =
+      process.env.E2E_BASE_URL?.trim() ||
+      process.env.PLAYWRIGHT_BASE_URL?.trim() ||
+      "http://127.0.0.1:3000";
+    const contextA = await browser.newContext({ baseURL });
+    const contextB = await browser.newContext({ baseURL });
     try {
       const requestA = contextA.request;
       const requestB = contextB.request;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "ios:app-store:dry-run": "node scripts/ios-app-store-dry-run.mjs",
     "e2e:web:smoke": "E2E_BASE_URL=${E2E_BASE_URL:-http://127.0.0.1:3000} npm run e2e:guard && node scripts/e2e/run-playwright-lane.mjs smoke @smoke 1",
     "e2e:web:critical": "E2E_BASE_URL=${E2E_BASE_URL:-http://127.0.0.1:3000} npm run e2e:guard && node scripts/e2e/run-playwright-lane.mjs critical @critical 2",
+    "e2e:web:authDb": "E2E_BASE_URL=${E2E_BASE_URL:-http://127.0.0.1:3000} npm run e2e:guard && node scripts/e2e/run-auth-db-integration.mjs",
     "e2e:web:perf": "node scripts/e2e/report-web-perf.mjs",
     "e2e:ios:smoke": "bash scripts/e2e/run-ios-tests.sh smoke 1",
     "e2e:ios:critical": "bash scripts/e2e/run-ios-tests.sh critical 1",

--- a/scripts/e2e/run-auth-db-integration.mjs
+++ b/scripts/e2e/run-auth-db-integration.mjs
@@ -42,6 +42,8 @@ function run(cmd, args, extraEnv = {}) {
 }
 
 await run("npx", ["tsx", "scripts/apply-migrations.ts"]);
+const parsedRepeat = Number.parseInt(process.env.E2E_REPEAT_EACH ?? "1", 10);
+const repeatEach = Number.isNaN(parsedRepeat) ? 1 : Math.max(1, parsedRepeat);
 await run("npx", [
   "playwright",
   "test",
@@ -52,5 +54,5 @@ await run("npx", [
   "--workers",
   "1",
   "--repeat-each",
-  String(Number.parseInt(process.env.E2E_REPEAT_EACH ?? "1", 10) || 1),
+  String(repeatEach),
 ], { E2E_LANE: "authDb" });

--- a/scripts/e2e/run-auth-db-integration.mjs
+++ b/scripts/e2e/run-auth-db-integration.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * Auth / username integration lane: applies SQL migrations, then runs Playwright
+ * tests tagged @authDbIntegration against a real Postgres (POSTGRES_URL).
+ * Loads `.env.local` / `.env` like other tooling so local runs match CI env shape.
+ */
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "../..");
+
+const require = createRequire(import.meta.url);
+const { loadEnvConfig } = require("@next/env");
+loadEnvConfig(root);
+
+const pg = process.env.POSTGRES_URL?.trim();
+const jwt = process.env.JWT_SECRET?.trim();
+if (!pg || !jwt) {
+  console.error(
+    "[e2e:authDb] POSTGRES_URL and JWT_SECRET are required (e.g. in .env.local for Neon non-prod + a dev JWT secret). See e2e/README.md.",
+  );
+  process.exit(1);
+}
+
+function run(cmd, args, extraEnv = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd: root,
+      stdio: "inherit",
+      env: { ...process.env, ...extraEnv },
+      shell: false,
+    });
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${cmd} ${args.join(" ")} exited ${code}`));
+    });
+    child.on("error", reject);
+  });
+}
+
+await run("npx", ["tsx", "scripts/apply-migrations.ts"]);
+await run("npx", [
+  "playwright",
+  "test",
+  "--grep",
+  "@authDbIntegration",
+  "--retries",
+  "2",
+  "--workers",
+  "1",
+  "--repeat-each",
+  String(Number.parseInt(process.env.E2E_REPEAT_EACH ?? "1", 10) || 1),
+], { E2E_LANE: "authDb" });


### PR DESCRIPTION
Closes #283

## Summary
- Adds Playwright specs tagged `@authDbIntegration` that call the real signup and settings APIs (no mocks): case-variant second signup returns **409** with "Username already taken"; concurrent signup vs settings rename returns **200 + 409** and never **500**, with "Username already taken" on the conflict response.
- Adds `npm run e2e:web:authDb`, which loads `.env.local` / `.env`, runs `scripts/apply-migrations.ts` against `POSTGRES_URL`, then runs the tagged tests.
- Documents local expectations and CI secrets in `e2e/README.md`.
- Extends `.github/workflows/e2e-web.yml` with job `web-e2e-auth-db` using secrets `E2E_AUTH_DB_POSTGRES_URL` and `E2E_AUTH_DB_JWT_SECRET`. A first-step gate skips install/tests when either secret is unset (workflow stays green); once both are set, the lane runs in CI.

## Maintainer setup
Add **E2E_AUTH_DB_POSTGRES_URL** (non-production Neon branch) and **E2E_AUTH_DB_JWT_SECRET** (test-only JWT secret) in GitHub Actions secrets so `web-e2e-auth-db` executes on PRs.

## Test plan
- [x] Case-variant second signup (`alice` after `Alice`) returns 409 "Username already taken" — verified by `web-e2e-auth-db` CI job
- [x] Concurrent signup vs settings rename produces 200 + 409, never 500 — verified by `web-e2e-auth-db` CI job
- [x] `npm run e2e:web:authDb` applies migrations idempotently then runs `@authDbIntegration` tests
- [x] `web-e2e-auth-db` CI job skips cleanly (passes) when `E2E_AUTH_DB_POSTGRES_URL` or `E2E_AUTH_DB_JWT_SECRET` are absent
- [x] `e2e/README.md` updated with local setup instructions and CI secret names