### PR TITLE
feat(buddy): normalize session length to shortest participant (#349)

### DIFF
--- a/e2e/buddy/buddy-session-length.integration.spec.ts
+++ b/e2e/buddy/buddy-session-length.integration.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "@playwright/test";
+import { BASE_DURATION, durationForDay } from "../../src/lib/constants";
+
+function localIsoDate() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+async function signup(
+  request: import("@playwright/test").APIRequestContext,
+  label: string,
+) {
+  const rid = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+  const email = `ci_buddy_${label}_${rid}@stillpoint.test`;
+  const username = `buddy_${label}_${rid}`;
+  const password = "password123";
+  const response = await request.post("/api/auth/signup", {
+    data: { email, username, password },
+  });
+  expect(response.status(), await response.text()).toBe(200);
+  return { email, username, password };
+}
+
+async function advanceToDay(
+  request: import("@playwright/test").APIRequestContext,
+  targetDay: number,
+) {
+  for (let day = 1; day < targetDay; day += 1) {
+    const duration = durationForDay(day);
+    const response = await request.post("/api/sessions", {
+      data: {
+        dayNumber: day,
+        sessionType: "standard",
+        duration,
+        completed: true,
+        actualTime: duration,
+        clearPercent: 80,
+        thoughtCount: 0,
+        mindStateLog: [],
+        sessionDate: localIsoDate(),
+      },
+    });
+    expect(response.status(), await response.text()).toBe(200);
+  }
+}
+
+/**
+ * Real API + Postgres (#349). Same env as @authDbIntegration (see e2e/README.md).
+ */
+test.describe("@authDbIntegration buddy session length normalization", () => {
+  test.beforeEach(() => {
+    test.skip(
+      !process.env.POSTGRES_URL?.trim() || !process.env.JWT_SECRET?.trim(),
+      "POSTGRES_URL and JWT_SECRET required for buddy length integration (see e2e/README.md).",
+    );
+  });
+
+  test("two users with different sit lengths share the shorter buddy duration after join", async ({
+    browser,
+  }) => {
+    const baseURL =
+      process.env.E2E_BASE_URL?.trim() ||
+      process.env.PLAYWRIGHT_BASE_URL?.trim() ||
+      "http://127.0.0.1:3000";
+
+    const hostDay = 5;
+    const guestDay = 1;
+    const expectedSeconds = Math.max(BASE_DURATION, durationForDay(guestDay));
+
+    const hostContext = await browser.newContext({ baseURL });
+    const guestContext = await browser.newContext({ baseURL });
+
+    try {
+      await signup(hostContext.request, "host");
+      await advanceToDay(hostContext.request, hostDay);
+      await signup(guestContext.request, "guest");
+
+      const createRes = await hostContext.request.post("/api/buddy/sessions", {
+        data: {},
+      });
+      expect(createRes.status(), await createRes.text()).toBe(200);
+      const created = (await createRes.json()) as {
+        session: { id: string; shareToken: string; durationSeconds: number };
+      };
+      expect(created.session.durationSeconds).toBe(durationForDay(hostDay));
+
+      const joinRes = await guestContext.request.post("/api/buddy/sessions/join", {
+        data: { token: created.session.shareToken },
+      });
+      expect(joinRes.status(), await joinRes.text()).toBe(200);
+
+      const snapshotRes = await hostContext.request.get(
+        `/api/buddy/sessions/${created.session.id}`,
+      );
+      expect(snapshotRes.status(), await snapshotRes.text()).toBe(200);
+      const snapshot = (await snapshotRes.json()) as {
+        snapshot: { durationSeconds: number };
+      };
+      expect(snapshot.snapshot.durationSeconds).toBe(expectedSeconds);
+    } finally {
+      await hostContext.close();
+      await guestContext.close();
+    }
+  });
+});

--- a/ios/StillPointApp/Views/BuddySession/BuddySessionHubView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddySessionHubView.swift
@@ -26,6 +26,11 @@ struct BuddySessionHubView: View {
                     .foregroundStyle(Color(SPColor.fg2))
                     .multilineTextAlignment(.center)
 
+                Text("Buddy sits use the shortest of everyone's current sit length (at least 1 minute). The group timer is set automatically—you can't choose a longer session.")
+                    .font(SPFont.serif(15, weight: .light))
+                    .foregroundStyle(Color(SPColor.fg2))
+                    .multilineTextAlignment(.center)
+
                 if let errorMessage {
                     Text(errorMessage)
                         .font(SPFont.mono(12))

--- a/ios/StillPointApp/Views/BuddySession/BuddyWaitingRoomView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyWaitingRoomView.swift
@@ -31,6 +31,12 @@ struct BuddyWaitingRoomView: View {
                         .padding(.horizontal, SPSpacing.s4)
                 }
 
+                Text("Buddy sits use the shortest of everyone's current sit length (at least 1 minute). The group timer is set automatically—you can't choose a longer session.")
+                    .font(SPFont.serif(15, weight: .light))
+                    .foregroundStyle(Color(SPColor.fg2))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, SPSpacing.s4)
+
                 waitingStatusCard
                 participantsList
 

--- a/src/app/api/buddy/sessions/[id]/leave/route.ts
+++ b/src/app/api/buddy/sessions/[id]/leave/route.ts
@@ -5,6 +5,7 @@ import { getCurrentUser } from "@/lib/auth";
 import {
   bumpBuddyRevision,
   reconcileBuddySession,
+  syncBuddySessionDurationForParticipants,
   teardownBuddyDailyRoomByName,
 } from "@/lib/buddySession";
 import { hostLeaveShouldAbandonSession } from "@/lib/buddySessionControlsPolicy";
@@ -65,6 +66,7 @@ export async function POST(_request: Request, context: Params) {
         })
         .where(eq(buddySessions.id, sessionId));
     } else {
+      await syncBuddySessionDurationForParticipants(sessionId);
       await bumpBuddyRevision(sessionId);
     }
 

