### PR TITLE
feat: multi-buddy calendar views (unified + per-buddy drill-down)

### DIFF
--- a/src/app/api/buddy/sessions/calendar/[buddyId]/route.ts
+++ b/src/app/api/buddy/sessions/calendar/[buddyId]/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth";
+import {
+  listBuddyCalendarSessionsForBuddy,
+  parseBuddyCalendarRange,
+} from "@/lib/buddyCalendar";
+import { isUuid } from "@/lib/friends";
+
+type Params = { params: Promise<{ buddyId: string }> };
+
+/**
+ * Per-buddy shared-session calendar (#350).
+ * iOS: mirror `GET /api/buddy/sessions/calendar/[buddyId]` — see `listBuddyCalendarSessionsForBuddy`.
+ */
+export async function GET(request: Request, context: Params) {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { buddyId } = await context.params;
+    if (!isUuid(buddyId)) {
+      return NextResponse.json({ error: "Invalid buddy id" }, { status: 400 });
+    }
+
+    let range;
+    try {
+      range = parseBuddyCalendarRange(new URL(request.url).searchParams);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "";
+      if (msg === "INVALID_FROM_DATE" || msg === "INVALID_TO_DATE") {
+        return NextResponse.json({ error: "Invalid date range" }, { status: 400 });
+      }
+      throw e;
+    }
+
+    const result = await listBuddyCalendarSessionsForBuddy(auth.userId, buddyId, range);
+    if ("error" in result) {
+      if (result.error === "NOT_FRIEND") {
+        return NextResponse.json({ error: "Not friends with this user" }, { status: 403 });
+      }
+      return NextResponse.json({ error: "Invalid buddy" }, { status: 400 });
+    }
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Buddy per-buddy calendar GET error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/buddy/sessions/calendar/[buddyId]/route.ts
+++ b/src/app/api/buddy/sessions/calendar/[buddyId]/route.ts
@@ -29,7 +29,11 @@ export async function GET(request: Request, context: Params) {
       range = parseBuddyCalendarRange(new URL(request.url).searchParams);
     } catch (e) {
       const msg = e instanceof Error ? e.message : "";
-      if (msg === "INVALID_FROM_DATE" || msg === "INVALID_TO_DATE") {
+      if (
+        msg === "INVALID_FROM_DATE" ||
+        msg === "INVALID_TO_DATE" ||
+        msg === "INVALID_DATE_RANGE"
+      ) {
         return NextResponse.json({ error: "Invalid date range" }, { status: 400 });
       }
       throw e;

--- a/src/app/api/buddy/sessions/calendar/route.test.ts
+++ b/src/app/api/buddy/sessions/calendar/route.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const getCurrentUser = vi.fn();
+const listBuddyCalendarSessions = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentUser,
+}));
+
+vi.mock("@/lib/buddyCalendar", () => ({
+  listBuddyCalendarSessions,
+  parseBuddyCalendarRange: vi.fn(() => ({
+    fromDate: "2025-03-01",
+    toDate: "2025-05-29",
+    limit: 200,
+    offset: 0,
+  })),
+}));
+
+describe("GET /api/buddy/sessions/calendar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCurrentUser.mockResolvedValue({ userId: "user-1", email: "a@b.com" });
+    listBuddyCalendarSessions.mockResolvedValue({
+      sessions: [],
+      fromDate: "2025-03-01",
+      toDate: "2025-05-29",
+      hasMore: false,
+    });
+  });
+
+  test("returns 401 when unauthenticated", async () => {
+    getCurrentUser.mockResolvedValue(null);
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://test/api/buddy/sessions/calendar"));
+    expect(res.status).toBe(401);
+  });
+
+  test("returns calendar sessions for authenticated user", async () => {
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://test/api/buddy/sessions/calendar"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sessions).toEqual([]);
+    expect(listBuddyCalendarSessions).toHaveBeenCalledWith("user-1", expect.any(Object));
+  });
+});

--- a/src/app/api/buddy/sessions/calendar/route.ts
+++ b/src/app/api/buddy/sessions/calendar/route.ts
@@ -21,7 +21,11 @@ export async function GET(request: Request) {
       range = parseBuddyCalendarRange(new URL(request.url).searchParams);
     } catch (e) {
       const msg = e instanceof Error ? e.message : "";
-      if (msg === "INVALID_FROM_DATE" || msg === "INVALID_TO_DATE") {
+      if (
+        msg === "INVALID_FROM_DATE" ||
+        msg === "INVALID_TO_DATE" ||
+        msg === "INVALID_DATE_RANGE"
+      ) {
         return NextResponse.json({ error: "Invalid date range" }, { status: 400 });
       }
       throw e;

--- a/src/app/api/buddy/sessions/calendar/route.ts
+++ b/src/app/api/buddy/sessions/calendar/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth";
+import {
+  listBuddyCalendarSessions,
+  parseBuddyCalendarRange,
+} from "@/lib/buddyCalendar";
+
+/**
+ * Unified multi-buddy calendar session list (#350).
+ * iOS: mirror `GET /api/buddy/sessions/calendar` — see `listBuddyCalendarSessions`.
+ */
+export async function GET(request: Request) {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    let range;
+    try {
+      range = parseBuddyCalendarRange(new URL(request.url).searchParams);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "";
+      if (msg === "INVALID_FROM_DATE" || msg === "INVALID_TO_DATE") {
+        return NextResponse.json({ error: "Invalid date range" }, { status: 400 });
+      }
+      throw e;
+    }
+
+    const result = await listBuddyCalendarSessions(auth.userId, range);
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Buddy calendar GET error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/app/buddies/[id]/calendar/page.tsx
+++ b/src/app/app/buddies/[id]/calendar/page.tsx
@@ -21,6 +21,7 @@ function PerBuddyCalendarContent({
     if (!buddyId) return;
     let cancelled = false;
     setBuddyLookupError(null);
+    setBuddyUsername(null);
 
     api
       .getFriends()

--- a/src/app/app/buddies/[id]/calendar/page.tsx
+++ b/src/app/app/buddies/[id]/calendar/page.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { AppSubpageShell } from "@/components/AppSubpageShell";
+import { BuddyCalendarView } from "@/components/BuddyCalendarView";
+import { AuthScreen } from "@/components/AuthScreen";
+import { api, type User } from "@/lib/api";
+
+export default function BuddyPerBuddyCalendarPage() {
+  const params = useParams();
+  const buddyId = typeof params.id === "string" ? params.id : "";
+  const [user, setUser] = useState<User | null>(null);
+  const [buddyUsername, setBuddyUsername] = useState<string | null>(null);
+  const [authChecked, setAuthChecked] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const meRes = await fetch("/api/auth/me");
+        if (!meRes.ok) {
+          if (!cancelled) {
+            setUser(null);
+            setAuthChecked(true);
+          }
+          return;
+        }
+        const meData = await meRes.json();
+        if (cancelled) return;
+        setUser(meData.user ?? null);
+
+        if (buddyId && meData.user) {
+          const { friends } = await api.getFriends();
+          const friend = friends.find((f) => f.id === buddyId);
+          if (!cancelled) setBuddyUsername(friend?.username ?? null);
+        }
+      } catch {
+        if (!cancelled) setUser(null);
+      } finally {
+        if (!cancelled) setAuthChecked(true);
+      }
+    }
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [buddyId]);
+
+  if (!authChecked) {
+    return (
+      <div
+        style={{
+          minHeight: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "var(--fg-4)",
+        }}
+      >
+        Loading…
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div
+        style={{
+          minHeight: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: "40px 20px",
+        }}
+      >
+        <AuthScreen onLogin={setUser} />
+      </div>
+    );
+  }
+
+  const title = buddyUsername
+    ? `Calendar with ${buddyUsername}`
+    : "Buddy calendar";
+
+  return (
+    <AppSubpageShell
+      title={title}
+      backHref="/app/buddies/calendar"
+      backLabel="All buddy sits"
+    >
+      <BuddyCalendarView
+        mode="perBuddy"
+        buddyId={buddyId}
+        buddyUsername={buddyUsername ?? undefined}
+        viewerUserId={user.id}
+      />
+    </AppSubpageShell>
+  );
+}

--- a/src/app/app/buddies/[id]/calendar/page.tsx
+++ b/src/app/app/buddies/[id]/calendar/page.tsx
@@ -3,83 +3,44 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import { AppSubpageShell } from "@/components/AppSubpageShell";
+import { BuddyCalendarAuthGate } from "@/components/BuddyCalendarAuthGate";
 import { BuddyCalendarView } from "@/components/BuddyCalendarView";
-import { AuthScreen } from "@/components/AuthScreen";
-import { api, type User } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 
-export default function BuddyPerBuddyCalendarPage() {
-  const params = useParams();
-  const buddyId = typeof params.id === "string" ? params.id : "";
-  const [user, setUser] = useState<User | null>(null);
+function PerBuddyCalendarContent({
+  buddyId,
+  userId,
+}: {
+  buddyId: string;
+  userId: string;
+}) {
   const [buddyUsername, setBuddyUsername] = useState<string | null>(null);
-  const [authChecked, setAuthChecked] = useState(false);
+  const [buddyLookupError, setBuddyLookupError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!buddyId) return;
     let cancelled = false;
+    setBuddyLookupError(null);
 
-    async function load() {
-      try {
-        const meRes = await fetch("/api/auth/me");
-        if (!meRes.ok) {
-          if (!cancelled) {
-            setUser(null);
-            setAuthChecked(true);
-          }
-          return;
-        }
-        const meData = await meRes.json();
+    api
+      .getFriends()
+      .then(({ friends }) => {
         if (cancelled) return;
-        setUser(meData.user ?? null);
+        const friend = friends.find((f) => f.id === buddyId);
+        setBuddyUsername(friend?.username ?? null);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setBuddyUsername(null);
+        setBuddyLookupError(
+          e instanceof ApiError ? e.message : "Could not load buddy name.",
+        );
+      });
 
-        if (buddyId && meData.user) {
-          const { friends } = await api.getFriends();
-          const friend = friends.find((f) => f.id === buddyId);
-          if (!cancelled) setBuddyUsername(friend?.username ?? null);
-        }
-      } catch {
-        if (!cancelled) setUser(null);
-      } finally {
-        if (!cancelled) setAuthChecked(true);
-      }
-    }
-
-    void load();
     return () => {
       cancelled = true;
     };
-  }, [buddyId]);
-
-  if (!authChecked) {
-    return (
-      <div
-        style={{
-          minHeight: "100%",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          color: "var(--fg-4)",
-        }}
-      >
-        Loading…
-      </div>
-    );
-  }
-
-  if (!user) {
-    return (
-      <div
-        style={{
-          minHeight: "100%",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          padding: "40px 20px",
-        }}
-      >
-        <AuthScreen onLogin={setUser} />
-      </div>
-    );
-  }
+  }, [buddyId, userId]);
 
   const title = buddyUsername
     ? `Calendar with ${buddyUsername}`
