### PR TITLE
feat(ios): Fastlane snapshot candidates + ASC screenshot upload (#325)

### DIFF
--- a/.github/workflows/ios-screenshots.yml
+++ b/.github/workflows/ios-screenshots.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   regenerate-candidates:
     name: fastlane screenshots
-    runs-on: macos-26
+    runs-on: macos-latest
     timeout-minutes: 120
 
     steps:
@@ -70,16 +70,23 @@ jobs:
             fi
             return 1
           }
+          pick_first() {
+            local candidate
+            for candidate in "$@"; do
+              if pick "$candidate" >/dev/null; then
+                devices+=("$candidate")
+                return 0
+              fi
+            done
+            return 1
+          }
+
           devices=()
-          pick "iPhone 17 Pro Max" && devices+=("iPhone 17 Pro Max") || true
-          pick "iPhone 16 Pro Max" && devices+=("iPhone 16 Pro Max") || true
-          pick "iPhone 17 Pro" && devices+=("iPhone 17 Pro") || true
-          pick "iPhone 16 Pro" && devices+=("iPhone 16 Pro") || true
-          pick "iPhone 11 Pro Max" && devices+=("iPhone 11 Pro Max") || true
-          pick "iPhone 8 Plus" && devices+=("iPhone 8 Plus") || true
-          pick "iPad Pro 13-inch (M5)" && devices+=("iPad Pro 13-inch (M5)") || true
-          pick "iPad Pro (12.9-inch) (6th generation)" && devices+=("iPad Pro (12.9-inch) (6th generation)") || true
-          if [[ "${#devices[@]}" -lt 4 ]]; then
+          pick_first "iPhone 17 Pro Max" "iPhone 16 Pro Max" || true
+          pick_first "iPhone 17 Pro" "iPhone 16 Pro" "iPhone 11 Pro Max" || true
+          pick_first "iPhone 8 Plus" "iPhone 7 Plus" || true
+          pick_first "iPad Pro 13-inch (M5)" "iPad Pro (12.9-inch) (6th generation)" || true
+          if [[ "${#devices[@]}" -ne 4 ]]; then
             echo "::error::Could not resolve enough simulators for snapshot (need 6.7 / 6.5 / 5.5 / iPad Pro classes)."
             echo "$list"
             exit 1

--- a/.github/workflows/ios-screenshots.yml
+++ b/.github/workflows/ios-screenshots.yml
@@ -83,7 +83,7 @@ jobs:
 
           devices=()
           pick_first "iPhone 17 Pro Max" "iPhone 16 Pro Max" || true
-          pick_first "iPhone 17 Pro" "iPhone 16 Pro" "iPhone 11 Pro Max" || true
+          pick_first "iPhone 11 Pro Max" "iPhone XS Max" || true
           pick_first "iPhone 8 Plus" "iPhone 7 Plus" || true
           pick_first "iPad Pro 13-inch (M5)" "iPad Pro (12.9-inch) (6th generation)" || true
           if [[ "${#devices[@]}" -ne 4 ]]; then

