### PR TITLE
Apple Sign In (web Auth.js + native iOS) (#286)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,13 +61,17 @@ AUTH_GOOGLE_SECRET=
 # AUTH_FACEBOOK_ID=
 # AUTH_FACEBOOK_SECRET=
 
-# Apple sign-in (deferred to #286). Console: https://developer.apple.com/account/
-# Apple does NOT allow localhost. Local dev requires a tunnel.
-# Services ID Return URL: https://www.still-point.me/api/auth/callback/apple
-# AUTH_APPLE_ID=                      # Services ID identifier (e.g. com.brettonauerbach.stillpoint.web.signin)
+# Apple sign-in (#286). Console: https://developer.apple.com/account/
+# Apple does NOT allow localhost redirect URIs. Use ngrok / cloudflared with a
+# stable HTTPS hostname and register that host + path in the Services ID, or
+# test Sign in with Apple only against staging/production.
+# Services ID Return URL (web): https://www.still-point.me/api/auth/callback/apple
+# AUTH_APPLE_ID=                      # Services ID identifier (web client id), e.g. com.brettonauerbach.stillpoint.web.signin
 # APPLE_TEAM_ID=                      # 10-char Team ID
 # APPLE_KEY_ID=                       # 10-char Key ID from Sign in with Apple key
 # APPLE_PRIVATE_KEY=                  # Full .p8 contents incl. BEGIN/END lines (escape newlines as \n in single-line .env)
+# Optional: native iOS `identityToken` JWT `aud` when it is the app bundle id (default com.brettonauerbach.stillpoint). Set if your bundle id differs.
+# AUTH_APPLE_NATIVE_ID=
 
 # Optional: set to exactly "true" to require friendship before buddy join (see README)
 # BUDDY_REQUIRE_FRIENDSHIP=

--- a/docs/mobile-oauth-integration.md
+++ b/docs/mobile-oauth-integration.md
@@ -7,10 +7,6 @@ companion spec for issue #136 (web Google sign-in) and follow-ups
 [#285](https://github.com/auerbachb/still-point/issues/285) (Facebook), and
 [#286](https://github.com/auerbachb/still-point/issues/286) (Apple).
 
-The iOS implementation itself ships in a separate iOS-side issue. This file
-describes only what the web backend already supports today and what each
-provider expects from the client.
-
 ---
 
 ## Account model
@@ -22,15 +18,19 @@ A single Still Point user account can have:
 - Zero or more linked OAuth identities, recorded in `oauth_accounts` as
   `(provider, provider_account_id) -> user_id`.
 
-Linking rule: when a sign-in provider returns a verified email that matches
-an existing `users.email` (case-insensitively), the new
-`(provider, provider_account_id)` is attached to that user. Otherwise a new
-user is created with a null `password_hash`.
+Linking rule: **provider identity is authoritative.** On each sign-in we first
+look up `(provider, provider_account_id)` in `oauth_accounts`. If a row exists,
+that user owns the session — even when the provider-supplied email is a relay
+address or changes. If no row exists, we may attach the new identity to an
+existing user whose `users.email` matches (case-insensitive), or create a new
+user. Shared implementation: `src/lib/oauth-account-resolution.ts` (used by
+Auth.js web callbacks and native bridges).
 
 The session token format is unchanged. The web backend mints the same
 HttpOnly `sp_token` JWT it has always used; iOS continues to read
 `sp_token` from `HTTPCookieStorage.shared` and attach it to subsequent
-requests.
+requests. For native flows, `APIClient` also persists the JWT from the JSON
+body when the server returns `token` (header `X-Still-Point-Client: ios`).
 
 ---
 
@@ -38,18 +38,18 @@ requests.
 
 There are two patterns iOS uses depending on the provider:
 
-### Pattern A: Native SDK + dedicated server endpoint (Apple only)
+### Pattern A: Native SDK + dedicated server endpoint (Apple)
 
 Apple requires Sign in with Apple to use `ASAuthorizationController` on iOS
 when the platform supports it. The native flow returns an `identityToken`
 (JWT signed by Apple) and an `authorizationCode` to the app, not a redirect.
 
-Endpoint (to be implemented under issue
-[#286](https://github.com/auerbachb/still-point/issues/286)):
+Endpoint (implemented under [#286](https://github.com/auerbachb/still-point/issues/286)):
 
 ```http
 POST /api/auth/apple-native
 Content-Type: application/json
+X-Still-Point-Client: ios
 ```
 
 ```json
@@ -60,21 +60,38 @@ Content-Type: application/json
 }
 ```
 
+`fullName` is optional; Apple only supplies it on the **first** authorization
+for that Apple ID in your app. Omit or send `{}` on subsequent sign-ins.
+
 Server responsibilities:
 
 1. Verify `identityToken` against Apple's JWKS
-   (`https://appleid.apple.com/auth/keys`) using the `jose` library that is
-   already in the project; check `iss == "https://appleid.apple.com"`,
-   `aud == AUTH_APPLE_ID` (the Services ID), and `exp`.
-2. Extract `sub` (Apple user id, stable across sign-ins) and `email`.
-3. Apply the same find/create-and-link logic as the web `signIn` callback,
-   keyed on email when present (Apple may return a relay address) and on
-   `(provider='apple', provider_account_id=sub)` for re-sign-in.
-4. Mint `sp_token`, set the cookie, and return the same response shape as
-   `POST /api/auth/login`.
+   (`https://appleid.apple.com/auth/keys`) with `jose.jwtVerify`; require
+   `iss === "https://appleid.apple.com"`, valid signature, and `exp`.
+2. Require `aud` to be either `AUTH_APPLE_ID` (Services ID / web client id) or
+   the iOS host app bundle id (default `com.brettonauerbach.stillpoint`). If
+   your bundle id differs, set optional `AUTH_APPLE_NATIVE_ID` on the server.
+3. Extract `sub` (Apple user id, stable across sign-ins) and `email` from the
+   JWT. Reject if `email` or `email_verified` is missing or false — Apple omits
+   `email` on later native sign-ins unless the user revoked and re-granted; in
+   that case the user should complete a fresh authorization or use web sign-in
+   once so we can store the relay address.
+4. Call `resolveOrCreateUserForOAuthLink({ provider: 'apple', providerAccountId: sub, email, profileName })`.
+5. Mint `sp_token`, set the HttpOnly cookie, return the same JSON shape as
+   `POST /api/auth/login`, plus `token` in the body when `X-Still-Point-Client: ios`.
 
-This endpoint does not exist yet. It is gated on
-[#286](https://github.com/auerbachb/still-point/issues/286).
+**Hide My Email:** Relay addresses (`*@privaterelay.appleid.com`) are stable
+per (user, app). We always key `oauth_accounts` rows by Apple `sub`, so repeat
+sign-ins attach to the same Still Point user even if email matching would
+otherwise be ambiguous.
+
+**Security:** Do not log `identityToken`, `authorizationCode`, or provider access
+tokens. The route logs only generic errors.
+
+**iOS app wiring:** `AppleSignInController` + `AppleSignInButtonView` in
+`ios/StillPointApp` call `APIClient.appleNativeSignIn`. Enable the Sign in with
+Apple capability in Xcode / Apple Developer for the app id that matches the
+native token `aud`.
 
 ### Pattern B: `ASWebAuthenticationSession` over the web flow (Google, Microsoft, Facebook)
 
@@ -138,7 +155,7 @@ Caveats for Pattern B:
 | Provider | Pattern | iOS framework | Status |
 |---|---|---|---|
 | Google | B (web flow) | `ASWebAuthenticationSession` | Web available today (#136). iOS-side issue not yet filed. |
-| Apple | A (native) | `ASAuthorizationController` | Web Auth.js + native endpoint deferred to [#286](https://github.com/auerbachb/still-point/issues/286). |
+| Apple | A (native) | `ASAuthorizationController` | Web Auth.js + `POST /api/auth/apple-native` (#286). |
 | Facebook | B (web flow) | `ASWebAuthenticationSession` | Deferred to [#285](https://github.com/auerbachb/still-point/issues/285). |
 | Microsoft | B (web flow) | `ASWebAuthenticationSession` | Deferred to [#284](https://github.com/auerbachb/still-point/issues/284). |
 
@@ -150,7 +167,7 @@ Caveats for Pattern B:
   identifiers.
 - Provider tokens (`identityToken`, OAuth access tokens, refresh tokens)
   must not appear in application logs. Auth.js does not log them by default;
-  custom server code (e.g., `/api/auth/apple-native`) must follow the same
+  custom server code (e.g. `/api/auth/apple-native`) must follow the same
   rule.
 - `sp_token` remains the only credential the iOS app sees and stores. It is
   HttpOnly on web; on iOS it lives in `HTTPCookieStorage.shared` and is

--- a/ios/StillPoint.xcodeproj/project.pbxproj
+++ b/ios/StillPoint.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		50CD873CA594B5A6FCDBB251 /* HistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F75039BBEED880C73680860 /* HistoryViewModel.swift */; };
 		55CB825BEE151D314A4DD2FA /* AppViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 218693B76FDAF56B6E0321DE /* AppViewModel.swift */; };
 		5CD3F9D38AB8369BA65DD128 /* Newsreader-Italic-Variable.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4F0CE80470C4C3CE0D9B4C00 /* Newsreader-Italic-Variable.ttf */; };
+		A28600000000000000000003 /* AppleSignInButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28600000000000000000001 /* AppleSignInButtonView.swift */; };
+		A28600000000000000000004 /* AppleSignInController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28600000000000000000002 /* AppleSignInController.swift */; };
 		5EA3E8C9B84298DE1F37251F /* AuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00D7B1EDF2C56A1B6EB4C28 /* AuthView.swift */; };
 		74AE784447C3D50E1E6980E9 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7766937C968433C205A250C /* HistoryView.swift */; };
 		760C4A2F57E6B207F729ABEA /* BuddyActiveSessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E9BBE4830753E3B8FCC1C0 /* BuddyActiveSessionView.swift */; };
@@ -66,6 +68,8 @@
 		85EAF998E3470CBB4056699F /* BlockGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockGridView.swift; sourceTree = "<group>"; };
 		9311B0CBDED4DF207E799ACC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9A0F8BA13F32BC68EEA0198C /* BuddyVideoWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyVideoWebView.swift; sourceTree = "<group>"; };
+		A28600000000000000000001 /* AppleSignInButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInButtonView.swift; sourceTree = "<group>"; };
+		A28600000000000000000002 /* AppleSignInController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInController.swift; sourceTree = "<group>"; };
 		A00D7B1EDF2C56A1B6EB4C28 /* AuthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthView.swift; sourceTree = "<group>"; };
 		A67F64CE400EF98ED2925FF9 /* StillPointShared */ = {isa = PBXFileReference; lastKnownFileType = folder; name = StillPointShared; path = StillPointShared; sourceTree = SOURCE_ROOT; };
 		AB8762D63FDB945A01DEA97F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -98,6 +102,7 @@
 		0125A97693D46BCCED4DC74E /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				A28600000000000000000001 /* AppleSignInButtonView.swift */,
 				A00D7B1EDF2C56A1B6EB4C28 /* AuthView.swift */,
 				9AEB18D5D4C55CB98F814D43 /* BuddySession */,
 				7D13B1D65F99CF21AA713D32 /* CompletionView.swift */,
@@ -132,6 +137,14 @@
 			path = Fonts;
 			sourceTree = "<group>";
 		};
+		A28600000000000000000005 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				A28600000000000000000002 /* AppleSignInController.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
 		489EB05EBE530B8F6E4F1C7F /* StillPointApp */ = {
 			isa = PBXGroup;
 			children = (
@@ -140,6 +153,7 @@
 				14CEC6DBFFB1C10CFDDA8424 /* StillPointApp.swift */,
 				4DB1C67E76477BADB30F0F77 /* Components */,
 				17A248000000000000000006 /* Managers */,
+				A28600000000000000000005 /* Services */,
 				551003AC2B5AD8A7B3C3D426 /* Navigation */,
 				09EA4336C05552F95AE85178 /* Resources */,
 				AC788F412B1414C8C2BDB3CB /* Theme */,
@@ -316,6 +330,8 @@
 				55CB825BEE151D314A4DD2FA /* AppViewModel.swift in Sources */,
 				17A248000000000000000001 /* AppBlockingManager.swift in Sources */,
 				17A248000000000000000003 /* AppBlockingSettingsView.swift in Sources */,
+				A28600000000000000000003 /* AppleSignInButtonView.swift in Sources */,
+				A28600000000000000000004 /* AppleSignInController.swift in Sources */,
 				5EA3E8C9B84298DE1F37251F /* AuthView.swift in Sources */,
 				8A9734076E9FB3D5477913A0 /* AuthViewModel.swift in Sources */,
 				F370AA8F6AA102355FC599C9 /* BlockGridView.swift in Sources */,

--- a/ios/StillPointApp/Services/AppleSignInController.swift
+++ b/ios/StillPointApp/Services/AppleSignInController.swift
@@ -1,0 +1,96 @@
+import AuthenticationServices
+import StillPointShared
+import SwiftUI
+import UIKit
+
+/// Bridges Sign in with Apple (`ASAuthorizationController`) to
+/// `POST /api/auth/apple-native` (#286).
+enum AppleSignInController {
+    static func makeCoordinator(
+        onSuccess: @escaping @Sendable (UserDTO) -> Void,
+        onError: @escaping @Sendable (String) -> Void
+    ) -> Coordinator {
+        Coordinator(onSuccess: onSuccess, onError: onError)
+    }
+
+    final class Coordinator: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
+        private let onSuccess: @Sendable (UserDTO) -> Void
+        private let onError: @Sendable (String) -> Void
+
+        init(onSuccess: @escaping @Sendable (UserDTO) -> Void, onError: @escaping @Sendable (String) -> Void) {
+            self.onSuccess = onSuccess
+            self.onError = onError
+        }
+
+        @objc func handleTap() {
+            let request = ASAuthorizationAppleIDProvider().createRequest()
+            request.requestedScopes = [.fullName, .email]
+            let controller = ASAuthorizationController(authorizationRequests: [request])
+            controller.delegate = self
+            controller.presentationContextProvider = self
+            controller.performRequests()
+        }
+
+        func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+            let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+            let window = scenes
+                .flatMap(\.windows)
+                .first { $0.isKeyWindow }
+                ?? scenes.flatMap(\.windows).first
+            precondition(window != nil, "Sign in with Apple requires an active UIWindow")
+            return window!
+        }
+
+        func authorizationController(
+            controller: ASAuthorizationController,
+            didCompleteWithAuthorization authorization: ASAuthorization
+        ) {
+            guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+                onError("Unexpected credential type")
+                return
+            }
+            guard let tokenData = credential.identityToken,
+                  let identityToken = String(data: tokenData, encoding: .utf8) else {
+                onError("Missing identity token")
+                return
+            }
+            guard let codeData = credential.authorizationCode,
+                  let authorizationCode = String(data: codeData, encoding: .utf8) else {
+                onError("Missing authorization code")
+                return
+            }
+
+            var fullNamePayload: [String: String]?
+            if let pn = credential.fullName {
+                var d: [String: String] = [:]
+                if let g = pn.givenName { d["givenName"] = g }
+                if let f = pn.familyName { d["familyName"] = f }
+                fullNamePayload = d.isEmpty ? nil : d
+            }
+
+            Task {
+                do {
+                    let user = try await APIClient.shared.appleNativeSignIn(
+                        identityToken: identityToken,
+                        authorizationCode: authorizationCode,
+                        fullName: fullNamePayload
+                    )
+                    await MainActor.run { onSuccess(user) }
+                } catch let api as APIError {
+                    await MainActor.run { onError(api.message) }
+                } catch {
+                    await MainActor.run { onError("Connection failed. Please try again.") }
+                }
+            }
+        }
+
+        func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+            let ns = error as NSError
+            if ns.domain == ASAuthorizationError.errorDomain,
+               ns.code == ASAuthorizationError.canceled.rawValue {
+                return
+            }
+            onError(error.localizedDescription)
+        }
+    }
+}

--- a/ios/StillPointApp/StillPointApp.entitlements
+++ b/ios/StillPointApp/StillPointApp.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 </dict>
 </plist>

--- a/ios/StillPointApp/ViewModels/AuthViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AuthViewModel.swift
@@ -11,6 +11,8 @@ final class AuthViewModel {
     var resetMessage: String?
     var isSubmitting = false
     var isRequestingPasswordReset = false
+    /// Lazily created for Sign in with Apple (#286).
+    private(set) var appleCoordinator: AppleSignInController.Coordinator?
 
     var isValid: Bool {
         let emailValid = email.contains("@") && email.contains(".")
@@ -50,6 +52,23 @@ final class AuthViewModel {
             self.error = "Connection failed. Please try again."
             return nil
         }
+    }
+
+    func ensureAppleCoordinator(appVM: AppViewModel) {
+        guard appleCoordinator == nil else { return }
+        appleCoordinator = AppleSignInController.makeCoordinator(
+            onSuccess: { [weak self] user in
+                Task { @MainActor in
+                    self?.error = nil
+                    appVM.didLogin(user: user)
+                }
+            },
+            onError: { [weak self] msg in
+                Task { @MainActor in
+                    self?.error = msg
+                }
+            }
+        )
     }
 
     func requestPasswordReset() async {

--- a/ios/StillPointApp/Views/AppleSignInButtonView.swift
+++ b/ios/StillPointApp/Views/AppleSignInButtonView.swift
@@ -1,0 +1,15 @@
+import AuthenticationServices
+import SwiftUI
+
+struct AppleSignInButtonView: UIViewRepresentable {
+    let coordinator: AppleSignInController.Coordinator
+
+    func makeUIView(context: Context) -> ASAuthorizationAppleIDButton {
+        let button = ASAuthorizationAppleIDButton(type: .signIn, style: .black)
+        button.cornerRadius = 22
+        button.addTarget(coordinator, action: #selector(AppleSignInController.Coordinator.handleTap), for: .touchUpInside)
+        return button
+    }
+
+    func updateUIView(_ uiView: ASAuthorizationAppleIDButton, context: Context) {}
+}

--- a/ios/StillPointApp/Views/AuthView.swift
+++ b/ios/StillPointApp/Views/AuthView.swift
@@ -22,6 +22,13 @@ struct AuthView: View {
                 }
                 .padding(.top, 60)
 
+                if let coord = vm.appleCoordinator {
+                    AppleSignInButtonView(coordinator: coord)
+                        .frame(height: 48)
+                        .padding(.horizontal, SPSpacing.s4)
+                        .accessibilityIdentifier("auth.appleSignInButton")
+                }
+
                 // Login / Sign Up toggle
                 HStack(spacing: 0) {
                     toggleButton("Log In", isSelected: !vm.isSignUp) {
@@ -125,6 +132,9 @@ struct AuthView: View {
             .padding(.bottom, SPSpacing.s6)
         }
         .stillPointBackground()
+        .task {
+            vm.ensureAppleCoordinator(appVM: appVM)
+        }
     }
 
     private func toggleButton(_ title: String, isSelected: Bool, action: @escaping () -> Void) -> some View {

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -132,6 +132,36 @@ public actor APIClient {
         return response.user
     }
 
+    /// Native Sign in with Apple → server JWKS verification (#286).
+    public func appleNativeSignIn(
+        identityToken: String,
+        authorizationCode: String,
+        fullName: [String: String]?
+    ) async throws -> UserDTO {
+        if let user = try uiTestAppleNativeSignIn() {
+            return user
+        }
+        struct Body: Encodable {
+            let identityToken: String
+            let authorizationCode: String
+            let fullName: [String: String]?
+        }
+        let body = Body(
+            identityToken: identityToken,
+            authorizationCode: authorizationCode,
+            fullName: fullName
+        )
+        let response: UserResponse = try await post("/api/auth/apple-native", body: body)
+        if let token = response.token, !token.isEmpty {
+            guard AuthTokenStore.save(token) else {
+                throw APIError(status: 0, message: "Unable to securely save auth token")
+            }
+        } else {
+            _ = AuthTokenStore.clear()
+        }
+        return response.user
+    }
+
     public func requestPasswordReset(email: String) async throws -> String {
         if let message = try uiTestRequestPasswordReset(email: email) {
             return message
@@ -471,6 +501,11 @@ public actor APIClient {
         uiTestStore = store
         persistUITestStore()
         return store.user
+    }
+
+    private func uiTestAppleNativeSignIn() throws -> UserDTO? {
+        guard uiTestConfig != nil else { return nil }
+        throw APIError(status: 0, message: "Apple sign-in is not stubbed in UI tests")
     }
 
     private func uiTestRequestPasswordReset(email: String) throws -> String? {

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -21,6 +21,8 @@ targets:
         buildPhase: resources
     dependencies:
       - package: StillPointShared
+    entitlements:
+      path: StillPointApp/StillPointApp.entitlements
     info:
       path: StillPointApp/Info.plist
       properties:

--- a/src/app/api/auth/apple-native/route.test.ts
+++ b/src/app/api/auth/apple-native/route.test.ts
@@ -1,0 +1,134 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const jwtVerify = vi.fn();
+vi.mock("jose", () => ({
+  createRemoteJWKSet: vi.fn(() => ({})),
+  jwtVerify,
+}));
+
+const resolveOrCreateUserForOAuthLink = vi.fn();
+vi.mock("@/lib/oauth-account-resolution", () => ({
+  resolveOrCreateUserForOAuthLink,
+}));
+
+const dbSelectLimit = vi.fn();
+const dbSelectWhere = vi.fn(() => ({ limit: dbSelectLimit }));
+const dbSelectFrom = vi.fn(() => ({ where: dbSelectWhere }));
+const dbSelect = vi.fn(() => ({ from: dbSelectFrom }));
+
+vi.mock("@/db", () => ({
+  db: { select: dbSelect },
+}));
+
+vi.mock("@/db/schema", () => ({
+  users: { id: "id" },
+}));
+
+const createToken = vi.fn();
+const setAuthCookie = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  createToken,
+  setAuthCookie,
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((a, b) => ({ a, b })),
+}));
+
+describe("POST /api/auth/apple-native", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("AUTH_APPLE_ID", "com.example.services");
+    jwtVerify.mockResolvedValue({
+      payload: {
+        sub: "apple-sub-1",
+        email: "relay@privaterelay.appleid.com",
+        email_verified: true,
+        aud: "com.brettonauerbach.stillpoint",
+      },
+    });
+    resolveOrCreateUserForOAuthLink.mockResolvedValue("user-uuid-1");
+    dbSelectLimit.mockResolvedValue([
+      {
+        id: "user-uuid-1",
+        email: "relay@privaterelay.appleid.com",
+        username: "ada",
+        isPublic: false,
+        currentDay: 1,
+      },
+    ]);
+    createToken.mockResolvedValue("jwt-token");
+  });
+
+  test("returns 400 when identityToken missing", async () => {
+    const { POST } = await import("./route");
+    const res = await POST(
+      new Request("http://test.local/api/auth/apple-native", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ authorizationCode: "code" }),
+      }) as NextRequest,
+    );
+    expect(res.status).toBe(400);
+    expect(jwtVerify).not.toHaveBeenCalled();
+  });
+
+  test("verifies JWT and returns user JSON", async () => {
+    const { POST } = await import("./route");
+    const res = await POST(
+      new Request("http://test.local/api/auth/apple-native", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-still-point-client": "ios",
+        },
+        body: JSON.stringify({
+          identityToken: "eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiIxIn0.sig",
+          authorizationCode: "auth-code",
+          fullName: { givenName: "Ada", familyName: "Lovelace" },
+        }),
+      }) as NextRequest,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user).toMatchObject({
+      id: "user-uuid-1",
+      email: "relay@privaterelay.appleid.com",
+      username: "ada",
+    });
+    expect(body.token).toBe("jwt-token");
+    expect(resolveOrCreateUserForOAuthLink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "apple",
+        providerAccountId: "apple-sub-1",
+        email: "relay@privaterelay.appleid.com",
+        profileName: "Ada Lovelace",
+      }),
+    );
+    expect(createToken).toHaveBeenCalled();
+    expect(setAuthCookie).toHaveBeenCalledWith("jwt-token");
+  });
+
+  test("rejects wrong audience", async () => {
+    jwtVerify.mockResolvedValue({
+      payload: {
+        sub: "sub",
+        email: "a@b.com",
+        email_verified: true,
+        aud: "wrong.bundle",
+      },
+    });
+    const { POST } = await import("./route");
+    const res = await POST(
+      new Request("http://test.local/api/auth/apple-native", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ identityToken: "t", authorizationCode: "c" }),
+      }) as NextRequest,
+    );
+    expect(res.status).toBe(401);
+    expect(resolveOrCreateUserForOAuthLink).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/auth/apple-native/route.ts
+++ b/src/app/api/auth/apple-native/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createRemoteJWKSet, jwtVerify } from "jose";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { users } from "@/db/schema";
+import { createToken, setAuthCookie } from "@/lib/auth";
+import { resolveOrCreateUserForOAuthLink } from "@/lib/oauth-account-resolution";
+
+const APPLE_ISSUER = "https://appleid.apple.com";
+const APPLE_JWKS = createRemoteJWKSet(new URL("https://appleid.apple.com/auth/keys"));
+
+/** Default matches `PRODUCT_BUNDLE_IDENTIFIER` in ios/project.yml. Override with
+ *  AUTH_APPLE_NATIVE_ID when the bundle id differs (forks, other targets). */
+const DEFAULT_APPLE_NATIVE_AUDIENCE = "com.brettonauerbach.stillpoint";
+
+function audienceAccepted(aud: unknown, servicesId: string, nativeAudience: string): boolean {
+  const list = Array.isArray(aud) ? aud : aud != null ? [aud] : [];
+  return list.some((a) => a === servicesId || a === nativeAudience);
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const servicesId = process.env.AUTH_APPLE_ID?.trim();
+    const nativeAudience =
+      process.env.AUTH_APPLE_NATIVE_ID?.trim() || DEFAULT_APPLE_NATIVE_AUDIENCE;
+
+    if (!servicesId) {
+      return NextResponse.json({ error: "Apple sign-in is not configured" }, { status: 503 });
+    }
+
+    const body = (await request.json()) as Record<string, unknown>;
+    const identityToken =
+      typeof body?.identityToken === "string" ? body.identityToken.trim() : "";
+    const authorizationCode =
+      typeof body?.authorizationCode === "string" ? body.authorizationCode.trim() : "";
+
+    if (!identityToken || !authorizationCode) {
+      return NextResponse.json(
+        { error: "identityToken and authorizationCode are required" },
+        { status: 400 },
+      );
+    }
+
+    // Verify signature + standard claims. Do not log tokens or codes.
+    const { payload } = await jwtVerify(identityToken, APPLE_JWKS, {
+      issuer: APPLE_ISSUER,
+    });
+
+    if (!audienceAccepted(payload.aud, servicesId, nativeAudience)) {
+      return NextResponse.json({ error: "Invalid token audience" }, { status: 401 });
+    }
+
+    const sub = typeof payload.sub === "string" ? payload.sub : null;
+    if (!sub) {
+      return NextResponse.json({ error: "Invalid token subject" }, { status: 401 });
+    }
+
+    const rawEmail = typeof payload.email === "string" ? payload.email : null;
+    if (!rawEmail) {
+      return NextResponse.json(
+        { error: "Email not available on this sign-in. Use Apple Settings to share email, or sign in on the web first." },
+        { status: 400 },
+      );
+    }
+
+    const emailVerified = payload.email_verified === true || payload.email_verified === "true";
+    if (!emailVerified) {
+      return NextResponse.json({ error: "Email not verified" }, { status: 401 });
+    }
+
+    const email = rawEmail.trim().toLowerCase();
+
+    let fullName: string | null = null;
+    const fn = body.fullName as Record<string, unknown> | undefined;
+    if (fn && typeof fn === "object") {
+      const given = typeof fn.givenName === "string" ? fn.givenName.trim() : "";
+      const family = typeof fn.familyName === "string" ? fn.familyName.trim() : "";
+      const combined = [given, family].filter(Boolean).join(" ").trim();
+      fullName = combined.length > 0 ? combined : null;
+    }
+
+    const userId = await resolveOrCreateUserForOAuthLink({
+      provider: "apple",
+      providerAccountId: sub,
+      email,
+      profileName: fullName,
+    });
+
+    const [user] = await db.select().from(users).where(eq(users.id, userId)).limit(1);
+    if (!user) {
+      return NextResponse.json({ error: "Account resolution failed" }, { status: 500 });
+    }
+
+    const token = await createToken({ userId: user.id, email: user.email });
+    await setAuthCookie(token);
+
+    const includeToken = request.headers.get("x-still-point-client") === "ios";
+
+    return NextResponse.json({
+      user: {
+        id: user.id,
+        email: user.email,
+        username: user.username,
+        isPublic: user.isPublic,
+        currentDay: user.currentDay,
+      },
+      ...(includeToken ? { token } : {}),
+    });
+  } catch (error) {
+    // Never log identityToken / authorizationCode
+    console.error("Apple native sign-in error:", error instanceof Error ? error.message : "unknown");
+    return NextResponse.json({ error: "Sign-in failed" }, { status: 401 });
+  }
+}