@@ -91,12 +52,37 @@ export default function BuddyPerBuddyCalendarPage() {
       backHref="/app/buddies/calendar"
       backLabel="All buddy sits"
     >
+      {buddyLookupError && (
+        <p
+          role="status"
+          style={{
+            margin: "0 0 12px",
+            textAlign: "center",
+            fontSize: "12px",
+            color: "var(--fg-3)",
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+          }}
+        >
+          {buddyLookupError}
+        </p>
+      )}
       <BuddyCalendarView
         mode="perBuddy"
         buddyId={buddyId}
         buddyUsername={buddyUsername ?? undefined}
-        viewerUserId={user.id}
+        viewerUserId={userId}
       />
     </AppSubpageShell>
+  );
+}
+
+export default function BuddyPerBuddyCalendarPage() {
+  const params = useParams();
+  const buddyId = typeof params.id === "string" ? params.id : "";
+
+  return (
+    <BuddyCalendarAuthGate>
+      {(user) => <PerBuddyCalendarContent buddyId={buddyId} userId={user.id} />}
+    </BuddyCalendarAuthGate>
   );
 }

--- a/src/app/app/buddies/calendar/page.tsx
+++ b/src/app/app/buddies/calendar/page.tsx
@@ -1,68 +1,17 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { AppSubpageShell } from "@/components/AppSubpageShell";
+import { BuddyCalendarAuthGate } from "@/components/BuddyCalendarAuthGate";
 import { BuddyCalendarView } from "@/components/BuddyCalendarView";
-import { AuthScreen } from "@/components/AuthScreen";
-import { api, type User } from "@/lib/api";
 
 export default function BuddyUnifiedCalendarPage() {
-  const [user, setUser] = useState<User | null>(null);
-  const [authChecked, setAuthChecked] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    fetch("/api/auth/me")
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data) => {
-        if (!cancelled) {
-          setUser(data?.user ?? null);
-          setAuthChecked(true);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) setAuthChecked(true);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  if (!authChecked) {
-    return (
-      <div
-        style={{
-          minHeight: "100%",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          color: "var(--fg-4)",
-        }}
-      >
-        Loading…
-      </div>
-    );
-  }
-
-  if (!user) {
-    return (
-      <div
-        style={{
-          minHeight: "100%",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          padding: "40px 20px",
-        }}
-      >
-        <AuthScreen onLogin={setUser} />
-      </div>
-    );
-  }
-
   return (
-    <AppSubpageShell title="Buddy calendar" backHref="/app" backLabel="Back to app">
-      <BuddyCalendarView mode="unified" viewerUserId={user.id} />
-    </AppSubpageShell>
+    <BuddyCalendarAuthGate>
+      {(user) => (
+        <AppSubpageShell title="Buddy calendar" backHref="/app" backLabel="Back to app">
+          <BuddyCalendarView mode="unified" viewerUserId={user.id} />
+        </AppSubpageShell>
+      )}
+    </BuddyCalendarAuthGate>
   );
 }

--- a/src/app/app/buddies/calendar/page.tsx
+++ b/src/app/app/buddies/calendar/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AppSubpageShell } from "@/components/AppSubpageShell";
+import { BuddyCalendarView } from "@/components/BuddyCalendarView";
+import { AuthScreen } from "@/components/AuthScreen";
+import { api, type User } from "@/lib/api";
+
+export default function BuddyUnifiedCalendarPage() {
+  const [user, setUser] = useState<User | null>(null);
+  const [authChecked, setAuthChecked] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/auth/me")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!cancelled) {
+          setUser(data?.user ?? null);
+          setAuthChecked(true);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setAuthChecked(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!authChecked) {
+    return (
+      <div
+        style={{
+          minHeight: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "var(--fg-4)",
+        }}
+      >
+        Loading…
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div
+        style={{
+          minHeight: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: "40px 20px",
+        }}
+      >
+        <AuthScreen onLogin={setUser} />
+      </div>
+    );
+  }
+
+  return (
+    <AppSubpageShell title="Buddy calendar" backHref="/app" backLabel="Back to app">
+      <BuddyCalendarView mode="unified" viewerUserId={user.id} />
+    </AppSubpageShell>
+  );
+}

