### PR TITLE
ci(ios-e2e): bump smoke + critical from 0 to 1 retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "e2e:web:smoke": "E2E_BASE_URL=${E2E_BASE_URL:-http://127.0.0.1:3000} npm run e2e:guard && node scripts/e2e/run-playwright-lane.mjs smoke @smoke 1",
     "e2e:web:critical": "E2E_BASE_URL=${E2E_BASE_URL:-http://127.0.0.1:3000} npm run e2e:guard && node scripts/e2e/run-playwright-lane.mjs critical @critical 2",
     "e2e:web:perf": "node scripts/e2e/report-web-perf.mjs",
-    "e2e:ios:smoke": "bash scripts/e2e/run-ios-tests.sh smoke 1",
-    "e2e:ios:critical": "bash scripts/e2e/run-ios-tests.sh critical 1",
+    "e2e:ios:smoke": "bash scripts/e2e/run-ios-tests.sh smoke 2",
+    "e2e:ios:critical": "bash scripts/e2e/run-ios-tests.sh critical 2",
     "e2e:ios:perf": "node scripts/e2e/report-ios-perf.mjs"
   },
   "dependencies": {


### PR DESCRIPTION
## **User description**
## Summary

- Flips `package.json` ios e2e args from `1` (= 1 attempt, 0 retries) to `2` (= 2 attempts, 1 retry).
- Aligns with the cross-cutting policy at [`docs/testing/e2e-policy.md`](https://github.com/auerbachb/still-point/blob/main/docs/testing/e2e-policy.md) Section 1, which already permits **1 retry** for both `ios-e2e-smoke` and `ios-e2e-critical`.
- Activates the existing retry loop at [`scripts/e2e/run-ios-tests.sh:156-171`](https://github.com/auerbachb/still-point/blob/main/scripts/e2e/run-ios-tests.sh#L156); per-attempt artifacts (`<lane>-attempt-1.xcresult`, `<lane>-attempt-2.xcresult`) continue to upload.
- Motivation: macos-26 / iOS 26 simulator pipeline is producing intermittent `EXC_GUARD` / `XPC_EXIT_REASON_FAULT` crashes inside Apple's BackboardServices XPC handling on arbitrary SHAs. PR #308 green yesterday red today on same branch; PR #311 green at 17:09 red at 17:24 with only an unrelated 1-line SettingsView change between. Stacks have zero StillPoint frames. Engineers are manually rerunning these via `gh run rerun --failed`; this PR moves the recovery into the runner so transient infra crashes self-heal without human intervention.

Closes #322

## Test plan

- [ ] `package.json` smoke arg flipped `1` → `2`
- [ ] `package.json` critical arg flipped `1` → `2`
- [ ] No other files changed (single-file `+2/-2` diff)
- [ ] Both `ios-e2e-smoke` and `ios-e2e-critical` lanes pass on this PR's HEAD
- [ ] On a (likely) transient first-attempt failure, the retry kicks in and the lane still reports green; logs and artifacts contain `attempt-2.xcresult` evidence

## Trade-offs

- When the first attempt fails, total CI time for that lane roughly doubles (~25-30 min added). Common case (first attempt passes) adds zero cost.
- A real product regression takes 2× the attempts to surface red but engineers were already manually rerunning flakes — net wall-clock impact is neutral or better.
- The script doesn't distinguish retriable (infra) vs non-retriable (assertion) failures — a real bug consistently fails both attempts and still shows red. Costs ~25 min of compute, not human time. Refining this is a separate larger ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Retry iOS smoke and critical end-to-end tests once after transient failures

### What Changed
- iOS smoke and critical test runs now get one retry instead of failing after the first attempt
- Transient simulator crashes are less likely to leave these CI lanes red when the next attempt passes

### Impact
`✅ Fewer flaky iOS CI failures`
`✅ Fewer manual reruns after simulator crashes`
`✅ Higher pass rate for iOS smoke and critical checks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=91F5JxZ_xT2J_vdSg4Yv_VCtvNUYqfGChrSVP0nqX9Y&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
