### PR TITLE
docs(#348): Phase 2 daily app gate spec (blocked on Phase 1)

### DIFF
--- a/docs/issues/348-phase2-spec.md
+++ b/docs/issues/348-phase2-spec.md
@@ -62,7 +62,7 @@ File separate bugs for anything broken beyond the model change.
 
 ## Phase 2 target state machine
 
-```
+```text
 States: MORNING_BLOCKED | EARNED_UNLOCKED  (per calendar day, device local TZ)
 
 MORNING_BLOCKED + session_completed_today     → EARNED_UNLOCKED

--- a/docs/issues/348-phase2-spec.md
+++ b/docs/issues/348-phase2-spec.md
@@ -1,0 +1,177 @@
+# Issue #348 — Phase 2 refactor spec (draft)
+
+**Status:** Blocked on Phase 1 real-device verify + design sign-off in [#348](https://github.com/auerbachb/still-point/issues/348).
+
+## Phase 1 — Owner: human (real iOS device)
+
+Use this checklist when posting findings on the issue:
+
+| Step | Expected (PR #271 / `main`) | Pass? | Notes |
+|------|-----------------------------|-------|-------|
+| Install TestFlight build with Family Controls entitlement | App installs; Settings shows **APP GATE** | | |
+| Grant Screen Time permission | Picker opens after "Choose apps" | | |
+| Select 1–2 apps | `selectedCount` badge; status: blocked until session | | |
+| Open blocked app before sit | Shield / block UI from iOS | | |
+| Complete **standard** timer naturally | Completion shows **APP GATE OPEN**; apps usable | | |
+| End session **early** | No unlock; apps stay blocked | | |
+| Wait 2+ hours (or change device time) | Apps re-block; status no longer "Unlocked until …" | | |
+| **Quick minute** (#239) complete | Apps stay blocked (by design today) | | |
+| Buddy session complete | Apps unlock (`unlockAppGate: true` always) | | |
+| Foreground after background | `RootView` calls `refreshShielding()` — state consistent | | |
+| Add app to list while **unlocked** | New app should stay open until 2hr window ends | | |
+| "Lock now" while unlocked | Immediate re-block | | |
+
+File separate bugs for anything broken beyond the model change.
+
+---
+
+## Static audit of merged PR #271 (`AppBlockingManager`)
+
+**Surface area (14 files in PR #271):**
+
+- `ios/StillPointApp/Managers/AppBlockingManager.swift` — core state + shields
+- `ios/StillPointApp/Views/AppBlockingSettingsView.swift` — picker + copy
+- `ios/StillPointApp/ViewModels/AppViewModel.swift` — `completeSession(unlockAppGate:)`
+- `ios/StillPointApp/Views/SessionView.swift`, `CompletionView.swift`, `HomeView.swift`, `RootView.swift`
+- `StillPoint.entitlements` — `com.apple.developer.family-controls`
+- UITest: `testCompletedSessionUnlocksConfiguredAppGate` (settings smoke only; no shield E2E)
+
+**Current model (time-based):**
+
+- `unlockUntil = Date() + 2 hours` on natural **standard** completion
+- `isUnlocked` ⇔ `unlockUntil > Date()`
+- Midnight **not** used; timer + foreground `refreshShielding()` handle expiry
+- Quick sessions: `unlockAppGate: completedNaturally && sessionType == .standard` → **no** unlock
+- Buddy: `unlockAppGate: true` always → unlocks gate even without standard sit
+
+**Gap vs Phase 2 AC — "mid-day toggle off":**
+
+- No master on/off toggle today. Disabling ≈ clear selection or "Lock now" (only while unlocked).
+- Phase 2 should add **`appBlocking.isEnabled`** (or equivalent) with immediate `clearShielding()` when turned off.
+
+**Gap vs daily model — second session early end:**
+
+- `completeSession(..., unlockAppGate: false)` calls `prepareForSession()`, which **clears** `unlockUntil`.
+- If user already earned unlock today, a later abandoned sit would **re-lock** under a daily model unless `prepareForSession` is changed to preserve `unlockedForDate` for the calendar day.
+
+**Mid-day blocklist add (while unlocked):**
+
+- `refreshShielding()` → `clearShielding()` when `isUnlocked` — new tokens stay open until window ends. ✓ aligns with Phase 2 "earned" behavior.
+
+---
+
+## Phase 2 target state machine
+
+```
+States: MORNING_BLOCKED | EARNED_UNLOCKED  (per calendar day, device local TZ)
+
+MORNING_BLOCKED + session_completed_today     → EARNED_UNLOCKED
+EARNED_UNLOCKED + local_midnight              → MORNING_BLOCKED
+Any + blocking_disabled (toggle off)            → shields cleared immediately
+EARNED_UNLOCKED + add_apps_to_blocklist       → new apps stay UNLOCKED today
+MORNING_BLOCKED + add_apps_to_blocklist       → new apps BLOCKED immediately
+```
+
+### Persistence (replace v1 time keys)
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `appBlocking.selection.v1` | Data | unchanged |
+| `appBlocking.unlockedForDate.v1` | Date | last calendar day user **earned** unlock (start-of-day or completion instant — use `Calendar.current.startOfDay` for comparisons) |
+| `appBlocking.isEnabled.v1` | Bool | master gate toggle (default `true` when selection non-empty) |
+
+Remove: `appBlocking.unlockUntil.v1`, `unlockWindow`, 2-hour timer (replace with optional **midnight** one-shot timer for foreground-across-midnight).
+
+### Core logic changes (`AppBlockingManager`)
+
+```swift
+var isUnlocked: Bool {
+    guard isEnabled, hasSelection, let unlockedForDate else { return false }
+    return Calendar.current.isDateInToday(unlockedForDate)
+}
+
+func unlockAfterCompletedSession() {
+    unlockedForDate = Date() // or startOfDay(for: Date())
+    // persist, clearShielding(), didUnlockFromLastCompletedSession = true
+}
+
+func refreshShielding() {
+    if let unlockedForDate, !Calendar.current.isDateInToday(unlockedForDate) {
+        self.unlockedForDate = nil // midnight rollover
+    }
+    guard isEnabled, hasSelection else { clearShielding(); return }
+    guard !isUnlocked else { clearShielding(); scheduleMidnightTimerIfNeeded(); return }
+    applyShielding()
+}
+
+func prepareForSession() {
+    // Only reset completion badge — do NOT clear unlockedForDate
+    didUnlockFromLastCompletedSession = false
+}
+```
+
+### `AppViewModel.completeSession`
+
+- Keep `unlockAppGate` gating; align with design decision on quick + buddy (see below).
+- `prepareForSession()` must not revoke today's earned unlock.
+
+### Copy updates
+
+| Location | New copy |
+|----------|----------|
+| `AppBlockingSettingsView` | "Blocked until you complete today's meditation, then unlocked until midnight. Ending early keeps the gate closed." |
+| `statusText` blocked | "Locked — meditate to unlock" |
+| `statusText` unlocked | "Unlocked until midnight" |
+| `HomeView` FAQ | Replace 2-hour wording with daily model |
+| `SessionView` hint | "Complete today's sit to open your app gate…" |
+| Remove `unlockWindowText` | — |
+
+### Tests
+
+- Unit tests on simulator stub: `isUnlocked` across day boundary (inject `Calendar` or test helper with fixed dates).
+- UITest: update status string expectations; optional launch-arg to seed `unlockedForDate`.
+- Real device: full cycle AC (human).
+
+---
+
+## Design decisions — need issue comment sign-off
+
+### 1. Quick minute (#239) counts for today's meditation?
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A. Standard only** (current code) | Stronger incentive for full sit | Quick sit doesn't help gate |
+| **B. Any completed sit** (quick + standard) | Light-touch; matches issue suggestion | 60s may feel like "gaming" the gate |
+
+**Agent recommendation:** **B** if product goal is "any mindfulness today"; **A** if gate is strictly tied to daily progression sit. Document choice in PR body.
+
+**Code today:** `SessionView` passes `unlockAppGate: completedNaturally && sessionType == .standard`.
+
+### 2. Feature flag vs dual mode (casual 2hr / strict daily)?
+
+| Option | Notes |
+|--------|-------|
+| Replace 2hr entirely | Simplest; matches issue default |
+| Feature flag | Safer rollout; more branches in manager |
+| Settings: Casual (2hr) / Strict (daily) | User-visible complexity |
+
+**Agent recommendation:** Ship **daily-only** on `main` unless Phase 1 finds 2hr behavior users rely on — then flag.
+
+### 3. Buddy sessions
+
+**Today:** always `unlockAppGate: true`. **Recommend:** same as quick-minute decision — if "any completed sit counts," include buddy; else standard-only.
+
+### 4. Master toggle
+
+Add **Enable app gate** toggle in `AppBlockingSettingsView`; off → `clearShielding()` immediately, persist `isEnabled = false`.
+
+---
+
+## Implementation order (after gates)
+
+1. Manager: date-based state + midnight rollover + `isEnabled` + fix `prepareForSession`
+2. ViewModel / session call sites per design decisions
+3. Copy (Settings, Home, Session, Completion)
+4. Tests + CodeRabbit + real-device full-day cycle
+
+**Do not open Phase 2 PR until Phase 1 comment exists and decisions 1–2 are agreed on the issue.**


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Planning-only PR for **#348**. Does **not** implement Phase 2 or close the issue.

Per issue protocol:
- **Phase 1** (real iOS device verify of PR #271) must be completed by a human with findings on the issue.
- **Design decisions** (quick-minute counts, feature flag vs daily-only) must be signed off on the issue before `AppBlockingManager` refactor lands.

## What's in this PR

- [`docs/issues/348-phase2-spec.md`](docs/issues/348-phase2-spec.md): state machine, persistence migration (`unlockUntil` → `unlockedForDate`), copy table, test plan, static audit of merged PR #271, and open design choices.

## Static audit highlights (PR #271 on `main`)

| Area | Current behavior |
|------|------------------|
| Unlock model | 2-hour `unlockUntil` window |
| Standard sit (natural complete) | Unlocks gate |
| Quick minute | Does **not** unlock |
| Buddy sit | Always unlocks |
| Master toggle | **Missing** — needs `isEnabled` for AC |
| Second sit ended early | `prepareForSession()` clears unlock — **must change** for daily model |

## Design decisions (need issue comment)

1. **Quick minute (#239):** count for today's meditation? *Spec recommends yes; code is standard-only today.*
2. **Rollout:** daily-only vs feature flag vs casual/strict dual mode? *Spec recommends daily-only unless Phase 1 says otherwise.*
3. **Buddy:** include in unlock-eligible sits?

## Next steps

1. Human: Phase 1 device checklist → comment on #348
2. Sign off decisions 1–3 on the issue
3. Follow-up PR: implement Phase 2 per spec (`Closes #348`)

Related: PR #271 (merged), replaces #248.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31932228-353f-4f0e-92fb-e9c596d0668c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31932228-353f-4f0e-92fb-e9c596d0668c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Phase 2 spec for app-gating describing a daily state machine with local-day earned unlocks and midnight rollover.
  * Specifies a master enable/disable toggle, preservation of earned unlocks across sessions, and revised unlock persistence.
  * Includes proposed UI/status copy, day-boundary testing guidance, design decisions needing sign-off, and an implementation order.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/auerbachb/still-point/pull/351?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Draft the Phase 2 daily app gate plan for issue #348**

### What Changed
- Adds a full Phase 2 spec for moving the app gate from a 2-hour unlock window to a daily unlock that lasts until midnight
- Defines the expected user flow for blocked, unlocked, and re-blocked states, including what happens when the gate is turned off, apps are added, or a session ends early
- Replaces the current time-based storage plan with calendar-day unlock tracking and a master enable/disable setting
- Updates the planned user-facing copy for Settings, Home, and Session screens to match the daily model
- Lists the required tests, real-device verification steps, and the remaining product decisions that must be signed off before implementation

### Impact
`✅ Clearer app gate behavior for daily meditation`
`✅ Fewer unlock-state misunderstandings`
`✅ Safer rollout after real-device verification`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