--- a/src/app/api/auth/signup/route.test.ts
+++ b/src/app/api/auth/signup/route.test.ts
@@ -104,8 +104,12 @@ describe("POST /api/auth/signup uniqueness handling", () => {
     // Pin the predicate shape so a regression to plain eq(users.username, ...)
     // (which would be case-sensitive) fails this test instead of silently passing.
     expect(selectWhere).toHaveBeenCalledTimes(2);
-    const usernamePredicate = selectWhere.mock.calls[1][0] as { kind?: string };
-    expect(usernamePredicate?.kind).toBe("sql");
+    const calls = selectWhere.mock.calls as unknown[][];
+    const predicates = calls
+      .map((c) => (Array.isArray(c) && c.length > 0 ? (c[0] as { kind?: string }) : undefined))
+      .filter((p): p is { kind?: string } => p != null);
+    const usernamePredicate = predicates.find((p) => p?.kind === "sql");
+    expect(usernamePredicate).toBeDefined();
   });
 
   test("maps Postgres 23505 on email constraint to 'Email already in use' (race fallback)", async () => {

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -210,6 +210,18 @@ export default function PrivacyPolicyPage() {
             </a>
             .
           </li>
+          <li>
+            <strong style={{ color: "var(--fg)" }}>Apple:</strong>{" "}
+            <a
+              href="https://www.apple.com/legal/privacy/data/en/sign-in-with-apple/"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: "var(--accent-green-text)", textDecoration: "underline" }}
+            >
+              Sign in with Apple: how we handle your data
+            </a>
+            .
+          </li>
         </ul>
 
         <h2 style={sectionTitle}>Retention and your choices</h2>

--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -169,10 +169,16 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
           Continue with Google
         </button>
 
-        <a
-          href="/api/auth/signin?provider=apple"
+        <button
+          type="button"
+          onClick={() => {
+            const params = new URLSearchParams(window.location.search);
+            params.delete("error");
+            const search = params.toString();
+            const callbackUrl = `${window.location.pathname}${search ? `?${search}` : ""}`;
+            void signIn("apple", { callbackUrl });
+          }}
           style={{
-            textDecoration: "none",
             background: "var(--surface-1)",
             border: "1px solid var(--border-2)",
             color: "var(--fg)",
@@ -201,7 +207,7 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
             <path d="M13.65 9.52c-.02-1.95 1.6-2.89 1.67-2.93-.91-1.33-2.33-1.51-2.83-1.53-1.2-.12-2.35.71-2.96.71-.61 0-1.55-.69-2.55-.67-1.31.02-2.52.76-3.2 1.93-1.36 2.36-.35 5.86.98 7.78.65.94 1.42 2 2.44 1.96.98-.04 1.35-.63 2.53-.63 1.18 0 1.51.63 2.54.61 1.05-.02 1.71-.95 2.36-1.9.74-1.08 1.05-2.13 1.06-2.19-.02-.01-2.04-.78-2.06-3.1zM11.29 3.07c.53-.64.89-1.53.79-2.42-.76.03-1.68.51-2.22 1.15-.49.57-.92 1.48-.8 2.36.85.07 1.71-.43 2.23-1.09z" />
           </svg>
           Continue with Apple
-        </a>
+        </button>
 
         <p style={{
           fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",

--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -11,11 +11,11 @@ const OAUTH_ERROR_MESSAGES: Record<string, string> = {
   oauth_session_missing: "Sign-in didn't complete. Please try again.",
   oauth_user_missing: "We couldn't find your account. Please try again.",
   oauth_internal_error: "Something went wrong on our end. Please try again.",
-  OAuthSignin: "Couldn't start Google sign-in. Please try again.",
-  OAuthCallback: "Google sign-in was cancelled or failed.",
+  OAuthSignin: "Couldn't start sign-in. Please try again.",
+  OAuthCallback: "Sign-in was cancelled or failed.",
   OAuthCreateAccount: "Couldn't create your account. Please try again.",
   AccessDenied: "Access denied. Please try again.",
-  Verification: "We couldn't verify your Google account.",
+  Verification: "We couldn't verify your account with the provider.",
   Configuration: "Sign-in is temporarily unavailable.",
 };
 
@@ -168,6 +168,40 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
           </svg>
           Continue with Google
         </button>
+
+        <a
+          href="/api/auth/signin?provider=apple"
+          style={{
+            textDecoration: "none",
+            background: "var(--surface-1)",
+            border: "1px solid var(--border-2)",
+            color: "var(--fg)",
+            fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+            fontSize: "15px",
+            padding: "12px 16px",
+            borderRadius: "30px",
+            cursor: "pointer",
+            transition: "all 0.3s",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "10px",
+          }}
+          onMouseEnter={e => {
+            e.currentTarget.style.borderColor = "var(--border-3)";
+            e.currentTarget.style.background = "var(--surface-2)";
+          }}
+          onMouseLeave={e => {
+            e.currentTarget.style.borderColor = "var(--border-2)";
+            e.currentTarget.style.background = "var(--surface-1)";
+          }}
+          aria-label="Continue with Apple"
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true" fill="currentColor">
+            <path d="M13.65 9.52c-.02-1.95 1.6-2.89 1.67-2.93-.91-1.33-2.33-1.51-2.83-1.53-1.2-.12-2.35.71-2.96.71-.61 0-1.55-.69-2.55-.67-1.31.02-2.52.76-3.2 1.93-1.36 2.36-.35 5.86.98 7.78.65.94 1.42 2 2.44 1.96.98-.04 1.35-.63 2.53-.63 1.18 0 1.51.63 2.54.61 1.05-.02 1.71-.95 2.36-1.9.74-1.08 1.05-2.13 1.06-2.19-.02-.01-2.04-.78-2.06-3.1zM11.29 3.07c.53-.64.89-1.53.79-2.42-.76.03-1.68.51-2.22 1.15-.49.57-.92 1.48-.8 2.36.85.07 1.71-.43 2.23-1.09z" />
+          </svg>
+          Continue with Apple
+        </a>
 
         <p style={{
           fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -72,7 +72,7 @@ export const accountDeletionLog = pgTable("account_deletion_log", {
 /** OAuth provider identities linked to a user (#136).
  *  One row per (provider, providerAccountId); a single user may have
  *  multiple rows (one per provider). Email-match account linking is
- *  performed in `src/lib/auth-config.ts` signIn callback. */
+ *  performed in `src/lib/oauth-account-resolution.ts` (Auth.js + native). */
 export const oauthAccounts = pgTable("oauth_accounts", {
   id: uuid("id").primaryKey().defaultRandom(),
   userId: uuid("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),

--- a/src/lib/apple-client-secret.ts
+++ b/src/lib/apple-client-secret.ts
@@ -1,0 +1,52 @@
+import { SignJWT, importPKCS8 } from "jose";
+
+const CACHE_MS = 130 * 24 * 60 * 60 * 1000; // ~130 days (< 6 months Apple rotation window)
+
+let cachedSecret: { value: string; expiresAt: number } | null = null;
+
+function normalizePem(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.includes("\\n")) {
+    return trimmed.replace(/\\n/g, "\n");
+  }
+  return trimmed;
+}
+
+/** Mint the client_secret JWT Apple requires for the “web” / server OAuth
+ *  client (Services ID). Cached so we do not re-sign on every request. */
+export async function getAppleClientSecret(): Promise<string> {
+  const now = Date.now();
+  if (cachedSecret && cachedSecret.expiresAt > now + 60_000) {
+    return cachedSecret.value;
+  }
+
+  const teamId = process.env.APPLE_TEAM_ID;
+  const keyId = process.env.APPLE_KEY_ID;
+  const clientId = process.env.AUTH_APPLE_ID;
+  const privateKeyRaw = process.env.APPLE_PRIVATE_KEY;
+
+  if (!teamId || !keyId || !clientId || !privateKeyRaw) {
+    throw new Error("Apple OAuth env incomplete: need AUTH_APPLE_ID, APPLE_TEAM_ID, APPLE_KEY_ID, APPLE_PRIVATE_KEY");
+  }
+
+  const privateKey = await importPKCS8(normalizePem(privateKeyRaw), "ES256");
+
+  const issuedAt = Math.floor(now / 1000);
+  const expiresAtSec = issuedAt + 60 * 60 * 24 * 150; // 150 days; Apple accepts up to 6 months
+
+  const jwt = await new SignJWT({})
+    .setProtectedHeader({ alg: "ES256", kid: keyId })
+    .setIssuer(teamId)
+    .setAudience("https://appleid.apple.com")
+    .setSubject(clientId)
+    .setIssuedAt(issuedAt)
+    .setExpirationTime(expiresAtSec)
+    .sign(privateKey);
+
+  cachedSecret = {
+    value: jwt,
+    expiresAt: now + CACHE_MS,
+  };
+
+  return jwt;
+}

--- a/src/lib/apple-jwt.ts
+++ b/src/lib/apple-jwt.ts
@@ -12,9 +12,9 @@ function normalizePem(raw: string): string {
   return trimmed;
 }
 
-/** Mint the client_secret JWT Apple requires for the “web” / server OAuth
- *  client (Services ID). Cached so we do not re-sign on every request. */
-export async function getAppleClientSecret(): Promise<string> {
+/** Mint the client_secret JWT Apple requires for the Services ID (web OAuth).
+ *  Cached so we do not re-sign on every cold start. */
+export async function getAppleClientSecretJwt(): Promise<string> {
   const now = Date.now();
   if (cachedSecret && cachedSecret.expiresAt > now + 60_000) {
     return cachedSecret.value;
@@ -26,7 +26,9 @@ export async function getAppleClientSecret(): Promise<string> {
   const privateKeyRaw = process.env.APPLE_PRIVATE_KEY;
 
   if (!teamId || !keyId || !clientId || !privateKeyRaw) {
-    throw new Error("Apple OAuth env incomplete: need AUTH_APPLE_ID, APPLE_TEAM_ID, APPLE_KEY_ID, APPLE_PRIVATE_KEY");
+    throw new Error(
+      "Apple OAuth env incomplete: need AUTH_APPLE_ID, APPLE_TEAM_ID, APPLE_KEY_ID, APPLE_PRIVATE_KEY",
+    );
   }
 
   const privateKey = await importPKCS8(normalizePem(privateKeyRaw), "ES256");

--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -1,7 +1,8 @@
+import type { NextAuthConfig } from "next-auth";
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
 import Apple from "next-auth/providers/apple";
-import { getAppleClientSecret } from "@/lib/apple-client-secret";
+import { getAppleClientSecretJwt } from "@/lib/apple-jwt";
 import { resolveOrCreateUserForOAuthLink } from "@/lib/oauth-account-resolution";
 
 declare module "next-auth" {
@@ -16,125 +17,138 @@ const googleProvider = Google({
   authorization: { params: { scope: "openid email profile" } },
 });
 
-const appleConfigured =
-  Boolean(process.env.AUTH_APPLE_ID) &&
-  Boolean(process.env.APPLE_TEAM_ID) &&
-  Boolean(process.env.APPLE_KEY_ID) &&
-  Boolean(process.env.APPLE_PRIVATE_KEY);
+function appleEnvComplete(): boolean {
+  return (
+    Boolean(process.env.AUTH_APPLE_ID) &&
+    Boolean(process.env.APPLE_TEAM_ID) &&
+    Boolean(process.env.APPLE_KEY_ID) &&
+    Boolean(process.env.APPLE_PRIVATE_KEY)
+  );
+}
 
-const appleProvider = Apple({
-  clientId: process.env.AUTH_APPLE_ID!,
-  // Auth.js resolves this at token exchange; runtime accepts async factory though types say string.
-  clientSecret: getAppleClientSecret as unknown as string,
-});
+async function buildAuthConfig(): Promise<NextAuthConfig> {
+  const providers: NextAuthConfig["providers"] = [googleProvider];
 
-export const { handlers, auth, signIn, signOut } = NextAuth({
-  trustHost: true,
-  providers: [googleProvider, ...(appleConfigured ? [appleProvider] : [])],
-  // Only override `error`. Setting `pages.signIn` to a custom path tells
-  // Auth.js v5 that we render our own signin UI on that path, which
-  // changes the routing — the built-in `/api/auth/signin/<provider>`
-  // route then expects to be reached only via POST+CSRF from that page.
-  // We don't need a custom signin page: AuthScreen renders at /app
-  // whenever sp_token is missing, completely outside Auth.js's flow. The
-  // `signIn()` helper in AuthScreen handles POST+CSRF automatically.
-  pages: {
-    error: "/app",
-  },
-  callbacks: {
-    async signIn({ user, account, profile }) {
-      if (!account || !profile) return false;
-      const rawEmail = typeof profile.email === "string" ? profile.email : null;
-      if (!rawEmail) return false;
+  if (appleEnvComplete()) {
+    const appleClientSecret = await getAppleClientSecretJwt();
+    providers.push(
+      Apple({
+        clientId: process.env.AUTH_APPLE_ID!,
+        clientSecret: appleClientSecret,
+      }),
+    );
+  }
 
-      const provider = account.provider;
-      const providerAccountId = account.providerAccountId;
-      if (!provider || !providerAccountId) return false;
-
-      // Per-provider email-verification check. Auth.js v5 normalises the
-      // raw OIDC `profile` through each provider's `profile()` mapper
-      // BEFORE this callback fires, and Google's default mapper strips
-      // `email_verified`. The signal we trust instead:
-      //   - Google: granting the `email` scope returns a verified address
-      //     by Google's own contract; presence of `profile.email` here is
-      //     the verification signal.
-      //   - Apple: OIDC `email_verified` from the id_token (mapped onto profile).
-      //   - Other providers (Microsoft / Facebook, deferred):
-      //     require an explicit `email_verified === true` claim.
-      const p = profile as { email_verified?: boolean | string };
-      const emailVerified =
-        provider === "google"
-          ? true
-          : provider === "apple"
-            ? p.email_verified === true || p.email_verified === "true"
-            : p.email_verified === true;
-      if (!emailVerified) return false;
-
-      const email = rawEmail.trim().toLowerCase();
-      const profileName = typeof profile.name === "string" && profile.name ? profile.name : null;
-
-      const userId = await resolveOrCreateUserForOAuthLink({
-        provider,
-        providerAccountId,
-        email,
-        profileName,
-      });
-
-      // Auth.js passes `user` into the jwt callback only on initial sign-in;
-      // overwriting `user.id` here is how we hand the database id to the JWT.
-      user.id = userId;
-      return true;
+  return {
+    trustHost: true,
+    providers,
+    // Only override `error`. Setting `pages.signIn` to a custom path tells
+    // Auth.js v5 that we render our own signin UI on that path, which
+    // changes the routing — the built-in `/api/auth/signin/<provider>`
+    // route then expects to be reached only via POST+CSRF from that page.
+    // We don't need a custom signin page: AuthScreen renders at /app
+    // whenever sp_token is missing, completely outside Auth.js's flow. The
+    // `signIn()` helper in AuthScreen handles POST+CSRF automatically.
+    pages: {
+      error: "/app",
     },
-    async jwt({ token, user }) {
-      if (user?.id) token.userId = user.id;
-      return token;
+    callbacks: {
+      async signIn({ user, account, profile }) {
+        if (!account || !profile) return false;
+        const rawEmail = typeof profile.email === "string" ? profile.email : null;
+        if (!rawEmail) return false;
+
+        const provider = account.provider;
+        const providerAccountId = account.providerAccountId;
+        if (!provider || !providerAccountId) return false;
+
+        // Per-provider email-verification check. Auth.js v5 normalises the
+        // raw OIDC `profile` through each provider's `profile()` mapper
+        // BEFORE this callback fires, and Google's default mapper strips
+        // `email_verified`. The signal we trust instead:
+        //   - Google: granting the `email` scope returns a verified address
+        //     by Google's own contract; presence of `profile.email` here is
+        //     the verification signal.
+        //   - Apple: OIDC `email_verified` from the id_token (mapped onto profile).
+        //   - Other providers (Microsoft / Facebook, deferred):
+        //     require an explicit `email_verified === true` claim.
+        const p = profile as { email_verified?: boolean | string };
+        const emailVerified =
+          provider === "google"
+            ? true
+            : provider === "apple"
+              ? p.email_verified === true || p.email_verified === "true"
+              : p.email_verified === true;
+        if (!emailVerified) return false;
+
+        const email = rawEmail.trim().toLowerCase();
+        const profileName = typeof profile.name === "string" && profile.name ? profile.name : null;
+
+        const userId = await resolveOrCreateUserForOAuthLink({
+          provider,
+          providerAccountId,
+          email,
+          profileName,
+        });
+
+        // Auth.js passes `user` into the jwt callback only on initial sign-in;
+        // overwriting `user.id` here is how we hand the database id to the JWT.
+        user.id = userId;
+        return true;
+      },
+      async jwt({ token, user }) {
+        if (user?.id) token.userId = user.id;
+        return token;
+      },
+      async session({ session, token }) {
+        const tokenUserId = (token as { userId?: unknown }).userId;
+        if (typeof tokenUserId === "string") {
+          session.userId = tokenUserId;
+        }
+        return session;
+      },
+      async redirect({ url, baseUrl }) {
+        // Auth.js may invoke this callback with a relative same-origin path
+        // (e.g. "/app?error=AccessDenied" or a relative `callbackUrl`).
+        // Normalise to an absolute URL up front so the comparisons below
+        // match both relative and absolute forms — without this, relative
+        // values fell through to the final fallback and lost their error /
+        // deep-link state.
+        const normalizedUrl = url.startsWith("/") ? `${baseUrl}${url}` : url;
+
+        // Auth.js error redirects (e.g. /app?error=AccessDenied,
+        // /app?error=OAuthCallback) come through here when sign-in fails or
+        // is cancelled. Identify them by the explicit ?error= query param
+        // and pass through unchanged so AuthScreen renders the inline error.
+        // The earlier broader rule (any /app URL) was too wide — the default
+        // post-sign-in callbackUrl is also /app, which would bypass the
+        // sp_token bridge entirely.
+        if (
+          normalizedUrl.startsWith(`${baseUrl}/app`) &&
+          /[?&]error=/.test(normalizedUrl)
+        ) {
+          return normalizedUrl;
+        }
+
+        // Already in our sp_token bridge. Pass through.
+        if (normalizedUrl.startsWith(`${baseUrl}/api/auth/oauth-complete`)) {
+          return normalizedUrl;
+        }
+
+        // Successful sign-in (or any other same-origin destination): route
+        // through the bridge so sp_token is minted before the user lands on
+        // the SPA. Encode the original target as ?return= so the bridge can
+        // honour deep-link/callbackUrl state after minting the cookie.
+        if (normalizedUrl.startsWith(baseUrl)) {
+          const target = normalizedUrl.slice(baseUrl.length) || "/app";
+          return `${baseUrl}/api/auth/oauth-complete?return=${encodeURIComponent(target)}`;
+        }
+
+        // Off-origin URL (defensive). Drop and use the bridge default.
+        return `${baseUrl}/api/auth/oauth-complete`;
+      },
     },
-    async session({ session, token }) {
-      const tokenUserId = (token as { userId?: unknown }).userId;
-      if (typeof tokenUserId === "string") {
-        session.userId = tokenUserId;
-      }
-      return session;
-    },
-    async redirect({ url, baseUrl }) {
-      // Auth.js may invoke this callback with a relative same-origin path
-      // (e.g. "/app?error=AccessDenied" or a relative `callbackUrl`).
-      // Normalise to an absolute URL up front so the comparisons below
-      // match both relative and absolute forms — without this, relative
-      // values fell through to the final fallback and lost their error /
-      // deep-link state.
-      const normalizedUrl = url.startsWith("/") ? `${baseUrl}${url}` : url;
+  };
+}
 
-      // Auth.js error redirects (e.g. /app?error=AccessDenied,
-      // /app?error=OAuthCallback) come through here when sign-in fails or
-      // is cancelled. Identify them by the explicit ?error= query param
-      // and pass through unchanged so AuthScreen renders the inline error.
-      // The earlier broader rule (any /app URL) was too wide — the default
-      // post-sign-in callbackUrl is also /app, which would bypass the
-      // sp_token bridge entirely.
-      if (
-        normalizedUrl.startsWith(`${baseUrl}/app`) &&
-        /[?&]error=/.test(normalizedUrl)
-      ) {
-        return normalizedUrl;
-      }
-
-      // Already in our sp_token bridge. Pass through.
-      if (normalizedUrl.startsWith(`${baseUrl}/api/auth/oauth-complete`)) {
-        return normalizedUrl;
-      }
-
-      // Successful sign-in (or any other same-origin destination): route
-      // through the bridge so sp_token is minted before the user lands on
-      // the SPA. Encode the original target as ?return= so the bridge can
-      // honour deep-link/callbackUrl state after minting the cookie.
-      if (normalizedUrl.startsWith(baseUrl)) {
-        const target = normalizedUrl.slice(baseUrl.length) || "/app";
-        return `${baseUrl}/api/auth/oauth-complete?return=${encodeURIComponent(target)}`;
-      }
-
-      // Off-origin URL (defensive). Drop and use the bridge default.
-      return `${baseUrl}/api/auth/oauth-complete`;
-    },
-  },
-});
+export const { handlers, auth, signIn, signOut } = NextAuth(async () => buildAuthConfig());

--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -1,149 +1,8 @@
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
-import { db } from "@/db";
-import { users, oauthAccounts } from "@/db/schema";
-import { and, eq, sql } from "drizzle-orm";
-import {
-  MAX_USERNAME_LENGTH,
-  MIN_USERNAME_LENGTH,
-  USERNAME_REGEX,
-} from "@/lib/username";
-import { uniqueViolationConstraint } from "@/lib/dbErrors";
-
-/** Sanitize a Google profile field into a username candidate that satisfies
- *  the existing users.username constraints (#136 + #8 case-insensitive
- *  uniqueness). The function may still return a colliding name; the
- *  surrounding loop appends random suffixes until a free slot is found. */
-function sanitizeUsernameSeed(seed: string): string {
-  const cleaned = seed.replace(/[^A-Za-z0-9_]/g, "");
-  if (cleaned.length === 0) return "user";
-  return cleaned.slice(0, MAX_USERNAME_LENGTH);
-}
-
-function randomSuffix(length: number): string {
-  return crypto.randomUUID().replace(/-/g, "").slice(0, length);
-}
-
-async function generateUniqueUsername(seed: string): Promise<string> {
-  const base = sanitizeUsernameSeed(seed);
-  const padded = base.length < MIN_USERNAME_LENGTH ? `${base}user`.slice(0, MAX_USERNAME_LENGTH) : base;
-
-  for (let attempt = 0; attempt < 8; attempt++) {
-    const suffix = attempt === 0 ? "" : `_${randomSuffix(4)}`;
-    const candidate = `${padded.slice(0, MAX_USERNAME_LENGTH - suffix.length)}${suffix}`;
-
-    if (!USERNAME_REGEX.test(candidate)) continue;
-    if (candidate.length < MIN_USERNAME_LENGTH || candidate.length > MAX_USERNAME_LENGTH) continue;
-
-    const [collision] = await db
-      .select({ id: users.id })
-      .from(users)
-      .where(sql`lower(${users.username}) = lower(${candidate})`)
-      .limit(1);
-    if (!collision) return candidate;
-  }
-
-  // Last resort: 10-char random suffix. Crypto-RNG keeps the probability of
-  // collision negligible even under contention.
-  return `user_${randomSuffix(10)}`;
-}
-
-/** Insert a (provider, providerAccountId) -> userId link, returning the
- *  userId that ends up owning the link. If a link already exists (race or
- *  re-sign-in), the existing row's userId wins via ON CONFLICT DO NOTHING +
- *  fallback lookup. This guarantees the link/userId mapping is unique. */
-async function linkProviderToUser(
-  provider: string,
-  providerAccountId: string,
-  userId: string,
-): Promise<string> {
-  const inserted = await db
-    .insert(oauthAccounts)
-    .values({ userId, provider, providerAccountId })
-    .onConflictDoNothing({
-      target: [oauthAccounts.provider, oauthAccounts.providerAccountId],
-    })
-    .returning({ userId: oauthAccounts.userId });
-
-  if (inserted.length > 0) return inserted[0].userId;
-
-  // Race: another callback inserted the same link. Use whichever userId
-  // ended up owning it. (Cannot be `userId` we passed in if we lost the
-  // race for an already-linked-to-different-user row.)
-  const [existing] = await db
-    .select({ userId: oauthAccounts.userId })
-    .from(oauthAccounts)
-    .where(
-      and(
-        eq(oauthAccounts.provider, provider),
-        eq(oauthAccounts.providerAccountId, providerAccountId),
-      ),
-    )
-    .limit(1);
-  if (!existing) {
-    throw new Error("oauth_accounts insert returned no rows and no existing link");
-  }
-  return existing.userId;
-}
-
-/** Insert a new user, retrying with a fresh username if the
- *  case-insensitive username unique index races. The pre-check in
- *  `generateUniqueUsername()` reduces but does not eliminate the race —
- *  two concurrent first-time OAuth sign-ins with the same name seed could
- *  both pre-check, both pick the same candidate, and both attempt the
- *  same insert. The first wins; the loser regenerates and retries.
- *
- *  Email conflicts collapse via ON CONFLICT DO NOTHING (we re-look-up the
- *  row a sibling callback inserted). Username conflicts cannot be handled
- *  with a single ON CONFLICT clause alongside email, so they're caught as
- *  a Postgres unique_violation and re-attempted with a new candidate. */
-const MAX_USERNAME_RETRIES = 5;
-
-async function createUserWithUsernameRetry(email: string, seed: string): Promise<string> {
-  for (let attempt = 0; attempt <= MAX_USERNAME_RETRIES; attempt++) {
-    const username = await generateUniqueUsername(seed);
-    try {
-      const inserted = await db
-        .insert(users)
-        .values({ email, username })
-        .onConflictDoNothing({ target: users.email })
-        .returning({ id: users.id });
-
-      if (inserted.length > 0) return inserted[0].id;
-
-      // Email conflict — another callback created this user. Look up.
-      const [racedRow] = await db
-        .select({ id: users.id })
-        .from(users)
-        .where(eq(users.email, email))
-        .limit(1);
-      if (!racedRow) {
-        throw new Error("users insert raced and lookup returned no row");
-      }
-      return racedRow.id;
-    } catch (err) {
-      const constraint = uniqueViolationConstraint(err);
-      // uniqueViolationConstraint returns:
-      //   - null  → not a unique_violation, do not retry
-      //   - ""    → unique_violation but driver did not surface the
-      //             constraint name (Neon HTTP can do this)
-      //   - "..." → constraint name string
-      // The email conflict path is handled by onConflictDoNothing above
-      // (no throw), so any unique_violation that reaches here must be on
-      // the username index. Treat empty/unknown names as retryable too,
-      // otherwise an empty-string constraint silently falls through and
-      // the truthy check on `constraint &&` would skip the retry.
-      if (constraint === null) throw err;
-      const isLikelyUsernameConstraint =
-        constraint === "" || constraint.toLowerCase().includes("username");
-      if (isLikelyUsernameConstraint && attempt < MAX_USERNAME_RETRIES) {
-        continue;
-      }
-      throw err;
-    }
-  }
-  throw new Error("Failed to allocate a unique username after retries");
-}
+import Apple from "next-auth/providers/apple";
+import { getAppleClientSecret } from "@/lib/apple-client-secret";
+import { resolveOrCreateUserForOAuthLink } from "@/lib/oauth-account-resolution";
 
 declare module "next-auth" {
   interface Session {
@@ -151,15 +10,27 @@ declare module "next-auth" {
   }
 }
 
+const googleProvider = Google({
+  clientId: process.env.AUTH_GOOGLE_ID,
+  clientSecret: process.env.AUTH_GOOGLE_SECRET,
+  authorization: { params: { scope: "openid email profile" } },
+});
+
+const appleConfigured =
+  Boolean(process.env.AUTH_APPLE_ID) &&
+  Boolean(process.env.APPLE_TEAM_ID) &&
+  Boolean(process.env.APPLE_KEY_ID) &&
+  Boolean(process.env.APPLE_PRIVATE_KEY);
+
+const appleProvider = Apple({
+  clientId: process.env.AUTH_APPLE_ID!,
+  // Auth.js resolves this at token exchange; runtime accepts async factory though types say string.
+  clientSecret: getAppleClientSecret as unknown as string,
+});
+
 export const { handlers, auth, signIn, signOut } = NextAuth({
   trustHost: true,
-  providers: [
-    Google({
-      clientId: process.env.AUTH_GOOGLE_ID,
-      clientSecret: process.env.AUTH_GOOGLE_SECRET,
-      authorization: { params: { scope: "openid email profile" } },
-    }),
-  ],
+  providers: [googleProvider, ...(appleConfigured ? [appleProvider] : [])],
   // Only override `error`. Setting `pages.signIn` to a custom path tells
   // Auth.js v5 that we render our own signin UI on that path, which
   // changes the routing — the built-in `/api/auth/signin/<provider>`
@@ -187,63 +58,27 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       //   - Google: granting the `email` scope returns a verified address
       //     by Google's own contract; presence of `profile.email` here is
       //     the verification signal.
-      //   - Other providers (Microsoft / Facebook / Apple, deferred):
-      //     require an explicit `email_verified === true` claim. An
-      //     unknown verification state must NOT be treated as verified —
-      //     extend this allow-list deliberately as each provider lands.
+      //   - Apple: OIDC `email_verified` from the id_token (mapped onto profile).
+      //   - Other providers (Microsoft / Facebook, deferred):
+      //     require an explicit `email_verified === true` claim.
+      const p = profile as { email_verified?: boolean | string };
       const emailVerified =
         provider === "google"
           ? true
-          : (profile as { email_verified?: boolean }).email_verified === true;
+          : provider === "apple"
+            ? p.email_verified === true || p.email_verified === "true"
+            : p.email_verified === true;
       if (!emailVerified) return false;
 
       const email = rawEmail.trim().toLowerCase();
+      const profileName = typeof profile.name === "string" && profile.name ? profile.name : null;
 
-      // Resolve provider identity FIRST: if (provider, providerAccountId)
-      // is already linked to a user, that's the owner — full stop. Email
-      // matching is only used to attach a *new* provider identity to an
-      // existing email-only account; we must never let an email match
-      // hijack a provider identity that already belongs to a different
-      // user (account-takeover guard).
-      const [existingLink] = await db
-        .select({ userId: oauthAccounts.userId })
-        .from(oauthAccounts)
-        .where(
-          and(
-            eq(oauthAccounts.provider, provider),
-            eq(oauthAccounts.providerAccountId, providerAccountId),
-          ),
-        )
-        .limit(1);
-
-      let userId: string;
-
-      if (existingLink) {
-        userId = existingLink.userId;
-      } else {
-        // No link yet → resolve target user (existing email match or
-        // freshly created), then link the provider identity to them
-        // atomically. ON CONFLICT collapses concurrent callbacks into a
-        // single row.
-        const [emailMatch] = await db
-          .select({ id: users.id })
-          .from(users)
-          .where(eq(users.email, email))
-          .limit(1);
-
-        let targetUserId: string;
-        if (emailMatch) {
-          targetUserId = emailMatch.id;
-        } else {
-          const seed =
-            (typeof profile.name === "string" && profile.name) ||
-            email.split("@")[0] ||
-            "user";
-          targetUserId = await createUserWithUsernameRetry(email, seed);
-        }
-
-        userId = await linkProviderToUser(provider, providerAccountId, targetUserId);
-      }
+      const userId = await resolveOrCreateUserForOAuthLink({
+        provider,
+        providerAccountId,
+        email,
+        profileName,
+      });
 
       // Auth.js passes `user` into the jwt callback only on initial sign-in;
       // overwriting `user.id` here is how we hand the database id to the JWT.

--- a/src/lib/email.test.ts
+++ b/src/lib/email.test.ts
@@ -6,12 +6,15 @@ import { passwordResetAppBaseUrl } from "./email";
 
 describe("passwordResetAppBaseUrl", () => {
   const env = { ...process.env };
+  const setNodeEnv = (value: string) => {
+    (process.env as Record<string, string | undefined>).NODE_ENV = value;
+  };
 
   beforeEach(() => {
     delete process.env.NEXT_PUBLIC_APP_URL;
     delete process.env.VERCEL_ENV;
     delete process.env.VERCEL_URL;
-    process.env.NODE_ENV = "test";
+    setNodeEnv("test");
   });
 
   afterEach(() => {
@@ -35,12 +38,12 @@ describe("passwordResetAppBaseUrl", () => {
   });
 
   it("uses localhost in non-production without Vercel", () => {
-    process.env.NODE_ENV = "development";
+    setNodeEnv("development");
     expect(passwordResetAppBaseUrl()).toBe("http://127.0.0.1:3000");
   });
 
   it("uses still-point.me in production without Vercel", () => {
-    process.env.NODE_ENV = "production";
+    setNodeEnv("production");
     expect(passwordResetAppBaseUrl()).toBe("https://still-point.me");
   });
 });

--- a/src/lib/oauth-account-resolution.ts
+++ b/src/lib/oauth-account-resolution.ts
@@ -1,0 +1,156 @@
+import { db } from "@/db";
+import { users, oauthAccounts } from "@/db/schema";
+import { and, eq, sql } from "drizzle-orm";
+import {
+  MAX_USERNAME_LENGTH,
+  MIN_USERNAME_LENGTH,
+  USERNAME_REGEX,
+} from "@/lib/username";
+import { uniqueViolationConstraint } from "@/lib/dbErrors";
+
+/** Sanitize a profile field into a username candidate that satisfies
+ *  users.username constraints (#136 + #8). */
+function sanitizeUsernameSeed(seed: string): string {
+  const cleaned = seed.replace(/[^A-Za-z0-9_]/g, "");
+  if (cleaned.length === 0) return "user";
+  return cleaned.slice(0, MAX_USERNAME_LENGTH);
+}
+
+function randomSuffix(length: number): string {
+  return crypto.randomUUID().replace(/-/g, "").slice(0, length);
+}
+
+async function generateUniqueUsername(seed: string): Promise<string> {
+  const base = sanitizeUsernameSeed(seed);
+  const padded = base.length < MIN_USERNAME_LENGTH ? `${base}user`.slice(0, MAX_USERNAME_LENGTH) : base;
+
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const suffix = attempt === 0 ? "" : `_${randomSuffix(4)}`;
+    const candidate = `${padded.slice(0, MAX_USERNAME_LENGTH - suffix.length)}${suffix}`;
+
+    if (!USERNAME_REGEX.test(candidate)) continue;
+    if (candidate.length < MIN_USERNAME_LENGTH || candidate.length > MAX_USERNAME_LENGTH) continue;
+
+    const [collision] = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(sql`lower(${users.username}) = lower(${candidate})`)
+      .limit(1);
+    if (!collision) return candidate;
+  }
+
+  return `user_${randomSuffix(10)}`;
+}
+
+async function linkProviderToUser(
+  provider: string,
+  providerAccountId: string,
+  userId: string,
+): Promise<string> {
+  const inserted = await db
+    .insert(oauthAccounts)
+    .values({ userId, provider, providerAccountId })
+    .onConflictDoNothing({
+      target: [oauthAccounts.provider, oauthAccounts.providerAccountId],
+    })
+    .returning({ userId: oauthAccounts.userId });
+
+  if (inserted.length > 0) return inserted[0].userId;
+
+  const [existing] = await db
+    .select({ userId: oauthAccounts.userId })
+    .from(oauthAccounts)
+    .where(
+      and(
+        eq(oauthAccounts.provider, provider),
+        eq(oauthAccounts.providerAccountId, providerAccountId),
+      ),
+    )
+    .limit(1);
+  if (!existing) {
+    throw new Error("oauth_accounts insert returned no rows and no existing link");
+  }
+  return existing.userId;
+}
+
+const MAX_USERNAME_RETRIES = 5;
+
+async function createUserWithUsernameRetry(email: string, seed: string): Promise<string> {
+  for (let attempt = 0; attempt <= MAX_USERNAME_RETRIES; attempt++) {
+    const username = await generateUniqueUsername(seed);
+    try {
+      const inserted = await db
+        .insert(users)
+        .values({ email, username })
+        .onConflictDoNothing({ target: users.email })
+        .returning({ id: users.id });
+
+      if (inserted.length > 0) return inserted[0].id;
+
+      const [racedRow] = await db
+        .select({ id: users.id })
+        .from(users)
+        .where(eq(users.email, email))
+        .limit(1);
+      if (!racedRow) {
+        throw new Error("users insert raced and lookup returned no row");
+      }
+      return racedRow.id;
+    } catch (err) {
+      const constraint = uniqueViolationConstraint(err);
+      if (constraint === null) throw err;
+      const isLikelyUsernameConstraint =
+        constraint === "" || constraint.toLowerCase().includes("username");
+      if (isLikelyUsernameConstraint && attempt < MAX_USERNAME_RETRIES) {
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw new Error("Failed to allocate a unique username after retries");
+}
+
+export type ResolveOAuthUserInput = {
+  provider: string;
+  providerAccountId: string;
+  email: string;
+  profileName: string | null;
+};
+
+/** Shared find-or-create + oauth_accounts link used by Auth.js `signIn` and
+ *  native bridges (e.g. Apple). Always resolves by `(provider, sub)` first so
+ *  “Hide My Email” relay addresses cannot fork accounts across sign-ins. */
+export async function resolveOrCreateUserForOAuthLink(input: ResolveOAuthUserInput): Promise<string> {
+  const { provider, providerAccountId, email, profileName } = input;
+
+  const [existingLink] = await db
+    .select({ userId: oauthAccounts.userId })
+    .from(oauthAccounts)
+    .where(
+      and(
+        eq(oauthAccounts.provider, provider),
+        eq(oauthAccounts.providerAccountId, providerAccountId),
+      ),
+    )
+    .limit(1);
+
+  if (existingLink) {
+    return existingLink.userId;
+  }
+
+  const [emailMatch] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1);
+
+  let targetUserId: string;
+  if (emailMatch) {
+    targetUserId = emailMatch.id;
+  } else {
+    const seed = profileName || email.split("@")[0] || "user";
+    targetUserId = await createUserWithUsernameRetry(email, seed);
+  }
+
+  return linkProviderToUser(provider, providerAccountId, targetUserId);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,6 +7,7 @@ const publicExactPaths = [
   "/api/auth/signup",
   "/api/auth/login",
   "/api/auth/logout",
+  "/api/auth/apple-native",
   "/api/auth/google/callback",
   "/api/auth/oauth-complete",
   // Auth.js v5 catch-all routes (#136) — bare endpoints. The catch-all


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #286

## Summary

Implements **Sign in with Apple** for the web using Auth.js’s built-in `Apple` provider (JWT `client_secret` minted from `AUTH_APPLE_ID`, `APPLE_TEAM_ID`, `APPLE_KEY_ID`, and `APPLE_PRIVATE_KEY` with ~130-day caching in `src/lib/apple-client-secret.ts`), and a **native iOS bridge** at `POST /api/auth/apple-native` that verifies `identityToken` against Apple JWKS, resolves the user via the same `oauth_accounts` logic as web (`src/lib/oauth-account-resolution.ts`), and mints `sp_token` (no provider tokens logged).

## Web

- `src/lib/auth-config.ts`: Google + Apple (Apple only when all four env vars are set); Apple email verification accepts boolean or string `true` per Apple’s OIDC quirks.
- `src/components/AuthScreen.tsx`: Apple control links to `/api/auth/signin?provider=apple` (GET entry to Auth.js sign-in); generic OAuth error copy where it was Google-only.

## Native iOS

- `ios/StillPointApp/Services/AppleSignInController.swift`, `AppleSignInButtonView.swift`, `AuthView` + `AuthViewModel`.
- `StillPointShared` `APIClient.appleNativeSignIn` → `POST /api/auth/apple-native` (already sends `X-Still-Point-Client: ios` for bearer token in JSON).
- `StillPointApp.entitlements`: Sign in with Apple capability; `project.yml` sets entitlements file for xcodegen.

## Other

- `src/middleware.ts`: public `POST /api/auth/apple-native`.
- `docs/mobile-oauth-integration.md`: Pattern A fully documented (request shape, server steps, hide-my-email, `AUTH_APPLE_NATIVE_ID`).
- `.env.example`: tunnel note + optional `AUTH_APPLE_NATIVE_ID`.
- `src/app/privacy/page.tsx`: link to Apple’s Sign in with Apple data-use page.

## Verification notes

- Apple Developer configuration and all four production env vars must be present on Vercel; web callback must match the Services ID (e.g. `https://www.still-point.me/api/auth/callback/apple`). Local Apple sign-in still needs an HTTPS tunnel (documented in `.env.example`).
- **Hide My Email**: linkage is always by Apple `sub` in `oauth_accounts` before email matching.
- **Manual QA** (not run in this agent): real Apple ID on prod/preview web; physical device for native; second sign-in with relay to confirm same user.

## Related

- iOS UI + controller shipped in this PR; no separate issue opened. If you prefer a split, we can extract native QA into a follow-up issue and link it here.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ca6e97b-a582-46a0-b33b-6b5afe9cf3a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ca6e97b-a582-46a0-b33b-6b5afe9cf3a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Continue with Apple" added to login (web) and native iOS Apple Sign-In support; iOS flow returns a client token when used.
  * OAuth linking improved to more reliably match/create user accounts across providers.

* **Documentation**
  * Updated OAuth integration and environment setup guidance for Apple native/web sign-in.
  * Privacy policy now references Apple sign-in handling.

* **Tests**
  * Added tests for the Apple native sign-in API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->