--- a/src/components/AppSubpageShell.tsx
+++ b/src/components/AppSubpageShell.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { useIsMobile } from "@/lib/useIsMobile";
+
+type AppSubpageShellProps = {
+  title: string;
+  backHref?: string;
+  backLabel?: string;
+  children: ReactNode;
+};
+
+export function AppSubpageShell({
+  title,
+  backHref = "/app",
+  backLabel = "Back to app",
+  children,
+}: AppSubpageShellProps) {
+  const isMobile = useIsMobile();
+
+  return (
+    <div
+      style={{
+        minHeight: "100%",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+        padding: isMobile
+          ? "var(--s4) var(--s3) calc(var(--s4) + env(safe-area-inset-bottom, 0px))"
+          : "var(--s4) var(--s4)",
+        width: "100%",
+      }}
+    >
+      <div
+        style={{
+          width: "100%",
+          maxWidth: "min(520px, calc(100vw - 32px))",
+          display: "flex",
+          flexDirection: "column",
+          gap: "var(--s4)",
+        }}
+      >
+        <Link
+          href={backHref}
+          style={{
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+            fontSize: "11px",
+            letterSpacing: "0.1em",
+            textTransform: "uppercase",
+            color: "var(--fg-3)",
+            textDecoration: "none",
+            alignSelf: "flex-start",
+          }}
+        >
+          ← {backLabel}
+        </Link>
+        <h1
+          style={{
+            fontSize: isMobile ? "26px" : "32px",
+            fontWeight: 300,
+            fontStyle: "italic",
+            margin: 0,
+            color: "var(--fg)",
+            textAlign: "center",
+          }}
+        >
+          {title}
+        </h1>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/BuddyCalendarAuthGate.tsx
+++ b/src/components/BuddyCalendarAuthGate.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { AuthScreen } from "@/components/AuthScreen";
+import { useBuddyCalendarAuth } from "@/lib/useBuddyCalendarAuth";
+import type { User } from "@/lib/api";
+
+type BuddyCalendarAuthGateProps = {
+  children: (user: User) => ReactNode;
+};
+
+export function BuddyCalendarAuthGate({ children }: BuddyCalendarAuthGateProps) {
+  const { user, setUser, authChecked, authError, retryAuth } = useBuddyCalendarAuth();
+
+  if (!authChecked) {
+    return (
+      <div
+        style={{
+          minHeight: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "var(--fg-4)",
+        }}
+      >
+        Loading…
+      </div>
+    );
+  }
+
+  if (authError) {
+    return (
+      <div
+        style={{
+          minHeight: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "var(--s3)",
+          padding: "40px 20px",
+          textAlign: "center",
+        }}
+      >
+        <p style={{ maxWidth: "44ch", color: "var(--fg-2)", lineHeight: 1.5 }}>{authError}</p>
+        <button
+          type="button"
+          onClick={retryAuth}
+          style={{
+            border: "1px solid var(--border-2)",
+            background: "transparent",
+            color: "var(--fg)",
+            borderRadius: "999px",
+            padding: "10px 16px",
+            cursor: "pointer",
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+            fontSize: "12px",
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+          }}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div
+        style={{
+          minHeight: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: "40px 20px",
+        }}
+      >
+        <AuthScreen onLogin={setUser} />
+      </div>
+    );
+  }
+
+  return <>{children(user)}</>;
+}

--- a/src/components/BuddyCalendarView.tsx
+++ b/src/components/BuddyCalendarView.tsx
@@ -8,7 +8,7 @@ import {
   type BuddyCalendarListResponse,
   type BuddyCalendarSession,
 } from "@/lib/api";
-import { buddyColorFromUserId } from "@/lib/buddyCalendar";
+import { buddyColorFromUserId } from "@/lib/buddyCalendarColors";
 import { useIsMobile } from "@/lib/useIsMobile";
 
 const labelStyle: React.CSSProperties = {
@@ -159,8 +159,8 @@ export function BuddyCalendarView({
   const visibleSessions = useMemo(() => {
     if (!data) return [];
     if (!showBuddyFilters || hiddenBuddyIds.size === 0) return data.sessions;
-    return data.sessions.filter((s) =>
-      s.buddyIds.some((id) => !hiddenBuddyIds.has(id)),
+    return data.sessions.filter(
+      (s) => !s.buddyIds.some((id) => hiddenBuddyIds.has(id)),
     );
   }, [data, showBuddyFilters, hiddenBuddyIds]);
 

--- a/src/components/BuddyCalendarView.tsx
+++ b/src/components/BuddyCalendarView.tsx
@@ -107,10 +107,15 @@ export function BuddyCalendarView({
     setLoading(true);
     setError(null);
     try {
-      const result =
-        mode === "perBuddy" && buddyId
-          ? await api.getBuddyCalendarForBuddy(buddyId)
-          : await api.getBuddyCalendar();
+      let result: BuddyCalendarListResponse;
+      if (mode === "perBuddy") {
+        if (!buddyId) {
+          throw new Error("Missing buddy id.");
+        }
+        result = await api.getBuddyCalendarForBuddy(buddyId);
+      } else {
+        result = await api.getBuddyCalendar();
+      }
       setData(result);
     } catch (e) {
       setError(e instanceof ApiError ? e.message : "Could not load buddy calendar.");

--- a/src/components/BuddyCalendarView.tsx
+++ b/src/components/BuddyCalendarView.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  api,
+  ApiError,
+  type BuddyCalendarListResponse,
+  type BuddyCalendarSession,
+} from "@/lib/api";
+import { buddyColorFromUserId } from "@/lib/buddyCalendar";
+import { useIsMobile } from "@/lib/useIsMobile";
+
+const labelStyle: React.CSSProperties = {
+  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+  fontSize: "11px",
+  color: "var(--fg-4)",
+  letterSpacing: "0.12em",
+  textTransform: "uppercase",
+};
+
+const cardStyle: React.CSSProperties = {
+  padding: "16px 20px",
+  background: "var(--surface-1)",
+  borderRadius: "10px",
+  display: "flex",
+  flexDirection: "column",
+  gap: "12px",
+  width: "100%",
+};
+
+function formatDateLabel(isoDate: string): string {
+  const d = new Date(isoDate + "T12:00:00");
+  const dow = d.toLocaleDateString("en-US", { weekday: "short" });
+  const mon = d.toLocaleDateString("en-US", { month: "short" });
+  const dayOfMonth = d.getDate();
+  return `${dow} ${mon} ${dayOfMonth}`;
+}
+
+function formatTimeLabel(iso: string | null): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  return d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+}
+
+function stateLabel(state: string): string {
+  switch (state) {
+    case "completed":
+      return "Completed";
+    case "active":
+      return "In progress";
+    case "abandoned":
+      return "Abandoned";
+    case "waiting":
+    case "ready_check":
+      return "Scheduled";
+    default:
+      return state;
+  }
+}
+
+function buddyLabelForSession(
+  session: BuddyCalendarSession,
+  viewerUserId: string | undefined,
+  focusBuddyId?: string,
+): string {
+  const others = session.participants.filter((p) => p.userId !== viewerUserId);
+  if (focusBuddyId) {
+    const focus = others.find((p) => p.userId === focusBuddyId);
+    if (focus) return focus.username;
+  }
+  if (others.length === 0) return "Buddy sit";
+  if (others.length === 1) return others[0].username;
+  return others.map((p) => p.username).join(", ");
+}
+
+function primaryBuddyId(
+  session: BuddyCalendarSession,
+  viewerUserId: string | undefined,
+  focusBuddyId?: string,
+): string | null {
+  if (focusBuddyId && session.buddyIds.includes(focusBuddyId)) return focusBuddyId;
+  const first = session.buddyIds.find((id) => id !== viewerUserId);
+  return first ?? session.buddyIds[0] ?? null;
+}
+
+type BuddyCalendarViewProps = {
+  mode: "unified" | "perBuddy";
+  buddyId?: string;
+  buddyUsername?: string;
+  viewerUserId?: string;
+};
+
+export function BuddyCalendarView({
+  mode,
+  buddyId,
+  buddyUsername,
+  viewerUserId,
+}: BuddyCalendarViewProps) {
+  const [data, setData] = useState<BuddyCalendarListResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [hiddenBuddyIds, setHiddenBuddyIds] = useState<Set<string>>(() => new Set());
+  const isMobile = useIsMobile();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result =
+        mode === "perBuddy" && buddyId
+          ? await api.getBuddyCalendarForBuddy(buddyId)
+          : await api.getBuddyCalendar();
+      setData(result);
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "Could not load buddy calendar.");
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [mode, buddyId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const allBuddyIds = useMemo(() => {
+    if (!data || mode === "perBuddy") return [];
+    const ids = new Set<string>();
+    for (const s of data.sessions) {
+      for (const id of s.buddyIds) ids.add(id);
+    }
+    return [...ids].sort((a, b) => {
+      const nameA =
+        data.sessions
+          .flatMap((s) => s.participants)
+          .find((p) => p.userId === a)?.username ?? "";
+      const nameB =
+        data.sessions
+          .flatMap((s) => s.participants)
+          .find((p) => p.userId === b)?.username ?? "";
+      return nameA.localeCompare(nameB);
+    });
+  }, [data, mode]);
+
+  const buddyNames = useMemo(() => {
+    const map = new Map<string, string>();
+    if (!data) return map;
+    for (const s of data.sessions) {
+      for (const p of s.participants) {
+        if (p.userId !== viewerUserId) map.set(p.userId, p.username);
+      }
+    }
+    return map;
+  }, [data, viewerUserId]);
+
+  const showBuddyFilters = mode === "unified" && allBuddyIds.length >= 3;
+
+  const visibleSessions = useMemo(() => {
+    if (!data) return [];
+    if (!showBuddyFilters || hiddenBuddyIds.size === 0) return data.sessions;
+    return data.sessions.filter((s) =>
+      s.buddyIds.some((id) => !hiddenBuddyIds.has(id)),
+    );
+  }, [data, showBuddyFilters, hiddenBuddyIds]);
+
+  const sessionsByDate = useMemo(() => {
+    const groups = new Map<string, BuddyCalendarSession[]>();
+    for (const s of visibleSessions) {
+      const list = groups.get(s.calendarDate) ?? [];
+      list.push(s);
+      groups.set(s.calendarDate, list);
+    }
+    return [...groups.entries()].sort((a, b) => b[0].localeCompare(a[0]));
+  }, [visibleSessions]);
+
+  const toggleBuddyVisibility = (id: string) => {
+    setHiddenBuddyIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const dateColWidth = isMobile ? "88px" : "100px";
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "20px", width: "100%" }}>
+      {mode === "unified" && (
+        <p
+          style={{
+            margin: 0,
+            textAlign: "center",
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+            fontSize: "11px",
+            color: "var(--fg-3)",
+            lineHeight: 1.5,
+          }}
+        >
+          Shared buddy sits from the last 90 days. Solo history is unchanged on Progress.
+        </p>
+      )}
+
+      {mode === "perBuddy" && buddyUsername && (
+        <p
+          style={{
+            margin: 0,
+            textAlign: "center",
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+            fontSize: "11px",
+            color: "var(--fg-3)",
+            lineHeight: 1.5,
+          }}
+        >
+          Shared sits with {buddyUsername} only — not their solo sessions.
+        </p>
+      )}
+
+      {data && (
+        <p
+          style={{
+            margin: 0,
+            textAlign: "center",
+            fontSize: "12px",
+            color: "var(--fg-4)",
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+          }}
+        >
+          {data.fromDate} — {data.toDate}
+        </p>
+      )}
+
+      {showBuddyFilters && (
+        <div style={cardStyle}>
+          <div style={labelStyle}>Show buddies</div>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
+            {allBuddyIds.map((id) => {
+              const hidden = hiddenBuddyIds.has(id);
+              const color = buddyColorFromUserId(id);
+              const name = buddyNames.get(id) ?? "Buddy";
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => toggleBuddyVisibility(id)}
+                  aria-pressed={!hidden}
+                  style={{
+                    border: `1px solid ${hidden ? "var(--border-2)" : color}`,
+                    background: hidden ? "transparent" : `${color}22`,
+                    color: hidden ? "var(--fg-3)" : "var(--fg)",
+                    borderRadius: "999px",
+                    padding: "6px 12px",
+                    cursor: "pointer",
+                    fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                    fontSize: "11px",
+                    letterSpacing: "0.06em",
+                    textDecoration: hidden ? "line-through" : "none",
+                  }}
+                >
+                  <span
+                    style={{
+                      display: "inline-block",
+                      width: "8px",
+                      height: "8px",
+                      borderRadius: "50%",
+                      background: color,
+                      marginRight: "6px",
+                      verticalAlign: "middle",
+                      opacity: hidden ? 0.35 : 1,
+                    }}
+                  />
+                  {name}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {loading && (
+        <p style={{ textAlign: "center", color: "var(--fg-3)", fontSize: "14px" }}>Loading…</p>
+      )}
+
+      {error && (
+        <div style={{ ...cardStyle, color: "var(--fg-2)", fontSize: "14px" }} role="alert">
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && visibleSessions.length === 0 && (
+        <div style={{ ...cardStyle, color: "var(--fg-3)", fontSize: "14px", textAlign: "center" }}>
+          {mode === "perBuddy"
+            ? `No shared sits with ${buddyUsername ?? "this buddy"} in this period.`
+            : "No shared buddy sits in this period yet."}
+        </div>
+      )}
+
+      {!loading && sessionsByDate.length > 0 && (
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+          {sessionsByDate.map(([date, sessions]) => (
+            <div key={date} style={{ display: "flex", gap: "12px", alignItems: "flex-start" }}>
+              <div
+                style={{
+                  width: dateColWidth,
+                  flexShrink: 0,
+                  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                  fontSize: isMobile ? "10px" : "11px",
+                  color: "var(--fg-3)",
+                  lineHeight: 1.35,
+                  paddingTop: "10px",
+                }}
+              >
+                {formatDateLabel(date)}
+              </div>
+              <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: "10px" }}>
+                {sessions.map((session) => {
+                  const buddyIdForColor = primaryBuddyId(session, viewerUserId, buddyId);
+                  const accent = buddyIdForColor
+                    ? buddyColorFromUserId(buddyIdForColor)
+                    : "var(--fg-3)";
+                  const time =
+                    formatTimeLabel(session.startedAt) ??
+                    formatTimeLabel(session.scheduledStartAt);
+                  const label = buddyLabelForSession(session, viewerUserId, buddyId);
+                  const durationMin = Math.round(session.durationSeconds / 60);
+
+                  return (
+                    <div
+                      key={session.id}
+                      style={{
+                        ...cardStyle,
+                        borderLeft: `3px solid ${accent}`,
+                        padding: "12px 16px",
+                        gap: "6px",
+                      }}
+                    >
+                      <div
+                        style={{
+                          display: "flex",
+                          flexWrap: "wrap",
+                          alignItems: "center",
+                          gap: "8px",
+                          justifyContent: "space-between",
+                        }}
+                      >
+                        <span
+                          style={{
+                            fontSize: "16px",
+                            color: "var(--fg)",
+                            fontWeight: 400,
+                          }}
+                        >
+                          {label}
+                        </span>
+                        <span style={{ ...labelStyle, textTransform: "none", letterSpacing: "0.04em" }}>
+                          {stateLabel(session.state)}
+                        </span>
+                      </div>
+                      <div
+                        style={{
+                          fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                          fontSize: "11px",
+                          color: "var(--fg-3)",
+                        }}
+                      >
+                        {durationMin} min
+                        {time ? ` · ${time}` : ""}
+                      </div>
+                      {mode === "unified" && session.buddyIds.length === 1 && (
+                        <Link
+                          href={`/app/buddies/${session.buddyIds[0]}/calendar`}
+                          style={{
+                            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                            fontSize: "10px",
+                            letterSpacing: "0.08em",
+                            textTransform: "uppercase",
+                            color: "var(--fg-3)",
+                            textDecoration: "underline",
+                            alignSelf: "flex-start",
+                          }}
+                        >
+                          View with {buddyNames.get(session.buddyIds[0]) ?? "buddy"}
+                        </Link>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {data?.hasMore && (
+        <p
+          style={{
+            textAlign: "center",
+            fontSize: "12px",
+            color: "var(--fg-4)",
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+          }}
+        >
+          More sessions available — narrow the date range or increase limit via API.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/FriendsView.tsx
+++ b/src/components/FriendsView.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState, useEffect, useCallback } from "react";
 import { api, ApiError, type FriendPublicUser, type FriendRequestRow } from "@/lib/api";
 
@@ -314,7 +315,28 @@ export function FriendsView() {
       </div>
 
       <div style={{ ...cardStyle, gap: "16px" }}>
-        <div style={labelStyle}>Your friends</div>
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: "10px",
+          }}
+        >
+          <div style={labelStyle}>Your friends</div>
+          <Link
+            href="/app/buddies/calendar"
+            style={{
+              ...btnOutline,
+              textDecoration: "none",
+              display: "inline-flex",
+              alignItems: "center",
+            }}
+          >
+            Buddy calendar
+          </Link>
+        </div>
         {loading ? (
           <span style={{ color: "var(--fg-3)", fontSize: "14px" }}>Loading…</span>
         ) : friends.length === 0 ? (
@@ -322,16 +344,39 @@ export function FriendsView() {
         ) : (
           <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: "12px" }}>
             {friends.map((f) => (
-              <li key={f.id} style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "12px" }}>
-                <span style={{ color: "var(--fg)" }}>{f.username}</span>
-                <button
-                  type="button"
-                  disabled={actionId === f.id}
-                  onClick={() => unfriend(f.id)}
-                  style={{ ...btnOutline, fontSize: "10px" }}
-                >
-                  Remove
-                </button>
+              <li
+                key={f.id}
+                style={{
+                  display: "flex",
+                  flexWrap: "wrap",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: "12px",
+                }}
+              >
+                <span style={{ color: "var(--fg)", flex: "1 1 120px" }}>{f.username}</span>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
+                  <Link
+                    href={`/app/buddies/${f.id}/calendar`}
+                    style={{
+                      ...btnOutline,
+                      textDecoration: "none",
+                      display: "inline-flex",
+                      alignItems: "center",
+                      fontSize: "10px",
+                    }}
+                  >
+                    View calendar
+                  </Link>
+                  <button
+                    type="button"
+                    disabled={actionId === f.id}
+                    onClick={() => unfriend(f.id)}
+                    style={{ ...btnOutline, fontSize: "10px" }}
+                  >
+                    Remove
+                  </button>
+                </div>
               </li>
             ))}
           </ul>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -127,6 +127,30 @@ export type CalendarSyncResult =
   | { status: "skipped"; userId: string; reason: string }
   | { status: "failed"; userId: string; error: string };
 
+/** #350: shared buddy sit row for unified / per-buddy calendar views. */
+export type BuddyCalendarParticipant = {
+  userId: string;
+  username: string;
+};
+
+export type BuddyCalendarSession = {
+  id: string;
+  state: string;
+  durationSeconds: number;
+  calendarDate: string;
+  scheduledStartAt: string | null;
+  startedAt: string | null;
+  participants: BuddyCalendarParticipant[];
+  buddyIds: string[];
+};
+
+export type BuddyCalendarListResponse = {
+  sessions: BuddyCalendarSession[];
+  fromDate: string;
+  toDate: string;
+  hasMore: boolean;
+};
+
 export const api = {
   signup: (data: { email: string; username: string; password: string }) =>
     request<{ user: User }>("/api/auth/signup", { method: "POST", body: JSON.stringify(data) }),
@@ -297,4 +321,38 @@ export const api = {
       `/api/buddy/sessions/${sessionId}/record-personal-session`,
       { method: "POST", body: JSON.stringify(body) },
     ),
+
+  /** #350: unified multi-buddy calendar — mirrors `listBuddyCalendarSessions`. */
+  getBuddyCalendar: (params?: {
+    from?: string;
+    to?: string;
+    limit?: number;
+    offset?: number;
+  }) => {
+    const q = new URLSearchParams();
+    if (params?.from) q.set("from", params.from);
+    if (params?.to) q.set("to", params.to);
+    if (params?.limit != null) q.set("limit", String(params.limit));
+    if (params?.offset != null) q.set("offset", String(params.offset));
+    const qs = q.toString();
+    return request<BuddyCalendarListResponse>(
+      `/api/buddy/sessions/calendar${qs ? `?${qs}` : ""}`,
+    );
+  },
+
+  /** #350: per-buddy shared calendar — mirrors `listBuddyCalendarSessionsForBuddy`. */
+  getBuddyCalendarForBuddy: (
+    buddyId: string,
+    params?: { from?: string; to?: string; limit?: number; offset?: number },
+  ) => {
+    const q = new URLSearchParams();
+    if (params?.from) q.set("from", params.from);
+    if (params?.to) q.set("to", params.to);
+    if (params?.limit != null) q.set("limit", String(params.limit));
+    if (params?.offset != null) q.set("offset", String(params.offset));
+    const qs = q.toString();
+    return request<BuddyCalendarListResponse>(
+      `/api/buddy/sessions/calendar/${buddyId}${qs ? `?${qs}` : ""}`,
+    );
+  },
 };

--- a/src/lib/buddyCalendar.test.ts
+++ b/src/lib/buddyCalendar.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "vitest";
+import { buddyColorFromUserId } from "./buddyCalendarColors";
 import {
   BUDDY_CALENDAR_DEFAULT_DAYS,
-  buddyColorFromUserId,
   buddySessionCalendarDate,
   parseBuddyCalendarRange,
-} from "./buddyCalendar";
+} from "./buddyCalendarRange";
 import { addDaysToIsoDate } from "./sessionCalendar";
 
 describe("buddyColorFromUserId", () => {
@@ -59,5 +59,13 @@ describe("parseBuddyCalendarRange", () => {
     expect(() =>
       parseBuddyCalendarRange(new URLSearchParams({ to: "not-a-date" })),
     ).toThrow("INVALID_TO_DATE");
+  });
+
+  test("rejects reversed from/to range", () => {
+    expect(() =>
+      parseBuddyCalendarRange(
+        new URLSearchParams({ from: "2025-06-01", to: "2025-01-01" }),
+      ),
+    ).toThrow("INVALID_DATE_RANGE");
   });
 });

--- a/src/lib/buddyCalendar.test.ts
+++ b/src/lib/buddyCalendar.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vitest";
+import {
+  BUDDY_CALENDAR_DEFAULT_DAYS,
+  buddyColorFromUserId,
+  buddySessionCalendarDate,
+  parseBuddyCalendarRange,
+} from "./buddyCalendar";
+import { addDaysToIsoDate } from "./sessionCalendar";
+
+describe("buddyColorFromUserId", () => {
+  test("returns stable color for the same id", () => {
+    const id = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+    expect(buddyColorFromUserId(id)).toBe(buddyColorFromUserId(id));
+  });
+
+  test("returns different colors for different ids when palette allows", () => {
+    const a = "00000000-0000-4000-8000-000000000001";
+    const b = "00000000-0000-4000-8000-000000000002";
+    expect(buddyColorFromUserId(a)).not.toBe(buddyColorFromUserId(b));
+  });
+});
+
+describe("buddySessionCalendarDate", () => {
+  test("prefers startedAt over scheduled and created", () => {
+    expect(
+      buddySessionCalendarDate({
+        startedAt: new Date("2024-06-15T18:00:00.000Z"),
+        scheduledStartAt: new Date("2024-06-14T10:00:00.000Z"),
+        createdAt: new Date("2024-06-10T08:00:00.000Z"),
+      }),
+    ).toBe("2024-06-15");
+  });
+
+  test("uses scheduledStartAt when not started", () => {
+    expect(
+      buddySessionCalendarDate({
+        startedAt: null,
+        scheduledStartAt: new Date("2024-07-01T12:00:00.000Z"),
+        createdAt: new Date("2024-06-28T08:00:00.000Z"),
+      }),
+    ).toBe("2024-07-01");
+  });
+});
+
+describe("parseBuddyCalendarRange", () => {
+  test("defaults to 90-day window ending today", () => {
+    const to = "2025-05-29";
+    const params = new URLSearchParams({ to });
+    const range = parseBuddyCalendarRange(params);
+    expect(range.toDate).toBe(to);
+    expect(range.fromDate).toBe(
+      addDaysToIsoDate(to, -(BUDDY_CALENDAR_DEFAULT_DAYS - 1)),
+    );
+    expect(range.limit).toBe(200);
+    expect(range.offset).toBe(0);
+  });
+
+  test("rejects invalid to date", () => {
+    expect(() =>
+      parseBuddyCalendarRange(new URLSearchParams({ to: "not-a-date" })),
+    ).toThrow("INVALID_TO_DATE");
+  });
+});

--- a/src/lib/buddyCalendar.ts
+++ b/src/lib/buddyCalendar.ts
@@ -8,6 +8,8 @@
  * Default window: last {@link BUDDY_CALENDAR_DEFAULT_DAYS} calendar days (#83-style scope).
  * Per-buddy views include only shared sits (not the other person's solo history).
  */
+import "server-only";
+
 import { db } from "@/db";
 import {
   buddySessions,
@@ -17,113 +19,22 @@ import {
 } from "@/db/schema";
 import { orderedUserPair, isUuid } from "@/lib/friends";
 import {
-  addDaysToIsoDate,
-  isValidSessionCalendarDate,
-} from "@/lib/sessionCalendar";
-import { and, eq, inArray } from "drizzle-orm";
+  type BuddyCalendarListResult,
+  type BuddyCalendarSession,
+  buddySessionCalendarDate,
+} from "@/lib/buddyCalendarRange";
+import { and, eq, inArray, sql } from "drizzle-orm";
 
-/** Default lookback for buddy calendar APIs (matches #83-style history windows). */
-export const BUDDY_CALENDAR_DEFAULT_DAYS = 90;
-
-export const BUDDY_CALENDAR_MAX_LIMIT = 500;
-
-export type BuddyCalendarParticipant = {
-  userId: string;
-  username: string;
-};
-
-export type BuddyCalendarSession = {
-  id: string;
-  state: string;
-  durationSeconds: number;
-  /** ISO `YYYY-MM-DD` placement date for the calendar row. */
-  calendarDate: string;
-  scheduledStartAt: string | null;
-  startedAt: string | null;
-  participants: BuddyCalendarParticipant[];
-  /** Co-participant user ids excluding the viewer (for filters / color chips). */
-  buddyIds: string[];
-};
-
-export type BuddyCalendarListResult = {
-  sessions: BuddyCalendarSession[];
-  fromDate: string;
-  toDate: string;
-  hasMore: boolean;
-};
-
-const BUDDY_CALENDAR_PALETTE = [
-  "#5B8C7A",
-  "#7A6B8C",
-  "#8C7A5B",
-  "#5B6F8C",
-  "#8C5B6B",
-  "#6B8C5B",
-  "#8C6B5B",
-  "#5B8C8C",
-] as const;
-
-/** Deterministic accent color from buddy user id (stable across unified + per-buddy views). */
-export function buddyColorFromUserId(userId: string): string {
-  let hash = 0;
-  for (let i = 0; i < userId.length; i++) {
-    hash = (hash * 31 + userId.charCodeAt(i)) >>> 0;
-  }
-  return BUDDY_CALENDAR_PALETTE[hash % BUDDY_CALENDAR_PALETTE.length];
-}
-
-export function todayIsoDateUtc(): string {
-  const now = new Date();
-  const y = now.getUTCFullYear();
-  const m = String(now.getUTCMonth() + 1).padStart(2, "0");
-  const d = String(now.getUTCDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
-}
-
-/** Pick calendar placement date: started → scheduled → created (UTC day). */
-export function buddySessionCalendarDate(session: {
-  startedAt: Date | null;
-  scheduledStartAt: Date | null;
-  createdAt: Date;
-}): string {
-  const ts = session.startedAt ?? session.scheduledStartAt ?? session.createdAt;
-  const y = ts.getUTCFullYear();
-  const m = String(ts.getUTCMonth() + 1).padStart(2, "0");
-  const d = String(ts.getUTCDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
-}
-
-export function parseBuddyCalendarRange(searchParams: URLSearchParams): {
-  fromDate: string;
-  toDate: string;
-  limit: number;
-  offset: number;
-} {
-  const toDate =
-    searchParams.get("to")?.trim() ||
-    searchParams.get("toDate")?.trim() ||
-    todayIsoDateUtc();
-  if (!isValidSessionCalendarDate(toDate)) {
-    throw new Error("INVALID_TO_DATE");
-  }
-
-  const fromParam = searchParams.get("from")?.trim() || searchParams.get("fromDate")?.trim();
-  const fromDate = fromParam
-    ? fromParam
-    : addDaysToIsoDate(toDate, -(BUDDY_CALENDAR_DEFAULT_DAYS - 1));
-  if (!isValidSessionCalendarDate(fromDate)) {
-    throw new Error("INVALID_FROM_DATE");
-  }
-
-  const limitRaw = Number.parseInt(searchParams.get("limit") ?? "200", 10);
-  const offsetRaw = Number.parseInt(searchParams.get("offset") ?? "0", 10);
-  const limit = Number.isFinite(limitRaw)
-    ? Math.min(Math.max(limitRaw, 1), BUDDY_CALENDAR_MAX_LIMIT)
-    : 200;
-  const offset = Number.isFinite(offsetRaw) ? Math.max(offsetRaw, 0) : 0;
-
-  return { fromDate, toDate, limit, offset };
-}
+export {
+  BUDDY_CALENDAR_DEFAULT_DAYS,
+  BUDDY_CALENDAR_MAX_LIMIT,
+  type BuddyCalendarListResult,
+  type BuddyCalendarParticipant,
+  type BuddyCalendarSession,
+  buddySessionCalendarDate,
+  parseBuddyCalendarRange,
+  todayIsoDateUtc,
+} from "@/lib/buddyCalendarRange";
 
 async function assertFriendship(userId: string, buddyId: string): Promise<boolean> {
   if (!isUuid(buddyId) || buddyId === userId) return false;
@@ -147,16 +58,35 @@ type SessionRow = {
   username: string;
 };
 
+function sessionPlacementDateSql() {
+  return sql<string>`to_char(
+    coalesce(
+      ${buddySessions.startedAt},
+      ${buddySessions.scheduledStartAt},
+      ${buddySessions.createdAt}
+    ) at time zone 'UTC',
+    'YYYY-MM-DD'
+  )`;
+}
+
 async function fetchParticipantRows(
   viewerUserId: string,
   buddyIdFilter: string | null,
+  fromDate: string,
+  toDate: string,
 ): Promise<SessionRow[]> {
+  const placementDate = sessionPlacementDateSql();
+
   const viewerSessionIds = db
     .select({ id: buddySessionParticipants.buddySessionId })
     .from(buddySessionParticipants)
     .where(eq(buddySessionParticipants.userId, viewerUserId));
 
-  const conditions = [inArray(buddySessions.id, viewerSessionIds)];
+  const conditions = [
+    inArray(buddySessions.id, viewerSessionIds),
+    sql`${placementDate} >= ${fromDate}`,
+    sql`${placementDate} <= ${toDate}`,
+  ];
 
   if (buddyIdFilter) {
     const buddySessionIds = db
@@ -227,25 +157,23 @@ function assembleSessions(
     }
   }
 
-  const sessions: BuddyCalendarSession[] = [];
+  const sessions: Array<BuddyCalendarSession & { sortTs: number }> = [];
   for (const entry of byId.values()) {
     entry.buddyIds = entry.participants
       .map((p) => p.userId)
       .filter((id) => id !== viewerUserId);
-    const { sortTs: _sortTs, ...rest } = entry;
-    sessions.push(rest);
+    sessions.push(entry);
   }
 
   sessions.sort((a, b) => {
     if (a.calendarDate !== b.calendarDate) {
       return b.calendarDate.localeCompare(a.calendarDate);
     }
-    const aTs = a.startedAt ?? a.scheduledStartAt ?? "";
-    const bTs = b.startedAt ?? b.scheduledStartAt ?? "";
-    return bTs.localeCompare(aTs);
+    if (b.sortTs !== a.sortTs) return b.sortTs - a.sortTs;
+    return b.id.localeCompare(a.id);
   });
 
-  return sessions;
+  return sessions.map(({ sortTs: _sortTs, ...rest }) => rest);
 }
 
 /**
@@ -256,7 +184,12 @@ export async function listBuddyCalendarSessions(
   viewerUserId: string,
   range: { fromDate: string; toDate: string; limit: number; offset: number },
 ): Promise<BuddyCalendarListResult> {
-  const rows = await fetchParticipantRows(viewerUserId, null);
+  const rows = await fetchParticipantRows(
+    viewerUserId,
+    null,
+    range.fromDate,
+    range.toDate,
+  );
   const filtered = assembleSessions(rows, viewerUserId, range.fromDate, range.toDate);
   const slice = filtered.slice(range.offset, range.offset + range.limit);
   const hasMore = range.offset + slice.length < filtered.length;
@@ -286,7 +219,12 @@ export async function listBuddyCalendarSessionsForBuddy(
     return { error: "NOT_FRIEND" };
   }
 
-  const rows = await fetchParticipantRows(viewerUserId, buddyId);
+  const rows = await fetchParticipantRows(
+    viewerUserId,
+    buddyId,
+    range.fromDate,
+    range.toDate,
+  );
   const filtered = assembleSessions(rows, viewerUserId, range.fromDate, range.toDate);
   const slice = filtered.slice(range.offset, range.offset + range.limit);
   const hasMore = range.offset + slice.length < filtered.length;

--- a/src/lib/buddyCalendar.ts
+++ b/src/lib/buddyCalendar.ts
@@ -23,7 +23,7 @@ import {
   type BuddyCalendarSession,
   buddySessionCalendarDate,
 } from "@/lib/buddyCalendarRange";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, exists, inArray, ne, sql } from "drizzle-orm";
 
 export {
   BUDDY_CALENDAR_DEFAULT_DAYS,
@@ -69,12 +69,20 @@ function sessionPlacementDateSql() {
   )`;
 }
 
-async function fetchParticipantRows(
+function sessionSortTimestampSql() {
+  return sql`coalesce(
+    ${buddySessions.startedAt},
+    ${buddySessions.scheduledStartAt},
+    ${buddySessions.createdAt}
+  )`;
+}
+
+function sharedSessionConditions(
   viewerUserId: string,
   buddyIdFilter: string | null,
   fromDate: string,
   toDate: string,
-): Promise<SessionRow[]> {
+) {
   const placementDate = sessionPlacementDateSql();
 
   const viewerSessionIds = db
@@ -82,10 +90,21 @@ async function fetchParticipantRows(
     .from(buddySessionParticipants)
     .where(eq(buddySessionParticipants.userId, viewerUserId));
 
+  const otherParticipant = db
+    .select({ id: buddySessionParticipants.id })
+    .from(buddySessionParticipants)
+    .where(
+      and(
+        eq(buddySessionParticipants.buddySessionId, buddySessions.id),
+        ne(buddySessionParticipants.userId, viewerUserId),
+      ),
+    );
+
   const conditions = [
     inArray(buddySessions.id, viewerSessionIds),
     sql`${placementDate} >= ${fromDate}`,
     sql`${placementDate} <= ${toDate}`,
+    exists(otherParticipant),
   ];
 
   if (buddyIdFilter) {
@@ -95,6 +114,43 @@ async function fetchParticipantRows(
       .where(eq(buddySessionParticipants.userId, buddyIdFilter));
     conditions.push(inArray(buddySessions.id, buddySessionIds));
   }
+
+  return conditions;
+}
+
+/** Paginated shared-session ids in range (SQL limit/offset before loading participants). */
+async function fetchPagedSharedSessionIds(
+  viewerUserId: string,
+  buddyIdFilter: string | null,
+  fromDate: string,
+  toDate: string,
+  limit: number,
+  offset: number,
+): Promise<{ sessionIds: string[]; hasMore: boolean }> {
+  const conditions = sharedSessionConditions(
+    viewerUserId,
+    buddyIdFilter,
+    fromDate,
+    toDate,
+  );
+
+  const rows = await db
+    .select({ id: buddySessions.id })
+    .from(buddySessions)
+    .where(and(...conditions))
+    .orderBy(desc(sessionSortTimestampSql()), desc(buddySessions.id))
+    .limit(limit + 1)
+    .offset(offset);
+
+  const hasMore = rows.length > limit;
+  const sessionIds = rows.slice(0, limit).map((r) => r.id);
+  return { sessionIds, hasMore };
+}
+
+async function fetchParticipantRowsForSessions(
+  sessionIds: string[],
+): Promise<SessionRow[]> {
+  if (sessionIds.length === 0) return [];
 
   return db
     .select({
@@ -113,7 +169,7 @@ async function fetchParticipantRows(
       eq(buddySessions.id, buddySessionParticipants.buddySessionId),
     )
     .innerJoin(users, eq(buddySessionParticipants.userId, users.id))
-    .where(and(...conditions));
+    .where(inArray(buddySessions.id, sessionIds));
 }
 
 function assembleSessions(
@@ -162,6 +218,7 @@ function assembleSessions(
     entry.buddyIds = entry.participants
       .map((p) => p.userId)
       .filter((id) => id !== viewerUserId);
+    if (entry.buddyIds.length === 0) continue;
     sessions.push(entry);
   }
 
@@ -184,18 +241,19 @@ export async function listBuddyCalendarSessions(
   viewerUserId: string,
   range: { fromDate: string; toDate: string; limit: number; offset: number },
 ): Promise<BuddyCalendarListResult> {
-  const rows = await fetchParticipantRows(
+  const { sessionIds, hasMore } = await fetchPagedSharedSessionIds(
     viewerUserId,
     null,
     range.fromDate,
     range.toDate,
+    range.limit,
+    range.offset,
   );
-  const filtered = assembleSessions(rows, viewerUserId, range.fromDate, range.toDate);
-  const slice = filtered.slice(range.offset, range.offset + range.limit);
-  const hasMore = range.offset + slice.length < filtered.length;
+  const rows = await fetchParticipantRowsForSessions(sessionIds);
+  const sessions = assembleSessions(rows, viewerUserId, range.fromDate, range.toDate);
 
   return {
-    sessions: slice,
+    sessions,
     fromDate: range.fromDate,
     toDate: range.toDate,
     hasMore,
@@ -219,18 +277,19 @@ export async function listBuddyCalendarSessionsForBuddy(
     return { error: "NOT_FRIEND" };
   }
 
-  const rows = await fetchParticipantRows(
+  const { sessionIds, hasMore } = await fetchPagedSharedSessionIds(
     viewerUserId,
     buddyId,
     range.fromDate,
     range.toDate,
+    range.limit,
+    range.offset,
   );
-  const filtered = assembleSessions(rows, viewerUserId, range.fromDate, range.toDate);
-  const slice = filtered.slice(range.offset, range.offset + range.limit);
-  const hasMore = range.offset + slice.length < filtered.length;
+  const rows = await fetchParticipantRowsForSessions(sessionIds);
+  const sessions = assembleSessions(rows, viewerUserId, range.fromDate, range.toDate);
 
   return {
-    sessions: slice,
+    sessions,
     fromDate: range.fromDate,
     toDate: range.toDate,
     hasMore,

--- a/src/lib/buddyCalendar.ts
+++ b/src/lib/buddyCalendar.ts
@@ -1,0 +1,300 @@
+/**
+ * Buddy shared-session calendar queries (#350).
+ *
+ * iOS parity: mirror these session-list queries against the same REST endpoints:
+ * - `GET /api/buddy/sessions/calendar` — unified multi-buddy calendar (`listBuddyCalendarSessions`)
+ * - `GET /api/buddy/sessions/calendar/[buddyId]` — per-buddy drill-down (`listBuddyCalendarSessionsForBuddy`)
+ *
+ * Default window: last {@link BUDDY_CALENDAR_DEFAULT_DAYS} calendar days (#83-style scope).
+ * Per-buddy views include only shared sits (not the other person's solo history).
+ */
+import { db } from "@/db";
+import {
+  buddySessions,
+  buddySessionParticipants,
+  friendships,
+  users,
+} from "@/db/schema";
+import { orderedUserPair, isUuid } from "@/lib/friends";
+import {
+  addDaysToIsoDate,
+  isValidSessionCalendarDate,
+} from "@/lib/sessionCalendar";
+import { and, eq, inArray } from "drizzle-orm";
+
+/** Default lookback for buddy calendar APIs (matches #83-style history windows). */
+export const BUDDY_CALENDAR_DEFAULT_DAYS = 90;
+
+export const BUDDY_CALENDAR_MAX_LIMIT = 500;
+
+export type BuddyCalendarParticipant = {
+  userId: string;
+  username: string;
+};
+
+export type BuddyCalendarSession = {
+  id: string;
+  state: string;
+  durationSeconds: number;
+  /** ISO `YYYY-MM-DD` placement date for the calendar row. */
+  calendarDate: string;
+  scheduledStartAt: string | null;
+  startedAt: string | null;
+  participants: BuddyCalendarParticipant[];
+  /** Co-participant user ids excluding the viewer (for filters / color chips). */
+  buddyIds: string[];
+};
+
+export type BuddyCalendarListResult = {
+  sessions: BuddyCalendarSession[];
+  fromDate: string;
+  toDate: string;
+  hasMore: boolean;
+};
+
+const BUDDY_CALENDAR_PALETTE = [
+  "#5B8C7A",
+  "#7A6B8C",
+  "#8C7A5B",
+  "#5B6F8C",
+  "#8C5B6B",
+  "#6B8C5B",
+  "#8C6B5B",
+  "#5B8C8C",
+] as const;
+
+/** Deterministic accent color from buddy user id (stable across unified + per-buddy views). */
+export function buddyColorFromUserId(userId: string): string {
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = (hash * 31 + userId.charCodeAt(i)) >>> 0;
+  }
+  return BUDDY_CALENDAR_PALETTE[hash % BUDDY_CALENDAR_PALETTE.length];
+}
+
+export function todayIsoDateUtc(): string {
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(now.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/** Pick calendar placement date: started → scheduled → created (UTC day). */
+export function buddySessionCalendarDate(session: {
+  startedAt: Date | null;
+  scheduledStartAt: Date | null;
+  createdAt: Date;
+}): string {
+  const ts = session.startedAt ?? session.scheduledStartAt ?? session.createdAt;
+  const y = ts.getUTCFullYear();
+  const m = String(ts.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(ts.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+export function parseBuddyCalendarRange(searchParams: URLSearchParams): {
+  fromDate: string;
+  toDate: string;
+  limit: number;
+  offset: number;
+} {
+  const toDate =
+    searchParams.get("to")?.trim() ||
+    searchParams.get("toDate")?.trim() ||
+    todayIsoDateUtc();
+  if (!isValidSessionCalendarDate(toDate)) {
+    throw new Error("INVALID_TO_DATE");
+  }
+
+  const fromParam = searchParams.get("from")?.trim() || searchParams.get("fromDate")?.trim();
+  const fromDate = fromParam
+    ? fromParam
+    : addDaysToIsoDate(toDate, -(BUDDY_CALENDAR_DEFAULT_DAYS - 1));
+  if (!isValidSessionCalendarDate(fromDate)) {
+    throw new Error("INVALID_FROM_DATE");
+  }
+
+  const limitRaw = Number.parseInt(searchParams.get("limit") ?? "200", 10);
+  const offsetRaw = Number.parseInt(searchParams.get("offset") ?? "0", 10);
+  const limit = Number.isFinite(limitRaw)
+    ? Math.min(Math.max(limitRaw, 1), BUDDY_CALENDAR_MAX_LIMIT)
+    : 200;
+  const offset = Number.isFinite(offsetRaw) ? Math.max(offsetRaw, 0) : 0;
+
+  return { fromDate, toDate, limit, offset };
+}
+
+async function assertFriendship(userId: string, buddyId: string): Promise<boolean> {
+  if (!isUuid(buddyId) || buddyId === userId) return false;
+  const [u1, u2] = orderedUserPair(userId, buddyId);
+  const [row] = await db
+    .select({ user1Id: friendships.user1Id })
+    .from(friendships)
+    .where(and(eq(friendships.user1Id, u1), eq(friendships.user2Id, u2)))
+    .limit(1);
+  return Boolean(row);
+}
+
+type SessionRow = {
+  id: string;
+  state: string;
+  durationSeconds: number;
+  scheduledStartAt: Date | null;
+  startedAt: Date | null;
+  createdAt: Date;
+  participantUserId: string;
+  username: string;
+};
+
+async function fetchParticipantRows(
+  viewerUserId: string,
+  buddyIdFilter: string | null,
+): Promise<SessionRow[]> {
+  const viewerSessionIds = db
+    .select({ id: buddySessionParticipants.buddySessionId })
+    .from(buddySessionParticipants)
+    .where(eq(buddySessionParticipants.userId, viewerUserId));
+
+  const conditions = [inArray(buddySessions.id, viewerSessionIds)];
+
+  if (buddyIdFilter) {
+    const buddySessionIds = db
+      .select({ id: buddySessionParticipants.buddySessionId })
+      .from(buddySessionParticipants)
+      .where(eq(buddySessionParticipants.userId, buddyIdFilter));
+    conditions.push(inArray(buddySessions.id, buddySessionIds));
+  }
+
+  return db
+    .select({
+      id: buddySessions.id,
+      state: buddySessions.state,
+      durationSeconds: buddySessions.durationSeconds,
+      scheduledStartAt: buddySessions.scheduledStartAt,
+      startedAt: buddySessions.startedAt,
+      createdAt: buddySessions.createdAt,
+      participantUserId: buddySessionParticipants.userId,
+      username: users.username,
+    })
+    .from(buddySessions)
+    .innerJoin(
+      buddySessionParticipants,
+      eq(buddySessions.id, buddySessionParticipants.buddySessionId),
+    )
+    .innerJoin(users, eq(buddySessionParticipants.userId, users.id))
+    .where(and(...conditions));
+}
+
+function assembleSessions(
+  rows: SessionRow[],
+  viewerUserId: string,
+  fromDate: string,
+  toDate: string,
+): BuddyCalendarSession[] {
+  const byId = new Map<string, BuddyCalendarSession & { sortTs: number }>();
+
+  for (const row of rows) {
+    const calendarDate = buddySessionCalendarDate(row);
+    if (calendarDate < fromDate || calendarDate > toDate) continue;
+
+    let entry = byId.get(row.id);
+    if (!entry) {
+      const sortTs = (
+        row.startedAt ??
+        row.scheduledStartAt ??
+        row.createdAt
+      ).getTime();
+      entry = {
+        id: row.id,
+        state: row.state,
+        durationSeconds: row.durationSeconds,
+        calendarDate,
+        scheduledStartAt: row.scheduledStartAt?.toISOString() ?? null,
+        startedAt: row.startedAt?.toISOString() ?? null,
+        participants: [],
+        buddyIds: [],
+        sortTs,
+      };
+      byId.set(row.id, entry);
+    }
+
+    if (!entry.participants.some((p) => p.userId === row.participantUserId)) {
+      entry.participants.push({
+        userId: row.participantUserId,
+        username: row.username,
+      });
+    }
+  }
+
+  const sessions: BuddyCalendarSession[] = [];
+  for (const entry of byId.values()) {
+    entry.buddyIds = entry.participants
+      .map((p) => p.userId)
+      .filter((id) => id !== viewerUserId);
+    const { sortTs: _sortTs, ...rest } = entry;
+    sessions.push(rest);
+  }
+
+  sessions.sort((a, b) => {
+    if (a.calendarDate !== b.calendarDate) {
+      return b.calendarDate.localeCompare(a.calendarDate);
+    }
+    const aTs = a.startedAt ?? a.scheduledStartAt ?? "";
+    const bTs = b.startedAt ?? b.scheduledStartAt ?? "";
+    return bTs.localeCompare(aTs);
+  });
+
+  return sessions;
+}
+
+/**
+ * Unified buddy calendar: all shared sessions for the viewer in `[fromDate, toDate]`.
+ * Powers `GET /api/buddy/sessions/calendar`.
+ */
+export async function listBuddyCalendarSessions(
+  viewerUserId: string,
+  range: { fromDate: string; toDate: string; limit: number; offset: number },
+): Promise<BuddyCalendarListResult> {
+  const rows = await fetchParticipantRows(viewerUserId, null);
+  const filtered = assembleSessions(rows, viewerUserId, range.fromDate, range.toDate);
+  const slice = filtered.slice(range.offset, range.offset + range.limit);
+  const hasMore = range.offset + slice.length < filtered.length;
+
+  return {
+    sessions: slice,
+    fromDate: range.fromDate,
+    toDate: range.toDate,
+    hasMore,
+  };
+}
+
+/**
+ * Per-buddy drill-down: shared sessions with `buddyId` only.
+ * Powers `GET /api/buddy/sessions/calendar/[buddyId]`.
+ */
+export async function listBuddyCalendarSessionsForBuddy(
+  viewerUserId: string,
+  buddyId: string,
+  range: { fromDate: string; toDate: string; limit: number; offset: number },
+): Promise<BuddyCalendarListResult | { error: "NOT_FRIEND" | "INVALID_BUDDY" }> {
+  if (!isUuid(buddyId) || buddyId === viewerUserId) {
+    return { error: "INVALID_BUDDY" };
+  }
+  const isFriend = await assertFriendship(viewerUserId, buddyId);
+  if (!isFriend) {
+    return { error: "NOT_FRIEND" };
+  }
+
+  const rows = await fetchParticipantRows(viewerUserId, buddyId);
+  const filtered = assembleSessions(rows, viewerUserId, range.fromDate, range.toDate);
+  const slice = filtered.slice(range.offset, range.offset + range.limit);
+  const hasMore = range.offset + slice.length < filtered.length;
+
+  return {
+    sessions: slice,
+    fromDate: range.fromDate,
+    toDate: range.toDate,
+    hasMore,
+  };
+}

--- a/src/lib/buddyCalendarColors.ts
+++ b/src/lib/buddyCalendarColors.ts
@@ -1,0 +1,21 @@
+/** Client-safe buddy accent colors (#350). Shared by web UI and iOS parity docs. */
+
+const BUDDY_CALENDAR_PALETTE = [
+  "#5B8C7A",
+  "#7A6B8C",
+  "#8C7A5B",
+  "#5B6F8C",
+  "#8C5B6B",
+  "#6B8C5B",
+  "#8C6B5B",
+  "#5B8C8C",
+] as const;
+
+/** Deterministic accent color from buddy user id (stable across unified + per-buddy views). */
+export function buddyColorFromUserId(userId: string): string {
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = (hash * 31 + userId.charCodeAt(i)) >>> 0;
+  }
+  return BUDDY_CALENDAR_PALETTE[hash % BUDDY_CALENDAR_PALETTE.length];
+}

--- a/src/lib/buddyCalendarRange.ts
+++ b/src/lib/buddyCalendarRange.ts
@@ -1,0 +1,91 @@
+import {
+  addDaysToIsoDate,
+  isValidSessionCalendarDate,
+} from "@/lib/sessionCalendar";
+
+/** Default lookback for buddy calendar APIs (matches #83-style history windows). */
+export const BUDDY_CALENDAR_DEFAULT_DAYS = 90;
+
+export const BUDDY_CALENDAR_MAX_LIMIT = 500;
+
+export type BuddyCalendarParticipant = {
+  userId: string;
+  username: string;
+};
+
+export type BuddyCalendarSession = {
+  id: string;
+  state: string;
+  durationSeconds: number;
+  /** ISO `YYYY-MM-DD` placement date for the calendar row. */
+  calendarDate: string;
+  scheduledStartAt: string | null;
+  startedAt: string | null;
+  participants: BuddyCalendarParticipant[];
+  /** Co-participant user ids excluding the viewer (for filters / color chips). */
+  buddyIds: string[];
+};
+
+export type BuddyCalendarListResult = {
+  sessions: BuddyCalendarSession[];
+  fromDate: string;
+  toDate: string;
+  hasMore: boolean;
+};
+
+export function todayIsoDateUtc(): string {
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(now.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/** Pick calendar placement date: started → scheduled → created (UTC day). */
+export function buddySessionCalendarDate(session: {
+  startedAt: Date | null;
+  scheduledStartAt: Date | null;
+  createdAt: Date;
+}): string {
+  const ts = session.startedAt ?? session.scheduledStartAt ?? session.createdAt;
+  const y = ts.getUTCFullYear();
+  const m = String(ts.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(ts.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+export function parseBuddyCalendarRange(searchParams: URLSearchParams): {
+  fromDate: string;
+  toDate: string;
+  limit: number;
+  offset: number;
+} {
+  const toDate =
+    searchParams.get("to")?.trim() ||
+    searchParams.get("toDate")?.trim() ||
+    todayIsoDateUtc();
+  if (!isValidSessionCalendarDate(toDate)) {
+    throw new Error("INVALID_TO_DATE");
+  }
+
+  const fromParam = searchParams.get("from")?.trim() || searchParams.get("fromDate")?.trim();
+  const fromDate = fromParam
+    ? fromParam
+    : addDaysToIsoDate(toDate, -(BUDDY_CALENDAR_DEFAULT_DAYS - 1));
+  if (!isValidSessionCalendarDate(fromDate)) {
+    throw new Error("INVALID_FROM_DATE");
+  }
+
+  if (fromDate > toDate) {
+    throw new Error("INVALID_DATE_RANGE");
+  }
+
+  const limitRaw = Number.parseInt(searchParams.get("limit") ?? "200", 10);
+  const offsetRaw = Number.parseInt(searchParams.get("offset") ?? "0", 10);
+  const limit = Number.isFinite(limitRaw)
+    ? Math.min(Math.max(limitRaw, 1), BUDDY_CALENDAR_MAX_LIMIT)
+    : 200;
+  const offset = Number.isFinite(offsetRaw) ? Math.max(offsetRaw, 0) : 0;
+
+  return { fromDate, toDate, limit, offset };
+}

--- a/src/lib/useBuddyCalendarAuth.ts
+++ b/src/lib/useBuddyCalendarAuth.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { User } from "@/lib/api";
+
+/** Auth bootstrap for buddy calendar subpages (matches `/app` 5xx vs 401 handling). */
+export function useBuddyCalendarAuth() {
+  const [user, setUser] = useState<User | null>(null);
+  const [authChecked, setAuthChecked] = useState(false);
+  const [authError, setAuthError] = useState<string | null>(null);
+  const [authRetryKey, setAuthRetryKey] = useState(0);
+
+  const retryAuth = useCallback(() => {
+    setAuthChecked(false);
+    setAuthError(null);
+    setAuthRetryKey((k) => k + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function checkAuth() {
+      try {
+        const res = await fetch("/api/auth/me");
+        if (cancelled) return;
+
+        if (res.ok) {
+          const data = await res.json();
+          setUser(data?.user ?? null);
+          setAuthError(null);
+          setAuthChecked(true);
+          return;
+        }
+
+        if (res.status === 401 || res.status === 403) {
+          setUser(null);
+          setAuthError(null);
+          setAuthChecked(true);
+          return;
+        }
+
+        if (res.status >= 500) {
+          setAuthError("Unable to verify your sign-in due to a server issue. Please retry.");
+          setAuthChecked(true);
+          return;
+        }
+
+        setUser(null);
+        setAuthError(null);
+        setAuthChecked(true);
+      } catch {
+        if (!cancelled) {
+          setAuthError("Unable to verify your sign-in due to a network issue. Please retry.");
+          setAuthChecked(true);
+        }
+      }
+    }
+
+    void checkAuth();
+    return () => {
+      cancelled = true;
+    };
+  }, [authRetryKey]);
+
+  return { user, setUser, authChecked, authError, retryAuth };
+}


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #350

## Summary

Adds web calendar views for shared buddy sits: a unified multi-buddy calendar and per-buddy drill-down pages, backed by new list APIs documented for iOS parity.

## Changes

### APIs
- `GET /api/buddy/sessions/calendar` — all shared buddy sessions for the signed-in user (90-day default window, optional `from`/`to`/`limit`/`offset`)
- `GET /api/buddy/sessions/calendar/[buddyId]` — shared sessions with a specific friend (friendship required)

Query logic lives in `src/lib/buddyCalendar.ts` (`listBuddyCalendarSessions`, `listBuddyCalendarSessionsForBuddy`) with iOS mirror notes in file + route comments.

### UI
- `/app/buddies/calendar` — unified calendar with date-grouped events, buddy name labels, deterministic per-buddy colors
- `/app/buddies/[id]/calendar` — per-buddy shared sessions only (not solo history)
- Buddy show/hide filter chips when 3+ buddies appear on the unified view
- Friends tab: “Buddy calendar” link + per-friend “View calendar”

### Unchanged
- Solo **Progress** (`HistoryView`) — no changes

## Verification
- `npm run test:unit` — 74 tests pass (includes `buddyCalendar.test.ts`, calendar route test)
- `npm run build` — succeeds; new routes listed in build output

## iOS follow-up
Mirror the two REST endpoints and `buddyColorFromUserId` / date placement rules from `buddyCalendar.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4cf36bb-e3ca-4ae3-bc40-c783e6f3531c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4cf36bb-e3ca-4ae3-bc40-c783e6f3531c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Add shared buddy calendar views with per-friend drill-down**

### What Changed
- Added a unified buddy calendar that shows shared sits across all friends, grouped by date with a 90-day default range
- Added a per-friend calendar page that shows only shared sessions with that friend, and blocks access when the viewer is not friends with them
- Friends pages now include links to the full buddy calendar and each friend’s calendar
- Calendar items use stable buddy colors, show session status and duration, and let users hide individual buddies when several appear together
- Shared-calendar APIs now return clear errors for invalid dates, invalid buddy IDs, and unauthorized access

### Impact
`✅ Easier review of shared sits`
`✅ Faster access to one buddy’s history`
`✅ Clearer calendar filtering for group sessions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added buddy calendar views to display shared sessions with friends across a date range.
  * Added per-buddy calendar for viewing sessions with specific friends.
  * Added navigation links to access buddy calendars from the friends list.
  * Included session filtering, pagination, and buddy visibility toggles in unified view.

* **Tests**
  * Added test coverage for buddy calendar API endpoints and utility functions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/auerbachb/still-point/pull/353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->