### PR TITLE
feat(ios): Settings username inline edit (closes #282)

### DIFF
--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -173,6 +173,7 @@ final class AppViewModel {
     }
 
     func applySettingsUser(_ user: UserDTO) {
+        guard currentView != .auth, let existing = currentUser, existing.id == user.id else { return }
         currentUser = user
     }
 

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -172,6 +172,10 @@ final class AppViewModel {
         Task { await consumePendingBuddyInviteIfNeeded() }
     }
 
+    func applySettingsUser(_ user: UserDTO) {
+        currentUser = user
+    }
+
     func didLogout() {
         currentUser = nil
         pendingBuddyInviteToken = nil

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -238,7 +238,9 @@ struct SettingsView: View {
 
                 HStack(spacing: SPSpacing.s2) {
                     Button {
-                        Task { await saveUsername(currentUsername: user.username) }
+                        Task { @MainActor in
+                            await saveUsername(currentUsername: user.username)
+                        }
                     } label: {
                         Text(savingUsername ? "Saving…" : "Save")
                             .font(SPFont.mono(11, weight: .medium))
@@ -316,8 +318,10 @@ struct SettingsView: View {
         usernameDraft = savedUsername
     }
 
+    @MainActor
     private func saveUsername(currentUsername: String) async {
-        guard !isUpdating else { return }
+        guard !isSavingSettings else { return }
+
         let trimmed = usernameDraft.trimmingCharacters(in: .whitespacesAndNewlines)
         usernameFieldError = nil
         usernameSuccessMessage = nil

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -5,6 +5,11 @@ struct SettingsView: View {
     let appVM: AppViewModel
     @State private var isPublic: Bool = false
     @State private var isUpdating = false
+    @State private var editingUsername = false
+    @State private var usernameDraft = ""
+    @State private var savingUsername = false
+    @State private var usernameFieldError: String?
+    @State private var usernameSuccessMessage: String?
     @State private var showDeleteAccountDialog = false
     @State private var showDeleteAccountConfirm = false
     @State private var isDeletingAccount = false
@@ -28,15 +33,7 @@ struct SettingsView: View {
                         .tracking(2)
 
                     if let user = appVM.currentUser {
-                        HStack {
-                            Text("Username")
-                                .font(SPFont.mono(13))
-                                .foregroundStyle(Color(SPColor.fg3))
-                            Spacer()
-                            Text(user.username)
-                                .font(SPFont.mono(13))
-                                .foregroundStyle(Color(SPColor.fg))
-                        }
+                        usernameSection(for: user)
 
                         HStack {
                             Text("Email")
@@ -112,7 +109,8 @@ struct SettingsView: View {
                             isUpdating = true
                             defer { isUpdating = false }
                             do {
-                                _ = try await APIClient.shared.updateSettings(isPublic: newValue)
+                                let updated = try await APIClient.shared.updateSettings(isPublic: newValue)
+                                appVM.applySettingsUser(updated)
                             } catch {
                                 // Revert on failure
                                 isPublic = !newValue
@@ -210,7 +208,153 @@ struct SettingsView: View {
         }
         .stillPointBackground()
         .onAppear {
-            isPublic = appVM.currentUser?.isPublic ?? false
+            syncFromCurrentUser()
+        }
+        .onChange(of: appVM.currentUser?.username) { _, _ in
+            if !editingUsername {
+                syncFromCurrentUser()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func usernameSection(for user: UserDTO) -> some View {
+        VStack(alignment: .leading, spacing: SPSpacing.s2) {
+            if editingUsername {
+                TextField("Username", text: $usernameDraft)
+                    .font(SPFont.mono(15))
+                    .foregroundStyle(Color(SPColor.fg))
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .disabled(savingUsername)
+                    .accessibilityIdentifier("settings.usernameField")
+                    .onChange(of: usernameDraft) { _, newValue in
+                        if newValue.count > UsernameValidation.maxLength {
+                            usernameDraft = String(newValue.prefix(UsernameValidation.maxLength))
+                        }
+                    }
+
+                HStack(spacing: SPSpacing.s2) {
+                    Button {
+                        Task { await saveUsername(currentUsername: user.username) }
+                    } label: {
+                        Text(savingUsername ? "Saving…" : "Save")
+                            .font(SPFont.mono(11, weight: .medium))
+                            .tracking(2)
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(savingUsername)
+                    .accessibilityIdentifier("settings.usernameSaveButton")
+
+                    Button("Cancel") {
+                        cancelUsernameEdit(savedUsername: user.username)
+                    }
+                    .font(SPFont.mono(11, weight: .medium))
+                    .tracking(2)
+                    .buttonStyle(.bordered)
+                    .disabled(savingUsername)
+                    .accessibilityIdentifier("settings.usernameCancelButton")
+                }
+
+                if let usernameFieldError {
+                    Text(usernameFieldError)
+                        .font(SPFont.mono(11))
+                        .foregroundStyle(SPColor.dangerMuted)
+                        .accessibilityIdentifier("settings.usernameError")
+                }
+            } else {
+                HStack(alignment: .center, spacing: SPSpacing.s2) {
+                    Text("Username")
+                        .font(SPFont.mono(13))
+                        .foregroundStyle(Color(SPColor.fg3))
+                    Spacer(minLength: SPSpacing.s2)
+                    Text(user.username)
+                        .font(SPFont.mono(13))
+                        .foregroundStyle(Color(SPColor.fg))
+                        .lineLimit(1)
+                        .accessibilityIdentifier("settings.usernameDisplay")
+                    Button("Edit") {
+                        beginUsernameEdit(savedUsername: user.username)
+                    }
+                    .font(SPFont.mono(10, weight: .medium))
+                    .tracking(2)
+                    .buttonStyle(.bordered)
+                    .accessibilityLabel("Edit username")
+                    .accessibilityIdentifier("settings.usernameEditButton")
+                }
+
+                if let usernameSuccessMessage {
+                    Text(usernameSuccessMessage)
+                        .font(SPFont.mono(11))
+                        .foregroundStyle(SPColor.green)
+                        .accessibilityIdentifier("settings.usernameSuccess")
+                }
+            }
+        }
+    }
+
+    private func syncFromCurrentUser() {
+        isPublic = appVM.currentUser?.isPublic ?? false
+        if !editingUsername, let u = appVM.currentUser {
+            usernameDraft = u.username
+        }
+    }
+
+    private func beginUsernameEdit(savedUsername: String) {
+        usernameDraft = savedUsername
+        usernameFieldError = nil
+        usernameSuccessMessage = nil
+        editingUsername = true
+    }
+
+    private func cancelUsernameEdit(savedUsername: String) {
+        editingUsername = false
+        usernameFieldError = nil
+        usernameDraft = savedUsername
+    }
+
+    private func saveUsername(currentUsername: String) async {
+        let trimmed = usernameDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        usernameFieldError = nil
+        usernameSuccessMessage = nil
+
+        if trimmed == currentUsername {
+            editingUsername = false
+            return
+        }
+
+        guard UsernameValidation.isValid(trimmed) else {
+            usernameFieldError = UsernameValidation.errorMessage
+            return
+        }
+
+        savingUsername = true
+        defer { savingUsername = false }
+
+        do {
+            let updated = try await APIClient.shared.updateSettings(username: trimmed)
+            appVM.applySettingsUser(updated)
+            usernameDraft = updated.username
+            editingUsername = false
+            usernameSuccessMessage = "Username updated"
+        } catch let error as APIError {
+            usernameFieldError = Self.message(for: error)
+        } catch {
+            usernameFieldError = "Could not update username. Please try again."
+        }
+    }
+
+    private static func message(for error: APIError) -> String {
+        switch error.status {
+        case 409:
+            return error.message
+        case 400:
+            if error.message == UsernameValidation.errorMessage {
+                return UsernameValidation.errorMessage
+            }
+            return error.message
+        default:
+            return "Could not update username. Please try again."
         }
     }
 

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -107,6 +107,7 @@ struct SettingsView: View {
                     .disabled(isSavingSettings)
                     .onChange(of: isPublic) { _, newValue in
                         guard !isSavingSettings else { return }
+                        guard appVM.currentUser?.isPublic != newValue else { return }
                         isUpdating = true
                         Task {
                             defer { isUpdating = false }

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -16,6 +16,8 @@ struct SettingsView: View {
     @State private var deleteAccountError = ""
     @State private var showDeleteAccountError = false
 
+    private var isSavingSettings: Bool { isUpdating || savingUsername }
+
     var body: some View {
         ScrollView {
             VStack(spacing: SPSpacing.s5) {
@@ -102,11 +104,11 @@ struct SettingsView: View {
                         }
                     }
                     .tint(SPColor.green)
-                    .disabled(isUpdating)
+                    .disabled(isSavingSettings)
                     .onChange(of: isPublic) { _, newValue in
-                        guard !isUpdating else { return }
+                        guard !isSavingSettings else { return }
+                        isUpdating = true
                         Task {
-                            isUpdating = true
                             defer { isUpdating = false }
                             do {
                                 let updated = try await APIClient.shared.updateSettings(isPublic: newValue)
@@ -226,7 +228,7 @@ struct SettingsView: View {
                     .foregroundStyle(Color(SPColor.fg))
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
-                    .disabled(savingUsername)
+                    .disabled(isSavingSettings)
                     .accessibilityIdentifier("settings.usernameField")
                     .onChange(of: usernameDraft) { _, newValue in
                         if newValue.count > UsernameValidation.maxLength {
@@ -243,7 +245,7 @@ struct SettingsView: View {
                             .tracking(2)
                     }
                     .buttonStyle(.bordered)
-                    .disabled(savingUsername)
+                    .disabled(isSavingSettings)
                     .accessibilityIdentifier("settings.usernameSaveButton")
 
                     Button("Cancel") {
@@ -252,7 +254,7 @@ struct SettingsView: View {
                     .font(SPFont.mono(11, weight: .medium))
                     .tracking(2)
                     .buttonStyle(.bordered)
-                    .disabled(savingUsername)
+                    .disabled(isSavingSettings)
                     .accessibilityIdentifier("settings.usernameCancelButton")
                 }
 
@@ -281,6 +283,7 @@ struct SettingsView: View {
                     .buttonStyle(.bordered)
                     .accessibilityLabel("Edit username")
                     .accessibilityIdentifier("settings.usernameEditButton")
+                    .disabled(isSavingSettings)
                 }
 
                 if let usernameSuccessMessage {
@@ -314,6 +317,7 @@ struct SettingsView: View {
     }
 
     private func saveUsername(currentUsername: String) async {
+        guard !isUpdating else { return }
         let trimmed = usernameDraft.trimmingCharacters(in: .whitespacesAndNewlines)
         usernameFieldError = nil
         usernameSuccessMessage = nil

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -62,10 +62,16 @@ final class StillPointAppUITests: XCTestCase {
         XCTAssertTrue(passwordField.waitForExistence(timeout: 5))
         passwordField.tapAndType("stillpoint-pass", in: app)
 
+        dismissKeyboardIfPresent(in: app)
+
         let submitButton = app.buttons["auth.submitButton"]
+        XCTAssertTrue(submitButton.waitForExistence(timeout: 5))
         tapByStableCenter(submitButton, in: app)
 
-        XCTAssertTrue(app.otherElements["root.currentView.home"].waitForExistence(timeout: 8))
+        XCTAssertTrue(
+            app.otherElements["root.currentView.home"].waitForExistence(timeout: 25),
+            "Home did not appear after login"
+        )
         let beginButton = app.buttons["home.beginButton"]
         XCTAssertTrue(beginButton.waitForExistence(timeout: 5))
         beginButton.tap()

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -178,12 +178,7 @@ final class StillPointAppUITests: XCTestCase {
 
         let field = app.textFields["settings.usernameField"]
         XCTAssertTrue(field.waitForExistence(timeout: 5))
-        field.tap()
-        field.press(forDuration: 1.2)
-        let selectAll = app.menuItems["Select All"]
-        if selectAll.waitForExistence(timeout: 2) {
-            selectAll.tap()
-        }
+        clearUsernameFieldForUITest(field, in: app)
         field.typeText("fixture_renamed")
 
         let saveButton = app.buttons["settings.usernameSaveButton"]
@@ -211,12 +206,7 @@ final class StillPointAppUITests: XCTestCase {
 
         let field = app.textFields["settings.usernameField"]
         XCTAssertTrue(field.waitForExistence(timeout: 5))
-        field.tap()
-        field.press(forDuration: 1.2)
-        let selectAll = app.menuItems["Select All"]
-        if selectAll.waitForExistence(timeout: 2) {
-            selectAll.tap()
-        }
+        clearUsernameFieldForUITest(field, in: app)
         field.typeText("no")
 
         let saveButton = app.buttons["settings.usernameSaveButton"]
@@ -247,12 +237,7 @@ final class StillPointAppUITests: XCTestCase {
 
         let field = app.textFields["settings.usernameField"]
         XCTAssertTrue(field.waitForExistence(timeout: 5))
-        field.tap()
-        field.press(forDuration: 1.2)
-        let selectAll = app.menuItems["Select All"]
-        if selectAll.waitForExistence(timeout: 2) {
-            selectAll.tap()
-        }
+        clearUsernameFieldForUITest(field, in: app)
         field.typeText("taken_name")
 
         let saveButton = app.buttons["settings.usernameSaveButton"]
@@ -594,6 +579,25 @@ final class StillPointAppUITests: XCTestCase {
             app.swipeDown()
         }
         RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+    }
+
+    /// Replaces field contents without relying on the "Select All" context menu (flaky in CI).
+    private func clearUsernameFieldForUITest(_ field: XCUIElement, in app: XCUIApplication) {
+        field.tap()
+        field.press(forDuration: 1.2)
+        let selectAll = app.menuItems["Select All"]
+        if selectAll.waitForExistence(timeout: 2) {
+            selectAll.tap()
+            return
+        }
+        let deleteKey = app.keyboards.keys["Delete"]
+        XCTAssertTrue(
+            deleteKey.waitForExistence(timeout: 3),
+            "Expected keyboard with Delete after focusing username field"
+        )
+        for _ in 0..<40 {
+            deleteKey.tap()
+        }
     }
 
     @discardableResult

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -165,6 +165,111 @@ final class StillPointAppUITests: XCTestCase {
     }
 
     @MainActor
+    func testSettingsUsernameInlineEditSucceeds() throws {
+        let app = makeApp(seedAuthenticated: true, resetStore: true)
+        app.launch()
+
+        waitForRoot("home", in: app, failureMessage: "Home screen did not appear")
+        openTab(identifier: "tab.settings", in: app, waitingFor: app.staticTexts["settings.title"])
+
+        let editButton = app.buttons["settings.usernameEditButton"]
+        XCTAssertTrue(editButton.waitForExistence(timeout: 5))
+        tapByStableCenter(editButton, in: app)
+
+        let field = app.textFields["settings.usernameField"]
+        XCTAssertTrue(field.waitForExistence(timeout: 5))
+        field.tap()
+        field.press(forDuration: 1.2)
+        let selectAll = app.menuItems["Select All"]
+        if selectAll.waitForExistence(timeout: 2) {
+            selectAll.tap()
+        }
+        field.typeText("fixture_renamed")
+
+        let saveButton = app.buttons["settings.usernameSaveButton"]
+        XCTAssertTrue(saveButton.waitForExistence(timeout: 5))
+        tapByStableCenter(saveButton, in: app)
+
+        let display = app.staticTexts["settings.usernameDisplay"]
+        XCTAssertTrue(display.waitForExistence(timeout: 8))
+        XCTAssertEqual(display.label, "fixture_renamed")
+
+        dismissKeyboardIfPresent(in: app)
+    }
+
+    @MainActor
+    func testSettingsUsernameValidationError() throws {
+        let app = makeApp(seedAuthenticated: true, resetStore: true)
+        app.launch()
+
+        waitForRoot("home", in: app, failureMessage: "Home screen did not appear")
+        openTab(identifier: "tab.settings", in: app, waitingFor: app.staticTexts["settings.title"])
+
+        let editButton = app.buttons["settings.usernameEditButton"]
+        XCTAssertTrue(editButton.waitForExistence(timeout: 5))
+        tapByStableCenter(editButton, in: app)
+
+        let field = app.textFields["settings.usernameField"]
+        XCTAssertTrue(field.waitForExistence(timeout: 5))
+        field.tap()
+        field.press(forDuration: 1.2)
+        let selectAll = app.menuItems["Select All"]
+        if selectAll.waitForExistence(timeout: 2) {
+            selectAll.tap()
+        }
+        field.typeText("no")
+
+        let saveButton = app.buttons["settings.usernameSaveButton"]
+        XCTAssertTrue(saveButton.waitForExistence(timeout: 5))
+        tapByStableCenter(saveButton, in: app)
+
+        let err = app.staticTexts["settings.usernameError"]
+        XCTAssertTrue(err.waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            err.label.contains("3-30"),
+            "Expected USERNAME_ERROR-style copy, got: \(err.label)"
+        )
+
+        dismissKeyboardIfPresent(in: app)
+    }
+
+    @MainActor
+    func testSettingsUsernameConflictShowsTakenMessage() throws {
+        let app = makeApp(seedAuthenticated: true, resetStore: true, forceUsernameConflict: true)
+        app.launch()
+
+        waitForRoot("home", in: app, failureMessage: "Home screen did not appear")
+        openTab(identifier: "tab.settings", in: app, waitingFor: app.staticTexts["settings.title"])
+
+        let editButton = app.buttons["settings.usernameEditButton"]
+        XCTAssertTrue(editButton.waitForExistence(timeout: 5))
+        tapByStableCenter(editButton, in: app)
+
+        let field = app.textFields["settings.usernameField"]
+        XCTAssertTrue(field.waitForExistence(timeout: 5))
+        field.tap()
+        field.press(forDuration: 1.2)
+        let selectAll = app.menuItems["Select All"]
+        if selectAll.waitForExistence(timeout: 2) {
+            selectAll.tap()
+        }
+        field.typeText("taken_name")
+
+        let saveButton = app.buttons["settings.usernameSaveButton"]
+        XCTAssertTrue(saveButton.waitForExistence(timeout: 5))
+        tapByStableCenter(saveButton, in: app)
+
+        let err = app.staticTexts["settings.usernameError"]
+        XCTAssertTrue(err.waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            err.label.localizedCaseInsensitiveContains("taken"),
+            "Expected 409 taken copy, got: \(err.label)"
+        )
+
+        dismissKeyboardIfPresent(in: app)
+    }
+
+    @MainActor
     func testKeyboardOverlapKeepsSubmitReachable() throws {
         let app = makeApp(seedAuthenticated: false, resetStore: true)
         app.launch()
@@ -314,7 +419,8 @@ final class StillPointAppUITests: XCTestCase {
         forceTokenExpired: Bool = false,
         forceSessionsFailure: Bool = false,
         appBlockingSelected: Bool = false,
-        forceProgressTab: Bool = false
+        forceProgressTab: Bool = false,
+        forceUsernameConflict: Bool = false
     ) -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["SP_UI_TEST_MODE"] = "1"
@@ -328,6 +434,7 @@ final class StillPointAppUITests: XCTestCase {
         app.launchEnvironment["SP_UI_TEST_FORCE_START_SESSION"] = "0"
         app.launchEnvironment["SP_UI_TEST_APP_BLOCKING_SELECTED"] = appBlockingSelected ? "1" : "0"
         app.launchEnvironment["SP_UI_TEST_FORCE_PROGRESS_TAB"] = forceProgressTab ? "1" : "0"
+        app.launchEnvironment["SP_UI_TEST_FORCE_USERNAME_CONFLICT"] = forceUsernameConflict ? "1" : "0"
         return app
     }
 

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -249,11 +249,18 @@ public actor APIClient {
     // MARK: - Settings
 
     public func updateSettings(isPublic: Bool) async throws -> UserDTO {
-        if let user = try uiTestUpdateSettings(isPublic: isPublic) {
+        try await updateSettings(patch: SettingsPatchBody(isPublic: isPublic, username: nil))
+    }
+
+    public func updateSettings(username: String) async throws -> UserDTO {
+        try await updateSettings(patch: SettingsPatchBody(isPublic: nil, username: username))
+    }
+
+    private func updateSettings(patch: SettingsPatchBody) async throws -> UserDTO {
+        if let user = try uiTestUpdateSettings(patch: patch) {
             return user
         }
-        let body = ["isPublic": isPublic]
-        let response: UserResponse = try await patch("/api/settings", body: body)
+        let response: UserResponse = try await patch("/api/settings", body: patch)
         return response.user
     }
 
@@ -597,17 +604,36 @@ public actor APIClient {
         return createdThoughts
     }
 
-    private func uiTestUpdateSettings(isPublic: Bool) throws -> UserDTO? {
-        guard uiTestConfig != nil else { return nil }
+    private func uiTestUpdateSettings(patch: SettingsPatchBody) throws -> UserDTO? {
+        guard let uiTestConfig else { return nil }
         guard var store = uiTestStore else {
             throw APIError(status: 0, message: "UI test store is unavailable")
         }
         try ensureUITestAuthenticated(store: store)
+
+        var nextUsername = store.user.username
+        var nextIsPublic = store.user.isPublic
+
+        if let usernamePatch = patch.username {
+            let trimmed = usernamePatch.trimmingCharacters(in: .whitespacesAndNewlines)
+            if uiTestConfig.forceUsernameConflict {
+                throw APIError(status: 409, message: "Username already taken")
+            }
+            guard UsernameValidation.isValid(trimmed) else {
+                throw APIError(status: 400, message: UsernameValidation.errorMessage)
+            }
+            nextUsername = trimmed
+        }
+
+        if let isPublicPatch = patch.isPublic {
+            nextIsPublic = isPublicPatch
+        }
+
         store.user = UserDTO(
             id: store.user.id,
             email: store.user.email,
-            username: store.user.username,
-            isPublic: isPublic,
+            username: nextUsername,
+            isPublic: nextIsPublic,
             currentDay: store.user.currentDay
         )
         uiTestStore = store
@@ -672,12 +698,29 @@ public actor APIClient {
     }
 }
 
+private struct SettingsPatchBody: Encodable {
+    let isPublic: Bool?
+    let username: String?
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        if let isPublic { try c.encode(isPublic, forKey: .isPublic) }
+        if let username { try c.encode(username, forKey: .username) }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case isPublic
+        case username
+    }
+}
+
 private struct UITestConfig: Sendable {
     let seedAuthenticated: Bool
     let resetStore: Bool
     let forceLaunchOffline: Bool
     let forceTokenExpired: Bool
     let forceSessionsFailure: Bool
+    let forceUsernameConflict: Bool
 
     static func fromProcessInfo() -> UITestConfig? {
         let env = ProcessInfo.processInfo.environment
@@ -687,7 +730,8 @@ private struct UITestConfig: Sendable {
             resetStore: truthy(env["SP_UI_TEST_RESET_STORE"]),
             forceLaunchOffline: truthy(env["SP_UI_TEST_FORCE_LAUNCH_OFFLINE"]),
             forceTokenExpired: truthy(env["SP_UI_TEST_FORCE_TOKEN_EXPIRED"]),
-            forceSessionsFailure: truthy(env["SP_UI_TEST_FORCE_SESSIONS_FAILURE"])
+            forceSessionsFailure: truthy(env["SP_UI_TEST_FORCE_SESSIONS_FAILURE"]),
+            forceUsernameConflict: truthy(env["SP_UI_TEST_FORCE_USERNAME_CONFLICT"])
         )
     }
 

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -249,18 +249,18 @@ public actor APIClient {
     // MARK: - Settings
 
     public func updateSettings(isPublic: Bool) async throws -> UserDTO {
-        try await updateSettings(patch: SettingsPatchBody(isPublic: isPublic, username: nil))
+        try await updateSettings(body: SettingsPatchBody(isPublic: isPublic, username: nil))
     }
 
     public func updateSettings(username: String) async throws -> UserDTO {
-        try await updateSettings(patch: SettingsPatchBody(isPublic: nil, username: username))
+        try await updateSettings(body: SettingsPatchBody(isPublic: nil, username: username))
     }
 
-    private func updateSettings(patch: SettingsPatchBody) async throws -> UserDTO {
-        if let user = try uiTestUpdateSettings(patch: patch) {
+    private func updateSettings(body: SettingsPatchBody) async throws -> UserDTO {
+        if let user = try uiTestUpdateSettings(body: body) {
             return user
         }
-        let response: UserResponse = try await patch("/api/settings", body: patch)
+        let response: UserResponse = try await patch("/api/settings", body: body)
         return response.user
     }
 
@@ -604,7 +604,7 @@ public actor APIClient {
         return createdThoughts
     }
 
-    private func uiTestUpdateSettings(patch: SettingsPatchBody) throws -> UserDTO? {
+    private func uiTestUpdateSettings(body: SettingsPatchBody) throws -> UserDTO? {
         guard let uiTestConfig else { return nil }
         guard var store = uiTestStore else {
             throw APIError(status: 0, message: "UI test store is unavailable")
@@ -614,7 +614,7 @@ public actor APIClient {
         var nextUsername = store.user.username
         var nextIsPublic = store.user.isPublic
 
-        if let usernamePatch = patch.username {
+        if let usernamePatch = body.username {
             let trimmed = usernamePatch.trimmingCharacters(in: .whitespacesAndNewlines)
             if uiTestConfig.forceUsernameConflict {
                 throw APIError(status: 409, message: "Username already taken")
@@ -625,7 +625,7 @@ public actor APIClient {
             nextUsername = trimmed
         }
 
-        if let isPublicPatch = patch.isPublic {
+        if let isPublicPatch = body.isPublic {
             nextIsPublic = isPublicPatch
         }
 

--- a/ios/StillPointShared/Sources/StillPointShared/UsernameValidation.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/UsernameValidation.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Mirrors `src/lib/username.ts` (PR #280).
+public enum UsernameValidation {
+    public static let minLength = 3
+    public static let maxLength = 30
+    public static let errorMessage =
+        "Username must be 3-30 characters (letters, numbers, underscores)"
+
+    private static let allowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_")
+
+    public static func isValid(_ raw: String) -> Bool {
+        let s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard s.count >= minLength, s.count <= maxLength else { return false }
+        return s.unicodeScalars.allSatisfy { allowed.contains($0) }
+    }
+}

--- a/ios/StillPointShared/Tests/StillPointSharedTests/UsernameValidationTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/UsernameValidationTests.swift
@@ -1,0 +1,27 @@
+import StillPointShared
+import XCTest
+
+final class UsernameValidationTests: XCTestCase {
+    func testValidUsernames() {
+        XCTAssertTrue(UsernameValidation.isValid("abc"))
+        XCTAssertTrue(UsernameValidation.isValid("ios_fixture"))
+        XCTAssertTrue(UsernameValidation.isValid("User_123"))
+        XCTAssertTrue(UsernameValidation.isValid(String(repeating: "a", count: 30)))
+    }
+
+    func testRejectsTooShortOrTooLong() {
+        XCTAssertFalse(UsernameValidation.isValid("ab"))
+        XCTAssertFalse(UsernameValidation.isValid(String(repeating: "a", count: 31)))
+    }
+
+    func testRejectsInvalidCharacters() {
+        XCTAssertFalse(UsernameValidation.isValid("user-name"))
+        XCTAssertFalse(UsernameValidation.isValid("user name"))
+        XCTAssertFalse(UsernameValidation.isValid("user.name"))
+    }
+
+    func testTrimsWhitespaceForLength() {
+        XCTAssertTrue(UsernameValidation.isValid("  abc  "))
+        XCTAssertFalse(UsernameValidation.isValid("  ab  "))
+    }
+}


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports web-style username editing to iOS Settings (inline edit, validation, PATCH, local user sync).

## Babysitter follow-ups

1. **CI compile**: Renamed `updateSettings` parameter from `patch` to `body` to avoid shadowing the HTTP `patch` method.
2. **CodeAnt**: `applySettingsUser` guarded when logged out / user id mismatch.
3. **CodeAnt**: Deterministic username field clear in UITests (Select All or Delete fallback).
4. **Smoke flake**: Dismiss keyboard before auth submit; longer wait for home after login.

Closes #282
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc5c70c3-12a2-4380-a034-d607373d3920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc5c70c3-12a2-4380-a034-d607373d3920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Add inline username editing in iOS Settings with validation and save feedback**

### What Changed
- Users can now edit their username directly in Settings, save it in place, or cancel without leaving the page.
- Username saves are checked for valid length and characters, and the screen shows a clear error when the name is too short, invalid, or already taken.
- After a successful save, the updated username appears immediately in Settings.
- Public profile changes and username updates now avoid stepping on each other, which keeps the displayed account info in sync.
- Login and Settings UI tests were hardened to reduce flakiness when the keyboard is open or the app responds slowly.

### Impact
`✅ Shorter username changes`
`✅ Clearer username error messages`
`✅ Fewer Settings update conflicts`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=G4pe1mp9_uC_AP-UYcOQKGvqRDjd5k0KrnEo1mNuMuQ&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