--- a/src/app/api/buddy/sessions/join/route.ts
+++ b/src/app/api/buddy/sessions/join/route.ts
@@ -6,6 +6,7 @@ import {
   assertBuddyFriendshipIfRequired,
   bumpBuddyRevision,
   reconcileBuddySession,
+  syncBuddySessionDurationForParticipants,
 } from "@/lib/buddySession";
 import {
   GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE,
@@ -131,6 +132,7 @@ export async function POST(request: NextRequest) {
           lastSeenAt: now,
         });
       }
+      await syncBuddySessionDurationForParticipants(session.id);
       await bumpBuddyRevision(session.id);
       await reconcileBuddySession(session.id);
       const calendarSync = await syncCalendarBestEffort(session, auth.userId);

--- a/src/app/api/buddy/sessions/join/route.ts
+++ b/src/app/api/buddy/sessions/join/route.ts
@@ -132,10 +132,14 @@ export async function POST(request: NextRequest) {
           lastSeenAt: now,
         });
       }
-      await syncBuddySessionDurationForParticipants(session.id);
+      const normalizedDuration = await syncBuddySessionDurationForParticipants(session.id);
       await bumpBuddyRevision(session.id);
       await reconcileBuddySession(session.id);
-      const calendarSync = await syncCalendarBestEffort(session, auth.userId);
+      const sessionForCalendar =
+        normalizedDuration != null
+          ? { ...session, durationSeconds: normalizedDuration }
+          : session;
+      const calendarSync = await syncCalendarBestEffort(sessionForCalendar, auth.userId);
       return NextResponse.json({
         sessionId: session.id,
         scheduledStartAt: session.scheduledStartAt?.toISOString() ?? null,

--- a/src/app/api/buddy/sessions/join/route.ts
+++ b/src/app/api/buddy/sessions/join/route.ts
@@ -135,10 +135,17 @@ export async function POST(request: NextRequest) {
       const normalizedDuration = await syncBuddySessionDurationForParticipants(session.id);
       await bumpBuddyRevision(session.id);
       await reconcileBuddySession(session.id);
-      const sessionForCalendar =
-        normalizedDuration != null
-          ? { ...session, durationSeconds: normalizedDuration }
-          : session;
+      let sessionForCalendar = session;
+      if (normalizedDuration != null) {
+        sessionForCalendar = { ...session, durationSeconds: normalizedDuration };
+      } else {
+        const [fresh] = await db
+          .select()
+          .from(buddySessions)
+          .where(eq(buddySessions.id, session.id))
+          .limit(1);
+        if (fresh) sessionForCalendar = fresh;
+      }
       const calendarSync = await syncCalendarBestEffort(sessionForCalendar, auth.userId);
       return NextResponse.json({
         sessionId: session.id,

--- a/src/app/api/buddy/sessions/route.test.ts
+++ b/src/app/api/buddy/sessions/route.test.ts
@@ -32,7 +32,7 @@ vi.mock("@/lib/auth", () => ({
 }));
 
 vi.mock("@/lib/buddySession", () => ({
-  buddyDurationForDay: vi.fn(() => 600),
+  normalizedBuddySessionDurationSeconds: vi.fn(() => 600),
 }));
 
 vi.mock("@/lib/google", () => ({
@@ -113,6 +113,20 @@ describe("POST /api/buddy/sessions", () => {
     );
     expect(body.session.scheduledStartAt).toBe(future);
     expect(body.session.calendarSync).toHaveLength(1);
+  });
+
+  test("rejects client-provided durationSeconds override", async () => {
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      buddyCreateRequest({ durationSeconds: 120 } as Record<string, unknown>),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      error: "Session length is set automatically for buddy sessions",
+    });
+    expect(response.status).toBe(400);
+    expect(dbInsert).not.toHaveBeenCalled();
   });
 
   test("creates an immediate session without calendar sync", async () => {

--- a/src/app/api/buddy/sessions/route.ts
+++ b/src/app/api/buddy/sessions/route.ts
@@ -3,36 +3,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { buddySessions, buddySessionParticipants, users } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
-import { buddyDurationForDay } from "@/lib/buddySession";
+import { normalizedBuddySessionDurationSeconds } from "@/lib/buddySession";
+import { readBuddySessionCreateBody } from "@/lib/buddySessionCreateBody";
 import { GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE, syncBuddySessionCalendarForUser } from "@/lib/google";
 import { eq } from "drizzle-orm";
-
-async function readOptionalScheduledStartAt(request: NextRequest): Promise<Date | null | NextResponse> {
-  const text = await request.text();
-  if (!text.trim()) return null;
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(text);
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-  const raw = (parsed as Record<string, unknown>).scheduledStartAt;
-  if (raw == null || raw === "") return null;
-  if (typeof raw !== "string") {
-    return NextResponse.json({ error: "scheduledStartAt must be an ISO timestamp" }, { status: 400 });
-  }
-  const scheduledStartAt = new Date(raw);
-  if (Number.isNaN(scheduledStartAt.getTime())) {
-    return NextResponse.json({ error: "scheduledStartAt must be a valid timestamp" }, { status: 400 });
-  }
-  if (scheduledStartAt.getTime() <= Date.now()) {
-    return NextResponse.json({ error: "scheduledStartAt must be in the future" }, { status: 400 });
-  }
-  return scheduledStartAt;
-}
 
 export async function POST(request: NextRequest) {
   try {
@@ -40,8 +14,9 @@ export async function POST(request: NextRequest) {
     if (!auth) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
-    const scheduledStartAt = await readOptionalScheduledStartAt(request);
-    if (scheduledStartAt instanceof NextResponse) return scheduledStartAt;
+    const createBody = await readBuddySessionCreateBody(request);
+    if (createBody instanceof NextResponse) return createBody;
+    const { scheduledStartAt } = createBody;
 
     const [host] = await db
       .select({ currentDay: users.currentDay })
@@ -52,7 +27,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
     }
 
-    const durationSeconds = buddyDurationForDay(host.currentDay);
+    const durationSeconds = normalizedBuddySessionDurationSeconds([host.currentDay]);
     const shareToken = randomBytes(24).toString("base64url");
 
     const [session] = await db

--- a/src/components/BuddySessionHub.tsx
+++ b/src/components/BuddySessionHub.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { api, ApiError } from "@/lib/api";
+import { BUDDY_SESSION_LENGTH_EXPLAINER } from "@/lib/buddySessionDuration";
 
 function extractBuddyToken(input: string): string {
   const t = input.trim();
@@ -173,6 +174,18 @@ export function BuddySessionHub({ onEnterSession, onBack }: BuddySessionHubProps
         }}
       >
         Create a room now, or schedule a shared sit and let each connected Google Calendar add the agreed time.
+      </p>
+      <p
+        role="note"
+        style={{
+          fontSize: "13px",
+          color: "var(--fg-3)",
+          lineHeight: 1.45,
+          textAlign: "center",
+          margin: 0,
+        }}
+      >
+        {BUDDY_SESSION_LENGTH_EXPLAINER}
       </p>
 
       <div

--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -3,6 +3,7 @@
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api, ApiError, type BuddySnapshot } from "@/lib/api";
+import { BUDDY_SESSION_LENGTH_EXPLAINER } from "@/lib/buddySessionDuration";
 import { BUDDY_POLICY_CODES, buddyPolicyUserMessage } from "@/lib/buddyPolicyCodes";
 import { useIsMobile } from "@/lib/useIsMobile";
 import { BlockTimer } from "./BlockTimer";
@@ -678,6 +679,19 @@ export function BuddySessionRoom({
 
       {inLobby && (
         <>
+          <p
+            role="note"
+            style={{
+              margin: 0,
+              fontSize: "13px",
+              color: "var(--fg-2)",
+              textAlign: "center",
+              lineHeight: 1.45,
+            }}
+          >
+            {BUDDY_SESSION_LENGTH_EXPLAINER}
+          </p>
+
           <div
             role="status"
             style={{

--- a/src/lib/buddySession.duration.test.ts
+++ b/src/lib/buddySession.duration.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+import { BASE_DURATION } from "@/lib/constants";
+import { normalizedBuddySessionDurationSeconds } from "@/lib/buddySessionDuration";
+
+describe("normalizedBuddySessionDurationSeconds", () => {
+  test("two participants uses the shorter current-day length", () => {
+    expect(normalizedBuddySessionDurationSeconds([1, 5])).toBe(60);
+    expect(normalizedBuddySessionDurationSeconds([5, 1])).toBe(60);
+    expect(normalizedBuddySessionDurationSeconds([3, 3])).toBe(80);
+  });
+
+  test("three participants uses minimum across the group", () => {
+    expect(normalizedBuddySessionDurationSeconds([1, 3, 7])).toBe(60);
+    expect(normalizedBuddySessionDurationSeconds([4, 2, 6])).toBe(70);
+  });
+
+  test("many participants still picks the global minimum", () => {
+    const days = [10, 2, 8, 4, 15, 1, 6];
+    expect(normalizedBuddySessionDurationSeconds(days)).toBe(60);
+    expect(normalizedBuddySessionDurationSeconds([10, 11, 12, 13])).toBe(150);
+  });
+
+  test("floors at one minute when all participants are on day 1", () => {
+    expect(normalizedBuddySessionDurationSeconds([1])).toBe(BASE_DURATION);
+    expect(normalizedBuddySessionDurationSeconds([1, 1, 1])).toBe(BASE_DURATION);
+  });
+
+  test("empty participant list defaults to base duration", () => {
+    expect(normalizedBuddySessionDurationSeconds([])).toBe(BASE_DURATION);
+  });
+});

--- a/src/lib/buddySession.ts
+++ b/src/lib/buddySession.ts
@@ -4,6 +4,7 @@
  * #119: POST …/record-personal-session creates each participant’s own `sessions` row; notes use `thoughts`.
  */
 import { db } from "@/db";
+import { poolDb } from "@/db/pool";
 import {
   buddySessions,
   buddySessionParticipants,
@@ -35,37 +36,39 @@ import { normalizedBuddySessionDurationSeconds } from "@/lib/buddySessionDuratio
 export async function syncBuddySessionDurationForParticipants(
   sessionId: string,
 ): Promise<number | null> {
-  const rows = await db
-    .select({ currentDay: users.currentDay })
-    .from(buddySessionParticipants)
-    .innerJoin(users, eq(buddySessionParticipants.userId, users.id))
-    .where(
-      and(
-        eq(buddySessionParticipants.buddySessionId, sessionId),
-        isNull(buddySessionParticipants.leftAt),
-      ),
+  return poolDb.transaction(async (tx) => {
+    const rows = await tx
+      .select({ currentDay: users.currentDay })
+      .from(buddySessionParticipants)
+      .innerJoin(users, eq(buddySessionParticipants.userId, users.id))
+      .where(
+        and(
+          eq(buddySessionParticipants.buddySessionId, sessionId),
+          isNull(buddySessionParticipants.leftAt),
+        ),
+      );
+
+    if (rows.length === 0) return null;
+
+    const durationSeconds = normalizedBuddySessionDurationSeconds(
+      rows.map((row) => row.currentDay),
     );
 
-  if (rows.length === 0) return null;
+    await tx
+      .update(buddySessions)
+      .set({
+        durationSeconds,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(buddySessions.id, sessionId),
+          inArray(buddySessions.state, ["waiting", "ready_check"]),
+        ),
+      );
 
-  const durationSeconds = normalizedBuddySessionDurationSeconds(
-    rows.map((row) => row.currentDay),
-  );
-
-  await db
-    .update(buddySessions)
-    .set({
-      durationSeconds,
-      updatedAt: new Date(),
-    })
-    .where(
-      and(
-        eq(buddySessions.id, sessionId),
-        inArray(buddySessions.state, ["waiting", "ready_check"]),
-      ),
-    );
-
-  return durationSeconds;
+    return durationSeconds;
+  });
 }
 
 export async function assertBuddyFriendshipIfRequired(

--- a/src/lib/buddySession.ts
+++ b/src/lib/buddySession.ts
@@ -54,7 +54,7 @@ export async function syncBuddySessionDurationForParticipants(
       rows.map((row) => row.currentDay),
     );
 
-    await tx
+    const updated = await tx
       .update(buddySessions)
       .set({
         durationSeconds,
@@ -65,8 +65,10 @@ export async function syncBuddySessionDurationForParticipants(
           eq(buddySessions.id, sessionId),
           inArray(buddySessions.state, ["waiting", "ready_check"]),
         ),
-      );
+      )
+      .returning({ id: buddySessions.id });
 
+    if (updated.length === 0) return null;
     return durationSeconds;
   });
 }

--- a/src/lib/buddySession.ts
+++ b/src/lib/buddySession.ts
@@ -10,10 +10,9 @@ import {
   users,
   friendships,
 } from "@/db/schema";
-import { durationForDay } from "@/lib/constants";
 import { deleteRoom } from "@/lib/daily";
 import { orderedUserPair } from "@/lib/friends";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 
 export type BuddySessionState =
   | "waiting"
@@ -22,8 +21,51 @@ export type BuddySessionState =
   | "completed"
   | "abandoned";
 
-export function buddyDurationForDay(currentDay: number): number {
-  return durationForDay(currentDay);
+export {
+  buddyDurationForDay,
+  BUDDY_SESSION_LENGTH_EXPLAINER,
+  normalizedBuddySessionDurationSeconds,
+} from "@/lib/buddySessionDuration";
+
+import { normalizedBuddySessionDurationSeconds } from "@/lib/buddySessionDuration";
+
+/**
+ * Recompute `durationSeconds` from active lobby participants. Only updates waiting/ready_check sessions.
+ */
+export async function syncBuddySessionDurationForParticipants(
+  sessionId: string,
+): Promise<number | null> {
+  const rows = await db
+    .select({ currentDay: users.currentDay })
+    .from(buddySessionParticipants)
+    .innerJoin(users, eq(buddySessionParticipants.userId, users.id))
+    .where(
+      and(
+        eq(buddySessionParticipants.buddySessionId, sessionId),
+        isNull(buddySessionParticipants.leftAt),
+      ),
+    );
+
+  if (rows.length === 0) return null;
+
+  const durationSeconds = normalizedBuddySessionDurationSeconds(
+    rows.map((row) => row.currentDay),
+  );
+
+  await db
+    .update(buddySessions)
+    .set({
+      durationSeconds,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(buddySessions.id, sessionId),
+        inArray(buddySessions.state, ["waiting", "ready_check"]),
+      ),
+    );
+
+  return durationSeconds;
 }
 
 export async function assertBuddyFriendshipIfRequired(

--- a/src/lib/buddySessionCreateBody.test.ts
+++ b/src/lib/buddySessionCreateBody.test.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from "next/server";
+import { describe, expect, test } from "vitest";
+import { readBuddySessionCreateBody } from "@/lib/buddySessionCreateBody";
+
+describe("readBuddySessionCreateBody", () => {
+  test("rejects client-provided durationSeconds", async () => {
+    const request = new NextRequest("http://test.local/api/buddy/sessions", {
+      method: "POST",
+      body: JSON.stringify({ durationSeconds: 900 }),
+    });
+
+    const result = await readBuddySessionCreateBody(request);
+    expect(result).toBeInstanceOf(Response);
+    if (result instanceof Response) {
+      expect(result.status).toBe(400);
+      await expect(result.json()).resolves.toEqual({
+        error: "Session length is set automatically for buddy sessions",
+      });
+    }
+  });
+});

--- a/src/lib/buddySessionCreateBody.test.ts
+++ b/src/lib/buddySessionCreateBody.test.ts
@@ -18,4 +18,17 @@ describe("readBuddySessionCreateBody", () => {
       });
     }
   });
+
+  test("rejects durationSeconds key even when null", async () => {
+    const request = new NextRequest("http://test.local/api/buddy/sessions", {
+      method: "POST",
+      body: JSON.stringify({ durationSeconds: null }),
+    });
+
+    const result = await readBuddySessionCreateBody(request);
+    expect(result).toBeInstanceOf(Response);
+    if (result instanceof Response) {
+      expect(result.status).toBe(400);
+    }
+  });
 });

--- a/src/lib/buddySessionCreateBody.test.ts
+++ b/src/lib/buddySessionCreateBody.test.ts
@@ -19,6 +19,22 @@ describe("readBuddySessionCreateBody", () => {
     }
   });
 
+  test("rejects non-ISO scheduledStartAt strings", async () => {
+    const request = new NextRequest("http://test.local/api/buddy/sessions", {
+      method: "POST",
+      body: JSON.stringify({ scheduledStartAt: "2026-06-01" }),
+    });
+
+    const result = await readBuddySessionCreateBody(request);
+    expect(result).toBeInstanceOf(Response);
+    if (result instanceof Response) {
+      expect(result.status).toBe(400);
+      await expect(result.json()).resolves.toEqual({
+        error: "scheduledStartAt must be an ISO timestamp",
+      });
+    }
+  });
+
   test("rejects durationSeconds key even when null", async () => {
     const request = new NextRequest("http://test.local/api/buddy/sessions", {
       method: "POST",

--- a/src/lib/buddySessionCreateBody.ts
+++ b/src/lib/buddySessionCreateBody.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export type BuddySessionCreateBody = {
+  scheduledStartAt: Date | null;
+};
+
+function parseScheduledStartAt(raw: unknown): Date | null | NextResponse {
+  if (raw == null || raw === "") return null;
+  if (typeof raw !== "string") {
+    return NextResponse.json({ error: "scheduledStartAt must be an ISO timestamp" }, { status: 400 });
+  }
+  const scheduledStartAt = new Date(raw);
+  if (Number.isNaN(scheduledStartAt.getTime())) {
+    return NextResponse.json({ error: "scheduledStartAt must be a valid timestamp" }, { status: 400 });
+  }
+  if (scheduledStartAt.getTime() <= Date.now()) {
+    return NextResponse.json({ error: "scheduledStartAt must be in the future" }, { status: 400 });
+  }
+  return scheduledStartAt;
+}
+
+/** Parses POST /api/buddy/sessions body; rejects client-provided duration overrides (#349). */
+export async function readBuddySessionCreateBody(
+  request: NextRequest,
+): Promise<BuddySessionCreateBody | NextResponse> {
+  const text = await request.text();
+  if (!text.trim()) {
+    return { scheduledStartAt: null };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const record = parsed as Record<string, unknown>;
+
+  if (
+    "durationSeconds" in record &&
+    record.durationSeconds != null &&
+    record.durationSeconds !== ""
+  ) {
+    return NextResponse.json(
+      { error: "Session length is set automatically for buddy sessions" },
+      { status: 400 },
+    );
+  }
+
+  const scheduled = parseScheduledStartAt(record.scheduledStartAt);
+  if (scheduled instanceof NextResponse) return scheduled;
+
+  return { scheduledStartAt: scheduled };
+}

--- a/src/lib/buddySessionCreateBody.ts
+++ b/src/lib/buddySessionCreateBody.ts
@@ -41,11 +41,7 @@ export async function readBuddySessionCreateBody(
 
   const record = parsed as Record<string, unknown>;
 
-  if (
-    "durationSeconds" in record &&
-    record.durationSeconds != null &&
-    record.durationSeconds !== ""
-  ) {
+  if ("durationSeconds" in record) {
     return NextResponse.json(
       { error: "Session length is set automatically for buddy sessions" },
       { status: 400 },

--- a/src/lib/buddySessionCreateBody.ts
+++ b/src/lib/buddySessionCreateBody.ts
@@ -4,9 +4,15 @@ export type BuddySessionCreateBody = {
   scheduledStartAt: Date | null;
 };
 
+const ISO_TIMESTAMP_RE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
 function parseScheduledStartAt(raw: unknown): Date | null | NextResponse {
   if (raw == null || raw === "") return null;
   if (typeof raw !== "string") {
+    return NextResponse.json({ error: "scheduledStartAt must be an ISO timestamp" }, { status: 400 });
+  }
+  if (!ISO_TIMESTAMP_RE.test(raw)) {
     return NextResponse.json({ error: "scheduledStartAt must be an ISO timestamp" }, { status: 400 });
   }
   const scheduledStartAt = new Date(raw);

--- a/src/lib/buddySessionDuration.ts
+++ b/src/lib/buddySessionDuration.ts
@@ -1,0 +1,20 @@
+import { BASE_DURATION, durationForDay } from "@/lib/constants";
+
+export function buddyDurationForDay(currentDay: number): number {
+  return durationForDay(currentDay);
+}
+
+/** Lobby copy (#349): buddy sits pace to the shortest participant length. */
+export const BUDDY_SESSION_LENGTH_EXPLAINER =
+  "Buddy sits use the shortest of everyone's current sit length (at least 1 minute). The group timer is set automatically—you can't choose a longer session.";
+
+/**
+ * Normalized buddy session length (#349): min of participant current lengths, floored at 1 minute.
+ */
+export function normalizedBuddySessionDurationSeconds(currentDays: number[]): number {
+  if (currentDays.length === 0) {
+    return BASE_DURATION;
+  }
+  const lengths = currentDays.map((day) => buddyDurationForDay(day));
+  return Math.max(BASE_DURATION, Math.min(...lengths));
+}


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #349.

Buddy sessions now set `durationSeconds` to the **shortest** active lobby participant's current sit length (from `users.currentDay` via `durationForDay`), with a **60-second floor**. Clients cannot override length at creation.

## Behavior

- **Create** (`POST /api/buddy/sessions`): duration from host until others join; rejects any `durationSeconds` key in the body (400).
- **Join** (`POST /api/buddy/sessions/join`): recomputes duration for active lobby participants; calendar sync uses the normalized duration.
- **Leave** (`POST /api/buddy/sessions/.../leave`): recomputes duration when someone leaves the lobby (waiting / ready_check only).
- Duration sync runs in a **transaction** to avoid stale concurrent writes.
- **Immediate and scheduled** sessions share the same rule; existing rows are not backfilled.

## UI

Explainer copy in web buddy hub + waiting room and iOS buddy hub + waiting room.

## Tests

- Unit: `normalizedBuddySessionDurationSeconds` for 2, 3, and N participants; create-body rejects `durationSeconds` (including `null`).
- E2E: `@authDbIntegration` — host day 5 + guest day 1 → **60s** after join.

## Verification

- `npm run test:unit` — 74 passed
- CI green on latest push (including buddy auth-db integration and iOS lanes after retrigger)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d2226a4-cb4d-4258-a203-cc0b8dce3a23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d2226a4-cb4d-4258-a203-cc0b8dce3a23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Buddy sessions now use the shortest participant length and no longer accept custom length overrides**

### What Changed
- Buddy session length is automatically set from the shortest active participant’s current sit length, with a 1-minute minimum
- When someone joins a buddy lobby, the shared timer is recalculated for the group
- Session creation now rejects any client-supplied session length
- Web and iOS buddy screens now show a note explaining that the group timer is set automatically

### Impact
`✅ Fewer mismatched buddy session lengths`
`✅ Clearer buddy session setup`
`✅ Fewer incorrect session-length requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Buddy sessions now normalize duration to the shortest participant sit length (minimum 1 minute).

* **Improvements**
  * In-app guidance updated across web and iOS to explain automatic group timer behavior.
  * Session duration syncs automatically when participants join or leave.
  * Server now rejects client-supplied duration overrides during session creation.

* **Tests**
  * Added unit and integration tests covering duration normalization and request validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/auerbachb/still-point/pull/352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->