--- a/.github/workflows/ios-screenshots.yml
+++ b/.github/workflows/ios-screenshots.yml
@@ -1,0 +1,103 @@
+name: iOS screenshot candidates
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ios-screenshots
+  cancel-in-progress: false
+
+jobs:
+  regenerate-candidates:
+    name: fastlane screenshots
+    runs-on: macos-26
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: false
+          working-directory: ios
+
+      - name: Install XcodeGen
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if brew install xcodegen; then
+              exit 0
+            fi
+            if [[ "$attempt" -lt 3 ]]; then
+              sleep $((attempt * 10))
+            fi
+          done
+          echo "Failed to install xcodegen after 3 attempts."
+          exit 1
+
+      - name: Bundle install (Fastlane)
+        working-directory: ios
+        run: bundle install
+
+      - name: Generate Xcode project
+        working-directory: ios
+        run: xcodegen generate
+
+      - name: Resolve Snapshot device names for this Xcode
+        working-directory: ios
+        shell: bash
+        run: |
+          set -euo pipefail
+          list="$(xcrun simctl list devices available)"
+          pick() {
+            local label="$1"
+            if grep -F "    ${label} (" <<<"${list}" >/dev/null 2>&1; then
+              printf '%s\n' "${label}"
+              return 0
+            fi
+            return 1
+          }
+          devices=()
+          pick "iPhone 17 Pro Max" && devices+=("iPhone 17 Pro Max") || true
+          pick "iPhone 16 Pro Max" && devices+=("iPhone 16 Pro Max") || true
+          pick "iPhone 17 Pro" && devices+=("iPhone 17 Pro") || true
+          pick "iPhone 16 Pro" && devices+=("iPhone 16 Pro") || true
+          pick "iPhone 11 Pro Max" && devices+=("iPhone 11 Pro Max") || true
+          pick "iPhone 8 Plus" && devices+=("iPhone 8 Plus") || true
+          pick "iPad Pro 13-inch (M5)" && devices+=("iPad Pro 13-inch (M5)") || true
+          pick "iPad Pro (12.9-inch) (6th generation)" && devices+=("iPad Pro (12.9-inch) (6th generation)") || true
+          if [[ "${#devices[@]}" -lt 4 ]]; then
+            echo "::error::Could not resolve enough simulators for snapshot (need 6.7 / 6.5 / 5.5 / iPad Pro classes)."
+            echo "$list"
+            exit 1
+          fi
+          joined="$(IFS=','; echo "${devices[*]}")"
+          echo "SNAPSHOT_DEVICES=${joined}" >> "${GITHUB_ENV}"
+
+      - name: Run snapshot lane
+        working-directory: ios
+        env:
+          FASTLANE_SKIP_UPDATE_CHECK: "1"
+          FASTLANE_HIDE_TIMESTAMP: "true"
+        run: bundle exec fastlane screenshots
+
+      - name: Upload candidates bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-screenshot-candidates
+          path: ios/screenshots/candidates/**
+          if-no-files-found: error
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,12 @@ ios/build/
 ios/StillPointShared/build/
 ios/StillPointShared/.build/
 
+# Fastlane snapshot output (regenerate via `fastlane screenshots`; curate into screenshots/selected/)
+ios/screenshots/candidates/
+
+# Bundler / Fastlane (install with `bundle install` under ios/)
+ios/vendor/
+
 # Nested agent worktrees (gitlinks); keep out of the app repo
 .claude/worktrees/
 .worktrees/

--- a/ios/Gemfile
+++ b/ios/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane", "~> 2.227"

--- a/ios/RELEASING.md
+++ b/ios/RELEASING.md
@@ -85,7 +85,7 @@ The repo ships a **wide candidate set** (Fastlane snapshot) under `ios/screensho
 3. `cd ios && bundle install` (installs Fastlane from `ios/Gemfile`).
 4. Edit `ios/fastlane/Snapfile` so every `devices([...])` entry matches a name from `xcrun simctl list devices available` on your machine (6.7", 6.5", 5.5", iPad Pro 12.9" class).
 
-Optional: export `SNAPSHOT_DEVICES='iPhone 17 Pro Max,iPhone 17 Pro,iPhone 8 Plus,iPad Pro 13-inch (M5)'` before `fastlane screenshots` to override the Snapfile list without editing files.
+Optional: export `SNAPSHOT_DEVICES='iPhone 17 Pro Max,iPhone 17 Pro,iPhone 11 Pro Max,iPhone 8 Plus,iPad Pro 13-inch (M5)'` before `fastlane screenshots` to override the Snapfile list without editing files.
 
 ### Regenerate candidates
 

--- a/ios/RELEASING.md
+++ b/ios/RELEASING.md
@@ -74,6 +74,56 @@ After the intended TestFlight build is processed and valid, use the delegate-rea
 - Tag value does not have to equal `MARKETING_VERSION`; uploaded app version is controlled by `ios/project.yml`.
 - Re-uploads for same marketing version require a new tag and incremented build number, e.g. `ios-v<marketing-version>-build<next-build>`.
 
+## Regenerate candidate App Store screenshots (Issue #325)
+
+The repo ships a **wide candidate set** (Fastlane snapshot) under `ios/screenshots/candidates/` when you run the lane locally or via GitHub Actions. Those files are **gitignored**; you **curate** into `ios/screenshots/selected/` and commit only the chosen PNGs.
+
+### One-time setup (Mac)
+
+1. Install Xcode and command-line tools.
+2. From repo root: `cd ios && brew install xcodegen` (CI uses the same).
+3. `cd ios && bundle install` (installs Fastlane from `ios/Gemfile`).
+4. Edit `ios/fastlane/Snapfile` so every `devices([...])` entry matches a name from `xcrun simctl list devices available` on your machine (6.7", 6.5", 5.5", iPad Pro 12.9" class).
+
+Optional: export `SNAPSHOT_DEVICES='iPhone 17 Pro Max,iPhone 17 Pro,iPhone 8 Plus,iPad Pro 13-inch (M5)'` before `fastlane screenshots` to override the Snapfile list without editing files.
+
+### Regenerate candidates
+
+```bash
+cd ios
+xcodegen generate
+bundle exec fastlane screenshots
+```
+
+This runs `StillPointAppUITests/SnapshotTests` with `SP_UI_TEST_SNAPSHOT_SEED=1` (deterministic in-app data, no backend). The lane writes PNGs to `ios/screenshots/candidates/` and builds `ios/screenshots/candidates/index.html` for side-by-side preview.
+
+### Curate and upload (selected set only)
+
+1. Pick up to **10 screenshots per device class** for App Store Connect.
+2. Copy chosen files into `ios/screenshots/selected/` using Fastlane’s folder layout, for example:
+
+   `ios/screenshots/selected/en-US/iPhone 17 Pro Max-01-home.png`
+
+   Use **numeric prefixes** in the filename (`01-`, `02-`, …) so ordering in Finder matches upload order (deliver preserves lexicographic order per device folder).
+
+3. Commit **only** `ios/screenshots/selected/` (not `candidates/`).
+
+4. Upload with API key env vars (same secrets as CI — never commit the `.p8`):
+
+   ```bash
+   cd ios
+   export APPSTORE_API_KEY_ID=...
+   export APPSTORE_API_ISSUER_ID=...
+   export APPSTORE_API_PRIVATE_KEY="$(cat AuthKey_xxx.p8)"
+   bundle exec fastlane upload_app_store_screenshots
+   ```
+
+   Alias: `bundle exec fastlane release` (screenshots-only; does not submit binary).
+
+### CI
+
+Workflow [`.github/workflows/ios-screenshots.yml`](../.github/workflows/ios-screenshots.yml) is **manual** (`workflow_dispatch`). It runs `fastlane screenshots`, resolves simulator names for the runner’s Xcode, and uploads `ios/screenshots/candidates/**` as an artifact for review.
+
 ## App Store metadata and release notes checklist
 
 Canonical App Store Connect copy (subtitle, description alignment, privacy URL) lives in [`ios/docs/app-store-metadata.md`](./docs/app-store-metadata.md). Reconcile App Store Connect with that file when preparing a submission.

--- a/ios/StillPointApp/Components/ThoughtCaptureView.swift
+++ b/ios/StillPointApp/Components/ThoughtCaptureView.swift
@@ -29,12 +29,14 @@ struct ThoughtCaptureView: View {
                         .frame(width: Self.minTapTarget, height: Self.minTapTarget)
                         .contentShape(Rectangle())
                 }
+                .accessibilityIdentifier("thoughtCapture.dismissButton")
             }
 
             TextField("what were you thinking about?", text: $text)
                 .font(SPFont.serifItalic(15))
                 .foregroundStyle(Color(SPColor.fg))
                 .focused($isFocused)
+                .accessibilityIdentifier("thoughtCapture.textField")
                 .onSubmit {
                     if !trimmedText.isEmpty {
                         onCapture(trimmedText)

--- a/ios/StillPointApp/Views/BuddySession/BuddySessionHubView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddySessionHubView.swift
@@ -53,6 +53,7 @@ struct BuddySessionHubView: View {
                         .font(SPFont.mono(12, weight: .medium))
                         .foregroundStyle(Color(SPColor.fg3))
                 }
+                .accessibilityIdentifier("buddy.backToHomeButton")
                 .padding(.top, SPSpacing.s2)
             }
             .padding(.horizontal, SPSpacing.s4)

--- a/ios/StillPointApp/Views/HomeView.swift
+++ b/ios/StillPointApp/Views/HomeView.swift
@@ -91,6 +91,7 @@ struct HomeView: View {
                             .clipShape(Capsule())
                             .overlay(Capsule().stroke(SPColor.border1))
                     }
+                    .accessibilityIdentifier("home.buddySessionButton")
                 }
 
                 if let inviteError = appVM.buddyInviteError {

--- a/ios/StillPointAppUITests/README.md
+++ b/ios/StillPointAppUITests/README.md
@@ -36,6 +36,8 @@ The app reads these launch environment keys in UI test mode:
 - `SP_UI_TEST_FORCE_LAUNCH_OFFLINE=1` (simulate failed API/airplane mode on launch)
 - `SP_UI_TEST_FORCE_TOKEN_EXPIRED=1` (simulate expired token during cold-start auth check)
 - `SP_UI_TEST_FORCE_SESSIONS_FAILURE=1` (optional sessions API failure simulation)
+- `SP_UI_TEST_FORCE_USERNAME_CONFLICT=1` (simulate username taken on settings save)
+- `SP_UI_TEST_SNAPSHOT_SEED=1` (Fastlane snapshot lane — canned sessions, thoughts, and practitioners board for marketing captures; use with `SP_UI_TEST_RESET_STORE=1` on first launch)
 
 Fixture login account (used when auth screen is shown):
 

--- a/ios/StillPointAppUITests/Snapshots/SnapshotHelper.swift
+++ b/ios/StillPointAppUITests/Snapshots/SnapshotHelper.swift
@@ -1,0 +1,294 @@
+//
+// SnapshotHelper.swift
+// Still Point — Fastlane snapshot (template from fastlane; SnapshotHelperVersion [1.30])
+//
+
+import Foundation
+import UIKit
+import XCTest
+
+@MainActor
+func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
+    Snapshot.setupSnapshot(app, waitForAnimations: waitForAnimations)
+}
+
+@MainActor
+func snapshot(_ name: String, waitForLoadingIndicator: Bool) {
+    if waitForLoadingIndicator {
+        snapshot(name)
+    } else {
+        Snapshot.snapshot(name, timeWaitingForIdle: 0)
+    }
+}
+
+/// - Parameters:
+///   - name: The name of the snapshot
+///   - timeout: Seconds to wait until the network loading indicator disappears. Pass `0` to skip waiting.
+@MainActor
+func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
+    Snapshot.snapshot(name, timeWaitingForIdle: timeout)
+}
+
+enum SnapshotError: Error, CustomDebugStringConvertible {
+    case cannotFindSimulatorHomeDirectory
+    case cannotRunOnPhysicalDevice
+
+    var debugDescription: String {
+        switch self {
+        case .cannotFindSimulatorHomeDirectory:
+            return "Couldn't find simulator home location. Please, check SIMULATOR_HOST_HOME env variable."
+        case .cannotRunOnPhysicalDevice:
+            return "Can't use Snapshot on a physical device."
+        }
+    }
+}
+
+@objcMembers
+@MainActor
+open class Snapshot: NSObject {
+    static var app: XCUIApplication?
+    static var waitForAnimations = true
+    static var cacheDirectory: URL?
+    static var screenshotsDirectory: URL? {
+        cacheDirectory?.appendingPathComponent("screenshots", isDirectory: true)
+    }
+    static var deviceLanguage = ""
+    static var currentLocale = ""
+
+    open class func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
+        Snapshot.app = app
+        Snapshot.waitForAnimations = waitForAnimations
+
+        do {
+            let cacheDir = try getCacheDirectory()
+            Snapshot.cacheDirectory = cacheDir
+            setLanguage(app)
+            setLocale(app)
+            setLaunchArguments(app)
+        } catch {
+            NSLog(error.localizedDescription)
+        }
+    }
+
+    class func setLanguage(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
+            return
+        }
+
+        let path = cacheDirectory.appendingPathComponent("language.txt")
+
+        do {
+            let trimCharacterSet = CharacterSet.whitespacesAndNewlines
+            deviceLanguage = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
+            app.launchArguments += ["-AppleLanguages", "(\(deviceLanguage))"]
+        } catch {
+            NSLog("Couldn't detect/set language...")
+        }
+    }
+
+    class func setLocale(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
+            return
+        }
+
+        let path = cacheDirectory.appendingPathComponent("locale.txt")
+
+        do {
+            let trimCharacterSet = CharacterSet.whitespacesAndNewlines
+            currentLocale = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
+        } catch {
+            NSLog("Couldn't detect/set locale...")
+        }
+
+        if currentLocale.isEmpty && !deviceLanguage.isEmpty {
+            currentLocale = Locale(identifier: deviceLanguage).identifier
+        }
+
+        if !currentLocale.isEmpty {
+            app.launchArguments += ["-AppleLocale", "\"\(currentLocale)\""]
+        }
+    }
+
+    class func setLaunchArguments(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
+            return
+        }
+
+        let path = cacheDirectory.appendingPathComponent("snapshot-launch_arguments.txt")
+        app.launchArguments += ["-FASTLANE_SNAPSHOT", "YES", "-ui_testing"]
+
+        do {
+            let launchArguments = try String(contentsOf: path, encoding: String.Encoding.utf8)
+            let regex = try NSRegularExpression(pattern: "(\\\".+?\\\"|\\S+)", options: [])
+            let matches = regex.matches(in: launchArguments, options: [], range: NSRange(location: 0, length: launchArguments.count))
+            let results = matches.map { result -> String in
+                (launchArguments as NSString).substring(with: result.range)
+            }
+            app.launchArguments += results
+        } catch {
+            NSLog("Couldn't detect/set launch_arguments...")
+        }
+    }
+
+    open class func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
+        if timeout > 0 {
+            waitForLoadingIndicatorToDisappear(within: timeout)
+        }
+
+        NSLog("snapshot: \(name)")
+
+        if Snapshot.waitForAnimations {
+            sleep(1)
+        }
+
+        #if os(OSX)
+        guard let app = self.app else {
+            NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+            return
+        }
+
+        app.typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
+        #else
+
+        guard self.app != nil else {
+            NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+            return
+        }
+
+        let screenshot = XCUIScreen.main.screenshot()
+        #if os(iOS) && !targetEnvironment(macCatalyst)
+        let image = XCUIDevice.shared.orientation.isLandscape ? fixLandscapeOrientation(image: screenshot.image) : screenshot.image
+        #else
+        let image = screenshot.image
+        #endif
+
+        guard var simulator = ProcessInfo().environment["SIMULATOR_DEVICE_NAME"], let screenshotsDir = screenshotsDirectory else { return }
+
+        do {
+            let regex = try NSRegularExpression(pattern: "Clone [0-9]+ of ")
+            let range = NSRange(location: 0, length: simulator.count)
+            simulator = regex.stringByReplacingMatches(in: simulator, range: range, withTemplate: "")
+
+            let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png")
+            try image.pngData()?.write(to: path, options: .atomic)
+        } catch {
+            NSLog("Problem writing screenshot: \(name) to \(screenshotsDir)/\(simulator)-\(name).png")
+            NSLog(error.localizedDescription)
+        }
+        #endif
+    }
+
+    class func fixLandscapeOrientation(image: UIImage) -> UIImage {
+        #if os(watchOS)
+        return image
+        #else
+        if #available(iOS 10.0, *) {
+            let format = UIGraphicsImageRendererFormat()
+            format.scale = image.scale
+            let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
+            return renderer.image { _ in
+                image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
+            }
+        } else {
+            return image
+        }
+        #endif
+    }
+
+    class func waitForLoadingIndicatorToDisappear(within timeout: TimeInterval) {
+        #if os(tvOS)
+        return
+        #endif
+
+        guard let app = self.app else {
+            NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+            return
+        }
+
+        let networkLoadingIndicator = app.otherElements.deviceStatusBars.networkLoadingIndicators.element
+        let networkLoadingIndicatorDisappeared = XCTNSPredicateExpectation(predicate: NSPredicate(format: "exists == false"), object: networkLoadingIndicator)
+        _ = XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
+    }
+
+    class func getCacheDirectory() throws -> URL {
+        let cachePath = "Library/Caches/tools.fastlane"
+        #if os(OSX)
+        let homeDir = URL(fileURLWithPath: NSHomeDirectory())
+        return homeDir.appendingPathComponent(cachePath)
+        #elseif arch(i386) || arch(x86_64) || arch(arm64)
+        guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
+            throw SnapshotError.cannotFindSimulatorHomeDirectory
+        }
+        let homeDir = URL(fileURLWithPath: simulatorHostHome)
+        return homeDir.appendingPathComponent(cachePath)
+        #else
+        throw SnapshotError.cannotRunOnPhysicalDevice
+        #endif
+    }
+}
+
+private extension XCUIElementAttributes {
+    var isNetworkLoadingIndicator: Bool {
+        if hasAllowListedIdentifier { return false }
+
+        let hasOldLoadingIndicatorSize = frame.size == CGSize(width: 10, height: 20)
+        let hasNewLoadingIndicatorSize = frame.size.width.isBetween(46, and: 47) && frame.size.height.isBetween(2, and: 3)
+
+        return hasOldLoadingIndicatorSize || hasNewLoadingIndicatorSize
+    }
+
+    var hasAllowListedIdentifier: Bool {
+        let allowListedIdentifiers = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
+        return allowListedIdentifiers.contains(identifier)
+    }
+
+    func isStatusBar(_ deviceWidth: CGFloat) -> Bool {
+        if elementType == .statusBar { return true }
+        guard frame.origin == .zero else { return false }
+
+        let oldStatusBarSize = CGSize(width: deviceWidth, height: 20)
+        let newStatusBarSize = CGSize(width: deviceWidth, height: 44)
+
+        return [oldStatusBarSize, newStatusBarSize].contains(frame.size)
+    }
+}
+
+private extension XCUIElementQuery {
+    var networkLoadingIndicators: XCUIElementQuery {
+        let isNetworkLoadingIndicator = NSPredicate { evaluatedObject, _ in
+            guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+            return element.isNetworkLoadingIndicator
+        }
+
+        return containing(isNetworkLoadingIndicator)
+    }
+
+    @MainActor
+    var deviceStatusBars: XCUIElementQuery {
+        guard let app = Snapshot.app else {
+            fatalError("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+        }
+
+        let deviceWidth = app.windows.firstMatch.frame.width
+
+        let isStatusBar = NSPredicate { evaluatedObject, _ in
+            guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+            return element.isStatusBar(deviceWidth)
+        }
+
+        return containing(isStatusBar)
+    }
+}
+
+private extension CGFloat {
+    func isBetween(_ numberA: CGFloat, and numberB: CGFloat) -> Bool {
+        (numberA ... numberB).contains(self)
+    }
+}
+
+// Please don't remove the lines below
+// They are used to detect outdated configuration files
+// SnapshotHelperVersion [1.30]

--- a/ios/StillPointAppUITests/Snapshots/SnapshotTests.swift
+++ b/ios/StillPointAppUITests/Snapshots/SnapshotTests.swift
@@ -1,0 +1,226 @@
+import XCTest
+
+/// Fastlane snapshot candidates for App Store marketing (Issue #325).
+/// Uses `SP_UI_TEST_SNAPSHOT_SEED` for deterministic in-app data (no backend).
+final class SnapshotTests: XCTestCase {
+    private let launchTimeout: TimeInterval = 45
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        XCUIDevice.shared.orientation = .portrait
+        RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+    }
+
+    override func tearDownWithError() throws {
+        XCUIDevice.shared.orientation = .portrait
+        RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+    }
+
+    @MainActor
+    func testStillPointMarketingSnapshots() throws {
+        let app = makeSnapshotApp(seedAuthenticated: true)
+        setupSnapshot(app, waitForAnimations: true)
+        app.launch()
+
+        waitForRoot("home", in: app, message: "Home did not appear for snapshots")
+
+        snapshot("01-home", timeWaitingForIdle: 0)
+
+        scrollHomeFAQIntoView(app)
+        snapshot("02-home-faq-expanded", timeWaitingForIdle: 0)
+
+        XCTAssertTrue(app.buttons["home.beginButton"].waitForExistence(timeout: 8))
+        tapStable(app.buttons["home.beginButton"], in: app)
+        waitForRoot("session", in: app, message: "Session did not open")
+
+        XCTAssertTrue(app.staticTexts["session.timerLabel"].waitForExistence(timeout: 12))
+        RunLoop.current.run(until: Date().addingTimeInterval(1.2))
+        snapshot("03-session-active", timeWaitingForIdle: 0)
+
+        let lightHold = app.staticTexts["session.lightDistractionHoldButton"]
+        XCTAssertTrue(lightHold.waitForExistence(timeout: 8))
+        pressAndHold(element: lightHold, duration: 2.0)
+        snapshot("04-session-distraction-hold", timeWaitingForIdle: 0)
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.15)).tap()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.8))
+
+        if app.textFields["thoughtCapture.textField"].waitForExistence(timeout: 3) {
+            snapshot("05-session-thought-capture", timeWaitingForIdle: 0)
+            dismissThoughtCaptureIfPresent(app)
+        } else if app.buttons["session.captureButton"].waitForExistence(timeout: 3) {
+            tapStable(app.buttons["session.captureButton"], in: app)
+            XCTAssertTrue(app.textFields["thoughtCapture.textField"].waitForExistence(timeout: 5))
+            snapshot("05-session-thought-capture", timeWaitingForIdle: 0)
+            dismissThoughtCaptureIfPresent(app)
+        }
+
+        let hyperHold = app.staticTexts["session.hyperfocusHoldButton"]
+        XCTAssertTrue(hyperHold.waitForExistence(timeout: 8))
+        pressAndHold(element: hyperHold, duration: 2.0)
+        snapshot("06-session-hyperfocus-hold", timeWaitingForIdle: 0)
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.15)).tap()
+
+        tapStable(app.buttons["session.extendOneMinuteButton"], in: app)
+        tapStable(app.buttons["session.extendFiveMinuteButton"], in: app)
+        tapStable(app.buttons["session.endEarlyButton"], in: app)
+
+        XCTAssertTrue(app.otherElements["root.currentView.completion"].waitForExistence(timeout: 35))
+        XCTAssertTrue(app.staticTexts["completion.dayTitle"].waitForExistence(timeout: 5))
+        snapshot("07-completion-bonus", timeWaitingForIdle: 0)
+
+        let noteField = app.textViews["completion.endNoteEditor"]
+        XCTAssertTrue(noteField.waitForExistence(timeout: 8))
+        tapStable(noteField, in: app)
+        noteField.typeText("Steady attention through the full sit.")
+
+        XCTAssertTrue(
+            app.staticTexts["completion.savedIndicator"].waitForExistence(timeout: 12),
+            "Expected UI-test auto-save of session note"
+        )
+        snapshot("08-completion-note-saved", timeWaitingForIdle: 0)
+
+        tapStable(app.buttons["completion.returnButton"], in: app)
+        XCTAssertTrue(app.otherElements["root.currentView.home"].waitForExistence(timeout: 12))
+
+        XCTAssertTrue(app.buttons["home.quickMinuteButton"].waitForExistence(timeout: 8))
+        tapStable(app.buttons["home.quickMinuteButton"], in: app)
+        waitForRoot("session", in: app, message: "Quick minute session did not open")
+        tapStable(app.buttons["session.endEarlyButton"], in: app)
+        XCTAssertTrue(app.staticTexts["completion.dayTitle"].waitForExistence(timeout: 25))
+        snapshot("17-quick-minute-complete", timeWaitingForIdle: 0)
+        tapStable(app.buttons["completion.returnButton"], in: app)
+
+        XCTAssertTrue(app.buttons["home.beginButton"].waitForExistence(timeout: 12))
+        tapStable(app.buttons["home.beginButton"], in: app)
+        waitForRoot("session", in: app, message: "Second session did not open")
+        XCTAssertTrue(app.buttons["session.pauseResumeButton"].waitForExistence(timeout: 8))
+        tapStable(app.buttons["session.pauseResumeButton"], in: app)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.6))
+        snapshot("18-session-paused", timeWaitingForIdle: 0)
+        tapStable(app.buttons["session.abandonButton"], in: app)
+        XCTAssertTrue(app.otherElements["root.currentView.home"].waitForExistence(timeout: 15))
+
+        openTab(index: 1, in: app)
+        XCTAssertTrue(app.staticTexts["history.title"].waitForExistence(timeout: 12))
+        snapshot("09-progress-history", timeWaitingForIdle: 0)
+
+        let sessionRow = app.buttons.matching(NSPredicate(format: "identifier BEGINSWITH %@", "history.session.")).firstMatch
+        XCTAssertTrue(sessionRow.waitForExistence(timeout: 8))
+        tapStable(sessionRow, in: app)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+        snapshot("10-progress-journey-expanded", timeWaitingForIdle: 0)
+
+        openTab(index: 3, in: app)
+        XCTAssertTrue(app.staticTexts["Practitioners"].waitForExistence(timeout: 12))
+        snapshot("11-practitioners-board", timeWaitingForIdle: 0)
+
+        openTab(index: 0, in: app)
+        XCTAssertTrue(app.buttons["home.buddySessionButton"].waitForExistence(timeout: 8))
+        tapStable(app.buttons["home.buddySessionButton"], in: app)
+        XCTAssertTrue(app.staticTexts["Meditate with a friend"].waitForExistence(timeout: 12))
+        snapshot("12-buddy-lobby", timeWaitingForIdle: 0)
+        tapStable(app.buttons["buddy.backToHomeButton"], in: app)
+
+        openTab(index: 4, in: app)
+        XCTAssertTrue(app.staticTexts["settings.title"].waitForExistence(timeout: 12))
+        snapshot("14-settings-account", timeWaitingForIdle: 0)
+
+        let appGateHeader = app.staticTexts["APP GATE"]
+        var scrollTries = 0
+        while !appGateHeader.exists && scrollTries < 12 {
+            app.swipeUp(velocity: .fast)
+            scrollTries += 1
+        }
+        XCTAssertTrue(appGateHeader.waitForExistence(timeout: 3))
+        snapshot("15-settings-app-gate", timeWaitingForIdle: 0)
+
+        openTab(index: 2, in: app)
+        XCTAssertTrue(app.staticTexts["Thought Journal"].waitForExistence(timeout: 12))
+        snapshot("16-thought-journal", timeWaitingForIdle: 0)
+
+        terminateAppReliably(app)
+
+        let authApp = makeSnapshotApp(seedAuthenticated: false)
+        setupSnapshot(authApp, waitForAnimations: true)
+        authApp.launch()
+        waitForRoot("auth", in: authApp, message: "Auth screen did not appear")
+        snapshot("13-auth-sign-in", timeWaitingForIdle: 0)
+    }
+
+    // MARK: - App factory
+
+    private func makeSnapshotApp(seedAuthenticated: Bool) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchEnvironment["SP_UI_TEST_MODE"] = "1"
+        app.launchEnvironment["SP_UI_TEST_SNAPSHOT_SEED"] = "1"
+        app.launchEnvironment["SP_UI_TEST_RESET_STORE"] = "1"
+        app.launchEnvironment["SP_UI_TEST_SEED_AUTH"] = seedAuthenticated ? "1" : "0"
+        app.launchEnvironment["SP_UI_TEST_SESSION_SECONDS"] = "120"
+        app.launchEnvironment["SP_UI_TEST_TIMER_MULTIPLIER"] = "0.25"
+        app.launchEnvironment["SP_UI_TEST_FORCE_START_SESSION"] = "0"
+        app.launchEnvironment["SP_UI_TEST_FORCE_LAUNCH_OFFLINE"] = "0"
+        app.launchEnvironment["SP_UI_TEST_FORCE_TOKEN_EXPIRED"] = "0"
+        app.launchEnvironment["SP_UI_TEST_FORCE_SESSIONS_FAILURE"] = "0"
+        app.launchEnvironment["SP_UI_TEST_APP_BLOCKING_SELECTED"] = "1"
+        app.launchEnvironment["SP_UI_TEST_FORCE_PROGRESS_TAB"] = "0"
+        app.launchEnvironment["SP_UI_TEST_FORCE_USERNAME_CONFLICT"] = "0"
+        return app
+    }
+
+    // MARK: - Navigation
+
+    private func openTab(index: Int, in app: XCUIApplication) {
+        let tab = app.tabBars.buttons.element(boundBy: index)
+        XCTAssertTrue(tab.waitForExistence(timeout: 10))
+        tapStable(tab, in: app)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.4))
+    }
+
+    private func scrollHomeFAQIntoView(_ app: XCUIApplication) {
+        let marker = app.staticTexts["This app is incredibly boring. What's the point?"]
+        var tries = 0
+        while !marker.isHittable && tries < 15 {
+            app.swipeUp(velocity: .fast)
+            tries += 1
+        }
+        XCTAssertTrue(marker.waitForExistence(timeout: 5))
+    }
+
+    // MARK: - Interaction
+
+    private func dismissThoughtCaptureIfPresent(_ app: XCUIApplication) {
+        let dismiss = app.buttons["thoughtCapture.dismissButton"]
+        if dismiss.waitForExistence(timeout: 2) {
+            dismiss.tap()
+        } else {
+            app.swipeDown()
+        }
+        RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+    }
+
+    private func pressAndHold(element: XCUIElement, duration: TimeInterval) {
+        element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).press(forDuration: duration)
+    }
+
+    private func tapStable(_ element: XCUIElement, in app: XCUIApplication) {
+        XCTAssertTrue(element.waitForExistence(timeout: 12))
+        element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+    }
+
+    private func waitForRoot(_ slug: String, in app: XCUIApplication, message: String) {
+        let root = app.otherElements["root.currentView.\(slug)"]
+        XCTAssertTrue(root.waitForExistence(timeout: launchTimeout), message)
+    }
+
+    private func terminateAppReliably(_ app: XCUIApplication, attempts: Int = 4) {
+        for _ in 1 ... attempts {
+            app.terminate()
+            let deadline = Date().addingTimeInterval(15)
+            while Date() < deadline {
+                if app.state == .notRunning { return }
+                RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+            }
+        }
+        XCTFail("App did not terminate")
+    }
+}

--- a/ios/StillPointAppUITests/Snapshots/SnapshotTests.swift
+++ b/ios/StillPointAppUITests/Snapshots/SnapshotTests.swift
@@ -73,6 +73,7 @@ final class SnapshotTests: XCTestCase {
         let noteField = app.textViews["completion.endNoteEditor"]
         XCTAssertTrue(noteField.waitForExistence(timeout: 8))
         tapStable(noteField, in: app)
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5), "Keyboard did not appear for note entry")
         noteField.typeText("Steady attention through the full sit.")
 
         XCTAssertTrue(
@@ -129,7 +130,7 @@ final class SnapshotTests: XCTestCase {
 
         let appGateHeader = app.staticTexts["APP GATE"]
         var scrollTries = 0
-        while !appGateHeader.exists && scrollTries < 12 {
+        while !appGateHeader.isHittable && scrollTries < 12 {
             app.swipeUp(velocity: .fast)
             scrollTries += 1
         }

--- a/ios/StillPointAppUITests/Snapshots/SnapshotTests.swift
+++ b/ios/StillPointAppUITests/Snapshots/SnapshotTests.swift
@@ -52,6 +52,8 @@ final class SnapshotTests: XCTestCase {
             XCTAssertTrue(app.textFields["thoughtCapture.textField"].waitForExistence(timeout: 5))
             snapshot("05-session-thought-capture", timeWaitingForIdle: 0)
             dismissThoughtCaptureIfPresent(app)
+        } else {
+            XCTFail("Thought capture did not appear for snapshot generation")
         }
 
         let hyperHold = app.staticTexts["session.hyperfocusHoldButton"]
@@ -184,6 +186,7 @@ final class SnapshotTests: XCTestCase {
             tries += 1
         }
         XCTAssertTrue(marker.waitForExistence(timeout: 5))
+        XCTAssertTrue(marker.isHittable, "FAQ marker not hittable after scrolling — cannot capture 02-home-faq-expanded snapshot")
     }
 
     // MARK: - Interaction

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -56,8 +56,11 @@ public actor APIClient {
             }
 
             let resolvedStore: UITestStore
-            if let persistedData = defaults.data(forKey: uiTestStoreDefaultsKey),
-               let persistedStore = try? JSONDecoder().decode(UITestStore.self, from: persistedData) {
+            if parsedUITestConfig.snapshotSeed {
+                resolvedStore = UITestStore.makeSnapshot(seedAuthenticated: parsedUITestConfig.seedAuthenticated)
+                Self.persist(store: resolvedStore, key: uiTestStoreDefaultsKey)
+            } else if let persistedData = defaults.data(forKey: uiTestStoreDefaultsKey),
+                      let persistedStore = try? JSONDecoder().decode(UITestStore.self, from: persistedData) {
                 resolvedStore = persistedStore
             } else {
                 resolvedStore = UITestStore.makeDefault(seedAuthenticated: parsedUITestConfig.seedAuthenticated)
@@ -247,8 +250,8 @@ public actor APIClient {
     // MARK: - Board
 
     public func getBoard() async throws -> [BoardEntryDTO] {
-        if uiTestConfig != nil {
-            return []
+        if let uiTestResult = uiTestGetBoard() {
+            return uiTestResult
         }
         let response: BoardResponse = try await get("/api/board")
         return response.board
@@ -531,6 +534,7 @@ public actor APIClient {
             dayNumber: data.dayNumber,
             sessionType: data.sessionType,
             duration: data.duration,
+            bonusSeconds: data.bonusSeconds == 0 ? nil : data.bonusSeconds,
             completed: data.completed,
             actualTime: data.actualTime,
             clearPercent: data.clearPercent,
@@ -629,6 +633,19 @@ public actor APIClient {
         return createdThoughts
     }
 
+    /// Fixed practitioner list for App Store marketing screenshots (UI-test snapshot seed only).
+    private func uiTestGetBoard() -> [BoardEntryDTO]? {
+        guard let uiTestConfig, uiTestConfig.snapshotSeed else { return nil }
+        guard let store = uiTestStore, store.isAuthenticated else { return nil }
+        let me = store.user.username
+        return [
+            BoardEntryDTO(username: "quietledger", currentDay: 24, streak: 18, avgClear: 84, totalSessions: 52),
+            BoardEntryDTO(username: me, currentDay: store.user.currentDay, streak: 6, avgClear: 77, totalSessions: 22),
+            BoardEntryDTO(username: "morningstill", currentDay: 11, streak: 9, avgClear: 71, totalSessions: 30),
+            BoardEntryDTO(username: "deepamber", currentDay: 9, streak: 4, avgClear: 68, totalSessions: 17),
+        ]
+    }
+
     private func uiTestUpdateSettings(body: SettingsPatchBody) throws -> UserDTO? {
         guard let uiTestConfig else { return nil }
         guard var store = uiTestStore else {
@@ -709,6 +726,8 @@ private struct UITestConfig: Sendable {
     let forceTokenExpired: Bool
     let forceSessionsFailure: Bool
     let forceUsernameConflict: Bool
+    /// Deterministic marketing/scenario data for Fastlane snapshot runs (Issue #325).
+    let snapshotSeed: Bool
 
     static func fromProcessInfo() -> UITestConfig? {
         let env = ProcessInfo.processInfo.environment
@@ -719,7 +738,8 @@ private struct UITestConfig: Sendable {
             forceLaunchOffline: truthy(env["SP_UI_TEST_FORCE_LAUNCH_OFFLINE"]),
             forceTokenExpired: truthy(env["SP_UI_TEST_FORCE_TOKEN_EXPIRED"]),
             forceSessionsFailure: truthy(env["SP_UI_TEST_FORCE_SESSIONS_FAILURE"]),
-            forceUsernameConflict: truthy(env["SP_UI_TEST_FORCE_USERNAME_CONFLICT"])
+            forceUsernameConflict: truthy(env["SP_UI_TEST_FORCE_USERNAME_CONFLICT"]),
+            snapshotSeed: truthy(env["SP_UI_TEST_SNAPSHOT_SEED"])
         )
     }
 
@@ -756,6 +776,146 @@ private struct UITestStore: Codable, Sendable {
             thoughts: [],
             nextSessionOrdinal: 1,
             nextThoughtOrdinal: 1
+        )
+    }
+
+    /// Rich canned history, journal rows, and board-relevant profile for Fastlane screenshots.
+    static func makeSnapshot(seedAuthenticated: Bool) -> UITestStore {
+        let fixtureUser = UserDTO(
+            id: "snapshot-user-1",
+            email: "snapshot@stillpoint.test",
+            username: "still_snapshot",
+            isPublic: true,
+            currentDay: 9
+        )
+
+        let sessions: [SessionDTO] = [
+            SessionDTO(
+                id: "snap-sess-1",
+                dayNumber: 4,
+                sessionType: .standard,
+                duration: 120,
+                bonusSeconds: 60,
+                completed: true,
+                actualTime: 125,
+                clearPercent: 74,
+                thoughtCount: 2,
+                mindStateLog: [],
+                sessionDate: "2026-01-05",
+                createdAt: "2026-01-05T08:30:00Z",
+                buddySessionId: nil
+            ),
+            SessionDTO(
+                id: "snap-sess-2",
+                dayNumber: 4,
+                sessionType: .standard,
+                duration: 120,
+                bonusSeconds: nil,
+                completed: true,
+                actualTime: 118,
+                clearPercent: 81,
+                thoughtCount: 1,
+                mindStateLog: [],
+                sessionDate: "2026-01-05",
+                createdAt: "2026-01-05T19:15:00Z",
+                buddySessionId: nil
+            ),
+            SessionDTO(
+                id: "snap-sess-3",
+                dayNumber: 5,
+                sessionType: .standard,
+                duration: 130,
+                bonusSeconds: 300,
+                completed: true,
+                actualTime: 400,
+                clearPercent: 69,
+                thoughtCount: 4,
+                mindStateLog: [],
+                sessionDate: "2026-01-06",
+                createdAt: "2026-01-06T07:00:00Z",
+                buddySessionId: nil
+            ),
+            SessionDTO(
+                id: "snap-sess-4",
+                dayNumber: 6,
+                sessionType: .standard,
+                duration: 140,
+                bonusSeconds: nil,
+                completed: true,
+                actualTime: 140,
+                clearPercent: 88,
+                thoughtCount: 0,
+                mindStateLog: [],
+                sessionDate: "2026-01-07",
+                createdAt: "2026-01-07T12:20:00Z",
+                buddySessionId: nil
+            ),
+            SessionDTO(
+                id: "snap-sess-5",
+                dayNumber: 7,
+                sessionType: .standard,
+                duration: 150,
+                bonusSeconds: nil,
+                completed: true,
+                actualTime: 150,
+                clearPercent: 72,
+                thoughtCount: 3,
+                mindStateLog: [],
+                sessionDate: "2026-01-08",
+                createdAt: "2026-01-08T06:45:00Z",
+                buddySessionId: nil
+            ),
+            SessionDTO(
+                id: "snap-sess-6",
+                dayNumber: 8,
+                sessionType: .standard,
+                duration: 160,
+                bonusSeconds: 120,
+                completed: true,
+                actualTime: 265,
+                clearPercent: 79,
+                thoughtCount: 2,
+                mindStateLog: [],
+                sessionDate: "2026-01-09",
+                createdAt: "2026-01-09T21:05:00Z",
+                buddySessionId: nil
+            ),
+            SessionDTO(
+                id: "snap-quick-1",
+                dayNumber: 8,
+                sessionType: .quick,
+                duration: StillPoint.quickDuration,
+                bonusSeconds: nil,
+                completed: true,
+                actualTime: StillPoint.quickDuration,
+                clearPercent: 62,
+                thoughtCount: 1,
+                mindStateLog: [],
+                sessionDate: "2026-01-09",
+                createdAt: "2026-01-09T08:10:00Z",
+                buddySessionId: nil
+            ),
+        ]
+
+        let thoughts: [ThoughtDTO] = [
+            ThoughtDTO(id: "snap-th-1", sessionId: "snap-sess-1", dayNumber: 4, timeInSession: 42, text: "Planning the week instead of watching the timer."),
+            ThoughtDTO(id: "snap-th-2", sessionId: "snap-sess-1", dayNumber: 4, timeInSession: 96, text: "Sound of traffic — came back to the breath."),
+            ThoughtDTO(id: "snap-th-3", sessionId: "snap-sess-3", dayNumber: 5, timeInSession: 55, text: "Should I adjust tomorrow's sit length?"),
+            ThoughtDTO(id: "snap-th-4", sessionId: "snap-sess-3", dayNumber: 5, timeInSession: 200, text: "Lost thread for a moment; noticed and returned."),
+            ThoughtDTO(id: "snap-th-5", sessionId: "snap-sess-5", dayNumber: 7, timeInSession: 22, text: "Flash of an old conversation."),
+            ThoughtDTO(id: "snap-th-6", sessionId: "snap-sess-6", dayNumber: 8, timeInSession: 140, text: "Room felt quieter toward the end."),
+            ThoughtDTO(id: "snap-th-7", sessionId: "snap-quick-1", dayNumber: 8, timeInSession: 12, text: "Quick reset between meetings."),
+        ]
+
+        return UITestStore(
+            user: fixtureUser,
+            loginEmail: fixtureUser.email,
+            loginPassword: "snapshot-pass",
+            isAuthenticated: seedAuthenticated,
+            sessions: sessions,
+            thoughts: thoughts,
+            nextSessionOrdinal: 100,
+            nextThoughtOrdinal: 100
         )
     }
 }

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -250,8 +250,8 @@ public actor APIClient {
     // MARK: - Board
 
     public func getBoard() async throws -> [BoardEntryDTO] {
-        if let uiTestResult = uiTestGetBoard() {
-            return uiTestResult
+        if uiTestConfig != nil {
+            return uiTestGetBoard()
         }
         let response: BoardResponse = try await get("/api/board")
         return response.board
@@ -633,10 +633,10 @@ public actor APIClient {
         return createdThoughts
     }
 
-    /// Fixed practitioner list for App Store marketing screenshots (UI-test snapshot seed only).
-    private func uiTestGetBoard() -> [BoardEntryDTO]? {
-        guard let uiTestConfig, uiTestConfig.snapshotSeed else { return nil }
-        guard let store = uiTestStore, store.isAuthenticated else { return nil }
+    /// Board data in UI test mode: empty unless snapshot seed is enabled (marketing screenshots).
+    private func uiTestGetBoard() -> [BoardEntryDTO] {
+        guard let uiTestConfig, uiTestConfig.snapshotSeed else { return [] }
+        guard let store = uiTestStore, store.isAuthenticated else { return [] }
         let me = store.user.username
         return [
             BoardEntryDTO(username: "quietledger", currentDay: 24, streak: 18, avgClear: 84, totalSessions: 52),

--- a/ios/StillPointShared/Sources/StillPointShared/HistoryJourney.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/HistoryJourney.swift
@@ -100,6 +100,8 @@ public enum SessionStatistics {
 
         let totalClear = completedSessions.reduce(0) { $0 + $1.clearPercent }
         let totalThoughts = standard.reduce(0) { $0 + $1.thoughtCount }
+        let bonusSecondsTotal = completedSessions.reduce(0) { $0 + ($1.bonusSeconds ?? 0) }
+        let bonusMinutesTotal = bonusSecondsTotal / 60
         let sumThoughtRates = standard.reduce(0.0) { sum, session in
             let minutes = Double(max(session.actualTime ?? session.duration, 1)) / 60.0
             return sum + (minutes > 0 ? Double(session.thoughtCount) / minutes : 0)
@@ -111,7 +113,8 @@ public enum SessionStatistics {
             streak: streak,
             avgClearPercent: avgClearPercent,
             avgThoughtsPerSession: avgThoughtsPerSession,
-            avgThoughtsPerMinute: avgThoughtsPerMinute
+            avgThoughtsPerMinute: avgThoughtsPerMinute,
+            bonusMinutesTotal: bonusMinutesTotal
         )
     }
 }

--- a/ios/fastlane/Appfile
+++ b/ios/fastlane/Appfile
@@ -1,0 +1,2 @@
+app_identifier("com.brettonauerbach.stillpoint")
+# Optional: FASTLANE_USER for Apple ID flows not used by API-key deliver.

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -40,6 +40,9 @@ platform :ios do
 
     snapshot(snapshot_params)
 
+    pngs = Dir.glob(File.join(candidate_root, "**", "*.png"))
+    UI.user_error!("snapshot completed without producing any PNGs") if pngs.empty?
+
     sh("node #{index_script} #{candidate_root}") if File.exist?(index_script)
 
     UI.success("Candidates written under ios/screenshots/candidates/ — open index.html locally.")
@@ -50,6 +53,16 @@ platform :ios do
     ios_root = File.expand_path("..", __dir__)
     selected = File.join(ios_root, "screenshots", "selected")
     UI.user_error!("Missing #{selected}. Create device-class folders (see ios/RELEASING.md).") unless Dir.exist?(selected)
+
+    counts = Hash.new(0)
+    Dir.glob(File.join(selected, "*", "*.png")).each do |path|
+      device = File.basename(File.dirname(path))
+      counts[device] += 1
+    end
+    counts.each do |device, count|
+      next if count <= 10
+      UI.user_error!("Too many screenshots for #{device}: #{count} (max 10)")
+    end
 
     api_key = app_store_connect_api_key(
       key_id: ENV.fetch("APPSTORE_API_KEY_ID"),

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -37,6 +37,7 @@ platform :ios do
       only_testing: ["StillPointAppUITests/SnapshotTests/testStillPointMarketingSnapshots"]
     }
     snapshot_params.delete(:devices) if resolved_devices.nil? || resolved_devices.empty?
+    snapshot_params.delete(:languages) if snapshot_params[:languages].nil?
 
     snapshot(snapshot_params)
 

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+default_platform(:ios)
+
+platform :ios do
+  desc "Regenerate App Store screenshot candidates (15–20 per device via SnapshotTests)"
+  lane :screenshots do
+    UI.header("Still Point — snapshot candidates")
+
+    ios_root = File.expand_path("..", __dir__)
+    candidate_root = File.join(ios_root, "screenshots", "candidates")
+    index_script = File.expand_path("../../scripts/ios-screenshot-index.mjs", __dir__)
+
+    xcodegen_available = system("which xcodegen > /dev/null 2>&1")
+    if xcodegen_available
+      Dir.chdir(ios_root) { sh("xcodegen generate") }
+    else
+      UI.important("xcodegen not found on PATH — assuming ios/StillPoint.xcodeproj is already generated.")
+    end
+
+    resolved_devices = ENV["SNAPSHOT_DEVICES"]
+      &.split(",")
+      &.map(&:strip)
+      &.reject(&:empty?)
+
+    snapshot_params = {
+      devices: resolved_devices,
+      languages: nil,
+      scheme: "StillPoint",
+      output_directory: candidate_root,
+      clear_previous_screenshots: true,
+      override_status_bar: true,
+      reinstall_app: true,
+      concurrent_simulators: false,
+      stop_after_first_error: false,
+      test_without_building: false,
+      only_testing: ["StillPointAppUITests/SnapshotTests/testStillPointMarketingSnapshots"]
+    }
+    snapshot_params.delete(:devices) if resolved_devices.nil? || resolved_devices.empty?
+
+    snapshot(snapshot_params)
+
+    sh("node #{index_script} #{candidate_root}") if File.exist?(index_script)
+
+    UI.success("Candidates written under ios/screenshots/candidates/ — open index.html locally.")
+  end
+
+  desc "Upload curated screenshots from ios/screenshots/selected to App Store Connect (max 10 per device class)"
+  lane :upload_app_store_screenshots do
+    ios_root = File.expand_path("..", __dir__)
+    selected = File.join(ios_root, "screenshots", "selected")
+    UI.user_error!("Missing #{selected}. Create device-class folders (see ios/RELEASING.md).") unless Dir.exist?(selected)
+
+    api_key = app_store_connect_api_key(
+      key_id: ENV.fetch("APPSTORE_API_KEY_ID"),
+      issuer_id: ENV.fetch("APPSTORE_API_ISSUER_ID"),
+      key_content: ENV.fetch("APPSTORE_API_PRIVATE_KEY"),
+      is_key_content_base64: false,
+      in_house: false
+    )
+
+    deliver(
+      api_key: api_key,
+      app_identifier: "com.brettonauerbach.stillpoint",
+      skip_binary_upload: true,
+      skip_metadata: true,
+      skip_screenshots: false,
+      screenshots_path: selected,
+      overwrite_screenshots: true,
+      force: true,
+      submit_for_review: false,
+      run_precheck_before_submit: false,
+      precheck_include_in_app_purchases: false
+    )
+  end
+
+  desc "Alias for upload_app_store_screenshots"
+  lane :release do
+    upload_app_store_screenshots
+  end
+end

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -43,7 +43,7 @@ platform :ios do
     pngs = Dir.glob(File.join(candidate_root, "**", "*.png"))
     UI.user_error!("snapshot completed without producing any PNGs") if pngs.empty?
 
-    sh("node #{index_script} #{candidate_root}") if File.exist?(index_script)
+    sh("node", index_script, candidate_root) if File.exist?(index_script)
 
     UI.success("Candidates written under ios/screenshots/candidates/ — open index.html locally.")
   end

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -56,12 +56,15 @@ platform :ios do
 
     counts = Hash.new(0)
     Dir.glob(File.join(selected, "*", "*.png")).each do |path|
-      device = File.basename(File.dirname(path))
-      counts[device] += 1
+      locale = File.basename(File.dirname(path))
+      basename = File.basename(path, ".png")
+      m = basename.match(/\A(.+)-\d{2}-.+\z/)
+      device = m ? m[1] : basename
+      counts[[locale, device]] += 1
     end
-    counts.each do |device, count|
+    counts.each do |(locale, device), count|
       next if count <= 10
-      UI.user_error!("Too many screenshots for #{device}: #{count} (max 10)")
+      UI.user_error!("Too many screenshots for #{locale}/#{device}: #{count} (max 10)")
     end
 
     api_key = app_store_connect_api_key(

--- a/ios/fastlane/Snapfile
+++ b/ios/fastlane/Snapfile
@@ -1,4 +1,7 @@
 # Docs: https://docs.fastlane.tools/actions/snapshot/
+#
+# Device strings must match `xcrun simctl list devices available` exactly.
+# CI overrides via SNAPSHOT_DEVICES (comma-separated). Local runs use this list.
 
 devices([
   "iPhone 17 Pro Max",

--- a/ios/fastlane/Snapfile
+++ b/ios/fastlane/Snapfile
@@ -1,0 +1,37 @@
+# Docs: https://docs.fastlane.tools/actions/snapshot/
+
+devices([
+  "iPhone 17 Pro Max",
+  "iPhone 17 Pro",
+  "iPhone 11 Pro Max",
+  "iPhone 8 Plus",
+  "iPad Pro 13-inch (M5)",
+])
+
+languages(["en-US"])
+
+scheme("StillPoint")
+
+output_directory("../screenshots/candidates")
+
+clear_previous_screenshots(true)
+
+override_status_bar(true)
+
+disable_slide_to_type(true)
+
+stop_after_first_error(false)
+
+launch_arguments(["-FASTLANE_SNAPSHOT", "YES"])
+
+output_simulator_logs(false)
+
+headless(false)
+
+concurrent_simulators(false)
+
+reinstall_app(true)
+
+number_of_retries(1)
+
+test_without_building(false)

--- a/scripts/ios-screenshot-index.mjs
+++ b/scripts/ios-screenshot-index.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Builds screenshots/index.html listing every PNG under a directory (recursive),
+ * grouped by basename prefix so multiple device rows align for side-by-side review.
+ *
+ * Usage: node scripts/ios-screenshot-index.mjs <directory>
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const root = process.argv[2];
+if (!root) {
+  console.error("Usage: ios-screenshot-index.mjs <screenshots-directory>");
+  process.exit(1);
+}
+
+async function collectPngs(dir) {
+  const out = [];
+  async function walk(current) {
+    const entries = await fs.readdir(current, { withFileTypes: true });
+    for (const ent of entries) {
+      const full = path.join(current, ent.name);
+      if (ent.isDirectory()) await walk(full);
+      else if (ent.name.endsWith(".png")) out.push(full);
+    }
+  }
+  await walk(dir);
+  return out.sort();
+}
+
+function devicePrefix(filename) {
+  const base = path.basename(filename, ".png");
+  const idx = base.indexOf("-");
+  return idx === -1 ? base : base.slice(0, idx);
+}
+
+function shotSuffix(filename) {
+  const base = path.basename(filename, ".png");
+  const idx = base.indexOf("-");
+  return idx === -1 ? base : base.slice(idx + 1);
+}
+
+const pngs = await collectPngs(root);
+const byShot = new Map();
+for (const file of pngs) {
+  const suffix = shotSuffix(file);
+  const rel = path.relative(root, file);
+  if (!byShot.has(suffix)) byShot.set(suffix, []);
+  byShot.get(suffix).push({ rel, device: devicePrefix(path.basename(file)) });
+}
+
+const rows = [...byShot.entries()].sort(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }));
+const devices = [...new Set(pngs.map((p) => devicePrefix(path.basename(p))))].sort();
+
+const esc = (s) =>
+  s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+let html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Still Point — screenshot candidates</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 24px; background: #0b0f14; color: #e8eef5; }
+    h1 { font-weight: 600; font-size: 1.25rem; }
+    p { color: #9fb0c3; max-width: 72rem; line-height: 1.5; }
+    table { border-collapse: collapse; margin-top: 16px; width: 100%; }
+    th, td { border: 1px solid #243042; padding: 8px; vertical-align: top; }
+    th { text-align: left; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.06em; color: #7d93ab; }
+    td img { max-width: 220px; height: auto; display: block; background: #111822; }
+    .shot { font-family: ui-monospace, monospace; font-size: 0.8rem; color: #c9d7e8; }
+    .device { font-size: 0.65rem; color: #7d93ab; margin-top: 6px; }
+  </style>
+</head>
+<body>
+  <h1>Screenshot candidates</h1>
+  <p>Open this file locally after <code>fastlane screenshots</code>. Rows share the same shot name across simulators; columns are devices present in the folder.</p>
+  <table>
+    <thead><tr><th>Shot</th>${devices.map((d) => `<th>${esc(d)}</th>`).join("")}</tr></thead>
+    <tbody>
+`;
+
+for (const [suffix, files] of rows) {
+  const byDevice = Object.fromEntries(files.map((f) => [f.device, f.rel]));
+  html += `<tr><td class="shot">${esc(suffix)}</td>`;
+  for (const d of devices) {
+    const rel = byDevice[d];
+    if (!rel) {
+      html += `<td>—</td>`;
+    } else {
+      html += `<td><img src="${esc(rel)}" alt="${esc(suffix)} ${esc(d)}"/><div class="device">${esc(d)}</div></td>`;
+    }
+  }
+  html += `</tr>`;
+}
+
+html += `
+    </tbody>
+  </table>
+</body>
+</html>
+`;
+
+await fs.writeFile(path.join(root, "index.html"), html, "utf8");
+console.log(`Wrote ${path.join(root, "index.html")}`);

--- a/scripts/ios-screenshot-index.mjs
+++ b/scripts/ios-screenshot-index.mjs
@@ -39,11 +39,7 @@ function splitSnapshotBasename(base) {
   if (m) {
     return { device: m[1], shot: m[2] };
   }
-  const idx = base.indexOf("-");
-  if (idx === -1) {
-    return { device: base, shot: base };
-  }
-  return { device: base.slice(0, idx), shot: base.slice(idx + 1) };
+  return { device: base, shot: base };
 }
 
 function devicePrefix(filename) {

--- a/scripts/ios-screenshot-index.mjs
+++ b/scripts/ios-screenshot-index.mjs
@@ -28,16 +28,32 @@ async function collectPngs(dir) {
   return out.sort();
 }
 
+/**
+ * Fastlane snapshot names files `{Simulator Name}-{snapshot name}.png`.
+ * Simulator names contain hyphens (e.g. iPad Pro 13-inch (M5)), so we split on
+ * the hyphen before the shot prefix `NN-` (numeric ordering).
+ */
+function splitSnapshotBasename(base) {
+  const re = /^(.+)-(\d{2}-.+)$/;
+  const m = base.match(re);
+  if (m) {
+    return { device: m[1], shot: m[2] };
+  }
+  const idx = base.indexOf("-");
+  if (idx === -1) {
+    return { device: base, shot: base };
+  }
+  return { device: base.slice(0, idx), shot: base.slice(idx + 1) };
+}
+
 function devicePrefix(filename) {
   const base = path.basename(filename, ".png");
-  const idx = base.indexOf("-");
-  return idx === -1 ? base : base.slice(0, idx);
+  return splitSnapshotBasename(base).device;
 }
 
 function shotSuffix(filename) {
   const base = path.basename(filename, ".png");
-  const idx = base.indexOf("-");
-  return idx === -1 ? base : base.slice(idx + 1);
+  return splitSnapshotBasename(base).shot;
 }
 
 const pngs = await collectPngs(root);


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements issue #325: Fastlane **snapshot** generates a wide **candidate** screenshot set (18 prefixed shots × configured device classes), writes an **HTML index** for side-by-side review, keeps **`candidates/` gitignored** vs committed **`selected/`**, and adds **`deliver`** lanes for uploading only the curated set to App Store Connect (respecting filename-prefix ordering). Adds **`workflow_dispatch`** CI to regenerate candidates and upload an artifact.

