### PR TITLE
Sign in with Apple: web (Auth.js) + native iOS bridge (#286)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,12 +68,12 @@ AUTH_GOOGLE_SECRET=
 #   https://www.still-point.me/api/auth/callback/apple
 # Apple does NOT allow localhost for web OAuth return URLs. Options: ngrok/cloudflared tunnel
 # (add tunnel URL to Services ID return URLs temporarily), or test on a Vercel preview / production.
-AUTH_APPLE_ID=
-APPLE_TEAM_ID=
 APPLE_KEY_ID=
 # Full .p8 contents including BEGIN/END lines. In .env.local you may use real newlines;
 # in Vercel paste single-line with \n escapes between lines.
 APPLE_PRIVATE_KEY=
+APPLE_TEAM_ID=
+AUTH_APPLE_ID=
 #
 # Optional: override iOS bundle id checked in identityToken `aud` for POST /api/auth/apple-native
 # (defaults to com.brettonauerbach.stillpoint — must match the native app’s bundle ID, not the Services ID).

--- a/.env.example
+++ b/.env.example
@@ -61,13 +61,23 @@ AUTH_GOOGLE_SECRET=
 # AUTH_FACEBOOK_ID=
 # AUTH_FACEBOOK_SECRET=
 
-# Apple sign-in (deferred to #286). Console: https://developer.apple.com/account/
-# Apple does NOT allow localhost. Local dev requires a tunnel.
-# Services ID Return URL: https://www.still-point.me/api/auth/callback/apple
-# AUTH_APPLE_ID=                      # Services ID identifier (e.g. com.brettonauerbach.stillpoint.web.signin)
-# APPLE_TEAM_ID=                      # 10-char Team ID
-# APPLE_KEY_ID=                       # 10-char Key ID from Sign in with Apple key
-# APPLE_PRIVATE_KEY=                  # Full .p8 contents incl. BEGIN/END lines (escape newlines as \n in single-line .env)
+# Apple Sign in — web (Auth.js) + native iOS (#286). Console: https://developer.apple.com/account/
+# Never commit the .p8 file or paste its contents into issues/PRs/commits.
+#
+# Web uses the Sign in with Apple *Services ID* as AUTH_APPLE_ID. Register return URL:
+#   https://www.still-point.me/api/auth/callback/apple
+# Apple does NOT allow localhost for web OAuth return URLs. Options: ngrok/cloudflared tunnel
+# (add tunnel URL to Services ID return URLs temporarily), or test on a Vercel preview / production.
+AUTH_APPLE_ID=
+APPLE_TEAM_ID=
+APPLE_KEY_ID=
+# Full .p8 contents including BEGIN/END lines. In .env.local you may use real newlines;
+# in Vercel paste single-line with \n escapes between lines.
+APPLE_PRIVATE_KEY=
+#
+# Optional: override iOS bundle id checked in identityToken `aud` for POST /api/auth/apple-native
+# (defaults to com.brettonauerbach.stillpoint — must match the native app’s bundle ID, not the Services ID).
+# AUTH_APPLE_IOS_AUDIENCE=com.brettonauerbach.stillpoint
 
 # Optional: set to exactly "true" to require friendship before buddy join (see README)
 # BUDDY_REQUIRE_FRIENDSHIP=

--- a/docs/mobile-oauth-integration.md
+++ b/docs/mobile-oauth-integration.md
@@ -1,160 +1,59 @@
-# Mobile OAuth Integration (iOS)
+# Mobile OAuth integration (native iOS)
 
-This document defines the architecture and API contract the iOS app uses to
-sign in users via the same OAuth providers offered on the web. It is the
-companion spec for issue #136 (web Google sign-in) and follow-ups
-[#284](https://github.com/auerbachb/still-point/issues/284) (Microsoft),
-[#285](https://github.com/auerbachb/still-point/issues/285) (Facebook), and
-[#286](https://github.com/auerbachb/still-point/issues/286) (Apple).
+This document describes how the Still Point iOS app completes OAuth-style sign-in **outside** Auth.js’s browser-only OAuth flow. Auth.js handles **web** redirects (`/api/auth/callback/…`); native apps receive Apple credentials locally and must verify them on the server.
 
-The iOS implementation itself ships in a separate iOS-side issue. This file
-describes only what the web backend already supports today and what each
-provider expects from the client.
+## Sign in with Apple (native)
 
----
+### Endpoint
 
-## Account model
+`POST /api/auth/apple-native`
 
-A single Still Point user account can have:
+Public route (no prior `sp_token`). Middleware allows this path without JWT verification.
 
-- An optional password (stored as a bcrypt hash in `users.password_hash`,
-  nullable as of #136).
-- Zero or more linked OAuth identities, recorded in `oauth_accounts` as
-  `(provider, provider_account_id) -> user_id`.
+### Request body (JSON)
 
-Linking rule: when a sign-in provider returns a verified email that matches
-an existing `users.email` (case-insensitively), the new
-`(provider, provider_account_id)` is attached to that user. Otherwise a new
-user is created with a null `password_hash`.
+| Field | Required | Description |
+| --- | --- | --- |
+| `identityToken` | Yes | UTF-8 string of the JWT from `ASAuthorizationAppleIDCredential.identityToken`. |
+| `authorizationCode` | No | Optional opaque authorization code from Apple (included for parity with Apple’s API and future server-side token exchange). Not used for account linking today. |
+| `user` | No | Present **only on the first consent** for this Apple ID + client pair. Same shape Apple sends to web (`name.firstName`, `name.lastName`, `email`). Subsequent sign-ins omit this object entirely — **never rely on name/email being present after first launch.** |
 
-The session token format is unchanged. The web backend mints the same
-HttpOnly `sp_token` JWT it has always used; iOS continues to read
-`sp_token` from `HTTPCookieStorage.shared` and attach it to subsequent
-requests.
+### Server validation
 
----
+1. Verifies `identityToken` with Apple’s JWKS (`https://appleid.apple.com/auth/keys`) via `jose` (`jwtVerify` + `createRemoteJWKSet`).
+2. Validates issuer `https://appleid.apple.com`.
+3. Validates **audience** against the iOS App ID bundle identifier — **not** the Sign in with Apple **Services ID** used for web (`AUTH_APPLE_ID`). Default audience is `com.brettonauerbach.stillpoint`. Override with optional env **`AUTH_APPLE_IOS_AUDIENCE`** if you use a different bundle ID or multiple apps.
+4. Requires `email_verified` true (Apple sends boolean or string `"true"`).
+5. Uses **`sub`** as the stable Apple account identifier. Lookup order matches web OAuth (`src/lib/oauth-user-resolution.ts`): existing `(provider='apple', provider_account_id=sub)` row wins; otherwise email match for linking or new user creation.
 
-## Provider integration patterns
+### Response
 
-There are two patterns iOS uses depending on the provider:
+- JSON `{ user, token }` — same shape as email/password login when `X-Still-Point-Client: ios` is used (`token` is the JWT for `Authorization: Bearer`).
+- Sets HTTP-only cookie **`sp_token`** for parity with web sessions (Safari / embedded WebViews if applicable).
 
-### Pattern A: Native SDK + dedicated server endpoint (Apple only)
+### Hide My Email (relay)
 
-Apple requires Sign in with Apple to use `ASAuthorizationController` on iOS
-when the platform supports it. The native flow returns an `identityToken`
-(JWT signed by Apple) and an `authorizationCode` to the app, not a redirect.
+Relay addresses (`@privaterelay.appleid.com`) are stable per user + app. We store the relay email on first sign-in and **always** resolve returning users by Apple `sub` in `oauth_accounts`, not by mutating email. If the user revokes relay or changes forwarding, sign-in still works.
 
-Endpoint (to be implemented under issue
-[#286](https://github.com/auerbachb/still-point/issues/286)):
+**Outbound email:** Apple Private Email Relay only delivers mail from **registered** sender domains. Until outgoing mail is registered with Apple (see **#339**), transactional email to relay addresses may not arrive. This does not block sign-in.
 
-```http
-POST /api/auth/apple-native
-Content-Type: application/json
-```
+### Device testing
 
-```json
-{
-  "identityToken": "<JWS from ASAuthorizationCredential.identityToken>",
-  "authorizationCode": "<from ASAuthorizationCredential.authorizationCode>",
-  "fullName": { "givenName": "Ada", "familyName": "Lovelace" }
-}
-```
+Sign in with Apple on the **Simulator is unreliable**. Use a **physical device** and a real Apple ID for acceptance testing.
 
-Server responsibilities:
+### Local API development
 
-1. Verify `identityToken` against Apple's JWKS
-   (`https://appleid.apple.com/auth/keys`) using the `jose` library that is
-   already in the project; check `iss == "https://appleid.apple.com"`,
-   `aud == AUTH_APPLE_ID` (the Services ID), and `exp`.
-2. Extract `sub` (Apple user id, stable across sign-ins) and `email`.
-3. Apply the same find/create-and-link logic as the web `signIn` callback,
-   keyed on email when present (Apple may return a relay address) and on
-   `(provider='apple', provider_account_id=sub)` for re-sign-in.
-4. Mint `sp_token`, set the cookie, and return the same response shape as
-   `POST /api/auth/login`.
-
-This endpoint does not exist yet. It is gated on
-[#286](https://github.com/auerbachb/still-point/issues/286).
-
-### Pattern B: `ASWebAuthenticationSession` over the web flow (Google, Microsoft, Facebook)
-
-For all non-Apple providers, iOS reuses the existing web OAuth flow rather
-than carrying provider SDKs. The flow:
-
-1. iOS opens `ASWebAuthenticationSession` pointed at:
-
-   ```text
-   https://www.still-point.me/api/auth/signin/<provider>
-   ```
-
-   For `<provider>` use the Auth.js id: `google`, `microsoft-entra-id`, or
-   `facebook`.
-
-2. The user authenticates with the provider in a system-managed browser tab
-   that shares cookies with Safari (set
-   `prefersEphemeralWebBrowserSession: false` so returning users do not
-   re-enter their password).
-
-3. Auth.js (server) handles `/api/auth/callback/<provider>` and redirects
-   to `/api/auth/oauth-complete`. `oauth-complete` mints `sp_token`, sets
-   the HttpOnly cookie scoped to `still-point.me`, then redirects to
-   `/app`.
-
-4. **Detecting completion on iOS.** The redirect chain ends on `/app` —
-   the server does not redirect to a custom URL scheme today, so
-   `ASWebAuthenticationSession`'s `callbackURLScheme` completion handler
-   does NOT fire automatically. The iOS-side issue (separate from #136)
-   will choose one of:
-   - **(a)** Have the server redirect to `stillpoint://oauth-complete`
-     after `oauth-complete` instead of `/app`, with a server-side
-     allow-list keyed off a request marker (e.g. `?ios=1` propagated
-     from `signin/<provider>?callbackUrl=...`). This requires a small
-     extension to the `redirect` callback in `src/lib/auth-config.ts` so
-     known custom schemes survive.
-   - **(b)** Poll the session's current URL on a timer; when it reaches
-     `https://www.still-point.me/app`, dismiss the session and read
-     `sp_token` from `HTTPCookieStorage.shared`.
-   Until that decision lands, treat the existing custom-scheme
-   registration in `Info.plist` as scaffolding — it does not yet
-   round-trip end-to-end.
-
-Caveats for Pattern B:
-
-- The redirect URI registered with each provider must be the **server**
-  callback (`https://www.still-point.me/api/auth/callback/<provider>`),
-  not the iOS custom scheme. Auth.js owns the OAuth handshake; iOS only
-  cares about the final `sp_token` cookie.
-- iOS must use `HTTPCookieStorage.shared` (the default) so cookies set
-  by the system browser are visible to the app's `URLSession`. Custom
-  cookie stores will miss `sp_token`.
-- If `sp_token` is unexpectedly absent after the session callback, the
-  app should call `GET /api/auth/me` once. If it returns 401, treat the
-  attempt as a failed sign-in and surface a retry UI.
+The native client targets `https://still-point.me` by default (`APIClient`). Point it at a Vercel preview URL if you need to test server changes before production.
 
 ---
 
-## Provider-specific notes
+## Follow-up work (not shipped here)
 
-| Provider | Pattern | iOS framework | Status |
-|---|---|---|---|
-| Google | B (web flow) | `ASWebAuthenticationSession` | Web available today (#136). iOS-side issue not yet filed. |
-| Apple | A (native) | `ASAuthorizationController` | Web Auth.js + native endpoint deferred to [#286](https://github.com/auerbachb/still-point/issues/286). |
-| Facebook | B (web flow) | `ASWebAuthenticationSession` | Deferred to [#285](https://github.com/auerbachb/still-point/issues/285). |
-| Microsoft | B (web flow) | `ASWebAuthenticationSession` | Deferred to [#284](https://github.com/auerbachb/still-point/issues/284). |
+- **#338** — Server-to-server Apple notifications (account deleted, consent revoked, email disabled).
+- **#339** — Register outbound email sources for Apple Private Email Relay deliverability.
 
 ---
 
-## Security expectations (all providers)
+## Other providers
 
-- Verify provider tokens server-side; never trust client-supplied user
-  identifiers.
-- Provider tokens (`identityToken`, OAuth access tokens, refresh tokens)
-  must not appear in application logs. Auth.js does not log them by default;
-  custom server code (e.g., `/api/auth/apple-native`) must follow the same
-  rule.
-- `sp_token` remains the only credential the iOS app sees and stores. It is
-  HttpOnly on web; on iOS it lives in `HTTPCookieStorage.shared` and is
-  attached automatically by `URLSession`.
-- CSRF/state for the OAuth handshake is owned by Auth.js for Pattern B;
-  Pattern A endpoints (`/api/auth/apple-native`) do not need CSRF protection
-  because the request is a one-shot exchange of a provider-issued JWT.
+Google / Microsoft / Facebook on mobile would follow the same **pattern**: native SDK obtains tokens → server route verifies tokens / exchanges codes → `resolveOAuthUserId`-style linking → `sp_token`. Only Apple is implemented in this shape today.

--- a/docs/mobile-oauth-integration.md
+++ b/docs/mobile-oauth-integration.md
@@ -23,8 +23,8 @@ Public route (no prior `sp_token`). Middleware allows this path without JWT veri
 1. Verifies `identityToken` with Apple’s JWKS (`https://appleid.apple.com/auth/keys`) via `jose` (`jwtVerify` + `createRemoteJWKSet`).
 2. Validates issuer `https://appleid.apple.com`.
 3. Validates **audience** against the iOS App ID bundle identifier — **not** the Sign in with Apple **Services ID** used for web (`AUTH_APPLE_ID`). Default audience is `com.brettonauerbach.stillpoint`. Override with optional env **`AUTH_APPLE_IOS_AUDIENCE`** if you use a different bundle ID or multiple apps.
-4. Requires `email_verified` true (Apple sends boolean or string `"true"`).
-5. Uses **`sub`** as the stable Apple account identifier. Lookup order matches web OAuth (`src/lib/oauth-user-resolution.ts`): existing `(provider='apple', provider_account_id=sub)` row wins; otherwise email match for linking or new user creation.
+4. When the JWT includes `email`, requires `email_verified` true (boolean or string `"true"`). When `email` is omitted (common on repeat native sign-ins), accepts the token if **`sub`** already maps to an existing `oauth_accounts` row; first-time account creation still requires `email` in the token (Apple sends it on first consent).
+5. Uses **`sub`** as the stable Apple account identifier. Lookup order matches web OAuth (`src/lib/oauth-user-resolution.ts`): existing `(provider='apple', provider_account_id=sub)` wins first; otherwise email match or new user creation when email is present.
 
 ### Response
 

--- a/docs/mobile-oauth-integration.md
+++ b/docs/mobile-oauth-integration.md
@@ -41,6 +41,8 @@ Relay addresses (`@privaterelay.appleid.com`) are stable per user + app. We stor
 
 Sign in with Apple on the **Simulator is unreliable**. Use a **physical device** and a real Apple ID for acceptance testing.
 
+In **UI test mode** (`SP_UI_TEST_MODE=1`), the app **does not render** the Sign in with Apple button so XCUITest can rely on stable hit-testing for email/password fields; production builds show the button normally.
+
 ### Local API development
 
 The native client targets `https://still-point.me` by default (`APIClient`). Point it at a Vercel preview URL if you need to test server changes before production.

--- a/ios/StillPoint.xcodeproj/project.pbxproj
+++ b/ios/StillPoint.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		15177B86F124B5A10AB03456 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C683A9F0586D58020E60DD87 /* RootView.swift */; };
 		1649BE1D765A6851D5802BBA /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D356465C1B0F69C57FE47A80 /* SettingsView.swift */; };
 		16697A0A2D8E95D300EEA791 /* BuddyVideoWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0F8BA13F32BC68EEA0198C /* BuddyVideoWebView.swift */; };
+		17A248000000000000000008 /* AppleSignInController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A248000000000000000007 /* AppleSignInController.swift */; };
 		17A248000000000000000001 /* AppBlockingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A248000000000000000002 /* AppBlockingManager.swift */; };
 		17A248000000000000000003 /* AppBlockingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A248000000000000000004 /* AppBlockingSettingsView.swift */; };
 		1BE60070F826B7B31DFAB315 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FA6DAE71EE23FAF8EE0F12 /* HomeView.swift */; };
@@ -50,6 +51,7 @@
 		17A248000000000000000002 /* AppBlockingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBlockingManager.swift; sourceTree = "<group>"; };
 		17A248000000000000000004 /* AppBlockingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBlockingSettingsView.swift; sourceTree = "<group>"; };
 		17A248000000000000000005 /* StillPoint.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StillPoint.entitlements; sourceTree = "<group>"; };
+		17A248000000000000000007 /* AppleSignInController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInController.swift; sourceTree = "<group>"; };
 		1F75039BBEED880C73680860 /* HistoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewModel.swift; sourceTree = "<group>"; };
 		218693B76FDAF56B6E0321DE /* AppViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppViewModel.swift; sourceTree = "<group>"; };
 		23FA6DAE71EE23FAF8EE0F12 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
@@ -140,6 +142,7 @@
 				14CEC6DBFFB1C10CFDDA8424 /* StillPointApp.swift */,
 				4DB1C67E76477BADB30F0F77 /* Components */,
 				17A248000000000000000006 /* Managers */,
+				17A248000000000000000009 /* Services */,
 				551003AC2B5AD8A7B3C3D426 /* Navigation */,
 				09EA4336C05552F95AE85178 /* Resources */,
 				AC788F412B1414C8C2BDB3CB /* Theme */,
@@ -173,6 +176,14 @@
 				17A248000000000000000002 /* AppBlockingManager.swift */,
 			);
 			path = Managers;
+			sourceTree = "<group>";
+		};
+		17A248000000000000000009 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				17A248000000000000000007 /* AppleSignInController.swift */,
+			);
+			path = Services;
 			sourceTree = "<group>";
 		};
 		9AEB18D5D4C55CB98F814D43 /* BuddySession */ = {
@@ -314,6 +325,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				55CB825BEE151D314A4DD2FA /* AppViewModel.swift in Sources */,
+				17A248000000000000000008 /* AppleSignInController.swift in Sources */,
 				17A248000000000000000001 /* AppBlockingManager.swift in Sources */,
 				17A248000000000000000003 /* AppBlockingSettingsView.swift in Sources */,
 				5EA3E8C9B84298DE1F37251F /* AuthView.swift in Sources */,

--- a/ios/StillPointApp/Services/AppleSignInController.swift
+++ b/ios/StillPointApp/Services/AppleSignInController.swift
@@ -1,0 +1,37 @@
+import AuthenticationServices
+import StillPointShared
+
+/// Maps `ASAuthorizationAppleIDCredential` from Sign in with Apple into the JSON body for
+/// `POST /api/auth/apple-native`. Use with `ASAuthorizationAppleIDButton`, SwiftUI's
+/// `SignInWithAppleButton`, or a raw `ASAuthorizationController` — all deliver the same credential type.
+enum AppleSignInController {
+    /// Returns `nil` if the identity token cannot be decoded as UTF-8 (should not happen for valid credentials).
+    static func nativeSignInRequest(from credential: ASAuthorizationAppleIDCredential) -> AppleNativeSignInRequest? {
+        guard
+            let tokenData = credential.identityToken,
+            let identityToken = String(data: tokenData, encoding: .utf8),
+            !identityToken.isEmpty
+        else {
+            return nil
+        }
+
+        let authorizationCode = credential.authorizationCode.flatMap { String(data: $0, encoding: .utf8) }
+
+        let user: AppleNativeSignInRequest.AppleUserFirstSignInPayload?
+        if credential.email != nil || credential.fullName != nil {
+            let name = AppleNativeSignInRequest.AppleUserFirstSignInPayload.Name(
+                firstName: credential.fullName?.givenName,
+                lastName: credential.fullName?.familyName
+            )
+            user = AppleNativeSignInRequest.AppleUserFirstSignInPayload(name: name, email: credential.email)
+        } else {
+            user = nil
+        }
+
+        return AppleNativeSignInRequest(
+            identityToken: identityToken,
+            authorizationCode: authorizationCode,
+            user: user
+        )
+    }
+}

--- a/ios/StillPointApp/StillPoint.entitlements
+++ b/ios/StillPointApp/StillPoint.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 	<key>com.apple.developer.family-controls</key>
 	<true/>
 </dict>

--- a/ios/StillPointApp/ViewModels/AuthViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AuthViewModel.swift
@@ -9,9 +9,9 @@ final class AuthViewModel {
     var password = ""
     var error: String?
     var resetMessage: String?
-    var isSubmitting = false
     var isRequestingPasswordReset = false
-    var isAppleSignInInFlight = false
+    /// True while any sign-in path (email/password or Apple) is in flight.
+    var isAuthInFlight = false
 
     var isValid: Bool {
         let emailValid = email.contains("@") && email.contains(".")
@@ -25,11 +25,11 @@ final class AuthViewModel {
     }
 
     func submit() async -> UserDTO? {
-        guard isValid, !isSubmitting else { return nil }
-        isSubmitting = true
+        guard isValid, !isAuthInFlight else { return nil }
+        isAuthInFlight = true
         error = nil
         resetMessage = nil
-        defer { isSubmitting = false }
+        defer { isAuthInFlight = false }
 
         do {
             if isSignUp {
@@ -54,11 +54,11 @@ final class AuthViewModel {
     }
 
     func signInWithApple(using request: AppleNativeSignInRequest) async -> UserDTO? {
-        guard !isAppleSignInInFlight else { return nil }
-        isAppleSignInInFlight = true
+        guard !isAuthInFlight else { return nil }
+        isAuthInFlight = true
         error = nil
         resetMessage = nil
-        defer { isAppleSignInInFlight = false }
+        defer { isAuthInFlight = false }
 
         do {
             return try await APIClient.shared.signInWithApple(request)

--- a/ios/StillPointApp/ViewModels/AuthViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AuthViewModel.swift
@@ -11,6 +11,7 @@ final class AuthViewModel {
     var resetMessage: String?
     var isSubmitting = false
     var isRequestingPasswordReset = false
+    var isAppleSignInInFlight = false
 
     var isValid: Bool {
         let emailValid = email.contains("@") && email.contains(".")
@@ -47,6 +48,24 @@ final class AuthViewModel {
             return nil
         } catch {
             print("Auth submit failed: \(error.localizedDescription)")
+            self.error = "Connection failed. Please try again."
+            return nil
+        }
+    }
+
+    func signInWithApple(using request: AppleNativeSignInRequest) async -> UserDTO? {
+        guard !isAppleSignInInFlight else { return nil }
+        isAppleSignInInFlight = true
+        error = nil
+        resetMessage = nil
+        defer { isAppleSignInInFlight = false }
+
+        do {
+            return try await APIClient.shared.signInWithApple(request)
+        } catch let apiError as APIError {
+            error = apiError.message
+            return nil
+        } catch {
             self.error = "Connection failed. Please try again."
             return nil
         }

--- a/ios/StillPointApp/Views/AuthView.swift
+++ b/ios/StillPointApp/Views/AuthView.swift
@@ -52,33 +52,38 @@ struct AuthView: View {
                         .textInputAutocapitalization(.never)
                         .accessibilityIdentifier("auth.emailField")
 
-                    SignInWithAppleButton(.signIn) { request in
-                        request.requestedScopes = [.fullName, .email]
-                    } onCompletion: { result in
-                        switch result {
-                        case .success(let authorization):
-                            guard
-                                let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
-                                let body = AppleSignInController.nativeSignInRequest(from: credential)
-                            else {
-                                vm.error = "Could not read Sign in with Apple credentials."
-                                return
-                            }
-                            Task {
-                                if let user = await vm.signInWithApple(using: body) {
-                                    appVM.didLogin(user: user)
+                    // `SignInWithAppleButton` sits in a UIKit bridge that can steal hit-testing /
+                    // layout from sibling fields on CI simulators. XCTest targets stable ids on the
+                    // email/password path — hide OAuth chrome under UI test mode only (#286 / CI).
+                    if !isUiTestMode {
+                        SignInWithAppleButton(.signIn) { request in
+                            request.requestedScopes = [.fullName, .email]
+                        } onCompletion: { result in
+                            switch result {
+                            case .success(let authorization):
+                                guard
+                                    let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+                                    let body = AppleSignInController.nativeSignInRequest(from: credential)
+                                else {
+                                    vm.error = "Could not read Sign in with Apple credentials."
+                                    return
                                 }
+                                Task {
+                                    if let user = await vm.signInWithApple(using: body) {
+                                        appVM.didLogin(user: user)
+                                    }
+                                }
+                            case .failure:
+                                vm.error = "Sign in with Apple was cancelled or failed."
                             }
-                        case .failure:
-                            vm.error = "Sign in with Apple was cancelled or failed."
                         }
+                        .signInWithAppleButtonStyle(.black)
+                        .frame(height: 44)
+                        .clipShape(Capsule())
+                        .overlay(Capsule().stroke(SPColor.border2))
+                        .disabled(vm.isAppleSignInInFlight)
+                        .opacity(vm.isAppleSignInInFlight ? 0.5 : 1)
                     }
-                    .signInWithAppleButtonStyle(.black)
-                    .frame(height: 44)
-                    .clipShape(Capsule())
-                    .overlay(Capsule().stroke(SPColor.border2))
-                    .disabled(vm.isAppleSignInInFlight)
-                    .opacity(vm.isAppleSignInInFlight ? 0.5 : 1)
 
                     if vm.isSignUp {
                         styledField("Username", text: $vm.username)
@@ -154,6 +159,10 @@ struct AuthView: View {
             .padding(.bottom, SPSpacing.s6)
         }
         .stillPointBackground()
+    }
+
+    private var isUiTestMode: Bool {
+        ProcessInfo.processInfo.environment["SP_UI_TEST_MODE"] == "1"
     }
 
     private func toggleButton(_ title: String, isSelected: Bool, action: @escaping () -> Void) -> some View {

--- a/ios/StillPointApp/Views/AuthView.swift
+++ b/ios/StillPointApp/Views/AuthView.swift
@@ -73,16 +73,20 @@ struct AuthView: View {
                                         appVM.didLogin(user: user)
                                     }
                                 }
-                            case .failure:
-                                vm.error = "Sign in with Apple was cancelled or failed."
+                            case .failure(let error):
+                                if let authError = error as? ASAuthorizationError,
+                                   authError.code == .canceled {
+                                    return
+                                }
+                                vm.error = "Sign in with Apple failed. Please try again."
                             }
                         }
                         .signInWithAppleButtonStyle(.black)
                         .frame(height: 44)
                         .clipShape(Capsule())
                         .overlay(Capsule().stroke(SPColor.border2))
-                        .disabled(vm.isAppleSignInInFlight)
-                        .opacity(vm.isAppleSignInInFlight ? 0.5 : 1)
+                        .disabled(vm.isAuthInFlight)
+                        .opacity(vm.isAuthInFlight ? 0.5 : 1)
                     }
 
                     if vm.isSignUp {
@@ -129,8 +133,8 @@ struct AuthView: View {
                             .overlay(Capsule().stroke(SPColor.border2))
                     }
                     .accessibilityIdentifier("auth.submitButton")
-                    .disabled(!vm.isValid || vm.isSubmitting)
-                    .opacity(vm.isValid ? 1 : 0.5)
+                    .disabled(!vm.isValid || vm.isAuthInFlight)
+                    .opacity(vm.isValid && !vm.isAuthInFlight ? 1 : 0.5)
 
                     if let resetMessage = vm.resetMessage {
                         Text(resetMessage)

--- a/ios/StillPointApp/Views/AuthView.swift
+++ b/ios/StillPointApp/Views/AuthView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AuthenticationServices
 import StillPointShared
 
 struct AuthView: View {
@@ -50,6 +51,34 @@ struct AuthView: View {
                         .keyboardType(.emailAddress)
                         .textInputAutocapitalization(.never)
                         .accessibilityIdentifier("auth.emailField")
+
+                    SignInWithAppleButton(.signIn) { request in
+                        request.requestedScopes = [.fullName, .email]
+                    } onCompletion: { result in
+                        switch result {
+                        case .success(let authorization):
+                            guard
+                                let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+                                let body = AppleSignInController.nativeSignInRequest(from: credential)
+                            else {
+                                vm.error = "Could not read Sign in with Apple credentials."
+                                return
+                            }
+                            Task {
+                                if let user = await vm.signInWithApple(using: body) {
+                                    appVM.didLogin(user: user)
+                                }
+                            }
+                        case .failure:
+                            vm.error = "Sign in with Apple was cancelled or failed."
+                        }
+                    }
+                    .signInWithAppleButtonStyle(.black)
+                    .frame(height: 44)
+                    .clipShape(Capsule())
+                    .overlay(Capsule().stroke(SPColor.border2))
+                    .disabled(vm.isAppleSignInInFlight)
+                    .opacity(vm.isAppleSignInInFlight ? 0.5 : 1)
 
                     if vm.isSignUp {
                         styledField("Username", text: $vm.username)

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -135,6 +135,22 @@ public actor APIClient {
         return response.user
     }
 
+    /// Native Sign in with Apple → server verifies JWT and returns `user` + `token` (same as login with ios header).
+    public func signInWithApple(_ request: AppleNativeSignInRequest) async throws -> UserDTO {
+        if uiTestConfig != nil {
+            throw APIError(status: 0, message: "Apple sign-in is not available in UI test mode")
+        }
+        let response: UserResponse = try await post("/api/auth/apple-native", body: request)
+        if let token = response.token, !token.isEmpty {
+            guard AuthTokenStore.save(token) else {
+                throw APIError(status: 0, message: "Unable to securely save auth token")
+            }
+        } else {
+            _ = AuthTokenStore.clear()
+        }
+        return response.user
+    }
+
     public func requestPasswordReset(email: String) async throws -> String {
         if let message = try uiTestRequestPasswordReset(email: email) {
             return message

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -256,6 +256,42 @@ public struct RecordBuddyPersonalSessionRequest: Codable, Sendable {
 
 // MARK: - API Wrappers (match JSON response shapes)
 
+public struct AppleNativeSignInRequest: Encodable, Sendable {
+    public let identityToken: String
+    public let authorizationCode: String?
+    public let user: AppleUserFirstSignInPayload?
+
+    public struct AppleUserFirstSignInPayload: Encodable, Sendable {
+        public let name: Name?
+        public let email: String?
+
+        public struct Name: Encodable, Sendable {
+            public let firstName: String?
+            public let lastName: String?
+
+            public init(firstName: String?, lastName: String?) {
+                self.firstName = firstName
+                self.lastName = lastName
+            }
+        }
+
+        public init(name: Name?, email: String?) {
+            self.name = name
+            self.email = email
+        }
+    }
+
+    public init(
+        identityToken: String,
+        authorizationCode: String?,
+        user: AppleUserFirstSignInPayload?
+    ) {
+        self.identityToken = identityToken
+        self.authorizationCode = authorizationCode
+        self.user = user
+    }
+}
+
 public struct UserResponse: Codable, Sendable {
     public let user: UserDTO
     public let token: String?

--- a/src/app/api/auth/apple-native/route.test.ts
+++ b/src/app/api/auth/apple-native/route.test.ts
@@ -8,10 +8,17 @@ vi.mock("jose", () => ({
   jwtVerify,
 }));
 
-const resolveOAuthUserId = vi.fn();
-vi.mock("@/lib/oauth-user-resolution", () => ({
-  resolveOAuthUserId,
+const { resolveOAuthUserId } = vi.hoisted(() => ({
+  resolveOAuthUserId: vi.fn(),
 }));
+
+vi.mock("@/lib/oauth-user-resolution", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/oauth-user-resolution")>();
+  return {
+    ...actual,
+    resolveOAuthUserId,
+  };
+});
 
 const dbSelectWhereLimit = vi.fn();
 const dbSelectFromWhere = vi.fn(() => ({ limit: dbSelectWhereLimit }));
@@ -86,6 +93,46 @@ describe("POST /api/auth/apple-native", () => {
 
     const cookie = res.cookies.get("sp_token");
     expect(cookie?.value).toBe("jwt-from-createToken");
+  });
+
+  test("accepts token without email when resolveOAuthUserId links by sub", async () => {
+    jwtVerify.mockResolvedValue({
+      payload: {
+        sub: "apple-sub-repeat",
+        email_verified: true,
+      },
+    });
+    const { POST } = await import("./route");
+    const req = {
+      json: async () => ({ identityToken: "tok" }),
+    } as unknown as NextRequest;
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(resolveOAuthUserId).toHaveBeenCalledWith({
+      provider: "apple",
+      providerAccountId: "apple-sub-repeat",
+      email: undefined,
+      profile: { name: null },
+    });
+  });
+
+  test("returns 400 when OAuthEmailRequiredError is thrown", async () => {
+    const { OAuthEmailRequiredError } = await import("@/lib/oauth-user-resolution");
+    jwtVerify.mockResolvedValue({
+      payload: {
+        sub: "apple-new",
+        email_verified: true,
+      },
+    });
+    resolveOAuthUserId.mockRejectedValueOnce(new OAuthEmailRequiredError());
+    const { POST } = await import("./route");
+    const req = {
+      json: async () => ({ identityToken: "tok" }),
+    } as unknown as NextRequest;
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
   });
 
   test("rejects missing identity token", async () => {

--- a/src/app/api/auth/apple-native/route.test.ts
+++ b/src/app/api/auth/apple-native/route.test.ts
@@ -1,0 +1,97 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const jwtVerify = vi.fn();
+
+vi.mock("jose", () => ({
+  createRemoteJWKSet: vi.fn(() => ({})),
+  jwtVerify,
+}));
+
+const resolveOAuthUserId = vi.fn();
+vi.mock("@/lib/oauth-user-resolution", () => ({
+  resolveOAuthUserId,
+}));
+
+const dbSelectWhereLimit = vi.fn();
+const dbSelectFromWhere = vi.fn(() => ({ limit: dbSelectWhereLimit }));
+const dbSelectFrom = vi.fn(() => ({ where: dbSelectFromWhere }));
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn(() => ({ from: dbSelectFrom })),
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  users: { id: "id", email: "email", username: "username", isPublic: "isPublic", currentDay: "currentDay" },
+}));
+
+const createToken = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  createToken,
+  SP_TOKEN_COOKIE: "sp_token",
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((a, b) => ({ a, b })),
+}));
+
+describe("POST /api/auth/apple-native", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("NODE_ENV", "test");
+    jwtVerify.mockResolvedValue({
+      payload: {
+        sub: "apple-sub-1",
+        email: "relay@privaterelay.appleid.com",
+        email_verified: true,
+      },
+    });
+    resolveOAuthUserId.mockResolvedValue("user-uuid-1");
+    dbSelectWhereLimit.mockResolvedValue([
+      {
+        id: "user-uuid-1",
+        email: "relay@privaterelay.appleid.com",
+        username: "alice",
+        isPublic: false,
+        currentDay: 3,
+      },
+    ]);
+    createToken.mockResolvedValue("jwt-from-createToken");
+  });
+
+  test("returns user + token and sets sp_token cookie on valid identity token", async () => {
+    const { POST } = await import("./route");
+    const req = {
+      json: async () => ({
+        identityToken: "header.payload.sig",
+        authorizationCode: "opaque-code",
+      }),
+    } as unknown as NextRequest;
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json.token).toBe("jwt-from-createToken");
+    expect(json.user.id).toBe("user-uuid-1");
+    expect(json.user.username).toBe("alice");
+
+    expect(resolveOAuthUserId).toHaveBeenCalledWith({
+      provider: "apple",
+      providerAccountId: "apple-sub-1",
+      email: "relay@privaterelay.appleid.com",
+      profile: { name: null },
+    });
+
+    const cookie = res.cookies.get("sp_token");
+    expect(cookie?.value).toBe("jwt-from-createToken");
+  });
+
+  test("rejects missing identity token", async () => {
+    const { POST } = await import("./route");
+    const req = { json: async () => ({}) } as unknown as NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/auth/apple-native/route.ts
+++ b/src/app/api/auth/apple-native/route.ts
@@ -4,7 +4,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { createToken, SP_TOKEN_COOKIE } from "@/lib/auth";
-import { resolveOAuthUserId } from "@/lib/oauth-user-resolution";
+import { resolveOAuthUserId, OAuthEmailRequiredError } from "@/lib/oauth-user-resolution";
 
 const APPLE_JWKS = createRemoteJWKSet(new URL("https://appleid.apple.com/auth/keys"));
 const ISSUER = "https://appleid.apple.com";
@@ -45,7 +45,7 @@ export async function POST(request: NextRequest) {
   }
 
   let sub: string;
-  let email: string;
+  let emailFromToken: string | undefined;
   try {
     const { payload } = await jwtVerify(identityToken, APPLE_JWKS, {
       issuer: ISSUER,
@@ -56,17 +56,18 @@ export async function POST(request: NextRequest) {
     }
     sub = payload.sub;
     const emailClaim = payload.email;
-    if (typeof emailClaim !== "string" || !emailClaim.trim()) {
-      return NextResponse.json({ error: "Email not available" }, { status: 401 });
-    }
-    email = emailClaim.trim().toLowerCase();
-    const ev = payload.email_verified;
-    if (ev !== true && ev !== "true") {
-      return NextResponse.json({ error: "Email not verified" }, { status: 401 });
+    if (typeof emailClaim === "string" && emailClaim.trim()) {
+      emailFromToken = emailClaim.trim().toLowerCase();
+      const ev = payload.email_verified;
+      if (ev !== true && ev !== "true") {
+        return NextResponse.json({ error: "Email not verified" }, { status: 401 });
+      }
     }
   } catch {
     return NextResponse.json({ error: "Invalid identity token" }, { status: 401 });
   }
+
+  const emailForResolution = emailFromToken;
 
   const fromApple = displayNameFromAppleUser(body.user);
   const nameForProfile = fromApple;
@@ -76,10 +77,16 @@ export async function POST(request: NextRequest) {
     userId = await resolveOAuthUserId({
       provider: "apple",
       providerAccountId: sub,
-      email,
+      email: emailForResolution,
       profile: { name: nameForProfile },
     });
   } catch (error) {
+    if (error instanceof OAuthEmailRequiredError) {
+      return NextResponse.json(
+        { error: "Email required for first sign-in with this Apple ID" },
+        { status: 400 },
+      );
+    }
     console.error("apple-native user resolution error:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }

--- a/src/app/api/auth/apple-native/route.ts
+++ b/src/app/api/auth/apple-native/route.ts
@@ -1,0 +1,111 @@
+import { createRemoteJWKSet, jwtVerify } from "jose";
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { users } from "@/db/schema";
+import { createToken, SP_TOKEN_COOKIE } from "@/lib/auth";
+import { resolveOAuthUserId } from "@/lib/oauth-user-resolution";
+
+const APPLE_JWKS = createRemoteJWKSet(new URL("https://appleid.apple.com/auth/keys"));
+const ISSUER = "https://appleid.apple.com";
+
+function defaultIOSAudience(): string {
+  return process.env.AUTH_APPLE_IOS_AUDIENCE ?? "com.brettonauerbach.stillpoint";
+}
+
+type AppleUserPayload = {
+  name?: { firstName?: string; lastName?: string };
+  email?: string;
+};
+
+type RequestBody = {
+  identityToken?: string;
+  authorizationCode?: string;
+  user?: AppleUserPayload;
+};
+
+function displayNameFromAppleUser(u: AppleUserPayload | undefined): string | null {
+  if (!u?.name) return null;
+  const { firstName = "", lastName = "" } = u.name;
+  const combined = `${firstName} ${lastName}`.trim();
+  return combined || null;
+}
+
+export async function POST(request: NextRequest) {
+  let body: RequestBody;
+  try {
+    body = (await request.json()) as RequestBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const identityToken = typeof body.identityToken === "string" ? body.identityToken : "";
+  if (!identityToken) {
+    return NextResponse.json({ error: "identityToken required" }, { status: 400 });
+  }
+
+  let sub: string;
+  let email: string;
+  try {
+    const { payload } = await jwtVerify(identityToken, APPLE_JWKS, {
+      issuer: ISSUER,
+      audience: defaultIOSAudience(),
+    });
+    if (typeof payload.sub !== "string" || !payload.sub) {
+      return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+    }
+    sub = payload.sub;
+    const emailClaim = payload.email;
+    if (typeof emailClaim !== "string" || !emailClaim.trim()) {
+      return NextResponse.json({ error: "Email not available" }, { status: 401 });
+    }
+    email = emailClaim.trim().toLowerCase();
+    const ev = payload.email_verified;
+    if (ev !== true && ev !== "true") {
+      return NextResponse.json({ error: "Email not verified" }, { status: 401 });
+    }
+  } catch {
+    return NextResponse.json({ error: "Invalid identity token" }, { status: 401 });
+  }
+
+  const fromApple = displayNameFromAppleUser(body.user);
+  const nameForProfile = fromApple;
+
+  let userId: string;
+  try {
+    userId = await resolveOAuthUserId({
+      provider: "apple",
+      providerAccountId: sub,
+      email,
+      profile: { name: nameForProfile },
+    });
+  } catch (error) {
+    console.error("apple-native user resolution error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+
+  const [user] = await db.select().from(users).where(eq(users.id, userId)).limit(1);
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 500 });
+  }
+
+  const token = await createToken({ userId: user.id, email: user.email });
+  const res = NextResponse.json({
+    user: {
+      id: user.id,
+      email: user.email,
+      username: user.username,
+      isPublic: user.isPublic,
+      currentDay: user.currentDay,
+    },
+    token,
+  });
+  res.cookies.set(SP_TOKEN_COOKIE, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: 60 * 60 * 24 * 7,
+    path: "/",
+  });
+  return res;
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -210,6 +210,18 @@ export default function PrivacyPolicyPage() {
             </a>
             .
           </li>
+          <li>
+            <strong style={{ color: "var(--fg)" }}>Apple (Sign in with Apple):</strong>{" "}
+            <a
+              href="https://www.apple.com/legal/privacy/data/en/sign-in-with-apple/"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: "var(--accent-green-text)", textDecoration: "underline" }}
+            >
+              Apple data-use policy for Sign in with Apple
+            </a>
+            .
+          </li>
         </ul>
 
         <h2 style={sectionTitle}>Retention and your choices</h2>

--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -11,11 +11,11 @@ const OAUTH_ERROR_MESSAGES: Record<string, string> = {
   oauth_session_missing: "Sign-in didn't complete. Please try again.",
   oauth_user_missing: "We couldn't find your account. Please try again.",
   oauth_internal_error: "Something went wrong on our end. Please try again.",
-  OAuthSignin: "Couldn't start Google sign-in. Please try again.",
-  OAuthCallback: "Google sign-in was cancelled or failed.",
+  OAuthSignin: "Couldn't start sign-in. Please try again.",
+  OAuthCallback: "Sign-in was cancelled or failed.",
   OAuthCreateAccount: "Couldn't create your account. Please try again.",
   AccessDenied: "Access denied. Please try again.",
-  Verification: "We couldn't verify your Google account.",
+  Verification: "We couldn't verify your account.",
   Configuration: "Sign-in is temporarily unavailable.",
 };
 
@@ -127,12 +127,8 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
             params.delete("error");
             const search = params.toString();
             const callbackUrl = `${window.location.pathname}${search ? `?${search}` : ""}`;
-            // Auth.js v5 changed the contract: GET /api/auth/signin/<provider>
-            // is rejected with UnknownAction. Signin requires POST + CSRF.
-            // The signIn() helper from next-auth/react fetches the CSRF
-            // token, posts the form, and navigates the browser to Google's
-            // authorize URL — same UX as the previous direct navigation,
-            // correct v5 contract.
+            // Auth.js v5: sign-in must use POST + CSRF via signIn() — a bare
+            // GET to /api/auth/signin?provider=google is rejected.
             void signIn("google", { callbackUrl });
           }}
           style={{
@@ -167,6 +163,46 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
             <path fill="#EA4335" d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.962L3.964 7.294C4.672 5.167 6.656 3.58 9 3.58z"/>
           </svg>
           Continue with Google
+        </button>
+
+        <button
+          type="button"
+          onClick={() => {
+            const params = new URLSearchParams(window.location.search);
+            params.delete("error");
+            const search = params.toString();
+            const callbackUrl = `${window.location.pathname}${search ? `?${search}` : ""}`;
+            void signIn("apple", { callbackUrl });
+          }}
+          style={{
+            background: "#000000",
+            border: "1px solid #000000",
+            color: "#ffffff",
+            fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+            fontSize: "15px",
+            padding: "12px 16px",
+            borderRadius: "30px",
+            cursor: "pointer",
+            transition: "all 0.3s",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "10px",
+          }}
+          onMouseEnter={e => {
+            e.currentTarget.style.background = "#1a1a1a";
+            e.currentTarget.style.borderColor = "#1a1a1a";
+          }}
+          onMouseLeave={e => {
+            e.currentTarget.style.background = "#000000";
+            e.currentTarget.style.borderColor = "#000000";
+          }}
+          aria-label="Continue with Apple"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor">
+            <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
+          </svg>
+          Continue with Apple
         </button>
 
         <p style={{

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -72,7 +72,7 @@ export const accountDeletionLog = pgTable("account_deletion_log", {
 /** OAuth provider identities linked to a user (#136).
  *  One row per (provider, providerAccountId); a single user may have
  *  multiple rows (one per provider). Email-match account linking is
- *  performed in `src/lib/auth-config.ts` signIn callback. */
+ *  performed in `src/lib/oauth-user-resolution.ts` (Auth.js + native Apple). */
 export const oauthAccounts = pgTable("oauth_accounts", {
   id: uuid("id").primaryKey().defaultRandom(),
   userId: uuid("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),

--- a/src/lib/apple-client-secret.ts
+++ b/src/lib/apple-client-secret.ts
@@ -3,10 +3,10 @@ import { SignJWT, importPKCS8 } from "jose";
 const APPLE_JWT_AUDIENCE = "https://appleid.apple.com";
 /** Apple allows up to 6 months; stay under with ample margin for cache refresh. */
 const SECRET_TTL_SECONDS = 130 * 24 * 60 * 60;
-/** Regenerate before Apple's max lifetime (~6 months). */
-const CACHE_MAX_MS = 140 * 24 * 60 * 60 * 1000;
+/** Refresh before JWT exp — must stay below SECRET_TTL_SECONDS wall time. */
+const CACHE_REFRESH_SKEW_MS = 7 * 24 * 60 * 60 * 1000;
 
-let cache: { jwt: string; mintedAt: number } | null = null;
+let cache: { jwt: string; expiresAt: number } | null = null;
 
 function requireAppleSigningEnv() {
   const teamId = process.env.APPLE_TEAM_ID;
@@ -49,10 +49,10 @@ export async function mintAppleClientSecret(): Promise<string> {
 /** Cached secret for Auth.js Apple provider (avoids re-importing the key every request). */
 export async function getAppleClientSecret(): Promise<string> {
   const now = Date.now();
-  if (cache && now - cache.mintedAt < CACHE_MAX_MS) {
+  if (cache && now < cache.expiresAt - CACHE_REFRESH_SKEW_MS) {
     return cache.jwt;
   }
   const jwt = await mintAppleClientSecret();
-  cache = { jwt, mintedAt: now };
+  cache = { jwt, expiresAt: now + SECRET_TTL_SECONDS * 1000 };
   return jwt;
 }

--- a/src/lib/apple-client-secret.ts
+++ b/src/lib/apple-client-secret.ts
@@ -1,0 +1,58 @@
+import { SignJWT, importPKCS8 } from "jose";
+
+const APPLE_JWT_AUDIENCE = "https://appleid.apple.com";
+/** Apple allows up to 6 months; stay under with ample margin for cache refresh. */
+const SECRET_TTL_SECONDS = 130 * 24 * 60 * 60;
+/** Regenerate before Apple's max lifetime (~6 months). */
+const CACHE_MAX_MS = 140 * 24 * 60 * 60 * 1000;
+
+let cache: { jwt: string; mintedAt: number } | null = null;
+
+function requireAppleSigningEnv() {
+  const teamId = process.env.APPLE_TEAM_ID;
+  const clientId = process.env.AUTH_APPLE_ID;
+  const keyId = process.env.APPLE_KEY_ID;
+  const rawKey = process.env.APPLE_PRIVATE_KEY;
+  if (!teamId || !clientId || !keyId || !rawKey) {
+    throw new Error(
+      "Apple Sign In is not configured (need AUTH_APPLE_ID, APPLE_TEAM_ID, APPLE_KEY_ID, APPLE_PRIVATE_KEY)",
+    );
+  }
+  return { teamId, clientId, keyId, rawKey };
+}
+
+function normalizePem(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.includes("\\n")) {
+    return trimmed.replace(/\\n/g, "\n");
+  }
+  return trimmed;
+}
+
+/** Mint the ES256 client secret JWT Apple expects for the web/Services ID flow. */
+export async function mintAppleClientSecret(): Promise<string> {
+  const { teamId, clientId, keyId, rawKey } = requireAppleSigningEnv();
+  const pem = normalizePem(rawKey);
+  const key = await importPKCS8(pem, "ES256");
+  const now = Math.floor(Date.now() / 1000);
+
+  return new SignJWT({})
+    .setProtectedHeader({ alg: "ES256", kid: keyId })
+    .setIssuer(teamId)
+    .setSubject(clientId)
+    .setAudience(APPLE_JWT_AUDIENCE)
+    .setIssuedAt(now)
+    .setExpirationTime(now + SECRET_TTL_SECONDS)
+    .sign(key);
+}
+
+/** Cached secret for Auth.js Apple provider (avoids re-importing the key every request). */
+export async function getAppleClientSecret(): Promise<string> {
+  const now = Date.now();
+  if (cache && now - cache.mintedAt < CACHE_MAX_MS) {
+    return cache.jwt;
+  }
+  const jwt = await mintAppleClientSecret();
+  cache = { jwt, mintedAt: now };
+  return jwt;
+}

--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -14,14 +14,14 @@ function isEmailVerifiedForProvider(
   provider: string,
   profile: { email_verified?: string | boolean | undefined },
 ): boolean {
+  const ev = profile.email_verified;
   if (provider === "google") {
-    return true;
+    return ev !== false && ev !== "false";
   }
   if (provider === "apple") {
-    const ev = profile.email_verified;
     return ev === true || ev === "true";
   }
-  return profile.email_verified === true;
+  return ev === true;
 }
 
 const appleEnvReady =
@@ -30,7 +30,15 @@ const appleEnvReady =
   Boolean(process.env.APPLE_KEY_ID) &&
   Boolean(process.env.APPLE_PRIVATE_KEY);
 
-const appleClientSecretForWeb = appleEnvReady ? await getAppleClientSecret() : undefined;
+let appleClientSecretForWeb: string | undefined;
+if (appleEnvReady) {
+  try {
+    appleClientSecretForWeb = await getAppleClientSecret();
+  } catch (error) {
+    console.error("Apple Sign In: failed to mint client secret; disabling Apple provider:", error);
+    appleClientSecretForWeb = undefined;
+  }
+}
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   trustHost: true,

--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -1,155 +1,36 @@
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
-import { db } from "@/db";
-import { users, oauthAccounts } from "@/db/schema";
-import { and, eq, sql } from "drizzle-orm";
-import {
-  MAX_USERNAME_LENGTH,
-  MIN_USERNAME_LENGTH,
-  USERNAME_REGEX,
-} from "@/lib/username";
-import { uniqueViolationConstraint } from "@/lib/dbErrors";
-
-/** Sanitize a Google profile field into a username candidate that satisfies
- *  the existing users.username constraints (#136 + #8 case-insensitive
- *  uniqueness). The function may still return a colliding name; the
- *  surrounding loop appends random suffixes until a free slot is found. */
-function sanitizeUsernameSeed(seed: string): string {
-  const cleaned = seed.replace(/[^A-Za-z0-9_]/g, "");
-  if (cleaned.length === 0) return "user";
-  return cleaned.slice(0, MAX_USERNAME_LENGTH);
-}
-
-function randomSuffix(length: number): string {
-  return crypto.randomUUID().replace(/-/g, "").slice(0, length);
-}
-
-async function generateUniqueUsername(seed: string): Promise<string> {
-  const base = sanitizeUsernameSeed(seed);
-  const padded = base.length < MIN_USERNAME_LENGTH ? `${base}user`.slice(0, MAX_USERNAME_LENGTH) : base;
-
-  for (let attempt = 0; attempt < 8; attempt++) {
-    const suffix = attempt === 0 ? "" : `_${randomSuffix(4)}`;
-    const candidate = `${padded.slice(0, MAX_USERNAME_LENGTH - suffix.length)}${suffix}`;
-
-    if (!USERNAME_REGEX.test(candidate)) continue;
-    if (candidate.length < MIN_USERNAME_LENGTH || candidate.length > MAX_USERNAME_LENGTH) continue;
-
-    const [collision] = await db
-      .select({ id: users.id })
-      .from(users)
-      .where(sql`lower(${users.username}) = lower(${candidate})`)
-      .limit(1);
-    if (!collision) return candidate;
-  }
-
-  // Last resort: 10-char random suffix. Crypto-RNG keeps the probability of
-  // collision negligible even under contention.
-  return `user_${randomSuffix(10)}`;
-}
-
-/** Insert a (provider, providerAccountId) -> userId link, returning the
- *  userId that ends up owning the link. If a link already exists (race or
- *  re-sign-in), the existing row's userId wins via ON CONFLICT DO NOTHING +
- *  fallback lookup. This guarantees the link/userId mapping is unique. */
-async function linkProviderToUser(
-  provider: string,
-  providerAccountId: string,
-  userId: string,
-): Promise<string> {
-  const inserted = await db
-    .insert(oauthAccounts)
-    .values({ userId, provider, providerAccountId })
-    .onConflictDoNothing({
-      target: [oauthAccounts.provider, oauthAccounts.providerAccountId],
-    })
-    .returning({ userId: oauthAccounts.userId });
-
-  if (inserted.length > 0) return inserted[0].userId;
-
-  // Race: another callback inserted the same link. Use whichever userId
-  // ended up owning it. (Cannot be `userId` we passed in if we lost the
-  // race for an already-linked-to-different-user row.)
-  const [existing] = await db
-    .select({ userId: oauthAccounts.userId })
-    .from(oauthAccounts)
-    .where(
-      and(
-        eq(oauthAccounts.provider, provider),
-        eq(oauthAccounts.providerAccountId, providerAccountId),
-      ),
-    )
-    .limit(1);
-  if (!existing) {
-    throw new Error("oauth_accounts insert returned no rows and no existing link");
-  }
-  return existing.userId;
-}
-
-/** Insert a new user, retrying with a fresh username if the
- *  case-insensitive username unique index races. The pre-check in
- *  `generateUniqueUsername()` reduces but does not eliminate the race —
- *  two concurrent first-time OAuth sign-ins with the same name seed could
- *  both pre-check, both pick the same candidate, and both attempt the
- *  same insert. The first wins; the loser regenerates and retries.
- *
- *  Email conflicts collapse via ON CONFLICT DO NOTHING (we re-look-up the
- *  row a sibling callback inserted). Username conflicts cannot be handled
- *  with a single ON CONFLICT clause alongside email, so they're caught as
- *  a Postgres unique_violation and re-attempted with a new candidate. */
-const MAX_USERNAME_RETRIES = 5;
-
-async function createUserWithUsernameRetry(email: string, seed: string): Promise<string> {
-  for (let attempt = 0; attempt <= MAX_USERNAME_RETRIES; attempt++) {
-    const username = await generateUniqueUsername(seed);
-    try {
-      const inserted = await db
-        .insert(users)
-        .values({ email, username })
-        .onConflictDoNothing({ target: users.email })
-        .returning({ id: users.id });
-
-      if (inserted.length > 0) return inserted[0].id;
-
-      // Email conflict — another callback created this user. Look up.
-      const [racedRow] = await db
-        .select({ id: users.id })
-        .from(users)
-        .where(eq(users.email, email))
-        .limit(1);
-      if (!racedRow) {
-        throw new Error("users insert raced and lookup returned no row");
-      }
-      return racedRow.id;
-    } catch (err) {
-      const constraint = uniqueViolationConstraint(err);
-      // uniqueViolationConstraint returns:
-      //   - null  → not a unique_violation, do not retry
-      //   - ""    → unique_violation but driver did not surface the
-      //             constraint name (Neon HTTP can do this)
-      //   - "..." → constraint name string
-      // The email conflict path is handled by onConflictDoNothing above
-      // (no throw), so any unique_violation that reaches here must be on
-      // the username index. Treat empty/unknown names as retryable too,
-      // otherwise an empty-string constraint silently falls through and
-      // the truthy check on `constraint &&` would skip the retry.
-      if (constraint === null) throw err;
-      const isLikelyUsernameConstraint =
-        constraint === "" || constraint.toLowerCase().includes("username");
-      if (isLikelyUsernameConstraint && attempt < MAX_USERNAME_RETRIES) {
-        continue;
-      }
-      throw err;
-    }
-  }
-  throw new Error("Failed to allocate a unique username after retries");
-}
+import Apple from "next-auth/providers/apple";
+import { getAppleClientSecret } from "@/lib/apple-client-secret";
+import { resolveOAuthUserId } from "@/lib/oauth-user-resolution";
 
 declare module "next-auth" {
   interface Session {
     userId?: string;
   }
 }
+
+function isEmailVerifiedForProvider(
+  provider: string,
+  profile: { email_verified?: string | boolean | undefined },
+): boolean {
+  if (provider === "google") {
+    return true;
+  }
+  if (provider === "apple") {
+    const ev = profile.email_verified;
+    return ev === true || ev === "true";
+  }
+  return profile.email_verified === true;
+}
+
+const appleEnvReady =
+  Boolean(process.env.AUTH_APPLE_ID) &&
+  Boolean(process.env.APPLE_TEAM_ID) &&
+  Boolean(process.env.APPLE_KEY_ID) &&
+  Boolean(process.env.APPLE_PRIVATE_KEY);
+
+const appleClientSecretForWeb = appleEnvReady ? await getAppleClientSecret() : undefined;
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   trustHost: true,
@@ -159,14 +40,15 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       clientSecret: process.env.AUTH_GOOGLE_SECRET,
       authorization: { params: { scope: "openid email profile" } },
     }),
+    ...(appleClientSecretForWeb
+      ? [
+          Apple({
+            clientId: process.env.AUTH_APPLE_ID!,
+            clientSecret: appleClientSecretForWeb,
+          }),
+        ]
+      : []),
   ],
-  // Only override `error`. Setting `pages.signIn` to a custom path tells
-  // Auth.js v5 that we render our own signin UI on that path, which
-  // changes the routing — the built-in `/api/auth/signin/<provider>`
-  // route then expects to be reached only via POST+CSRF from that page.
-  // We don't need a custom signin page: AuthScreen renders at /app
-  // whenever sp_token is missing, completely outside Auth.js's flow. The
-  // `signIn()` helper in AuthScreen handles POST+CSRF automatically.
   pages: {
     error: "/app",
   },
@@ -180,73 +62,19 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       const providerAccountId = account.providerAccountId;
       if (!provider || !providerAccountId) return false;
 
-      // Per-provider email-verification check. Auth.js v5 normalises the
-      // raw OIDC `profile` through each provider's `profile()` mapper
-      // BEFORE this callback fires, and Google's default mapper strips
-      // `email_verified`. The signal we trust instead:
-      //   - Google: granting the `email` scope returns a verified address
-      //     by Google's own contract; presence of `profile.email` here is
-      //     the verification signal.
-      //   - Other providers (Microsoft / Facebook / Apple, deferred):
-      //     require an explicit `email_verified === true` claim. An
-      //     unknown verification state must NOT be treated as verified —
-      //     extend this allow-list deliberately as each provider lands.
-      const emailVerified =
-        provider === "google"
-          ? true
-          : (profile as { email_verified?: boolean }).email_verified === true;
-      if (!emailVerified) return false;
+      if (!isEmailVerifiedForProvider(provider, profile as { email_verified?: string | boolean })) {
+        return false;
+      }
 
       const email = rawEmail.trim().toLowerCase();
 
-      // Resolve provider identity FIRST: if (provider, providerAccountId)
-      // is already linked to a user, that's the owner — full stop. Email
-      // matching is only used to attach a *new* provider identity to an
-      // existing email-only account; we must never let an email match
-      // hijack a provider identity that already belongs to a different
-      // user (account-takeover guard).
-      const [existingLink] = await db
-        .select({ userId: oauthAccounts.userId })
-        .from(oauthAccounts)
-        .where(
-          and(
-            eq(oauthAccounts.provider, provider),
-            eq(oauthAccounts.providerAccountId, providerAccountId),
-          ),
-        )
-        .limit(1);
+      const userId = await resolveOAuthUserId({
+        provider,
+        providerAccountId,
+        email,
+        profile: { name: typeof profile.name === "string" ? profile.name : null },
+      });
 
-      let userId: string;
-
-      if (existingLink) {
-        userId = existingLink.userId;
-      } else {
-        // No link yet → resolve target user (existing email match or
-        // freshly created), then link the provider identity to them
-        // atomically. ON CONFLICT collapses concurrent callbacks into a
-        // single row.
-        const [emailMatch] = await db
-          .select({ id: users.id })
-          .from(users)
-          .where(eq(users.email, email))
-          .limit(1);
-
-        let targetUserId: string;
-        if (emailMatch) {
-          targetUserId = emailMatch.id;
-        } else {
-          const seed =
-            (typeof profile.name === "string" && profile.name) ||
-            email.split("@")[0] ||
-            "user";
-          targetUserId = await createUserWithUsernameRetry(email, seed);
-        }
-
-        userId = await linkProviderToUser(provider, providerAccountId, targetUserId);
-      }
-
-      // Auth.js passes `user` into the jwt callback only on initial sign-in;
-      // overwriting `user.id` here is how we hand the database id to the JWT.
       user.id = userId;
       return true;
     },
@@ -262,21 +90,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       return session;
     },
     async redirect({ url, baseUrl }) {
-      // Auth.js may invoke this callback with a relative same-origin path
-      // (e.g. "/app?error=AccessDenied" or a relative `callbackUrl`).
-      // Normalise to an absolute URL up front so the comparisons below
-      // match both relative and absolute forms — without this, relative
-      // values fell through to the final fallback and lost their error /
-      // deep-link state.
       const normalizedUrl = url.startsWith("/") ? `${baseUrl}${url}` : url;
 
-      // Auth.js error redirects (e.g. /app?error=AccessDenied,
-      // /app?error=OAuthCallback) come through here when sign-in fails or
-      // is cancelled. Identify them by the explicit ?error= query param
-      // and pass through unchanged so AuthScreen renders the inline error.
-      // The earlier broader rule (any /app URL) was too wide — the default
-      // post-sign-in callbackUrl is also /app, which would bypass the
-      // sp_token bridge entirely.
       if (
         normalizedUrl.startsWith(`${baseUrl}/app`) &&
         /[?&]error=/.test(normalizedUrl)
@@ -284,21 +99,15 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         return normalizedUrl;
       }
 
-      // Already in our sp_token bridge. Pass through.
       if (normalizedUrl.startsWith(`${baseUrl}/api/auth/oauth-complete`)) {
         return normalizedUrl;
       }
 
-      // Successful sign-in (or any other same-origin destination): route
-      // through the bridge so sp_token is minted before the user lands on
-      // the SPA. Encode the original target as ?return= so the bridge can
-      // honour deep-link/callbackUrl state after minting the cookie.
       if (normalizedUrl.startsWith(baseUrl)) {
         const target = normalizedUrl.slice(baseUrl.length) || "/app";
         return `${baseUrl}/api/auth/oauth-complete?return=${encodeURIComponent(target)}`;
       }
 
-      // Off-origin URL (defensive). Drop and use the bridge default.
       return `${baseUrl}/api/auth/oauth-complete`;
     },
   },

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,7 +3,7 @@ import bcrypt from "bcryptjs";
 import { cookies } from "next/headers";
 import { headers } from "next/headers";
 
-const COOKIE_NAME = "sp_token";
+export const SP_TOKEN_COOKIE = "sp_token";
 
 function getSecret() {
   const secret = process.env.JWT_SECRET;
@@ -38,7 +38,7 @@ export async function verifyToken(token: string): Promise<{ userId: string; emai
 
 export async function setAuthCookie(token: string) {
   const cookieStore = await cookies();
-  cookieStore.set(COOKIE_NAME, token, {
+  cookieStore.set(SP_TOKEN_COOKIE, token, {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax",
@@ -49,12 +49,12 @@ export async function setAuthCookie(token: string) {
 
 export async function clearAuthCookie() {
   const cookieStore = await cookies();
-  cookieStore.delete(COOKIE_NAME);
+  cookieStore.delete(SP_TOKEN_COOKIE);
 }
 
 export async function getCurrentUser(): Promise<{ userId: string; email: string } | null> {
   const cookieStore = await cookies();
-  const tokenFromCookie = cookieStore.get(COOKIE_NAME)?.value;
+  const tokenFromCookie = cookieStore.get(SP_TOKEN_COOKIE)?.value;
   const authorization = (await headers()).get("authorization");
   const tokenFromBearer =
     authorization?.startsWith("Bearer ") ? authorization.slice("Bearer ".length).trim() : null;

--- a/src/lib/oauth-user-resolution.ts
+++ b/src/lib/oauth-user-resolution.ts
@@ -116,16 +116,26 @@ export type OAuthProfileInput = {
   name?: string | null;
 };
 
+/** Thrown when a new account / email-based link is needed but no verified email was supplied
+ *  (e.g. native Apple repeat sign-in with identity token omitting `email`). */
+export class OAuthEmailRequiredError extends Error {
+  constructor() {
+    super("Email is required to create or link a new account for this sign-in");
+    this.name = "OAuthEmailRequiredError";
+  }
+}
+
 /** Resolve or create the app user id for an OAuth provider identity.
  *  Lookup order: existing (provider, providerAccountId) link first;
- *  then email match for linking; else new user. */
+ *  then email match for linking; else new user. `email` may be omitted only when
+ *  an existing oauth_accounts row already exists for (provider, providerAccountId). */
 export async function resolveOAuthUserId(params: {
   provider: string;
   providerAccountId: string;
-  email: string;
+  email?: string | null;
   profile: OAuthProfileInput;
 }): Promise<string> {
-  const { provider, providerAccountId, email, profile } = params;
+  const { provider, providerAccountId, profile } = params;
 
   const [existingLink] = await db
     .select({ userId: oauthAccounts.userId })
@@ -140,6 +150,12 @@ export async function resolveOAuthUserId(params: {
 
   if (existingLink) {
     return existingLink.userId;
+  }
+
+  const rawEmail = params.email;
+  const email = typeof rawEmail === "string" ? rawEmail.trim().toLowerCase() : "";
+  if (!email) {
+    throw new OAuthEmailRequiredError();
   }
 
   const [emailMatch] = await db

--- a/src/lib/oauth-user-resolution.ts
+++ b/src/lib/oauth-user-resolution.ts
@@ -1,0 +1,163 @@
+import { db } from "@/db";
+import { users, oauthAccounts } from "@/db/schema";
+import { and, eq, sql } from "drizzle-orm";
+import {
+  MAX_USERNAME_LENGTH,
+  MIN_USERNAME_LENGTH,
+  USERNAME_REGEX,
+} from "@/lib/username";
+import { uniqueViolationConstraint } from "@/lib/dbErrors";
+
+/** Sanitize a profile seed into a username candidate that satisfies
+ *  users.username constraints (#136 + #8). */
+function sanitizeUsernameSeed(seed: string): string {
+  const cleaned = seed.replace(/[^A-Za-z0-9_]/g, "");
+  if (cleaned.length === 0) return "user";
+  return cleaned.slice(0, MAX_USERNAME_LENGTH);
+}
+
+function randomSuffix(length: number): string {
+  return crypto.randomUUID().replace(/-/g, "").slice(0, length);
+}
+
+async function generateUniqueUsername(seed: string): Promise<string> {
+  const base = sanitizeUsernameSeed(seed);
+  const padded = base.length < MIN_USERNAME_LENGTH ? `${base}user`.slice(0, MAX_USERNAME_LENGTH) : base;
+
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const suffix = attempt === 0 ? "" : `_${randomSuffix(4)}`;
+    const candidate = `${padded.slice(0, MAX_USERNAME_LENGTH - suffix.length)}${suffix}`;
+
+    if (!USERNAME_REGEX.test(candidate)) continue;
+    if (candidate.length < MIN_USERNAME_LENGTH || candidate.length > MAX_USERNAME_LENGTH) continue;
+
+    const [collision] = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(sql`lower(${users.username}) = lower(${candidate})`)
+      .limit(1);
+    if (!collision) return candidate;
+  }
+
+  return `user_${randomSuffix(10)}`;
+}
+
+/** Insert a (provider, providerAccountId) -> userId link, returning the
+ *  userId that ends up owning the link. */
+export async function linkProviderToUser(
+  provider: string,
+  providerAccountId: string,
+  userId: string,
+): Promise<string> {
+  const inserted = await db
+    .insert(oauthAccounts)
+    .values({ userId, provider, providerAccountId })
+    .onConflictDoNothing({
+      target: [oauthAccounts.provider, oauthAccounts.providerAccountId],
+    })
+    .returning({ userId: oauthAccounts.userId });
+
+  if (inserted.length > 0) return inserted[0].userId;
+
+  const [existing] = await db
+    .select({ userId: oauthAccounts.userId })
+    .from(oauthAccounts)
+    .where(
+      and(
+        eq(oauthAccounts.provider, provider),
+        eq(oauthAccounts.providerAccountId, providerAccountId),
+      ),
+    )
+    .limit(1);
+  if (!existing) {
+    throw new Error("oauth_accounts insert returned no rows and no existing link");
+  }
+  return existing.userId;
+}
+
+const MAX_USERNAME_RETRIES = 5;
+
+async function createUserWithUsernameRetry(email: string, seed: string): Promise<string> {
+  for (let attempt = 0; attempt <= MAX_USERNAME_RETRIES; attempt++) {
+    const username = await generateUniqueUsername(seed);
+    try {
+      const inserted = await db
+        .insert(users)
+        .values({ email, username })
+        .onConflictDoNothing({ target: users.email })
+        .returning({ id: users.id });
+
+      if (inserted.length > 0) return inserted[0].id;
+
+      const [racedRow] = await db
+        .select({ id: users.id })
+        .from(users)
+        .where(eq(users.email, email))
+        .limit(1);
+      if (!racedRow) {
+        throw new Error("users insert raced and lookup returned no row");
+      }
+      return racedRow.id;
+    } catch (err) {
+      const constraint = uniqueViolationConstraint(err);
+      if (constraint === null) throw err;
+      const isLikelyUsernameConstraint =
+        constraint === "" || constraint.toLowerCase().includes("username");
+      if (isLikelyUsernameConstraint && attempt < MAX_USERNAME_RETRIES) {
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw new Error("Failed to allocate a unique username after retries");
+}
+
+export type OAuthProfileInput = {
+  name?: string | null;
+};
+
+/** Resolve or create the app user id for an OAuth provider identity.
+ *  Lookup order: existing (provider, providerAccountId) link first;
+ *  then email match for linking; else new user. */
+export async function resolveOAuthUserId(params: {
+  provider: string;
+  providerAccountId: string;
+  email: string;
+  profile: OAuthProfileInput;
+}): Promise<string> {
+  const { provider, providerAccountId, email, profile } = params;
+
+  const [existingLink] = await db
+    .select({ userId: oauthAccounts.userId })
+    .from(oauthAccounts)
+    .where(
+      and(
+        eq(oauthAccounts.provider, provider),
+        eq(oauthAccounts.providerAccountId, providerAccountId),
+      ),
+    )
+    .limit(1);
+
+  if (existingLink) {
+    return existingLink.userId;
+  }
+
+  const [emailMatch] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1);
+
+  let targetUserId: string;
+  if (emailMatch) {
+    targetUserId = emailMatch.id;
+  } else {
+    const seed =
+      (typeof profile.name === "string" && profile.name) ||
+      email.split("@")[0] ||
+      "user";
+    targetUserId = await createUserWithUsernameRetry(email, seed);
+  }
+
+  return linkProviderToUser(provider, providerAccountId, targetUserId);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,6 +7,7 @@ const publicExactPaths = [
   "/api/auth/signup",
   "/api/auth/login",
   "/api/auth/logout",
+  "/api/auth/apple-native",
   "/api/auth/google/callback",
   "/api/auth/oauth-complete",
   // Auth.js v5 catch-all routes (#136) — bare endpoints. The catch-all


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds **Sign in with Apple** for the web using Auth.js’s built-in Apple provider and a **native iOS** path via `POST /api/auth/apple-native` (JWKS verification — Auth.js does not handle native identity tokens).

Account linking uses **`oauth_accounts` with `provider='apple'` and `sub` as `provider_account_id`**, with email only for new-user / link-by-email; subsequent sign-ins resolve by **Apple `sub`**, so Hide My Email relay addresses stay consistent.

## iOS + XCUITest
The **Sign in with Apple** control is **hidden when `SP_UI_TEST_MODE=1`** (UI tests) so the system button’s UIKit hosting does not break email/password hit-testing on CI simulators. Production / dev app runs still show the button.

## Key changes
- `src/lib/apple-client-secret.ts` — ES256 client secret JWT for the Services ID (cached ~5 months)
- `src/lib/oauth-user-resolution.ts` — shared resolution logic for Auth.js + native route
- `src/lib/auth-config.ts` — Apple provider when all four `AUTH_APPLE_ID` / `APPLE_*` vars are set
- `src/app/api/auth/apple-native/route.ts` — verify `identityToken` against Apple JWKS; optional `AUTH_APPLE_IOS_AUDIENCE` (defaults to bundle id `com.brettonauerbach.stillpoint`)
- `src/components/AuthScreen.tsx` — black Apple button using `signIn("apple")` (Auth.js POST+CSRF contract)
- `docs/mobile-oauth-integration.md` — native handshake, Hide My Email caveats, UI test gating note, pointers to **#338** / **#339**
- iOS: `SignInWithAppleButton`, `AppleSignInController.swift`, `APIClient.signInWithApple`, Sign in with Apple entitlement; **UI test gating** in `AuthView`

## Env vars (verify in Vercel Production + local `.env.local`; never commit `.p8`)
- `AUTH_APPLE_ID` — Services ID (`com.brettonauerbach.stillpoint.web.signin`)
- `APPLE_TEAM_ID`, `APPLE_KEY_ID`, `APPLE_PRIVATE_KEY`

## Testing performed (automated)
- `npm run test:unit`
- `npm run build`

## Manual QA (required — agent cannot complete)
- [ ] Web SIWA on Vercel preview/production with real Apple ID + Hide My Email twice (same user row)
- [ ] Native SIWA on a **physical** iOS device
- [ ] Confirm Vercel env: all four Apple variables present (GitHub `gh secret list` was **403** in this environment)

`coderabbit review --prompt-only` is not available in the agent environment (binary missing).

Closes #286
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aef659b1-8a0b-471b-b34c-158a4bf5422f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aef659b1-8a0b-471b-b34c-158a4bf5422f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Add Sign in with Apple on web and native iOS**

### What Changed
- Users can now sign in with Apple on the web and in the iOS app, and successful sign-in creates the same session token used by other login methods.
- Native Apple sign-in now verifies Apple’s token on the server, accepts repeat sign-ins without email, and still creates or links accounts correctly on first sign-in.
- The iOS auth screen now shows an Apple sign-in button, shares one in-flight guard across email/password and Apple sign-in, and ignores Apple cancel actions.
- Sign in with Apple is hidden during UI tests so email and password fields keep working reliably on CI simulators.
- The privacy page now includes Apple’s Sign in with Apple privacy policy link, and the mobile OAuth docs and examples were updated for the new flow.

### Impact
`✅ Faster Apple sign-in on web and iPhone`
`✅ Fewer failed repeat logins for Hide My Email users`
`✅ More reliable CI sign-in tests on iOS`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=crTGNtrNh6S7lG0VmcfNZWHXrAbNtU1Ce_zJBD0zpdQ&org=auerbachb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
