### PR TITLE
feat(history): multi-session days and calendar-day streaks

### DIFF
--- a/e2e/fixtures/auth.fixture.ts
+++ b/e2e/fixtures/auth.fixture.ts
@@ -1,4 +1,5 @@
 import { test as base, expect, type Page, type Route } from "@playwright/test";
+import { calculateSessionStats } from "../../src/lib/constants";
 import { tap } from "../utils/mobile-helpers";
 
 type UserRecord = {
@@ -71,43 +72,7 @@ function getLocalIsoDate(offsetDays = 0) {
 }
 
 function computeStats(sessions: SessionRecord[]) {
-  const standardSessions = sessions.filter((s) => s.sessionType === "standard");
-  const completedSessions = standardSessions.filter((s) => s.completed);
-  const totalSessions = standardSessions.length;
-  let streak = 0;
-  const completedByDay = new Map<number, boolean>();
-  for (const session of standardSessions) {
-    completedByDay.set(
-      session.dayNumber,
-      (completedByDay.get(session.dayNumber) ?? false) || session.completed,
-    );
-  }
-  const maxDay = Math.max(0, ...completedByDay.keys());
-  for (let day = maxDay; day >= 1; day -= 1) {
-    if (completedByDay.get(day) === true) {
-      streak += 1;
-    } else {
-      break;
-    }
-  }
-
-  const avgClearPercent = completedSessions.length
-    ? Math.round(completedSessions.reduce((sum, s) => sum + s.clearPercent, 0) / completedSessions.length)
-    : 0;
-  const avgThoughtsPerSession = totalSessions
-    ? Number((standardSessions.reduce((sum, s) => sum + s.thoughtCount, 0) / totalSessions).toFixed(1))
-    : 0;
-  const avgThoughtsPerMinute = totalSessions
-    ? Number(
-        (
-          standardSessions.reduce((sum, s) => {
-            const minutes = s.duration / 60;
-            return sum + (minutes > 0 ? s.thoughtCount / minutes : 0);
-          }, 0) / totalSessions
-        ).toFixed(1),
-      )
-    : 0;
-  return { streak, avgClearPercent, avgThoughtsPerSession, avgThoughtsPerMinute };
+  return calculateSessionStats(sessions);
 }
 
 function json(route: Route, status: number, body: unknown) {

--- a/e2e/layout/overflow.spec.ts
+++ b/e2e/layout/overflow.spec.ts
@@ -33,9 +33,10 @@ test.describe("mobile overflow and scrolling", () => {
     await expectNoHorizontalOverflow(page);
 
     const firstEntry = page.getByText(/^Session 1$/).first();
-    const lastEntry = page.getByText(/^Session 24$/).last();
+    // One standard sit per calendar day → each row is "Session 1"; target the chronologically last row.
+    const lastEntry = page.getByText(/^Session 1$/).last();
     await expect(firstEntry).toBeVisible();
-    await expect(lastEntry).toHaveCount(1);
+    await expect(lastEntry).toBeVisible();
 
     await lastEntry.scrollIntoViewIfNeeded();
     await expectVisibleInViewport(page, lastEntry, "latest history session row");

--- a/e2e/layout/overflow.spec.ts
+++ b/e2e/layout/overflow.spec.ts
@@ -32,15 +32,15 @@ test.describe("mobile overflow and scrolling", () => {
     await expect(page.getByRole("heading", { name: "Progress" })).toBeVisible();
     await expectNoHorizontalOverflow(page);
 
-    const firstEntry = page.getByText(/^D1$/).first();
-    const lastEntry = page.getByText(/^D24$/).last();
+    const firstEntry = page.getByText(/^Session 1$/).first();
+    const lastEntry = page.getByText(/^Session 24$/).last();
     await expect(firstEntry).toBeVisible();
     await expect(lastEntry).toHaveCount(1);
 
     await lastEntry.scrollIntoViewIfNeeded();
-    await expectVisibleInViewport(page, lastEntry, "latest history day chip");
+    await expectVisibleInViewport(page, lastEntry, "latest history session row");
     await expectNoVerticalOverlap(lastEntry, page.getByRole("button", { name: /^home$/i }), {
-      upper: "latest history day chip",
+      upper: "latest history session row",
       lower: "bottom home nav",
     });
   });

--- a/ios/StillPointApp/ViewModels/HistoryViewModel.swift
+++ b/ios/StillPointApp/ViewModels/HistoryViewModel.swift
@@ -1,20 +1,6 @@
 import SwiftUI
 import StillPointShared
 
-/// A display-ready row in the Journey list (session or missed day).
-struct HistoryEntry: Identifiable {
-    let id: String
-    let sessionId: String?
-    let dayNumber: Int?
-    let duration: Int
-    let actualTime: Int
-    let completed: Bool
-    let date: String          // "YYYY-MM-DD"
-    let clearPercent: Int
-    let thoughtCount: Int
-    let missed: Bool
-}
-
 @MainActor
 @Observable
 final class HistoryViewModel {
@@ -22,13 +8,14 @@ final class HistoryViewModel {
     var stats: StatsDTO?
     var isLoading = false
     var errorMessage: String?
-    var expandedDay: Int?
-    var dayThoughts: [Int: [ThoughtDTO]] = [:]
+    /// Expanded standard session (by row id).
+    var expandedSessionId: String?
+    var sessionThoughts: [String: [ThoughtDTO]] = [:]
 
-    /// Flattened journey entries including missed days.
-    var history: [HistoryEntry] = []
+    /// Standard sits only, ordered for the Journey list (missed gaps + per-day session indices).
+    var journeyRows: [HistoryJourneyListRow] = []
 
-    /// Longest actualTime across all real sessions (floor 60).
+    /// Longest actualTime across standard sessions in the journey (floor 60).
     var maxDuration: Int = 60
 
     func load() async {
@@ -41,24 +28,24 @@ final class HistoryViewModel {
             let result = try await APIClient.shared.getSessions()
             sessions = result.sessions.sorted { $0.sessionDate < $1.sessionDate }
             stats = result.stats
-            buildHistory()
+            buildJourney()
         } catch {
             errorMessage = "Failed to load sessions. Check your connection."
             print("Failed to load sessions: \(error)")
         }
     }
 
-    func toggleDay(_ dayNumber: Int) async {
-        if expandedDay == dayNumber {
-            expandedDay = nil
+    func toggleSession(_ sessionId: String) async {
+        if expandedSessionId == sessionId {
+            expandedSessionId = nil
         } else {
-            expandedDay = dayNumber
-            if dayThoughts[dayNumber] == nil {
+            expandedSessionId = sessionId
+            if sessionThoughts[sessionId] == nil {
                 do {
-                    let detail = try await APIClient.shared.getSession(dayNumber: dayNumber)
-                    dayThoughts[dayNumber] = detail.thoughts
+                    let detail = try await APIClient.shared.getSessionBySessionId(sessionId)
+                    sessionThoughts[sessionId] = detail.thoughts
                 } catch {
-                    print("Failed to load day \(dayNumber) thoughts: \(error)")
+                    print("Failed to load session \(sessionId) thoughts: \(error)")
                 }
             }
         }
@@ -66,55 +53,11 @@ final class HistoryViewModel {
 
     // MARK: - Private
 
-    private func buildHistory() {
-        var entries: [HistoryEntry] = []
-        let cal = Calendar.current
-        let df = DateFormatter()
-        df.dateFormat = "yyyy-MM-dd"
+    private func buildJourney() {
+        let standard = sessions.filter { $0.sessionType == .standard }
+        journeyRows = HistoryJourney.buildRows(fromStandardSessions: standard)
 
-        for (i, session) in sessions.enumerated() {
-            // Detect missed days between consecutive sessions
-            if i > 0,
-               let prevDate = df.date(from: sessions[i - 1].sessionDate),
-               let currDate = df.date(from: session.sessionDate) {
-                let daysBetween = cal.dateComponents([.day], from: prevDate, to: currDate).day ?? 0
-                if daysBetween > 1 {
-                    for gap in 1..<daysBetween {
-                        if let missedDate = cal.date(byAdding: .day, value: gap, to: prevDate) {
-                            entries.append(HistoryEntry(
-                                id: "missed-\(df.string(from: missedDate))",
-                                sessionId: nil,
-                                dayNumber: nil,
-                                duration: 0,
-                                actualTime: 0,
-                                completed: false,
-                                date: df.string(from: missedDate),
-                                clearPercent: 0,
-                                thoughtCount: 0,
-                                missed: true
-                            ))
-                        }
-                    }
-                }
-            }
-
-            entries.append(HistoryEntry(
-                id: session.id,
-                sessionId: session.id,
-                dayNumber: session.dayNumber,
-                duration: session.duration,
-                actualTime: session.actualTime ?? session.duration,
-                completed: session.completed,
-                date: session.sessionDate,
-                clearPercent: session.clearPercent,
-                thoughtCount: session.thoughtCount,
-                missed: false
-            ))
-        }
-
-        history = entries
-
-        let sessionTimes = entries.filter { !$0.missed }.map(\.actualTime)
+        let sessionTimes = standard.map { $0.actualTime ?? $0.duration }
         maxDuration = max(sessionTimes.max() ?? 60, 60)
     }
 }

--- a/ios/StillPointApp/ViewModels/HistoryViewModel.swift
+++ b/ios/StillPointApp/ViewModels/HistoryViewModel.swift
@@ -46,6 +46,7 @@ final class HistoryViewModel {
                     sessionThoughts[sessionId] = detail.thoughts
                 } catch {
                     print("Failed to load session \(sessionId) thoughts: \(error)")
+                    expandedSessionId = nil
                 }
             }
         }

--- a/ios/StillPointApp/ViewModels/HistoryViewModel.swift
+++ b/ios/StillPointApp/ViewModels/HistoryViewModel.swift
@@ -46,7 +46,9 @@ final class HistoryViewModel {
                     sessionThoughts[sessionId] = detail.thoughts
                 } catch {
                     print("Failed to load session \(sessionId) thoughts: \(error)")
-                    expandedSessionId = nil
+                    if expandedSessionId == sessionId {
+                        expandedSessionId = nil
+                    }
                 }
             }
         }

--- a/ios/StillPointApp/Views/HistoryView.swift
+++ b/ios/StillPointApp/Views/HistoryView.swift
@@ -40,7 +40,7 @@ struct HistoryView: View {
                         .foregroundStyle(SPColor.green)
                     }
                     .padding(.top, SPSpacing.s6)
-                } else if vm.sessions.isEmpty {
+                } else if vm.journeyRows.isEmpty {
                     VStack(spacing: SPSpacing.s3) {
                         Text("No sessions yet")
                             .font(SPFont.serifItalic(15))

--- a/ios/StillPointApp/Views/HistoryView.swift
+++ b/ios/StillPointApp/Views/HistoryView.swift
@@ -73,11 +73,15 @@ struct HistoryView: View {
                             .tracking(2)
                             .padding(.bottom, 4)
 
-                        ForEach(vm.history) { entry in
-                            if entry.missed {
-                                missedRow(entry)
-                            } else {
-                                sessionRow(entry)
+                        ForEach(0..<vm.journeyRows.count, id: \.self) { index in
+                            let row = vm.journeyRows[index]
+                            let prevDate: String? = index > 0 ? previousSessionDate(before: index) : nil
+                            switch row {
+                            case .missed(let date):
+                                missedRow(date: date)
+                            case .standardSession(let session, let sessionIndex):
+                                let showDate = prevDate.map { $0 != session.sessionDate } ?? true
+                                sessionRow(session: session, sessionIndexInDay: sessionIndex, showDateColumn: showDate)
                             }
                         }
 
@@ -93,6 +97,20 @@ struct HistoryView: View {
         .task {
             await vm.load()
         }
+    }
+
+    private func previousSessionDate(before index: Int) -> String? {
+        var i = index - 1
+        while i >= 0 {
+            switch vm.journeyRows[i] {
+            case .missed(let date):
+                return date
+            case .standardSession(let session, _):
+                return session.sessionDate
+            }
+            i -= 1
+        }
+        return nil
     }
 
     private func statCell(value: String, label: String) -> some View {
@@ -111,35 +129,34 @@ struct HistoryView: View {
     // MARK: - Session Row
 
     @ViewBuilder
-    private func sessionRow(_ entry: HistoryEntry) -> some View {
-        if let dayNumber = entry.dayNumber {
-            let isExpanded = vm.expandedDay == dayNumber
+    private func sessionRow(session: SessionDTO, sessionIndexInDay: Int, showDateColumn: Bool) -> some View {
+        let isExpanded = vm.expandedSessionId == session.id
 
         VStack(spacing: 0) {
             Button {
-                Task { await vm.toggleDay(dayNumber) }
+                Task { await vm.toggleSession(session.id) }
             } label: {
                 HStack(spacing: 8) {
-                    // Date label
-                    Text(shortDateLabel(entry.date))
+                    // Date label (only first row of each calendar day)
+                    Text(showDateColumn ? shortDateLabel(session.sessionDate) : "")
                         .font(SPFont.mono(10))
                         .foregroundStyle(Color(SPColor.fg4))
                         .frame(width: 56, alignment: .trailing)
                         .lineLimit(1)
 
-                    // Day number
-                    Text("D\(dayNumber)")
+                    // Session label within the day
+                    Text("Session \(sessionIndexInDay)")
                         .font(SPFont.mono(11, weight: .medium))
                         .foregroundStyle(Color(SPColor.fg3))
-                        .frame(width: 28, alignment: .trailing)
+                        .frame(width: 72, alignment: .trailing)
 
                     // Proportional bar
                     GeometryReader { geo in
                         let barFraction = vm.maxDuration > 0
-                            ? CGFloat(entry.actualTime) / CGFloat(vm.maxDuration)
+                            ? CGFloat(session.actualTime ?? session.duration) / CGFloat(vm.maxDuration)
                             : 0
                         let barWidth = geo.size.width * barFraction
-                        let clearWidth = barWidth * CGFloat(entry.clearPercent) / 100.0
+                        let clearWidth = barWidth * CGFloat(session.clearPercent) / 100.0
                         let thinkWidth = barWidth - clearWidth
 
                         ZStack(alignment: .leading) {
@@ -151,10 +168,10 @@ struct HistoryView: View {
                             // Proportional filled portion
                             HStack(spacing: 0) {
                                 Rectangle()
-                                    .fill(SPColor.green.opacity(entry.completed ? 0.7 : 0.4))
+                                    .fill(SPColor.green.opacity(session.completed ? 0.7 : 0.4))
                                     .frame(width: max(0, clearWidth))
                                 Rectangle()
-                                    .fill(SPColor.amber.opacity(entry.completed ? 0.5 : 0.3))
+                                    .fill(SPColor.amber.opacity(session.completed ? 0.5 : 0.3))
                                     .frame(width: max(0, thinkWidth))
                             }
                             .frame(height: 16)
@@ -165,15 +182,15 @@ struct HistoryView: View {
 
                     // Metadata: duration · clear% · thoughts
                     HStack(spacing: 4) {
-                        Text("\(entry.actualTime)s")
+                        Text("\(session.actualTime ?? session.duration)s")
                             .foregroundStyle(Color(SPColor.fg3))
                         Text("·")
                             .foregroundStyle(Color(SPColor.fg4))
-                        Text("\(entry.clearPercent)%")
+                        Text("\(session.clearPercent)%")
                             .foregroundStyle(SPColor.greenText)
                         Text("·")
                             .foregroundStyle(Color(SPColor.fg4))
-                        Text("\(entry.thoughtCount)\u{1F4AD}")
+                        Text("\(session.thoughtCount)\u{1F4AD}")
                             .foregroundStyle(SPColor.amberText)
                     }
                     .font(SPFont.mono(10))
@@ -182,10 +199,10 @@ struct HistoryView: View {
                 }
                 .padding(.vertical, 2)
             }
-            .accessibilityIdentifier("history.session.day.\(dayNumber)")
+            .accessibilityIdentifier("history.session.\(session.id)")
 
             // Expanded thoughts
-            if isExpanded, let thoughts = vm.dayThoughts[dayNumber] {
+            if isExpanded, let thoughts = vm.sessionThoughts[session.id] {
                 VStack(alignment: .leading, spacing: 4) {
                     ForEach(thoughts, id: \.id) { thought in
                         HStack(alignment: .top, spacing: SPSpacing.s2) {
@@ -204,25 +221,24 @@ struct HistoryView: View {
                 .padding(.vertical, 4)
             }
         }
-        } // if let dayNumber
     }
 
     // MARK: - Missed Row
 
-    private func missedRow(_ entry: HistoryEntry) -> some View {
+    private func missedRow(date: String) -> some View {
         HStack(spacing: 8) {
             // Date label
-            Text(shortDateLabel(entry.date))
+            Text(shortDateLabel(date))
                 .font(SPFont.mono(10))
                 .foregroundStyle(Color(SPColor.fg4))
                 .frame(width: 56, alignment: .trailing)
                 .lineLimit(1)
 
-            // Em-dash instead of day number
+            // Em-dash instead of session label
             Text("\u{2014}")
                 .font(SPFont.mono(11, weight: .medium))
                 .foregroundStyle(Color(SPColor.fg3))
-                .frame(width: 28, alignment: .trailing)
+                .frame(width: 72, alignment: .trailing)
 
             // Dashed border container
             RoundedRectangle(cornerRadius: 3)
@@ -256,11 +272,11 @@ struct HistoryView: View {
                 .foregroundStyle(Color(SPColor.fg4))
                 .frame(width: 56, alignment: .trailing)
 
-            // Day number
-            Text("D\(appVM.currentDay)")
+            // Placeholder aligned with session label column
+            Text("\u{2014}")
                 .font(SPFont.mono(11, weight: .medium))
                 .foregroundStyle(Color(SPColor.fg4))
-                .frame(width: 28, alignment: .trailing)
+                .frame(width: 72, alignment: .trailing)
 
             // Proportional dashed bar
             GeometryReader { geo in
@@ -293,8 +309,6 @@ struct HistoryView: View {
     }
 
     // MARK: - Helpers
-
-    // MARK: - Cached Formatters
 
     private static let isoDateFormatter: DateFormatter = {
         let df = DateFormatter()

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -133,8 +133,8 @@ final class StillPointAppUITests: XCTestCase {
             relaunch.staticTexts["history.title"].waitForExistence(timeout: launchTimeout),
             "History screen did not appear after relaunch"
         )
-        let dayRow = relaunch.buttons.matching(NSPredicate(format: "identifier BEGINSWITH %@", "history.session.day.")).firstMatch
-        XCTAssertTrue(dayRow.waitForExistence(timeout: 8), "Expected persisted history row after relaunch")
+        let sessionRow = relaunch.buttons.matching(NSPredicate(format: "identifier BEGINSWITH %@", "history.session.")).firstMatch
+        XCTAssertTrue(sessionRow.waitForExistence(timeout: 8), "Expected persisted history row after relaunch")
     }
 
     @MainActor

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -530,6 +530,7 @@ public actor APIClient {
             thoughtCount: data.thoughtCount,
             mindStateLog: data.mindStateLog,
             sessionDate: data.sessionDate,
+            createdAt: nil,
             buddySessionId: nil
         )
         store.nextSessionOrdinal += 1

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -218,6 +218,14 @@ public actor APIClient {
         return (response.session, response.thoughts)
     }
 
+    public func getSessionBySessionId(_ sessionId: String) async throws -> (session: SessionDTO, thoughts: [ThoughtDTO]) {
+        if let uiTestResult = try uiTestGetSession(sessionId: sessionId) {
+            return uiTestResult
+        }
+        let response: SessionDetailResponse = try await get("/api/sessions/by-session/\(sessionId)")
+        return (response.session, response.thoughts)
+    }
+
     // MARK: - Thoughts
 
     public func getThoughts() async throws -> [ThoughtDTO] {
@@ -500,7 +508,7 @@ public actor APIClient {
         }
 
         let sortedSessions = store.sessions.sorted { $0.sessionDate < $1.sessionDate }
-        return (sortedSessions, Self.makeUITestStats(for: sortedSessions))
+        return (sortedSessions, SessionStatistics.calculateStats(for: sortedSessions))
     }
 
     private func uiTestCreateSession(_ data: CreateSessionRequest) throws -> SessionDTO? {
@@ -540,6 +548,22 @@ public actor APIClient {
         uiTestStore = store
         persistUITestStore()
         return session
+    }
+
+    private func uiTestGetSession(sessionId: String) throws -> (session: SessionDTO, thoughts: [ThoughtDTO])? {
+        guard uiTestConfig != nil else { return nil }
+        guard let store = uiTestStore else {
+            throw APIError(status: 0, message: "UI test store is unavailable")
+        }
+        try ensureUITestAuthenticated(store: store)
+
+        guard let session = store.sessions.first(where: { $0.id == sessionId }) else {
+            throw APIError(status: 404, message: "Session not found")
+        }
+
+        let thoughts = store.thoughts.filter { $0.sessionId == session.id }
+            .sorted { $0.timeInSession < $1.timeInSession }
+        return (session, thoughts)
     }
 
     private func uiTestGetSession(dayNumber: Int) throws -> (session: SessionDTO, thoughts: [ThoughtDTO])? {
@@ -632,43 +656,6 @@ public actor APIClient {
     private static func persist(store: UITestStore, key: String) {
         guard let encoded = try? JSONEncoder().encode(store) else { return }
         UserDefaults.standard.set(encoded, forKey: key)
-    }
-
-    private static func makeUITestStats(for sessions: [SessionDTO]) -> StatsDTO {
-        let standardSessions = sessions.filter { $0.sessionType == .standard }
-        guard !standardSessions.isEmpty else {
-            return StatsDTO(streak: 0, avgClearPercent: 0, avgThoughtsPerSession: 0, avgThoughtsPerMinute: 0)
-        }
-
-        let completedSessions = standardSessions.filter(\.completed)
-        var completedByDay: [Int: Bool] = [:]
-        for session in standardSessions {
-            completedByDay[session.dayNumber] = (completedByDay[session.dayNumber] ?? false) || session.completed
-        }
-        let maxDay = completedByDay.keys.max() ?? 0
-        var streak = 0
-        for day in stride(from: maxDay, through: 1, by: -1) {
-            if completedByDay[day] == true {
-                streak += 1
-            } else {
-                break
-            }
-        }
-        let totalClear = completedSessions.reduce(0) { $0 + $1.clearPercent }
-        let totalThoughts = standardSessions.reduce(0) { $0 + $1.thoughtCount }
-        let totalMinutes = standardSessions.reduce(0.0) { partial, session in
-            let duration = Double(max(session.actualTime ?? session.duration, 1))
-            return partial + (duration / 60.0)
-        }
-        let avgClearPercent = completedSessions.isEmpty ? 0 : totalClear / completedSessions.count
-        let avgThoughtsPerSession = Double(totalThoughts) / Double(standardSessions.count)
-        let avgThoughtsPerMinute = totalMinutes > 0 ? Double(totalThoughts) / totalMinutes : 0
-        return StatsDTO(
-            streak: streak,
-            avgClearPercent: avgClearPercent,
-            avgThoughtsPerSession: avgThoughtsPerSession,
-            avgThoughtsPerMinute: avgThoughtsPerMinute
-        )
     }
 }
 

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -29,6 +29,8 @@ public struct SessionDTO: Codable, Sendable {
     public let thoughtCount: Int
     public let mindStateLog: [MindStateEntry]?
     public let sessionDate: String
+    /// ISO-8601 from API when present; used for same-day ordering (matches web `sessionSortKey`).
+    public let createdAt: String?
     public let buddySessionId: String?
 
     public init(
@@ -42,6 +44,7 @@ public struct SessionDTO: Codable, Sendable {
         thoughtCount: Int,
         mindStateLog: [MindStateEntry]?,
         sessionDate: String,
+        createdAt: String? = nil,
         buddySessionId: String?
     ) {
         self.id = id
@@ -54,6 +57,7 @@ public struct SessionDTO: Codable, Sendable {
         self.thoughtCount = thoughtCount
         self.mindStateLog = mindStateLog
         self.sessionDate = sessionDate
+        self.createdAt = createdAt
         self.buddySessionId = buddySessionId
     }
 }

--- a/ios/StillPointShared/Sources/StillPointShared/HistoryJourney.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/HistoryJourney.swift
@@ -3,6 +3,12 @@ import Foundation
 // MARK: - Calendar helpers (UTC date parts; matches `session_date` strings)
 
 public enum SessionCalendar {
+    private static let utcCalendar: Calendar = {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(secondsFromGMT: 0)!
+        return c
+    }()
+
     public static func addDays(toIsoDate isoDate: String, deltaDays: Int) -> String {
         let parts = isoDate.split(separator: "-").compactMap { Int($0) }
         guard parts.count == 3 else { return isoDate }
@@ -10,21 +16,19 @@ public enum SessionCalendar {
         c.year = parts[0]
         c.month = parts[1]
         c.day = parts[2]
-        c.calendar = Calendar(identifier: .gregorian)
+        c.calendar = utcCalendar
         c.timeZone = TimeZone(secondsFromGMT: 0)
         guard let base = c.date else { return isoDate }
-        guard let shifted = Calendar(identifier: .gregorian).date(byAdding: .day, value: deltaDays, to: base) else {
+        guard let shifted = utcCalendar.date(byAdding: .day, value: deltaDays, to: base) else {
             return isoDate
         }
-        let df = isoFormatter
-        return df.string(from: shifted)
+        return isoFormatter.string(from: shifted)
     }
 
     /// Inclusive day span: same calendar returns 0; consecutive returns 1.
     public static func daysBetweenInclusive(fromIso: String, toIso: String) -> Int {
         guard let a = isoFormatter.date(from: fromIso), let b = isoFormatter.date(from: toIso) else { return 0 }
-        let cal = Calendar(identifier: .gregorian)
-        let d = cal.dateComponents([.day], from: a, to: b).day ?? 0
+        let d = utcCalendar.dateComponents([.day], from: a, to: b).day ?? 0
         return d
     }
 
@@ -33,7 +37,9 @@ public enum SessionCalendar {
         df.dateFormat = "yyyy-MM-dd"
         df.locale = Locale(identifier: "en_US_POSIX")
         df.timeZone = TimeZone(secondsFromGMT: 0)
-        df.calendar = Calendar(identifier: .gregorian)
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(secondsFromGMT: 0)!
+        df.calendar = cal
         return df
     }()
 
@@ -94,13 +100,13 @@ public enum SessionStatistics {
 
         let totalClear = completedSessions.reduce(0) { $0 + $1.clearPercent }
         let totalThoughts = standard.reduce(0) { $0 + $1.thoughtCount }
-        let totalMinutes = standard.reduce(0.0) { partial, session in
-            let duration = Double(max(session.actualTime ?? session.duration, 1))
-            return partial + (duration / 60.0)
+        let sumThoughtRates = standard.reduce(0.0) { sum, session in
+            let minutes = Double(max(session.actualTime ?? session.duration, 1)) / 60.0
+            return sum + (minutes > 0 ? Double(session.thoughtCount) / minutes : 0)
         }
         let avgClearPercent = completedSessions.isEmpty ? 0 : totalClear / completedSessions.count
         let avgThoughtsPerSession = Double(totalThoughts) / Double(standard.count)
-        let avgThoughtsPerMinute = totalMinutes > 0 ? Double(totalThoughts) / totalMinutes : 0
+        let avgThoughtsPerMinute = sumThoughtRates / Double(standard.count)
         return StatsDTO(
             streak: streak,
             avgClearPercent: avgClearPercent,
@@ -117,11 +123,17 @@ public enum HistoryJourneyListRow: Sendable {
     case standardSession(session: SessionDTO, sessionIndexInDay: Int)
 }
 
+/// Max consecutive missed-day rows between two sessions (matches web `MAX_MISSED_GAP_ROWS`).
 public enum HistoryJourney {
-    /// `sessions` should be standard-only; sorted by `sessionDate` then stable id.
+    public static let maxMissedGapRows = 366
+
+    /// `sessions` should be standard-only; sorted by `sessionDate` then `createdAt` / `id`.
     public static func buildRows(fromStandardSessions sessions: [SessionDTO]) -> [HistoryJourneyListRow] {
         let sorted = sessions.sorted {
             if $0.sessionDate != $1.sessionDate { return $0.sessionDate < $1.sessionDate }
+            let a = $0.createdAt ?? ""
+            let b = $1.createdAt ?? ""
+            if a != b { return a < b }
             return $0.id < $1.id
         }
         var rows: [HistoryJourneyListRow] = []
@@ -131,9 +143,13 @@ public enum HistoryJourney {
             if i > 0 {
                 let prev = sorted[i - 1]
                 let daysBetween = SessionCalendar.daysBetweenInclusive(fromIso: prev.sessionDate, toIso: sorted[i].sessionDate)
-                for gap in 1..<daysBetween {
-                    let missedDate = SessionCalendar.addDays(toIsoDate: prev.sessionDate, deltaDays: gap)
-                    rows.append(.missed(date: missedDate))
+                let missedCount = max(0, daysBetween - 1)
+                let toEmit = min(missedCount, maxMissedGapRows)
+                if toEmit > 0 {
+                    for gap in 1...toEmit {
+                        let missedDate = SessionCalendar.addDays(toIsoDate: prev.sessionDate, deltaDays: gap)
+                        rows.append(.missed(date: missedDate))
+                    }
                 }
             }
             let cur = sorted[i]

--- a/ios/StillPointShared/Sources/StillPointShared/HistoryJourney.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/HistoryJourney.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+// MARK: - Calendar helpers (UTC date parts; matches `session_date` strings)
+
+public enum SessionCalendar {
+    public static func addDays(toIsoDate isoDate: String, deltaDays: Int) -> String {
+        let parts = isoDate.split(separator: "-").compactMap { Int($0) }
+        guard parts.count == 3 else { return isoDate }
+        var c = DateComponents()
+        c.year = parts[0]
+        c.month = parts[1]
+        c.day = parts[2]
+        c.calendar = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(secondsFromGMT: 0)
+        guard let base = c.date else { return isoDate }
+        guard let shifted = Calendar(identifier: .gregorian).date(byAdding: .day, value: deltaDays, to: base) else {
+            return isoDate
+        }
+        let df = isoFormatter
+        return df.string(from: shifted)
+    }
+
+    /// Inclusive day span: same calendar returns 0; consecutive returns 1.
+    public static func daysBetweenInclusive(fromIso: String, toIso: String) -> Int {
+        guard let a = isoFormatter.date(from: fromIso), let b = isoFormatter.date(from: toIso) else { return 0 }
+        let cal = Calendar(identifier: .gregorian)
+        let d = cal.dateComponents([.day], from: a, to: b).day ?? 0
+        return d
+    }
+
+    private static let isoFormatter: DateFormatter = {
+        let df = DateFormatter()
+        df.dateFormat = "yyyy-MM-dd"
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.timeZone = TimeZone(secondsFromGMT: 0)
+        df.calendar = Calendar(identifier: .gregorian)
+        return df
+    }()
+}
+
+// MARK: - Streak / aggregate stats (matches web `calculateSessionStats`)
+
+public enum SessionStatistics {
+    public static func calculateStats(for sessions: [SessionDTO]) -> StatsDTO {
+        let standard = sessions.filter { $0.sessionType == .standard }
+        guard !standard.isEmpty else {
+            return StatsDTO(streak: 0, avgClearPercent: 0, avgThoughtsPerSession: 0, avgThoughtsPerMinute: 0)
+        }
+
+        let completedSessions = standard.filter(\.completed)
+        let allHaveSessionDate = standard.allSatisfy { !$0.sessionDate.isEmpty }
+
+        var streak = 0
+        if allHaveSessionDate {
+            var completedDates = Set<String>()
+            for s in standard where s.completed {
+                completedDates.insert(s.sessionDate)
+            }
+            let latestCal = standard.map(\.sessionDate).max() ?? ""
+            let latestDayHasCompletion = standard.contains { $0.sessionDate == latestCal && $0.completed }
+            if latestCal.isEmpty || !latestDayHasCompletion {
+                streak = 0
+            } else {
+                var cursor = latestCal
+                while completedDates.contains(cursor) {
+                    streak += 1
+                    cursor = SessionCalendar.addDays(toIsoDate: cursor, deltaDays: -1)
+                }
+            }
+        } else {
+            var completedByDay: [Int: Bool] = [:]
+            for s in standard {
+                completedByDay[s.dayNumber] = (completedByDay[s.dayNumber] ?? false) || s.completed
+            }
+            let maxDay = completedByDay.keys.max() ?? 0
+            for day in stride(from: maxDay, through: 1, by: -1) {
+                if completedByDay[day] == true {
+                    streak += 1
+                } else {
+                    break
+                }
+            }
+        }
+
+        let totalClear = completedSessions.reduce(0) { $0 + $1.clearPercent }
+        let totalThoughts = standard.reduce(0) { $0 + $1.thoughtCount }
+        let totalMinutes = standard.reduce(0.0) { partial, session in
+            let duration = Double(max(session.actualTime ?? session.duration, 1))
+            return partial + (duration / 60.0)
+        }
+        let avgClearPercent = completedSessions.isEmpty ? 0 : totalClear / completedSessions.count
+        let avgThoughtsPerSession = Double(totalThoughts) / Double(standard.count)
+        let avgThoughtsPerMinute = totalMinutes > 0 ? Double(totalThoughts) / totalMinutes : 0
+        return StatsDTO(
+            streak: streak,
+            avgClearPercent: avgClearPercent,
+            avgThoughtsPerSession: avgThoughtsPerSession,
+            avgThoughtsPerMinute: avgThoughtsPerMinute
+        )
+    }
+}
+
+// MARK: - History journey rows (standard sessions; quick excluded by caller)
+
+public enum HistoryJourneyListRow: Equatable, Sendable {
+    case missed(date: String)
+    case standardSession(session: SessionDTO, sessionIndexInDay: Int)
+}
+
+public enum HistoryJourney {
+    /// `sessions` should be standard-only; sorted by `sessionDate` then stable id.
+    public static func buildRows(fromStandardSessions sessions: [SessionDTO]) -> [HistoryJourneyListRow] {
+        let sorted = sessions.sorted {
+            if $0.sessionDate != $1.sessionDate { return $0.sessionDate < $1.sessionDate }
+            return $0.id < $1.id
+        }
+        var rows: [HistoryJourneyListRow] = []
+        var perDayIndex: [String: Int] = [:]
+
+        for i in sorted.indices {
+            if i > 0 {
+                let prev = sorted[i - 1]
+                let daysBetween = SessionCalendar.daysBetweenInclusive(fromIso: prev.sessionDate, toIso: sorted[i].sessionDate)
+                for gap in 1..<daysBetween {
+                    let missedDate = SessionCalendar.addDays(toIsoDate: prev.sessionDate, deltaDays: gap)
+                    rows.append(.missed(date: missedDate))
+                }
+            }
+            let cur = sorted[i]
+            let n = (perDayIndex[cur.sessionDate] ?? 0) + 1
+            perDayIndex[cur.sessionDate] = n
+            rows.append(.standardSession(session: cur, sessionIndexInDay: n))
+        }
+        return rows
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/HistoryJourney.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/HistoryJourney.swift
@@ -36,6 +36,14 @@ public enum SessionCalendar {
         df.calendar = Calendar(identifier: .gregorian)
         return df
     }()
+
+    /// Strict `YYYY-MM-DD` that parses as a real UTC calendar day and round-trips.
+    public static func isValidSessionCalendarDate(_ value: String) -> Bool {
+        guard value.count == 10,
+              value.range(of: #"^\d{4}-\d{2}-\d{2}$"#, options: .regularExpression) != nil,
+              let date = isoFormatter.date(from: value) else { return false }
+        return isoFormatter.string(from: date) == value
+    }
 }
 
 // MARK: - Streak / aggregate stats (matches web `calculateSessionStats`)
@@ -48,7 +56,7 @@ public enum SessionStatistics {
         }
 
         let completedSessions = standard.filter(\.completed)
-        let allHaveSessionDate = standard.allSatisfy { !$0.sessionDate.isEmpty }
+        let allHaveSessionDate = standard.allSatisfy { SessionCalendar.isValidSessionCalendarDate($0.sessionDate) }
 
         var streak = 0
         if allHaveSessionDate {
@@ -64,7 +72,9 @@ public enum SessionStatistics {
                 var cursor = latestCal
                 while completedDates.contains(cursor) {
                     streak += 1
-                    cursor = SessionCalendar.addDays(toIsoDate: cursor, deltaDays: -1)
+                    let next = SessionCalendar.addDays(toIsoDate: cursor, deltaDays: -1)
+                    if next == cursor { break }
+                    cursor = next
                 }
             }
         } else {
@@ -102,7 +112,7 @@ public enum SessionStatistics {
 
 // MARK: - History journey rows (standard sessions; quick excluded by caller)
 
-public enum HistoryJourneyListRow: Equatable, Sendable {
+public enum HistoryJourneyListRow: Sendable {
     case missed(date: String)
     case standardSession(session: SessionDTO, sessionIndexInDay: Int)
 }

--- a/ios/StillPointShared/Tests/StillPointSharedTests/HistoryJourneyTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/HistoryJourneyTests.swift
@@ -39,6 +39,47 @@ final class HistoryJourneyTests: XCTestCase {
         XCTAssertEqual(n2, 2)
     }
 
+    func testSameDaySessionsOrderedByCreatedAt() {
+        let rows = HistoryJourney.buildRows(fromStandardSessions: [
+            SessionDTO(
+                id: "later-id",
+                dayNumber: 1,
+                sessionType: .standard,
+                duration: 60,
+                completed: true,
+                actualTime: 60,
+                clearPercent: 50,
+                thoughtCount: 0,
+                mindStateLog: nil,
+                sessionDate: "2026-04-28",
+                createdAt: "2026-04-28T12:00:00.000Z",
+                buddySessionId: nil
+            ),
+            SessionDTO(
+                id: "earlier-id",
+                dayNumber: 1,
+                sessionType: .standard,
+                duration: 60,
+                completed: true,
+                actualTime: 60,
+                clearPercent: 50,
+                thoughtCount: 0,
+                mindStateLog: nil,
+                sessionDate: "2026-04-28",
+                createdAt: "2026-04-28T10:00:00.000Z",
+                buddySessionId: nil
+            ),
+        ])
+        guard case .standardSession(let first, let n1) = rows[0],
+              case .standardSession(let second, let n2) = rows[1] else {
+            return XCTFail("expected two session rows")
+        }
+        XCTAssertEqual(first.id, "earlier-id")
+        XCTAssertEqual(second.id, "later-id")
+        XCTAssertEqual(n1, 1)
+        XCTAssertEqual(n2, 2)
+    }
+
     func testStreakCountsUniqueCalendarDays() {
         let stats = SessionStatistics.calculateStats(for: [
             SessionDTO(

--- a/ios/StillPointShared/Tests/StillPointSharedTests/HistoryJourneyTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/HistoryJourneyTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+import StillPointShared
+
+final class HistoryJourneyTests: XCTestCase {
+    func testSequentialSessionLabelsSameDay() {
+        let rows = HistoryJourney.buildRows(fromStandardSessions: [
+            SessionDTO(
+                id: "a",
+                dayNumber: 1,
+                sessionType: .standard,
+                duration: 60,
+                completed: true,
+                actualTime: 60,
+                clearPercent: 50,
+                thoughtCount: 0,
+                mindStateLog: nil,
+                sessionDate: "2026-04-28",
+                buddySessionId: nil
+            ),
+            SessionDTO(
+                id: "b",
+                dayNumber: 1,
+                sessionType: .standard,
+                duration: 60,
+                completed: true,
+                actualTime: 60,
+                clearPercent: 50,
+                thoughtCount: 0,
+                mindStateLog: nil,
+                sessionDate: "2026-04-28",
+                buddySessionId: nil
+            ),
+        ])
+        guard case .standardSession(_, let n1) = rows[0],
+              case .standardSession(_, let n2) = rows[1] else {
+            return XCTFail("expected two session rows")
+        }
+        XCTAssertEqual(n1, 1)
+        XCTAssertEqual(n2, 2)
+    }
+
+    func testStreakCountsUniqueCalendarDays() {
+        let stats = SessionStatistics.calculateStats(for: [
+            SessionDTO(
+                id: "1",
+                dayNumber: 1,
+                sessionType: .standard,
+                duration: 60,
+                completed: true,
+                actualTime: 60,
+                clearPercent: 80,
+                thoughtCount: 0,
+                mindStateLog: nil,
+                sessionDate: "2026-04-28",
+                buddySessionId: nil
+            ),
+            SessionDTO(
+                id: "2",
+                dayNumber: 2,
+                sessionType: .standard,
+                duration: 70,
+                completed: true,
+                actualTime: 70,
+                clearPercent: 90,
+                thoughtCount: 0,
+                mindStateLog: nil,
+                sessionDate: "2026-04-28",
+                buddySessionId: nil
+            ),
+        ])
+        XCTAssertEqual(stats.streak, 1)
+    }
+}

--- a/src/app/api/sessions/[dayNumber]/route.ts
+++ b/src/app/api/sessions/[dayNumber]/route.ts
@@ -46,7 +46,11 @@ export async function GET(
           eq(thoughts.userId, auth.userId),
         ),
       )
-      .orderBy(asc(thoughts.timeInSession));
+      .orderBy(
+        asc(thoughts.timeInSession),
+        asc(thoughts.createdAt),
+        asc(thoughts.id),
+      );
 
     return NextResponse.json({ session, thoughts: sessionThoughts });
   } catch (error) {

--- a/src/app/api/sessions/by-session/[sessionId]/route.ts
+++ b/src/app/api/sessions/by-session/[sessionId]/route.ts
@@ -46,7 +46,11 @@ export async function GET(
           eq(thoughts.userId, auth.userId),
         ),
       )
-      .orderBy(asc(thoughts.timeInSession));
+      .orderBy(
+        asc(thoughts.timeInSession),
+        asc(thoughts.createdAt),
+        asc(thoughts.id),
+      );
 
     return NextResponse.json({ session, thoughts: sessionThoughts });
   } catch (error) {

--- a/src/app/api/sessions/by-session/[sessionId]/route.ts
+++ b/src/app/api/sessions/by-session/[sessionId]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { sessions, thoughts } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
+import { isUuid } from "@/lib/friends";
 import { eq, and, asc } from "drizzle-orm";
 
 export async function GET(
@@ -15,7 +16,7 @@ export async function GET(
     }
 
     const { sessionId } = await params;
-    if (!sessionId) {
+    if (!sessionId || !isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }
 

--- a/src/app/api/sessions/by-session/[sessionId]/route.ts
+++ b/src/app/api/sessions/by-session/[sessionId]/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { sessions, thoughts } from "@/db/schema";
+import { getCurrentUser } from "@/lib/auth";
+import { eq, and, asc } from "drizzle-orm";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> },
+) {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { sessionId } = await params;
+    if (!sessionId) {
+      return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
+    }
+
+    const [session] = await db.select()
+      .from(sessions)
+      .where(and(
+        eq(sessions.userId, auth.userId),
+        eq(sessions.id, sessionId),
+      ))
+      .limit(1);
+
+    if (!session) {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    const sessionThoughts = await db.select({
+      id: thoughts.id,
+      sessionId: thoughts.sessionId,
+      dayNumber: thoughts.dayNumber,
+      timeInSession: thoughts.timeInSession,
+      text: thoughts.text,
+    })
+      .from(thoughts)
+      .where(
+        and(
+          eq(thoughts.sessionId, session.id),
+          eq(thoughts.userId, auth.userId),
+        ),
+      )
+      .orderBy(asc(thoughts.timeInSession));
+
+    return NextResponse.json({ session, thoughts: sessionThoughts });
+  } catch (error) {
+    console.error("Get session by id error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo } from "react";
 import { durationForDay } from "@/lib/constants";
 import type { Session, Thought } from "@/lib/api";
 import { useIsMobile } from "@/lib/useIsMobile";
+import { buildHistoryJourneyRows } from "@/lib/historyJourney";
 
 type HistoryEntry = {
   sessionId?: string;
@@ -16,7 +17,30 @@ type HistoryEntry = {
   thoughtCount: number;
   sessionType?: Session["sessionType"];
   missed?: boolean;
+  /** 1-based index among standard sessions on the same calendar day */
+  sessionIndexInDay?: number;
 };
+
+function formatFullDateLabel(isoDate: string): string {
+  const d = new Date(isoDate + "T12:00:00");
+  const dow = d.toLocaleDateString("en-US", { weekday: "short" });
+  const mon = d.toLocaleDateString("en-US", { month: "short" });
+  const dayOfMonth = d.getDate();
+  const y = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(dayOfMonth).padStart(2, "0");
+  return `${dow} ${mon} ${dayOfMonth} (${y}.${mm}.${dd})`;
+}
+
+function formatShortDateLabel(isoDate: string): string {
+  const d = new Date(isoDate + "T12:00:00");
+  return d.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
+}
+
+function sessionSortKey(s: Session): string {
+  if (s.createdAt) return s.createdAt;
+  return s.id;
+}
 
 type HistoryViewProps = {
   currentDay: number;
@@ -43,46 +67,48 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
     }).catch(() => setLoading(false));
   }, []);
 
-  // Build history entries including missed days
-  const history: HistoryEntry[] = [];
-  const sortedSessions = [...sessions]
-    .filter(s => s.sessionType !== "quick")
-    .sort((a, b) => a.dayNumber - b.dayNumber);
+  const journeyRows = useMemo(() => {
+    const standard = sessions.filter(s => s.sessionType !== "quick");
+    return buildHistoryJourneyRows(
+      standard.map(s => ({
+        sessionDate: s.sessionDate,
+        sortKey: sessionSortKey(s),
+        data: s,
+      })),
+    );
+  }, [sessions]);
 
-  for (let i = 0; i < sortedSessions.length; i++) {
-    const s = sortedSessions[i];
-    // Check for gaps between sessions (missed days)
-    if (i > 0) {
-      const prevDate = new Date(sortedSessions[i - 1].sessionDate + "T12:00:00");
-      const currDate = new Date(s.sessionDate + "T12:00:00");
-      const daysBetween = Math.round((currDate.getTime() - prevDate.getTime()) / (1000 * 60 * 60 * 24));
-      for (let gap = 1; gap < daysBetween; gap++) {
-        const missedDate = new Date(prevDate);
-        missedDate.setDate(missedDate.getDate() + gap);
-        history.push({
-          day: null,
-          duration: 0,
-          actualTime: 0,
-          completed: false,
-          date: missedDate.toISOString().split("T")[0],
-          clearPercent: 0,
-          thoughtCount: 0,
-          missed: true,
-        });
-      }
-    }
-    history.push({
-      sessionId: s.id,
-      day: s.dayNumber,
-      duration: s.duration,
-      actualTime: s.actualTime ?? s.duration,
-      completed: s.completed,
-      date: s.sessionDate,
-      clearPercent: s.clearPercent,
-      thoughtCount: s.thoughtCount,
-      sessionType: s.sessionType,
-    });
-  }
+  const history: HistoryEntry[] = useMemo(
+    () =>
+      journeyRows.map(row => {
+        if (row.kind === "missed") {
+          return {
+            day: null,
+            duration: 0,
+            actualTime: 0,
+            completed: false,
+            date: row.date,
+            clearPercent: 0,
+            thoughtCount: 0,
+            missed: true,
+          };
+        }
+        const s = row.data;
+        return {
+          sessionId: s.id,
+          day: s.dayNumber,
+          duration: s.duration,
+          actualTime: s.actualTime ?? s.duration,
+          completed: s.completed,
+          date: row.date,
+          clearPercent: s.clearPercent,
+          thoughtCount: s.thoughtCount,
+          sessionType: s.sessionType,
+          sessionIndexInDay: row.sessionIndexInDay,
+        };
+      }),
+    [journeyRows],
+  );
 
   const maxDuration = Math.max(
     ...history.filter(h => !h.missed).map(h => h.actualTime),
@@ -162,15 +188,13 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
 
         <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
           {history.map((entry, idx) => {
+            const prev = idx > 0 ? history[idx - 1] : undefined;
+            const showDateColumn = entry.missed
+              ? true
+              : !prev || prev.missed || prev.date !== entry.date;
+
             if (entry.missed) {
-              const d = new Date(entry.date + "T12:00:00");
-              const dow = d.toLocaleDateString("en-US", { weekday: "short" });
-              const mon = d.toLocaleDateString("en-US", { month: "short" });
-              const day = d.getDate();
-              const y = d.getFullYear();
-              const mm = String(d.getMonth() + 1).padStart(2, "0");
-              const dd = String(day).padStart(2, "0");
-              const dateLabel = `${dow} ${mon} ${day} (${y}.${mm}.${dd})`;
+              const dateLabel = formatFullDateLabel(entry.date);
               return (
                 <div key={`missed-${idx}`} style={{
                   display: "flex", alignItems: "center", gap: isMobile ? "8px" : "12px",
@@ -209,16 +233,12 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
               );
             }
 
-            const d = new Date(entry.date + "T12:00:00");
-            const dow = d.toLocaleDateString("en-US", { weekday: "short" });
-            const mon = d.toLocaleDateString("en-US", { month: "short" });
-            const dayOfMonth = d.getDate();
-            const y = d.getFullYear();
-            const mm = String(d.getMonth() + 1).padStart(2, "0");
-            const dd = String(dayOfMonth).padStart(2, "0");
-            const dateLabel = `${dow} ${mon} ${dayOfMonth} (${y}.${mm}.${dd})`;
+            const dateLabelFull = formatFullDateLabel(entry.date);
+            const dateLabelShort = formatShortDateLabel(entry.date);
+            const sessionOrdinal = entry.sessionIndexInDay ?? 1;
+            const sessionLabel = `Session ${sessionOrdinal}`;
 
-            const entryId = `day-${entry.day}-${idx}`;
+            const entryId = entry.sessionId ? `sess-${entry.sessionId}` : `day-${entry.day}-${idx}`;
             const isExpanded = expandedEntryId === entryId;
             const entryThoughts = getThoughtsForSession(entry.sessionId);
             const canExpand = entryThoughts.length > 0;
@@ -264,15 +284,24 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
                       fontSize: "11px", color: "var(--fg-4)",
                       width: "160px", textAlign: "right", whiteSpace: "nowrap",
                     }}>
-                      {dateLabel}
+                      {showDateColumn ? dateLabelFull : ""}
+                    </div>
+                  )}
+                  {isMobile && showDateColumn && (
+                    <div style={{
+                      fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                      fontSize: "10px", color: "var(--fg-4)",
+                      minWidth: "72px", textAlign: "right", whiteSpace: "nowrap",
+                    }}>
+                      {dateLabelShort}
                     </div>
                   )}
                   <div style={{
                     fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
                     fontSize: "11px", color: "var(--fg-3)",
-                    width: "32px", textAlign: "right",
+                    width: isMobile ? "88px" : "100px", textAlign: "right",
                   }}>
-                    D{entry.day}
+                    {sessionLabel}
                   </div>
                   <div style={{
                     flex: 1, height: "24px", borderRadius: "3px", overflow: "hidden",
@@ -313,7 +342,7 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
                   <div
                     id={`${entryId}-thoughts`}
                     role="region"
-                    aria-label={`Day ${entry.day} captured thoughts (entry ${idx + 1})`}
+                    aria-label={`${sessionLabel} on ${dateLabelFull} captured thoughts`}
                     style={{
                     marginLeft: isMobile ? "44px" : "216px", marginTop: "4px", marginBottom: "8px",
                     padding: "10px 14px", background: "var(--surface-1)",
@@ -407,7 +436,7 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
         fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
         fontSize: "11px", color: "var(--fg-4)", textAlign: "center",
       }}>
-        click any day to see captured thoughts
+        click any session row to see captured thoughts
       </p>
     </div>
   );

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -38,8 +38,7 @@ function formatShortDateLabel(isoDate: string): string {
 }
 
 function sessionSortKey(s: Session): string {
-  if (s.createdAt) return s.createdAt;
-  return s.id;
+  return s.createdAt;
 }
 
 type HistoryViewProps = {
@@ -200,13 +199,21 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
                   display: "flex", alignItems: "center", gap: isMobile ? "8px" : "12px",
                   padding: "2px 0", opacity: 0.35,
                 }}>
-                  {!isMobile && (
+                  {!isMobile ? (
                     <div style={{
                       fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
                       fontSize: "11px", color: "var(--fg-4)",
                       width: "160px", textAlign: "right", whiteSpace: "nowrap",
                     }}>
                       {dateLabel}
+                    </div>
+                  ) : (
+                    <div style={{
+                      fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                      fontSize: "10px", color: "var(--fg-4)",
+                      minWidth: "72px", textAlign: "right", whiteSpace: "nowrap",
+                    }}>
+                      {formatShortDateLabel(entry.date)}
                     </div>
                   )}
                   <div style={{

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -53,6 +53,7 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
   const [expandedEntryId, setExpandedEntryId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const isMobile = useIsMobile();
+  const sessionLabelColWidth = isMobile ? "88px" : "100px";
 
   useEffect(() => {
     Promise.all([
@@ -219,7 +220,7 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
                   <div style={{
                     fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
                     fontSize: "11px", color: "var(--fg-3)",
-                    width: "32px", textAlign: "right",
+                    width: sessionLabelColWidth, textAlign: "right",
                   }}>
                     &mdash;
                   </div>
@@ -294,19 +295,19 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
                       {showDateColumn ? dateLabelFull : ""}
                     </div>
                   )}
-                  {isMobile && showDateColumn && (
+                  {isMobile && (
                     <div style={{
                       fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
                       fontSize: "10px", color: "var(--fg-4)",
                       minWidth: "72px", textAlign: "right", whiteSpace: "nowrap",
                     }}>
-                      {dateLabelShort}
+                      {showDateColumn ? dateLabelShort : ""}
                     </div>
                   )}
                   <div style={{
                     fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
                     fontSize: "11px", color: "var(--fg-3)",
-                    width: isMobile ? "88px" : "100px", textAlign: "right",
+                    width: sessionLabelColWidth, textAlign: "right",
                   }}>
                     {sessionLabel}
                   </div>
@@ -389,10 +390,17 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
                 today
               </div>
             )}
+            {isMobile && (
+              <div style={{
+                fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                fontSize: "10px", color: "var(--fg-4)",
+                minWidth: "72px", textAlign: "right", whiteSpace: "nowrap",
+              }} />
+            )}
             <div style={{
               fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
               fontSize: "11px", color: "var(--fg-4)",
-              width: "32px", textAlign: "right",
+              width: sessionLabelColWidth, textAlign: "right",
             }}>
               D{currentDay}
             </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -40,6 +40,7 @@ export type Session = {
   thoughtCount: number;
   mindStateLog: Array<{ time: number; state: string }> | null;
   sessionDate: string;
+  createdAt?: string;
   /** Present when this row was created from a completed buddy sit (#119). */
   buddySessionId?: string | null;
 };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -40,7 +40,7 @@ export type Session = {
   thoughtCount: number;
   mindStateLog: Array<{ time: number; state: string }> | null;
   sessionDate: string;
-  createdAt?: string;
+  createdAt: string;
   /** Present when this row was created from a completed buddy sit (#119). */
   buddySessionId?: string | null;
 };

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,4 @@
-import { addDaysToIsoDate } from "./sessionCalendar";
+import { addDaysToIsoDate, isValidSessionCalendarDate } from "./sessionCalendar";
 
 export const BASE_DURATION = 60;
 export const QUICK_DURATION = 60;
@@ -56,7 +56,7 @@ export function calculateSessionStats(sessions: SessionStatsInput[]) {
 
   let streak = 0;
   const allHaveSessionDate = standardSessions.length > 0
-    && standardSessions.every(s => typeof s.sessionDate === "string" && s.sessionDate.length >= 10);
+    && standardSessions.every(s => isValidSessionCalendarDate(s.sessionDate));
 
   if (allHaveSessionDate) {
     const completedCalendarDates = new Set<string>();
@@ -80,7 +80,9 @@ export function calculateSessionStats(sessions: SessionStatsInput[]) {
       let cursor = latestCal;
       while (completedCalendarDates.has(cursor)) {
         streak++;
-        cursor = addDaysToIsoDate(cursor, -1);
+        const next = addDaysToIsoDate(cursor, -1);
+        if (next === cursor) break;
+        cursor = next;
       }
     }
   } else {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,5 @@
+import { addDaysToIsoDate } from "./sessionCalendar";
+
 export const BASE_DURATION = 60;
 export const QUICK_DURATION = 60;
 export const INCREMENT = 10;
@@ -12,6 +14,7 @@ export type SessionStatsInput = {
   completed: boolean;
   clearPercent: number;
   thoughtCount: number;
+  /** When set, streak counts unique calendar days (consecutive `sessionDate`s with a completed standard sit). */
   sessionDate?: string;
   createdAt?: Date | string;
 };
@@ -52,19 +55,49 @@ export function calculateSessionStats(sessions: SessionStatsInput[]) {
   const totalSessions = standardSessions.length;
 
   let streak = 0;
-  const completedByDay = new Map<number, boolean>();
-  for (const session of standardSessions) {
-    completedByDay.set(
-      session.dayNumber,
-      (completedByDay.get(session.dayNumber) ?? false) || session.completed,
+  const allHaveSessionDate = standardSessions.length > 0
+    && standardSessions.every(s => typeof s.sessionDate === "string" && s.sessionDate.length >= 10);
+
+  if (allHaveSessionDate) {
+    const completedCalendarDates = new Set<string>();
+    for (const session of standardSessions) {
+      if (session.completed && session.sessionDate) {
+        completedCalendarDates.add(session.sessionDate);
+      }
+    }
+    let latestCal = "";
+    for (const session of standardSessions) {
+      if (session.sessionDate && session.sessionDate > latestCal) {
+        latestCal = session.sessionDate;
+      }
+    }
+    const latestDayHasCompletion = standardSessions.some(
+      s => s.sessionDate === latestCal && s.completed,
     );
-  }
-  const maxDay = Math.max(0, ...completedByDay.keys());
-  for (let day = maxDay; day >= 1; day--) {
-    if (completedByDay.get(day) === true) {
-      streak++;
+    if (!latestCal || !latestDayHasCompletion) {
+      streak = 0;
     } else {
-      break;
+      let cursor = latestCal;
+      while (completedCalendarDates.has(cursor)) {
+        streak++;
+        cursor = addDaysToIsoDate(cursor, -1);
+      }
+    }
+  } else {
+    const completedByDay = new Map<number, boolean>();
+    for (const session of standardSessions) {
+      completedByDay.set(
+        session.dayNumber,
+        (completedByDay.get(session.dayNumber) ?? false) || session.completed,
+      );
+    }
+    const maxDay = Math.max(0, ...completedByDay.keys());
+    for (let day = maxDay; day >= 1; day--) {
+      if (completedByDay.get(day) === true) {
+        streak++;
+      } else {
+        break;
+      }
     }
   }
 

--- a/src/lib/historyJourney.test.ts
+++ b/src/lib/historyJourney.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { buildHistoryJourneyRows, sortSessionsForHistory } from "./historyJourney";
+
+describe("buildHistoryJourneyRows", () => {
+  test("labels sequential sessions on the same calendar day", () => {
+    const rows = buildHistoryJourneyRows([
+      { sessionDate: "2026-04-28", sortKey: "a", data: { id: "1" } },
+      { sessionDate: "2026-04-28", sortKey: "b", data: { id: "2" } },
+      { sessionDate: "2026-04-28", sortKey: "c", data: { id: "3" } },
+    ]);
+    expect(rows.filter(r => r.kind === "session").map(r => r.sessionIndexInDay)).toEqual([1, 2, 3]);
+  });
+
+  test("inserts missed rows for calendar gaps", () => {
+    const rows = buildHistoryJourneyRows([
+      { sessionDate: "2026-04-26", sortKey: "a", data: { id: "1" } },
+      { sessionDate: "2026-04-28", sortKey: "b", data: { id: "2" } },
+    ]);
+    expect(rows.map(r => (r.kind === "missed" ? `missed:${r.date}` : `session:${r.date}:${r.sessionIndexInDay}`))).toEqual([
+      "session:2026-04-26:1",
+      "missed:2026-04-27",
+      "session:2026-04-28:1",
+    ]);
+  });
+
+  test("sorts by date then sortKey", () => {
+    const sorted = sortSessionsForHistory([
+      { sessionDate: "2026-04-28", sortKey: "b", data: 2 },
+      { sessionDate: "2026-04-28", sortKey: "a", data: 1 },
+      { sessionDate: "2026-04-27", sortKey: "z", data: 0 },
+    ]);
+    expect(sorted.map(s => s.data)).toEqual([0, 1, 2]);
+  });
+});

--- a/src/lib/historyJourney.test.ts
+++ b/src/lib/historyJourney.test.ts
@@ -23,7 +23,14 @@ describe("buildHistoryJourneyRows", () => {
     ]);
   });
 
-  test("sorts by date then sortKey", () => {
+  test("caps missed rows for very large calendar gaps", () => {
+    const rows = buildHistoryJourneyRows([
+      { sessionDate: "2020-01-01", sortKey: "a", data: { id: "1" } },
+      { sessionDate: "2030-01-01", sortKey: "b", data: { id: "2" } },
+    ]);
+    const missed = rows.filter(r => r.kind === "missed");
+    expect(missed.length).toBe(366);
+  });
     const sorted = sortSessionsForHistory([
       { sessionDate: "2026-04-28", sortKey: "b", data: 2 },
       { sessionDate: "2026-04-28", sortKey: "a", data: 1 },

--- a/src/lib/historyJourney.test.ts
+++ b/src/lib/historyJourney.test.ts
@@ -31,6 +31,8 @@ describe("buildHistoryJourneyRows", () => {
     const missed = rows.filter(r => r.kind === "missed");
     expect(missed.length).toBe(366);
   });
+
+  test("sorts by sessionDate then sortKey", () => {
     const sorted = sortSessionsForHistory([
       { sessionDate: "2026-04-28", sortKey: "b", data: 2 },
       { sessionDate: "2026-04-28", sortKey: "a", data: 1 },

--- a/src/lib/historyJourney.ts
+++ b/src/lib/historyJourney.ts
@@ -1,5 +1,8 @@
 import { addDaysToIsoDate, daysBetweenIsoDatesInclusive } from "./sessionCalendar";
 
+/** Max consecutive missed-day rows between two sessions (then remaining gap is collapsed). */
+export const MAX_MISSED_GAP_ROWS = 366;
+
 export type HistoryJourneySession<T> = {
   sessionDate: string;
   sessionType?: string;
@@ -32,7 +35,9 @@ export function buildHistoryJourneyRows<T>(sessions: HistoryJourneySession<T>[])
     if (i > 0) {
       const prev = sorted[i - 1]!;
       const daysBetween = daysBetweenIsoDatesInclusive(prev.sessionDate, cur.sessionDate);
-      for (let gap = 1; gap < daysBetween; gap++) {
+      const missedCount = Math.max(0, daysBetween - 1);
+      const toEmit = Math.min(missedCount, MAX_MISSED_GAP_ROWS);
+      for (let gap = 1; gap <= toEmit; gap++) {
         const missedDate = addDaysToIsoDate(prev.sessionDate, gap);
         rows.push({ kind: "missed", date: missedDate });
       }

--- a/src/lib/historyJourney.ts
+++ b/src/lib/historyJourney.ts
@@ -1,0 +1,45 @@
+import { addDaysToIsoDate, daysBetweenIsoDatesInclusive } from "./sessionCalendar";
+
+export type HistoryJourneySession<T> = {
+  sessionDate: string;
+  sessionType?: string;
+  /** Lexicographic tiebreaker for multiple sessions on one calendar day */
+  sortKey: string;
+  data: T;
+};
+
+export type HistoryJourneyRow<T> =
+  | { kind: "missed"; date: string }
+  | { kind: "session"; date: string; sessionIndexInDay: number; data: T };
+
+/**
+ * Standard sessions only (quick filtered upstream). Sort by calendar date then stable order.
+ */
+export function sortSessionsForHistory<T>(sessions: HistoryJourneySession<T>[]): HistoryJourneySession<T>[] {
+  return [...sessions].sort((a, b) => {
+    if (a.sessionDate !== b.sessionDate) return a.sessionDate.localeCompare(b.sessionDate);
+    return a.sortKey.localeCompare(b.sortKey);
+  });
+}
+
+export function buildHistoryJourneyRows<T>(sessions: HistoryJourneySession<T>[]): HistoryJourneyRow<T>[] {
+  const sorted = sortSessionsForHistory(sessions);
+  const rows: HistoryJourneyRow<T>[] = [];
+  const perDayIndex = new Map<string, number>();
+
+  for (let i = 0; i < sorted.length; i++) {
+    const cur = sorted[i]!;
+    if (i > 0) {
+      const prev = sorted[i - 1]!;
+      const daysBetween = daysBetweenIsoDatesInclusive(prev.sessionDate, cur.sessionDate);
+      for (let gap = 1; gap < daysBetween; gap++) {
+        const missedDate = addDaysToIsoDate(prev.sessionDate, gap);
+        rows.push({ kind: "missed", date: missedDate });
+      }
+    }
+    const n = (perDayIndex.get(cur.sessionDate) ?? 0) + 1;
+    perDayIndex.set(cur.sessionDate, n);
+    rows.push({ kind: "session", date: cur.sessionDate, sessionIndexInDay: n, data: cur.data });
+  }
+  return rows;
+}

--- a/src/lib/sessionCalendar.ts
+++ b/src/lib/sessionCalendar.ts
@@ -1,5 +1,19 @@
 /** ISO calendar date `YYYY-MM-DD` helpers (UTC date arithmetic; matches stored `session_date`). */
 
+const ISO_CALENDAR_DAY = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Strict `YYYY-MM-DD` that parses as a real UTC calendar day and round-trips. */
+export function isValidSessionCalendarDate(value: string | undefined | null): boolean {
+  if (typeof value !== "string" || !ISO_CALENDAR_DAY.test(value)) return false;
+  const [ys, ms, ds] = value.split("-").map(Number);
+  const d = new Date(Date.UTC(ys, ms - 1, ds));
+  if (Number.isNaN(d.getTime())) return false;
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}` === value;
+}
+
 export function addDaysToIsoDate(isoDate: string, deltaDays: number): string {
   const [ys, ms, ds] = isoDate.split("-").map(Number);
   const base = new Date(Date.UTC(ys, ms - 1, ds));

--- a/src/lib/sessionCalendar.ts
+++ b/src/lib/sessionCalendar.ts
@@ -1,0 +1,19 @@
+/** ISO calendar date `YYYY-MM-DD` helpers (UTC date arithmetic; matches stored `session_date`). */
+
+export function addDaysToIsoDate(isoDate: string, deltaDays: number): string {
+  const [ys, ms, ds] = isoDate.split("-").map(Number);
+  const base = new Date(Date.UTC(ys, ms - 1, ds));
+  base.setUTCDate(base.getUTCDate() + deltaDays);
+  const y = base.getUTCFullYear();
+  const m = String(base.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(base.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+export function daysBetweenIsoDatesInclusive(fromIso: string, toIso: string): number {
+  const [fy, fm, fd] = fromIso.split("-").map(Number);
+  const [ty, tm, td] = toIso.split("-").map(Number);
+  const fromMs = Date.UTC(fy, fm - 1, fd);
+  const toMs = Date.UTC(ty, tm - 1, td);
+  return Math.round((toMs - fromMs) / (1000 * 60 * 60 * 24));
+}

--- a/src/lib/sessionProgression.test.ts
+++ b/src/lib/sessionProgression.test.ts
@@ -93,6 +93,30 @@ describe("session progression rules", () => {
     expect(calculateSessionStats(sessions).streak).toBe(0);
   });
 
+  test("falls back to day-number streak when sessionDate is not a strict calendar day", () => {
+    const sessions: SessionStatsInput[] = [
+      {
+        sessionType: "standard",
+        dayNumber: 2,
+        duration: 70,
+        completed: true,
+        clearPercent: 100,
+        thoughtCount: 0,
+        sessionDate: "2026-04-30T12:00:00.000Z",
+      },
+      {
+        sessionType: "standard",
+        dayNumber: 1,
+        duration: 60,
+        completed: true,
+        clearPercent: 80,
+        thoughtCount: 0,
+        sessionDate: "2026-04-30T18:00:00.000Z",
+      },
+    ];
+    expect(calculateSessionStats(sessions).streak).toBe(2);
+  });
+
   test("streak uses unique calendar days when sessionDate is present (multiple sits same day)", () => {
     const sessions: SessionStatsInput[] = [
       {

--- a/src/lib/sessionProgression.test.ts
+++ b/src/lib/sessionProgression.test.ts
@@ -93,6 +93,78 @@ describe("session progression rules", () => {
     expect(calculateSessionStats(sessions).streak).toBe(0);
   });
 
+  test("streak uses unique calendar days when sessionDate is present (multiple sits same day)", () => {
+    const sessions: SessionStatsInput[] = [
+      {
+        sessionType: "standard",
+        dayNumber: 2,
+        duration: 70,
+        completed: true,
+        clearPercent: 100,
+        thoughtCount: 0,
+        sessionDate: "2026-04-30",
+      },
+      {
+        sessionType: "standard",
+        dayNumber: 1,
+        duration: 60,
+        completed: true,
+        clearPercent: 80,
+        thoughtCount: 0,
+        sessionDate: "2026-04-30",
+      },
+    ];
+    expect(calculateSessionStats(sessions).streak).toBe(1);
+  });
+
+  test("calendar-day streak walks consecutive dates including gaps in day numbers", () => {
+    const sessions: SessionStatsInput[] = [
+      {
+        sessionType: "standard",
+        dayNumber: 5,
+        duration: 100,
+        completed: true,
+        clearPercent: 80,
+        thoughtCount: 0,
+        sessionDate: "2026-04-29",
+      },
+      {
+        sessionType: "standard",
+        dayNumber: 3,
+        duration: 60,
+        completed: true,
+        clearPercent: 90,
+        thoughtCount: 0,
+        sessionDate: "2026-04-28",
+      },
+    ];
+    expect(calculateSessionStats(sessions).streak).toBe(2);
+  });
+
+  test("calendar streak breaks on missed calendar day", () => {
+    const sessions: SessionStatsInput[] = [
+      {
+        sessionType: "standard",
+        dayNumber: 3,
+        duration: 80,
+        completed: true,
+        clearPercent: 90,
+        thoughtCount: 0,
+        sessionDate: "2026-04-30",
+      },
+      {
+        sessionType: "standard",
+        dayNumber: 2,
+        duration: 70,
+        completed: true,
+        clearPercent: 100,
+        thoughtCount: 0,
+        sessionDate: "2026-04-28",
+      },
+    ];
+    expect(calculateSessionStats(sessions).streak).toBe(1);
+  });
+
   test("stops the streak at missing day gaps", () => {
     const sessions: SessionStatsInput[] = [
       { sessionType: "standard", dayNumber: 7, duration: 120, completed: true, clearPercent: 90, thoughtCount: 0 },


### PR DESCRIPTION
Closes #110

## Summary
- **Web history:** Standard sessions grouped by calendar day with Session 1/2 labels; missed gaps; mobile date on first row per day and on missed rows.
- **Streak:** Consecutive calendar days with a completed standard sit when all `sessionDate` values are strict `YYYY-MM-DD`; fallback to day-number streak otherwise.
- **API:** `GET /api/sessions/by-session/[sessionId]` for per-session thoughts.
- **iOS:** Shared `HistoryJourney` / `SessionStatistics`; history expands by session id.

## Follow-up (534768e)
- Fix mobile E2E: last journey row is `Session 1` when seed has one sit per day.
- Fix iOS compile: `HistoryJourneyListRow` no longer declares `Equatable` (associated `SessionDTO`); strict date validation + streak loop guard.
- Web: `isValidSessionCalendarDate`, streak non-progress guard, required `createdAt` on `Session` type, mobile missed-row date.

## Test plan
- [x] Same-day sessions appear as "Session 1", "Session 2" rows — verified by E2E mobile web CI (all 3 browser projects)
- [x] Last journey row shows "Session 1" when seed has one sit per day — E2E fix verified by CI
- [x] Streak counts consecutive calendar days (not inflated by multi-session days) — unit tests + CI
- [x] `GET /api/sessions/by-session/[sessionId]` returns per-session thoughts in consistent order
- [x] iOS history expands by session id, compiles without `Equatable` on `HistoryJourneyListRow` — ios-e2e-smoke + ios-e2e-critical passed
- [x] Strict `YYYY-MM-DD` date validation guards streak loop — web-e2e-smoke + web-e2e-critical passed