## Key changes

- **`SP_UI_TEST_SNAPSHOT_SEED`**: deterministic UI-test store with sessions, thoughts, bonus minutes, and a stub practitioners board (`APIClient` + `SessionStatistics.bonusMinutesTotal`).
- **`StillPointAppUITests/Snapshots/`**: `SnapshotTests` + Fastlane `SnapshotHelper`.
- **`ios/fastlane/`**: `Snapfile`, `screenshots` lane (runs `xcodegen` when available, `snapshot`, then `scripts/ios-screenshot-index.mjs`), `upload_app_store_screenshots` / `release` alias using App Store Connect API key env vars.
- **`.github/workflows/ios-screenshots.yml`**: manual workflow; resolves simulator names; runs Fastlane; uploads `ios/screenshots/candidates/**`.
- **`ios/RELEASING.md`**: regenerate → curate → upload flow.

## Verification notes

- **Swift / Fastlane / snapshot** could not be executed in this Linux agent** (no Xcode). Please run locally or rely on the new CI workflow after merge:
  - `cd ios && xcodegen generate && bundle install && bundle exec fastlane screenshots`
- **`coderabbit review --prompt-only`** is not available in this environment.

Closes #325

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7455ad05-9409-4657-a393-3954007db201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7455ad05-9409-4657-a393-3954007db201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bonus-minutes total to session statistics for clearer progress metrics.

* **Accessibility Improvements**
  * Added stable accessibility identifiers to key UI elements for improved navigation and testing.

* **Tests**
  * Added deterministic UI snapshot tests and a snapshot helper plus new test launch knobs for consistent screenshots.

* **Chores**
  * Added a manual screenshot workflow, Fastlane lanes for screenshot generation and App Store upload, CI-friendly device handling, an indexer script, and updated ignore rules.

* **Documentation**
  * Documented screenshot generation, curation, and upload/release steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add Fastlane screenshot capture and App Store screenshot upload**

### What Changed
- Adds a new snapshot flow that generates a wide set of App Store screenshot candidates from the app, along with an HTML page to review them side by side
- Adds a curated upload path so only selected screenshots are sent to App Store Connect, with a per-device limit check before upload
- Uses deterministic in-app test data for screenshot runs, including sample sessions, thoughts, progress history, and a populated practitioners board
- Fixes screenshot ordering and grouping for device names with hyphens, so the preview page matches the captured screens correctly

### Impact
`✅ Faster App Store screenshot updates`
`✅ Fewer mistaken screenshot uploads`
`✅ Clearer screenshot review across devices`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=pXSsKrJYO3ZwYQMp37IjBsF0GswmH5PYF6q9ynMTbt4&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
