### PR TITLE
fix(ios-e2e): wait for session root before terminate to avoid launchd race

### DIFF
--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -68,8 +68,12 @@ final class StillPointAppUITests: XCTestCase {
         XCTAssertTrue(app.otherElements["root.currentView.home"].waitForExistence(timeout: 8))
         let beginButton = app.buttons["home.beginButton"]
         XCTAssertTrue(beginButton.waitForExistence(timeout: 5))
+        beginButton.tap()
         // Wait for session root before terminating: terminate() during Begin's nav/audio init races launchd ("Failed to terminate ... :0").
-        tap(beginButton, thenWaitForRoot: "session", in: app)
+        XCTAssertTrue(
+            app.otherElements["root.currentView.session"].waitForExistence(timeout: 20),
+            "Session screen did not appear after Begin tap"
+        )
         app.launchEnvironment["SP_UI_TEST_SEED_AUTH"] = "1"
         terminateAppReliably(app)
         app.launch()

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -68,7 +68,8 @@ final class StillPointAppUITests: XCTestCase {
         XCTAssertTrue(app.otherElements["root.currentView.home"].waitForExistence(timeout: 8))
         let beginButton = app.buttons["home.beginButton"]
         XCTAssertTrue(beginButton.waitForExistence(timeout: 5))
-        beginButton.tap()
+        // Wait for session root before terminating: terminate() during Begin's nav/audio init races launchd ("Failed to terminate ... :0").
+        tap(beginButton, thenWaitForRoot: "session", in: app)
         app.launchEnvironment["SP_UI_TEST_SEED_AUTH"] = "1"
         terminateAppReliably(app)
         app.launch()


### PR DESCRIPTION
## Summary

- Fixes flake in `ios-e2e-smoke` lane: `testLaunchLoginCompleteSessionAndHistoryPersistence` was failing with `Failed to terminate ... :0` (or post-relaunch home-wait timeout) on macOS-26 / iOS 26 runners, while `ios-e2e-critical` stayed green on the same SHAs across 4 recent runs (`25215904325`, `25216409703`, `25216402153`, `25216777439`).
- Root cause: `terminate()` was called immediately after `beginButton.tap()`, racing launchd while the app was mid-navigation / audio engine startup / timer init.
- Fix (after v1 helper-based attempt failed CI): keep direct `beginButton.tap()` and add an explicit `waitForExistence(timeout: 20)` for `root.currentView.session` before `terminateAppReliably`. v1 used `tap(_:thenWaitForRoot:in:)`, but its `tapByStableCenter` stable-frame check failed on this test's specific flow (run [25218186115](https://github.com/auerbachb/still-point/actions/runs/25218186115)).

Closes #318

## Test plan

- [x] `testLaunchLoginCompleteSessionAndHistoryPersistence` passes on iOS 26 simulator (verified via smoke lane green on `607af03`)
- [x] `ios-e2e-smoke` lane passes on this PR ([run 25218888601](https://github.com/auerbachb/still-point/actions/runs/25218888601))
- [x] `ios-e2e-critical` lane passes on this PR
- [ ] Smoke lane re-run twice in a row to demonstrate flake reduction (1/2 so far on `607af03`; one more re-run pending)
- [x] Other UI tests in `StillPointAppUITests` unaffected (diff modifies only the one method; 9 other tests untouched)
- [x] No product code in `ios/StillPointApp/` changed (test-only single-file diff: +5/-0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)