### PR TITLE
feat(notifications): web push parity for daily reminders (#347)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,12 @@ AUTH_APPLE_ID=
 # Vercel Cron auth for scheduled notification dispatch (#345). Required in production.
 # CRON_SECRET=
 
+# Web Push (VAPID) for browser notifications (#347). Generate: npx web-push generate-vapid-keys
+# Never commit WEB_PUSH_VAPID_PRIVATE_KEY.
+# WEB_PUSH_VAPID_PUBLIC_KEY=
+# WEB_PUSH_VAPID_PRIVATE_KEY=
+# WEB_PUSH_VAPID_SUBJECT=mailto:you@still-point.me
+
 # Optional: set to exactly "true" to require friendship before buddy join (see README)
 # BUDDY_REQUIRE_FRIENDSHIP=
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Third-party keys in use today:
 | Daily.co | `DAILY_API_KEY` | Create/delete rooms, issue meeting tokens for buddy video (`src/lib/daily.ts`, `src/app/api/buddy/sessions/[id]/start`, `…/meeting-token`). |
 | YouTube (optional) | `STILLPOINT_HOMEPAGE_YOUTUBE_VIDEO_ID` | **Marketing only:** 11-character video id for the landing-page demo embed. Unset or empty → no embed (#166). |
 | Apple Push Notification service | `APNS_BUNDLE_ID`, `APNS_TEAM_ID`, `APNS_KEY_ID`, `APNS_PRIVATE_KEY` | iOS push notifications (`src/lib/apns.ts`). |
+| Web Push (VAPID) | `WEB_PUSH_VAPID_PUBLIC_KEY`, `WEB_PUSH_VAPID_PRIVATE_KEY`, `WEB_PUSH_VAPID_SUBJECT` | Browser push (`src/lib/web-push.ts`, `public/sw.js`). See [docs/notifications.md](docs/notifications.md). |
 
 ### `vercel.json`
 

--- a/docs/issues/unified-notifications-settings.md
+++ b/docs/issues/unified-notifications-settings.md
@@ -1,0 +1,162 @@
+# Unified Notifications settings (iOS + Web parity)
+
+**Suggested title:** Settings → Notifications: single screen, all notification types  
+**Suggested labels:** `enhancement`, `notifications`, `ios`, `web`  
+**Blocks / related:** #345 (foundation), #346 (daily reminder), #347 (web push), #247 (miss-a-day, if tracked separately)
+
+## Problem
+
+Product expectation: **one Notifications screen**, reachable from **Settings**, that is **the same on iOS and web** and lets users **control every notification type** the app sends (opt-in, schedule where applicable).
+
+Today that is **not** true:
+
+| Area | iOS (`SettingsView` → NOTIFICATIONS section) | Web (`SettingsView` → `WebNotificationSettings`) |
+|------|-----------------------------------------------|--------------------------------------------------|
+| Entry | Section inside Settings scroll | Section inside Settings scroll |
+| Master push opt-in | Yes | Yes (+ Web Push subscription) |
+| Daily reminder + time + frequency | Yes | Yes |
+| Quiet hours | Yes | **No** |
+| Miss-a-day | **No** (API field only) | **No** |
+| Friend request pushes | **No** (always sent; no preference) | **No** (iOS/APNs only today) |
+| Timezone display/edit | Implicit (device) | Read-only display on opt-in |
+
+Backend `notification_preferences` already has `missADayEnabled`, but **no scheduler send path** exists for `miss_a_day` yet (only dedup against existing dispatches). Friend requests call `sendFriendRequestNotification` with **no preference gate** and **no web push**.
+
+## Notification inventory (codebase today)
+
+| Type | `notification_type` | Trigger | Preference gate | Scheduled? | iOS UI | Web UI | Web Push |
+|------|---------------------|---------|-----------------|------------|--------|--------|----------|
+| Daily practice reminder | `daily_reminder` | Cron `/api/cron/dispatch-notifications` | `pushEnabled` + `dailyReminderEnabled` + quiet hours + frequency + tz | Yes (user time) | Partial | Partial | Yes (#347) |
+| Miss a day | `miss_a_day` | **Not implemented** (flag + dedup only) | `missADayEnabled` (unused by sender) | TBD (#247) | No | No | No |
+| Friend request | `friend_request` | `POST /api/friends/requests` | **None** | No (event) | No | No | No |
+
+**Shared API:** `GET|PATCH /api/notifications/preferences`  
+**iOS device registration:** `POST|DELETE /api/device-token`  
+**Web device registration:** `POST|DELETE /api/notifications/push/subscription`
+
+## Target UX
+
+### Navigation
+
+- **Settings** includes a row/menu item: **Notifications** (same label on both platforms).
+- Tapping opens a **dedicated Notifications screen** (not buried mid-scroll), so iOS and web share the same information architecture.
+- Web route suggestion: `/app/settings/notifications` (or modal/sheet from Settings — pick one pattern and mirror on iOS as `NavigationLink`).
+
+### Screen layout (parity contract)
+
+Use the **same section order and copy** on iOS and web (allow platform-native controls: `Toggle` vs button, `DatePicker` vs `<input type="time">`).
+
+1. **Push on this device**
+   - Master toggle: enable/disable push for this device/browser.
+   - iOS: system permission + APNs token registration (existing `NotificationPreferencesViewModel` / `PushNotificationCoordinator`).
+   - Web: permission + service worker + subscription (existing `WebNotificationSettings` flow).
+   - Web-only helper text: Safari iOS home-screen PWA requirement.
+
+2. **Daily practice reminder** (only when master push is on)
+   - Toggle: on/off → `dailyReminderEnabled`
+   - Time → `dailyReminderTime` (`HH:MM`, 24h)
+   - Frequency → `dailyReminderFrequency` (`daily` | `every_other` | `weekly`)
+   - Timezone → `tz` (IANA): show current value; allow change on **both** platforms (web today only auto-sets on opt-in).
+
+3. **Quiet hours** (only when master push is on)
+   - Toggle + start/end → `quietHoursStart` / `quietHoursEnd` (nullable pair, existing API rule: update both together).
+   - **Web: add** (iOS already has).
+
+4. **Miss a day** (only when master push is on)
+   - Toggle → `missADayEnabled`
+   - Short description of when it fires (product copy once #247 behavior is defined).
+   - **Requires backend:** implement miss-a-day send + scheduler branch before toggle does anything user-visible.
+
+5. **Friend activity** (or “Social”) (only when master push is on)
+   - Toggle → **new** preference field (recommended: `friendRequestNotificationsEnabled` on `notification_preferences`).
+   - Gate `sendFriendRequestNotification` in `src/app/api/friends/requests/route.ts`.
+   - **Web push:** extend `sendFriendRequestNotification` to fan out via `sendWebPushToUser` (mirror #347 daily reminder pattern).
+   - Deep link: define web URL + iOS `deepLink` for friend requests/inbox.
+
+6. **Errors / saving state**
+   - Inline error from PATCH failures (both platforms).
+   - Disabled controls while saving (iOS has `isSaving`; web has `busy`).
+
+### Out of scope for this ticket (unless product says otherwise)
+
+- Cross-device dedup (“only notify once if iOS + web both enabled”) — keep V1 dual-send.
+- Notification history / inbox UI.
+- Email/SMS channels.
+
+## Acceptance criteria
+
+- [ ] **Settings → Notifications** entry on **iOS** and **web** opens a dedicated screen (not only an inline section).
+- [ ] Screen content and section order **match** between platforms (copy deck in PR or linked Figma).
+- [ ] User can control **every shipped notification type** from that screen:
+  - [ ] Master push (per device)
+  - [ ] Daily reminder (enable, time, frequency, timezone)
+  - [ ] Quiet hours (enable, start, end) — **web parity**
+  - [ ] Miss a day (enable) — **after** sender + scheduler exist
+  - [ ] Friend requests (enable) — **after** preference column + API gate exist
+- [ ] Disabling master push disables dependent toggles in UI and persists `pushEnabled: false` (and unsubscribes web / disables token on iOS as today).
+- [ ] All changes persist via `PATCH /api/notifications/preferences` (and device registration endpoints as today).
+- [ ] Unit tests for new preference field + friend-request gate; scheduler tests for miss-a-day when implemented.
+- [ ] E2E or manual matrix: iOS Settings → Notifications; web Settings → Notifications; verify PATCH round-trip.
+
+## Implementation checklist
+
+### A. Product / copy
+
+- [ ] Final strings for each toggle and helper (including miss-a-day schedule description).
+- [ ] Confirm friend-request toggle default (on vs off for existing users).
+
+### B. Backend
+
+- [ ] Add `friend_request_notifications_enabled` (name TBD) to `notification_preferences` + migration + PATCH validation.
+- [ ] Gate `sendFriendRequestNotification` on master push + friend toggle.
+- [ ] Implement miss-a-day: `sendMissADayNotification`, scheduler branch, gating on `missADayEnabled` (coordinate with #247).
+- [ ] Fan out friend-request (and miss-a-day when added) to **web push** where applicable.
+- [ ] Document new fields in `docs/notifications.md`.
+
+### C. iOS
+
+- [ ] Extract NOTIFICATIONS block from `SettingsView.swift` into `NotificationsSettingsView` (or equivalent).
+- [ ] Add Settings row **Notifications** → push destination.
+- [ ] Add UI: miss-a-day toggle, friend-request toggle, timezone picker/display.
+- [ ] Wire PATCH fields in `NotificationPreferencesViewModel`.
+- [ ] Handle notification tap `type` for friend request / miss-a-day if new deep links added.
+
+### D. Web
+
+- [ ] Add Settings link to `/app/settings/notifications` (or chosen route).
+- [ ] Move `WebNotificationSettings` into dedicated page; add quiet hours, miss-a-day, friend-request, timezone edit.
+- [ ] Align component structure with iOS section order.
+
+### E. QA
+
+- [ ] Preferences sync: change on web, reload iOS (same account) and vice versa.
+- [ ] Verify cron still respects quiet hours + frequency after UI moves.
+- [ ] Friend request off → no push on new request; on → push on iOS + web.
+
+## Current file map (starting points)
+
+| Layer | Path |
+|-------|------|
+| API | `src/app/api/notifications/preferences/route.ts` |
+| Prefs model | `src/lib/notification-preferences.ts` |
+| Scheduler | `src/lib/notification-scheduler.ts` |
+| Send helpers | `src/lib/notifications.ts`, `src/lib/notifications/daily-reminder.ts` |
+| Web UI | `src/components/WebNotificationSettings.tsx`, `src/components/SettingsView.tsx` |
+| iOS UI | `ios/StillPointApp/Views/SettingsView.swift`, `NotificationPreferencesViewModel.swift` |
+| Docs | `docs/notifications.md` |
+
+## Gap summary (what this ticket delivers)
+
+| Gap | Work |
+|-----|------|
+| Not a dedicated **Notifications** screen | New route/view on web; navigation push on iOS |
+| Web missing quiet hours | UI + PATCH (API ready) |
+| Miss-a-day not controllable | UI + backend sender/scheduler (#247) |
+| Friend requests not controllable | New preference + gate + optional web push |
+| Friend / miss-a-day not on web push | Extend send helpers |
+| Timezone not editable on web | Timezone picker |
+| iOS/web layout drift | Shared copy + section order spec |
+
+---
+
+**Do not claim parity until all rows in “Acceptance criteria” are checked.** #347 (web push for daily reminder) is a prerequisite channel layer, not a complete Notifications settings product.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,19 +1,23 @@
 # Notifications
 
-Still Point delivers remote push notifications via APNs. User-facing schedules and opt-in live in `notification_preferences`; the server dispatches on a cron and records sends in `notification_dispatches` for idempotency.
+Still Point delivers remote push notifications via **APNs** (iOS) and **Web Push** (browsers). User-facing schedules and opt-in live in `notification_preferences`; the server dispatches on a cron and records sends in `notification_dispatches` for idempotency.
 
 ## Architecture
 
 ```mermaid
 flowchart LR
-  iOS[Settings UI] -->|GET/PATCH| PrefsAPI["/api/notifications/preferences"]
+  Clients[iOS + Web Settings] -->|GET/PATCH| PrefsAPI["/api/notifications/preferences"]
+  Web[Web browser] -->|POST/DELETE| SubAPI["/api/notifications/push/subscription"]
+  SubAPI --> WPS[(web_push_subscriptions)]
   PrefsAPI --> NP[(notification_preferences)]
   Cron["/api/cron/dispatch-notifications"] --> Scheduler[notification-scheduler]
   Scheduler --> NP
   Scheduler --> Ledger[(notification_dispatches)]
   Scheduler --> Send[notifications.ts]
   Send --> APNs[apns.ts]
+  Send --> WebPush[web-push.ts]
   Send --> DT[(device_tokens)]
+  WebPush --> WPS
 ```
 
 ## Database
@@ -22,8 +26,9 @@ flowchart LR
 |-------|---------|
 | `notification_preferences` | One row per user: master `push_enabled`, per-type flags, reminder time/frequency, quiet hours, IANA `tz` |
 | `notification_dispatches` | Unique `(user_id, notification_type, window_key)` — claim before send so cron retries do not double-send |
+| `web_push_subscriptions` | Browser Push API endpoints + `p256dh` / `auth` keys per device (#347) |
 
-Apply schema with `npm run db:migrate` (incremental SQL: `drizzle/notification_preferences_345_incremental.sql`).
+Apply schema with `npm run db:migrate` (incremental SQL: `drizzle/notification_preferences_345_incremental.sql`, `drizzle/web_push_subscriptions_347_incremental.sql`).
 
 ## API
 
@@ -64,6 +69,41 @@ Partial update. Supported fields:
 - Helper: `sendDailyReminderNotification`
 - Gated by: `push_enabled` && `daily_reminder_enabled`
 
+## Web Push (#347)
+
+### Environment
+
+Generate keys locally (never commit the private key):
+
+```bash
+npx web-push generate-vapid-keys
+```
+
+Set in Vercel (and `.env.local` for local sends):
+
+| Variable | Purpose |
+|----------|---------|
+| `WEB_PUSH_VAPID_PUBLIC_KEY` | VAPID public key (also exposed to the client as `NEXT_PUBLIC_WEB_PUSH_VAPID_PUBLIC_KEY` via `next.config.ts`) |
+| `WEB_PUSH_VAPID_PRIVATE_KEY` | Server-only; used by `src/lib/web-push.ts` |
+| `WEB_PUSH_VAPID_SUBJECT` | `mailto:you@still-point.me` contact for push services |
+
+### Service worker
+
+- Static file: `public/sw.js` (scope `/`)
+- Handles `push` → `showNotification`, `notificationclick` → focus or open `/app` (deep link from payload `url`)
+
+### API
+
+- `GET /api/notifications/push/subscription` — returns `{ publicKey }` when configured
+- `POST /api/notifications/push/subscription` — body `{ subscription: { endpoint, keys } }` (authenticated)
+- `DELETE /api/notifications/push/subscription` — body `{ endpoint }` (authenticated)
+
+Web Settings (`WebNotificationSettings` in `SettingsView`) mirrors iOS: master push toggle, daily reminder, time, frequency. **Safari on iOS** requires the site as a home-screen PWA (iOS 16.4+); the UI explains this.
+
+### Cross-channel behavior
+
+If a user has both iOS and web push enabled, **both channels receive** the daily reminder (V1). Per-channel opt-out is via disabling push on that device/browser.
+
 ## iOS
 
 - Settings → **NOTIFICATIONS**: master push toggle (triggers system permission on first opt-in), daily reminder toggle, time picker, frequency picker, quiet hours.
@@ -72,11 +112,13 @@ Partial update. Supported fields:
 
 ## Security
 
-- Never log raw APNs device tokens.
+- Never log raw APNs device tokens or Web Push `auth` keys.
+- Never commit `WEB_PUSH_VAPID_PRIVATE_KEY`.
 - Cron endpoint must not be callable without `CRON_SECRET` in production.
 
 ## Related issues
 
 - #203 — APNs + `device_tokens`
-- #346 — Daily reminder product behavior (builds on this foundation)
-- #347 — Miss-a-day notifications
+- #345 — Preferences + scheduler foundation
+- #346 — Daily reminder product behavior
+- #347 — Web Push parity

--- a/drizzle/web_push_subscriptions_347_incremental.sql
+++ b/drizzle/web_push_subscriptions_347_incremental.sql
@@ -1,0 +1,33 @@
+-- Web Push subscription storage (#347). One row per browser endpoint per user.
+
+CREATE TABLE IF NOT EXISTS "web_push_subscriptions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"endpoint" text NOT NULL,
+	"endpoint_hash" varchar(64) NOT NULL,
+	"p256dh" text NOT NULL,
+	"auth" text NOT NULL,
+	"user_agent" varchar(512),
+	"enabled" boolean DEFAULT true NOT NULL,
+	"last_used_at" timestamptz,
+	"created_at" timestamptz DEFAULT now() NOT NULL,
+	"updated_at" timestamptz DEFAULT now() NOT NULL
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'web_push_subscriptions_user_id_users_id_fk'
+  ) THEN
+    ALTER TABLE "web_push_subscriptions"
+      ADD CONSTRAINT "web_push_subscriptions_user_id_users_id_fk"
+      FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "web_push_subscriptions_endpoint_hash_unique"
+  ON "web_push_subscriptions" USING btree ("endpoint_hash");
+
+CREATE INDEX IF NOT EXISTS "idx_web_push_subscriptions_user_enabled"
+  ON "web_push_subscriptions" USING btree ("user_id", "enabled");

--- a/next.config.ts
+++ b/next.config.ts
@@ -47,10 +47,14 @@ const nextConfig: NextConfig = {
   // Externalize Neon's WS driver and `ws` so Next does not bundle them.
   // Bundling tree-shakes `ws`'s mask path on Vercel and crashes every
   // `poolDb.transaction()` with `b.mask is not a function`. See #246.
-  serverExternalPackages: ["@neondatabase/serverless", "ws"],
+  serverExternalPackages: ["@neondatabase/serverless", "ws", "web-push"],
   env: {
     NEXT_PUBLIC_APP_VERSION: readPackageVersion(),
     NEXT_PUBLIC_BUILD_SHA: shortGitSha(buildShaFull),
+    NEXT_PUBLIC_WEB_PUSH_VAPID_PUBLIC_KEY:
+      nonBlankEnv(process.env.NEXT_PUBLIC_WEB_PUSH_VAPID_PUBLIC_KEY)
+      ?? nonBlankEnv(process.env.WEB_PUSH_VAPID_PUBLIC_KEY)
+      ?? "",
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "server-only": "^0.0.1",
+        "web-push": "^3.6.7",
         "ws": "^8.20.0"
       },
       "devDependencies": {
@@ -28,6 +29,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/web-push": "^3.6.4",
         "@types/ws": "^8.18.1",
         "drizzle-kit": "^0.31.9",
         "tsx": "^4.21.0",
@@ -2399,6 +2401,16 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -2550,6 +2562,27 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2581,11 +2614,23 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
     "node_modules/bowser": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -2695,7 +2740,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3362,6 +3406,15 @@
         }
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/entities": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
@@ -3536,6 +3589,34 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -3624,6 +3705,27 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/lightningcss": {
@@ -3924,11 +4026,25 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4383,6 +4499,32 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -5403,6 +5545,25 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "server-only": "^0.0.1",
+    "web-push": "^3.6.7",
     "ws": "^8.20.0"
   },
   "devDependencies": {
@@ -49,6 +50,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/web-push": "^3.6.4",
     "@types/ws": "^8.18.1",
     "drizzle-kit": "^0.31.9",
     "tsx": "^4.21.0",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,49 @@
+/* Still Point Web Push service worker (#347). Served from site root. */
+
+self.addEventListener("push", (event) => {
+  let data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch {
+    data = {};
+  }
+
+  const title = typeof data.title === "string" ? data.title : "Still Point";
+  const body = typeof data.body === "string" ? data.body : "";
+  const url = typeof data.url === "string" ? data.url : "/app";
+
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body,
+      icon: "/og.png",
+      badge: "/og.png",
+      data: { url },
+      tag: typeof data.type === "string" ? data.type : "still-point",
+    }),
+  );
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const targetPath = event.notification.data?.url || "/app";
+  const targetUrl = new URL(targetPath, self.location.origin).href;
+
+  event.waitUntil(
+    clients.matchAll({ type: "window", includeUncontrolled: true }).then((windowClients) => {
+      for (const client of windowClients) {
+        if (client.url.startsWith(self.location.origin) && "focus" in client) {
+          return client.focus().then((focused) => {
+            if (focused && "navigate" in focused) {
+              return focused.navigate(targetUrl);
+            }
+            return undefined;
+          });
+        }
+      }
+      if (clients.openWindow) {
+        return clients.openWindow(targetUrl);
+      }
+      return undefined;
+    }),
+  );
+});

--- a/src/app/api/notifications/push/subscription/route.test.ts
+++ b/src/app/api/notifications/push/subscription/route.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const getCurrentUser = vi.fn();
+const insertReturning = vi.fn();
+const insertOnConflict = vi.fn(() => ({ returning: insertReturning }));
+const insertValues = vi.fn(() => ({ onConflictDoUpdate: insertOnConflict }));
+const dbInsert = vi.fn(() => ({ values: insertValues }));
+const updateReturning = vi.fn();
+const updateWhere = vi.fn(() => ({ returning: updateReturning }));
+const updateSet = vi.fn(() => ({ where: updateWhere }));
+const dbUpdate = vi.fn(() => ({ set: updateSet }));
+
+vi.mock("@/lib/auth", () => ({ getCurrentUser }));
+vi.mock("@/db", () => ({
+  db: {
+    insert: dbInsert,
+    update: dbUpdate,
+  },
+}));
+vi.mock("@/db/schema", () => ({
+  webPushSubscriptions: {
+    id: "id",
+    endpointHash: "endpointHash",
+    userId: "userId",
+  },
+}));
+vi.mock("@/lib/web-push", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/web-push")>();
+  return {
+    ...actual,
+    getWebPushPublicKey: vi.fn(() => "BPublicKey"),
+  };
+});
+
+describe("/api/notifications/push/subscription", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    process.env.WEB_PUSH_VAPID_PUBLIC_KEY = "BPublicKey";
+    getCurrentUser.mockResolvedValue({ userId: "user-1" });
+    insertReturning.mockResolvedValue([{ id: "sub-1" }]);
+    updateReturning.mockResolvedValue([{ id: "sub-1" }]);
+  });
+
+  test("GET returns the VAPID public key", async () => {
+    const { GET } = await import("./route");
+    const res = await GET();
+    await expect(res.json()).resolves.toEqual({ publicKey: "BPublicKey" });
+    expect(res.status).toBe(200);
+  });
+
+  test("POST registers a subscription for the authenticated user", async () => {
+    const { POST } = await import("./route");
+    const res = await POST(new NextRequest("http://localhost/api/notifications/push/subscription", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        subscription: {
+          endpoint: "https://push.example/sub",
+          keys: { p256dh: "p256", auth: "auth" },
+        },
+      }),
+    }));
+
+    expect(res.status).toBe(201);
+    await expect(res.json()).resolves.toEqual({ subscription: { id: "sub-1" } });
+    expect(dbInsert).toHaveBeenCalled();
+  });
+
+  test("DELETE disables a subscription by endpoint", async () => {
+    const { DELETE } = await import("./route");
+    const res = await DELETE(new NextRequest("http://localhost/api/notifications/push/subscription", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ endpoint: "https://push.example/sub" }),
+    }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true, removed: true });
+    expect(dbUpdate).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/notifications/push/subscription/route.ts
+++ b/src/app/api/notifications/push/subscription/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db";
+import { webPushSubscriptions } from "@/db/schema";
+import { getCurrentUser } from "@/lib/auth";
+import { readJsonObject } from "@/lib/readJsonObject";
+import {
+  getWebPushPublicKey,
+  hashWebPushEndpoint,
+  isValidPushSubscriptionInput,
+} from "@/lib/web-push";
+
+export async function GET() {
+  const publicKey = getWebPushPublicKey();
+  if (!publicKey) {
+    return NextResponse.json({ error: "Web Push is not configured" }, { status: 503 });
+  }
+  return NextResponse.json({ publicKey });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    if (!getWebPushPublicKey()) {
+      return NextResponse.json({ error: "Web Push is not configured" }, { status: 503 });
+    }
+
+    const json = await readJsonObject(request);
+    if (!json.ok) {
+      return json.response;
+    }
+
+    const subscription = json.body.subscription;
+    if (!isValidPushSubscriptionInput(subscription)) {
+      return NextResponse.json(
+        { error: "subscription must include endpoint and keys.p256dh / keys.auth" },
+        { status: 400 },
+      );
+    }
+
+    const userAgent = request.headers.get("user-agent")?.slice(0, 512) ?? null;
+    const endpointHash = hashWebPushEndpoint(subscription.endpoint);
+    const now = new Date();
+
+    const [registered] = await db
+      .insert(webPushSubscriptions)
+      .values({
+        userId: auth.userId,
+        endpoint: subscription.endpoint,
+        endpointHash,
+        p256dh: subscription.keys.p256dh,
+        auth: subscription.keys.auth,
+        userAgent,
+        enabled: true,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: webPushSubscriptions.endpointHash,
+        set: {
+          userId: auth.userId,
+          endpoint: subscription.endpoint,
+          p256dh: subscription.keys.p256dh,
+          auth: subscription.keys.auth,
+          userAgent,
+          enabled: true,
+          updatedAt: now,
+        },
+      })
+      .returning({ id: webPushSubscriptions.id });
+
+    return NextResponse.json({ subscription: { id: registered.id } }, { status: 201 });
+  } catch (error) {
+    console.error("Web Push subscription registration error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const json = await readJsonObject(request);
+    if (!json.ok) {
+      return json.response;
+    }
+
+    const endpoint = json.body.endpoint;
+    if (typeof endpoint !== "string" || endpoint.length < 8) {
+      return NextResponse.json({ error: "endpoint is required" }, { status: 400 });
+    }
+
+    const [updated] = await db
+      .update(webPushSubscriptions)
+      .set({ enabled: false, updatedAt: new Date() })
+      .where(
+        and(
+          eq(webPushSubscriptions.userId, auth.userId),
+          eq(webPushSubscriptions.endpointHash, hashWebPushEndpoint(endpoint)),
+        ),
+      )
+      .returning({ id: webPushSubscriptions.id });
+
+    return NextResponse.json({ ok: true, removed: Boolean(updated) });
+  } catch (error) {
+    console.error("Web Push subscription removal error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { DeleteAccountSection } from "@/components/DeleteAccountSection";
+import { WebNotificationSettings } from "@/components/WebNotificationSettings";
 import { api } from "@/lib/api";
 import {
   MAX_USERNAME_LENGTH,
@@ -258,6 +259,8 @@ export function SettingsView({
             {user.email}
           </div>
         </div>
+
+        <WebNotificationSettings />
 
         {/* Public board toggle */}
         <div style={{

--- a/src/components/WebNotificationSettings.tsx
+++ b/src/components/WebNotificationSettings.tsx
@@ -1,0 +1,362 @@
+"use client";
+
+import { useCallback, useEffect, useState, type CSSProperties } from "react";
+import {
+  detectedTimezone,
+  fetchNotificationPreferences,
+  fetchVapidPublicKey,
+  isWebPushSupported,
+  needsPwaInstallForWebPush,
+  patchNotificationPreferences,
+  registerWebPushSubscription,
+  subscribeBrowserPush,
+  type NotificationPreferencesDto,
+  unsubscribeBrowserPush,
+  unregisterWebPushEndpoint,
+} from "@/lib/web-push-client";
+
+const frequencyOptions = [
+  { value: "daily", label: "Daily" },
+  { value: "every_other", label: "Every other day" },
+  { value: "weekly", label: "Weekly (Mondays)" },
+] as const;
+
+export function WebNotificationSettings() {
+  const [prefs, setPrefs] = useState<NotificationPreferencesDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [pushEndpoint, setPushEndpoint] = useState<string | null>(null);
+
+  const supported = isWebPushSupported();
+  const pwaRequired = needsPwaInstallForWebPush();
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await fetchNotificationPreferences();
+      setPrefs(next);
+      if (supported && next.pushEnabled) {
+        const registration = await navigator.serviceWorker.ready.catch(() => null);
+        const sub = registration ? await registration.pushManager.getSubscription() : null;
+        setPushEndpoint(sub?.endpoint ?? null);
+      } else {
+        setPushEndpoint(null);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not load notifications");
+    } finally {
+      setLoading(false);
+    }
+  }, [supported]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const persist = async (patch: Partial<NotificationPreferencesDto>) => {
+    const updated = await patchNotificationPreferences(patch);
+    setPrefs(updated);
+    return updated;
+  };
+
+  const enablePush = async () => {
+    if (pwaRequired) {
+      setError("On iPhone and iPad, add Still Point to your Home Screen first, then enable notifications from that app.");
+      return;
+    }
+    const permission = await Notification.requestPermission();
+    if (permission !== "granted") {
+      setError("Notification permission was not granted.");
+      return;
+    }
+    const publicKey = await fetchVapidPublicKey();
+    const subscription = await subscribeBrowserPush(publicKey);
+    await registerWebPushSubscription(subscription);
+    setPushEndpoint(subscription.endpoint);
+    await persist({
+      pushEnabled: true,
+      tz: detectedTimezone(),
+    });
+  };
+
+  const disablePush = async () => {
+    const subscription = await unsubscribeBrowserPush();
+    if (subscription?.endpoint) {
+      await unregisterWebPushEndpoint(subscription.endpoint);
+    } else if (pushEndpoint) {
+      await unregisterWebPushEndpoint(pushEndpoint);
+    }
+    setPushEndpoint(null);
+    await persist({ pushEnabled: false, dailyReminderEnabled: false });
+  };
+
+  const handlePushToggle = async () => {
+    if (!prefs || busy) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      if (prefs.pushEnabled) {
+        await disablePush();
+      } else {
+        await enablePush();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not update push notifications");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDailyReminderToggle = async () => {
+    if (!prefs || busy || !prefs.pushEnabled) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await persist({ dailyReminderEnabled: !prefs.dailyReminderEnabled });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not update daily reminder");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleTimeChange = async (value: string) => {
+    if (!prefs || busy) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await persist({ dailyReminderTime: value });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not update reminder time");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleFrequencyChange = async (value: NotificationPreferencesDto["dailyReminderFrequency"]) => {
+    if (!prefs || busy) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await persist({ dailyReminderFrequency: value });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not update reminder frequency");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div style={cardStyle}>
+        <div style={labelStyle}>NOTIFICATIONS</div>
+        <div style={hintStyle}>Loading…</div>
+      </div>
+    );
+  }
+
+  if (!supported) {
+    return (
+      <div style={cardStyle}>
+        <div style={labelStyle}>NOTIFICATIONS</div>
+        <div style={hintStyle}>
+          This browser does not support web push. Use Chrome, Firefox, or Safari on desktop, Chrome on Android,
+          or add Still Point to your iPhone Home Screen (iOS 16.4+).
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ ...cardStyle, display: "flex", flexDirection: "column", gap: "14px" }}>
+      <div style={labelStyle}>NOTIFICATIONS</div>
+
+      {pwaRequired && (
+        <div style={hintStyle} role="note">
+          On iPhone and iPad, web push only works when you open Still Point from your Home Screen (Share → Add to Home Screen), not from Safari tabs.
+        </div>
+      )}
+
+      <ToggleRow
+        title="Push notifications"
+        description="Reminders and updates in this browser"
+        pressed={Boolean(prefs?.pushEnabled)}
+        disabled={busy}
+        onToggle={() => { void handlePushToggle(); }}
+      />
+
+      {prefs?.pushEnabled && (
+        <>
+          <ToggleRow
+            title="Daily reminder"
+            description="Nudge to sit at your chosen local time"
+            pressed={prefs.dailyReminderEnabled}
+            disabled={busy}
+            onToggle={() => { void handleDailyReminderToggle(); }}
+          />
+
+          {prefs.dailyReminderEnabled && (
+            <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+              <label style={fieldLabelStyle}>
+                Reminder time
+                <input
+                  type="time"
+                  value={prefs.dailyReminderTime}
+                  disabled={busy}
+                  onChange={(e) => { void handleTimeChange(e.target.value); }}
+                  style={timeInputStyle}
+                />
+              </label>
+              <label style={fieldLabelStyle}>
+                Frequency
+                <select
+                  value={prefs.dailyReminderFrequency}
+                  disabled={busy}
+                  onChange={(e) => {
+                    void handleFrequencyChange(
+                      e.target.value as NotificationPreferencesDto["dailyReminderFrequency"],
+                    );
+                  }}
+                  style={selectStyle}
+                >
+                  {frequencyOptions.map((opt) => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </select>
+              </label>
+              <div style={hintStyle}>
+                Timezone: {prefs.tz}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {error && (
+        <div role="alert" style={errorStyle}>{error}</div>
+      )}
+    </div>
+  );
+}
+
+function ToggleRow(props: {
+  title: string;
+  description: string;
+  pressed: boolean;
+  disabled?: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "16px" }}>
+      <div>
+        <div style={{ fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace", fontSize: "12px", color: "var(--fg)" }}>
+          {props.title}
+        </div>
+        <div style={{
+          fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+          fontSize: "13px",
+          fontStyle: "italic",
+          color: "var(--fg-3)",
+        }}
+        >
+          {props.description}
+        </div>
+      </div>
+      <button
+        type="button"
+        aria-label={props.pressed ? `Disable ${props.title}` : `Enable ${props.title}`}
+        aria-pressed={props.pressed}
+        onClick={props.onToggle}
+        disabled={props.disabled}
+        style={{
+          width: "48px",
+          height: "26px",
+          borderRadius: "13px",
+          border: "none",
+          background: props.pressed ? "var(--accent-green-bg)" : "var(--surface-3)",
+          position: "relative",
+          cursor: props.disabled ? "not-allowed" : "pointer",
+          transition: "background 0.3s",
+          flexShrink: 0,
+        }}
+      >
+        <div style={{
+          width: "20px",
+          height: "20px",
+          borderRadius: "10px",
+          background: props.pressed ? "var(--accent-green)" : "var(--border-3)",
+          position: "absolute",
+          top: "3px",
+          left: props.pressed ? "25px" : "3px",
+          transition: "all 0.3s",
+        }}
+        />
+      </button>
+    </div>
+  );
+}
+
+const cardStyle: CSSProperties = {
+  padding: "16px 20px",
+  background: "var(--surface-1)",
+  borderRadius: "10px",
+};
+
+const labelStyle: CSSProperties = {
+  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+  fontSize: "11px",
+  color: "var(--fg-4)",
+  letterSpacing: "0.12em",
+  textTransform: "uppercase",
+};
+
+const hintStyle: CSSProperties = {
+  fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+  fontSize: "13px",
+  fontStyle: "italic",
+  color: "var(--fg-3)",
+  lineHeight: 1.5,
+};
+
+const errorStyle: CSSProperties = {
+  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+  fontSize: "11px",
+  color: "var(--accent-danger-muted)",
+};
+
+const fieldLabelStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "6px",
+  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+  fontSize: "11px",
+  color: "var(--fg-3)",
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+};
+
+const timeInputStyle: CSSProperties = {
+  fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+  fontSize: "16px",
+  color: "var(--fg)",
+  background: "var(--surface-2)",
+  border: "1px solid var(--border-3)",
+  borderRadius: "6px",
+  padding: "6px 10px",
+};
+
+const selectStyle: CSSProperties = {
+  ...timeInputStyle,
+  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+  fontSize: "13px",
+};

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -78,6 +78,24 @@ export const notificationDispatches = pgTable("notification_dispatches", {
   ),
 }));
 
+/** Browser Web Push subscriptions (#347). One row per Push API endpoint. */
+export const webPushSubscriptions = pgTable("web_push_subscriptions", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  userId: uuid("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
+  endpoint: text("endpoint").notNull(),
+  endpointHash: varchar("endpoint_hash", { length: 64 }).notNull(),
+  p256dh: text("p256dh").notNull(),
+  auth: text("auth").notNull(),
+  userAgent: varchar("user_agent", { length: 512 }),
+  enabled: boolean("enabled").default(true).notNull(),
+  lastUsedAt: timestamp("last_used_at", { withTimezone: true }),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  endpointHashUnique: uniqueIndex("web_push_subscriptions_endpoint_hash_unique").on(table.endpointHash),
+  userEnabledIdx: index("idx_web_push_subscriptions_user_enabled").on(table.userId, table.enabled),
+}));
+
 export const deviceTokens = pgTable("device_tokens", {
   id: uuid("id").primaryKey().defaultRandom(),
   userId: uuid("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
@@ -322,6 +340,7 @@ export const usersRelations = relations(users, ({ one, many }) => ({
   thoughts: many(thoughts),
   passwordResetTokens: many(passwordResetTokens),
   deviceTokens: many(deviceTokens),
+  webPushSubscriptions: many(webPushSubscriptions),
   notificationPreferences: one(notificationPreferences, {
     fields: [users.id],
     references: [notificationPreferences.userId],
@@ -349,6 +368,10 @@ export const notificationDispatchesRelations = relations(notificationDispatches,
 
 export const deviceTokensRelations = relations(deviceTokens, ({ one }) => ({
   user: one(users, { fields: [deviceTokens.userId], references: [users.id] }),
+}));
+
+export const webPushSubscriptionsRelations = relations(webPushSubscriptions, ({ one }) => ({
+  user: one(users, { fields: [webPushSubscriptions.userId], references: [users.id] }),
 }));
 
 export const passwordResetTokensRelations = relations(passwordResetTokens, ({ one }) => ({

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -32,6 +32,12 @@ vi.mock("@/lib/apns", () => ({
   sendApnsNotification,
 }));
 
+const sendWebPushToUser = vi.fn();
+
+vi.mock("@/lib/web-push", () => ({
+  sendWebPushToUser,
+}));
+
 vi.mock("drizzle-orm", () => ({
   and: vi.fn((...args) => ({ and: args })),
   eq: vi.fn((left, right) => ({ left, right })),
@@ -43,6 +49,7 @@ describe("sendFriendRequestNotification", () => {
     tokenRows.length = 0;
     selectWhere.mockResolvedValue(tokenRows);
     sendApnsNotification.mockResolvedValue({ ok: true, status: 200 });
+    sendWebPushToUser.mockResolvedValue(undefined);
   });
 
   test("sends the friend request APNs payload to each enabled device token", async () => {
@@ -101,12 +108,21 @@ describe("sendFriendRequestNotification", () => {
     expect(updateSet).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
   });
 
-  test("sends the daily reminder APNs payload", async () => {
+  test("sends the daily reminder to APNs and Web Push", async () => {
     tokenRows.push({ id: "dt-1", token: "a".repeat(64), apnsEnvironment: "development" });
     const { sendDailyReminderNotification } = await import("./notifications");
 
     await sendDailyReminderNotification({ recipientUserId: "recipient-id" });
 
+    expect(sendWebPushToUser).toHaveBeenCalledWith({
+      recipientUserId: "recipient-id",
+      payload: {
+        title: "Time for your sit",
+        body: "Take a few minutes for your daily practice.",
+        type: "daily_reminder",
+        url: "/app",
+      },
+    });
     expect(sendApnsNotification).toHaveBeenCalledWith("a".repeat(64), "development", {
       aps: {
         alert: {

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -2,6 +2,10 @@ import { and, eq } from "drizzle-orm";
 import { db } from "@/db";
 import { deviceTokens } from "@/db/schema";
 import { type ApnsEnvironment, type ApnsPayload, sendApnsNotification } from "@/lib/apns";
+import { sendWebPushToUser } from "@/lib/web-push";
+
+const DAILY_REMINDER_TITLE = "Time for your sit";
+const DAILY_REMINDER_BODY = "Take a few minutes for your daily practice.";
 
 const invalidTokenReasons = new Set(["BadDeviceToken", "DeviceTokenNotForTopic", "Unregistered"]);
 const PUSH_SEND_CONCURRENCY = 3;
@@ -53,20 +57,31 @@ export async function sendPushNotificationToUser(params: {
 export async function sendDailyReminderNotification(params: {
   recipientUserId: string;
 }): Promise<void> {
-  await sendPushNotificationToUser({
-    recipientUserId: params.recipientUserId,
-    payload: {
-      aps: {
-        alert: {
-          title: "Time for your sit",
-          body: "Take a few minutes for your daily practice.",
+  await Promise.all([
+    sendPushNotificationToUser({
+      recipientUserId: params.recipientUserId,
+      payload: {
+        aps: {
+          alert: {
+            title: DAILY_REMINDER_TITLE,
+            body: DAILY_REMINDER_BODY,
+          },
+          sound: "default",
+          "thread-id": "daily-reminder",
         },
-        sound: "default",
-        "thread-id": "daily-reminder",
+        type: "daily_reminder",
       },
-      type: "daily_reminder",
-    },
-  });
+    }),
+    sendWebPushToUser({
+      recipientUserId: params.recipientUserId,
+      payload: {
+        title: DAILY_REMINDER_TITLE,
+        body: DAILY_REMINDER_BODY,
+        type: "daily_reminder",
+        url: "/app",
+      },
+    }),
+  ]);
 }
 
 export async function sendFriendRequestNotification(params: {

--- a/src/lib/web-push-client.ts
+++ b/src/lib/web-push-client.ts
@@ -1,0 +1,140 @@
+"use client";
+
+export type NotificationPreferencesDto = {
+  pushEnabled: boolean;
+  dailyReminderEnabled: boolean;
+  missADayEnabled: boolean;
+  dailyReminderTime: string;
+  dailyReminderFrequency: "daily" | "every_other" | "weekly";
+  quietHoursStart: string | null;
+  quietHoursEnd: string | null;
+  tz: string;
+};
+
+export function isWebPushSupported(): boolean {
+  return typeof window !== "undefined"
+    && "serviceWorker" in navigator
+    && "PushManager" in window
+    && "Notification" in window;
+}
+
+/** iOS Safari only delivers web push to home-screen PWAs (iOS 16.4+). */
+export function needsPwaInstallForWebPush(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  const ua = navigator.userAgent;
+  const isIos = /iphone|ipad|ipod/i.test(ua);
+  if (!isIos) {
+    return false;
+  }
+  const nav = navigator as Navigator & { standalone?: boolean };
+  return nav.standalone !== true;
+}
+
+export function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = window.atob(base64);
+  const output = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i += 1) {
+    output[i] = raw.charCodeAt(i);
+  }
+  return output;
+}
+
+export async function registerServiceWorker(): Promise<ServiceWorkerRegistration> {
+  return navigator.serviceWorker.register("/sw.js", { scope: "/" });
+}
+
+export async function fetchVapidPublicKey(): Promise<string> {
+  const res = await fetch("/api/notifications/push/subscription");
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || typeof data.publicKey !== "string") {
+    throw new Error(data.error ?? "Web Push is not available");
+  }
+  return data.publicKey;
+}
+
+export async function subscribeBrowserPush(publicKey: string): Promise<PushSubscription> {
+  const registration = await registerServiceWorker();
+  const existing = await registration.pushManager.getSubscription();
+  if (existing) {
+    return existing;
+  }
+  return registration.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(publicKey),
+  });
+}
+
+export async function unsubscribeBrowserPush(): Promise<PushSubscription | null> {
+  const registration = await navigator.serviceWorker.ready;
+  const subscription = await registration.pushManager.getSubscription();
+  if (!subscription) {
+    return null;
+  }
+  await subscription.unsubscribe();
+  return subscription;
+}
+
+export async function registerWebPushSubscription(subscription: PushSubscription): Promise<void> {
+  const json = subscription.toJSON();
+  if (!json.endpoint || !json.keys?.p256dh || !json.keys?.auth) {
+    throw new Error("Invalid push subscription");
+  }
+  const res = await fetch("/api/notifications/push/subscription", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      subscription: {
+        endpoint: json.endpoint,
+        keys: { p256dh: json.keys.p256dh, auth: json.keys.auth },
+      },
+    }),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data.error ?? "Could not save push subscription");
+  }
+}
+
+export async function unregisterWebPushEndpoint(endpoint: string): Promise<void> {
+  await fetch("/api/notifications/push/subscription", {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ endpoint }),
+  });
+}
+
+export async function patchNotificationPreferences(
+  patch: Partial<NotificationPreferencesDto>,
+): Promise<NotificationPreferencesDto> {
+  const res = await fetch("/api/notifications/preferences", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(patch),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(data.error ?? "Could not update notification preferences");
+  }
+  return data.preferences as NotificationPreferencesDto;
+}
+
+export async function fetchNotificationPreferences(): Promise<NotificationPreferencesDto> {
+  const res = await fetch("/api/notifications/preferences");
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(data.error ?? "Could not load notification preferences");
+  }
+  return data.preferences as NotificationPreferencesDto;
+}
+
+export function detectedTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}

--- a/src/lib/web-push.test.ts
+++ b/src/lib/web-push.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const subscriptionRows: Array<{
+  id: string;
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+}> = [];
+const updateWhere = vi.fn();
+const updateSet = vi.fn(() => ({ where: updateWhere }));
+const dbUpdate = vi.fn(() => ({ set: updateSet }));
+const selectWhere = vi.fn();
+const selectFrom = vi.fn(() => ({ where: selectWhere }));
+const dbSelect = vi.fn(() => ({ from: selectFrom }));
+const sendNotification = vi.fn();
+
+vi.mock("@/db", () => ({
+  db: {
+    select: dbSelect,
+    update: dbUpdate,
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  webPushSubscriptions: {
+    id: "id",
+    endpoint: "endpoint",
+    p256dh: "p256dh",
+    auth: "auth",
+    userId: "userId",
+    enabled: "enabled",
+    lastUsedAt: "lastUsedAt",
+    updatedAt: "updatedAt",
+  },
+}));
+
+vi.mock("web-push", () => ({
+  default: {
+    setVapidDetails: vi.fn(),
+    sendNotification: sendNotification,
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn((...args) => ({ and: args })),
+  eq: vi.fn((left, right) => ({ left, right })),
+}));
+
+describe("sendWebPushToUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    subscriptionRows.length = 0;
+    selectWhere.mockResolvedValue(subscriptionRows);
+    sendNotification.mockResolvedValue(undefined);
+    process.env.WEB_PUSH_VAPID_PUBLIC_KEY = "BPublicKey";
+    process.env.WEB_PUSH_VAPID_PRIVATE_KEY = "privateKey";
+    process.env.WEB_PUSH_VAPID_SUBJECT = "mailto:ops@still-point.me";
+  });
+
+  test("sends daily reminder payload to enabled subscriptions", async () => {
+    subscriptionRows.push({
+      id: "wps-1",
+      endpoint: "https://push.example/1",
+      p256dh: "p256",
+      auth: "auth",
+    });
+    const { sendWebPushToUser } = await import("./web-push");
+
+    await sendWebPushToUser({
+      recipientUserId: "user-1",
+      payload: {
+        title: "Time for your sit",
+        body: "Take a few minutes for your daily practice.",
+        type: "daily_reminder",
+        url: "/app",
+      },
+    });
+
+    expect(sendNotification).toHaveBeenCalledWith(
+      { endpoint: "https://push.example/1", keys: { p256dh: "p256", auth: "auth" } },
+      JSON.stringify({
+        title: "Time for your sit",
+        body: "Take a few minutes for your daily practice.",
+        type: "daily_reminder",
+        url: "/app",
+      }),
+    );
+    expect(dbUpdate).toHaveBeenCalled();
+  });
+
+  test("disables expired subscriptions", async () => {
+    subscriptionRows.push({
+      id: "wps-1",
+      endpoint: "https://push.example/1",
+      p256dh: "p256",
+      auth: "auth",
+    });
+    sendNotification.mockRejectedValue({ statusCode: 410 });
+    const { sendWebPushToUser } = await import("./web-push");
+
+    await sendWebPushToUser({
+      recipientUserId: "user-1",
+      payload: { title: "T", body: "B", type: "daily_reminder" },
+    });
+
+    expect(updateSet).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
+  });
+
+  test("no-ops when VAPID is not configured", async () => {
+    delete process.env.WEB_PUSH_VAPID_PRIVATE_KEY;
+    subscriptionRows.push({
+      id: "wps-1",
+      endpoint: "https://push.example/1",
+      p256dh: "p256",
+      auth: "auth",
+    });
+    const { sendWebPushToUser } = await import("./web-push");
+
+    await sendWebPushToUser({
+      recipientUserId: "user-1",
+      payload: { title: "T", body: "B", type: "daily_reminder" },
+    });
+
+    expect(sendNotification).not.toHaveBeenCalled();
+  });
+});
+
+describe("isValidPushSubscriptionInput", () => {
+  test("accepts well-formed subscription JSON", async () => {
+    const { isValidPushSubscriptionInput } = await import("./web-push");
+    expect(isValidPushSubscriptionInput({
+      endpoint: "https://push.example/sub",
+      keys: { p256dh: "key", auth: "secret" },
+    })).toBe(true);
+  });
+});

--- a/src/lib/web-push.ts
+++ b/src/lib/web-push.ts
@@ -1,0 +1,136 @@
+import crypto from "node:crypto";
+import webpush from "web-push";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db";
+import { webPushSubscriptions } from "@/db/schema";
+
+const PUSH_SEND_CONCURRENCY = 3;
+
+export type WebPushPayload = {
+  title: string;
+  body: string;
+  type: string;
+  /** Path opened when the user clicks the notification (default /app). */
+  url?: string;
+};
+
+export type PushSubscriptionInput = {
+  endpoint: string;
+  keys: {
+    p256dh: string;
+    auth: string;
+  };
+};
+
+let vapidConfigured = false;
+
+export function hashWebPushEndpoint(endpoint: string): string {
+  return crypto.createHash("sha256").update(endpoint.trim()).digest("hex");
+}
+
+export function isValidPushSubscriptionInput(value: unknown): value is PushSubscriptionInput {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.endpoint !== "string" || record.endpoint.length < 8) {
+    return false;
+  }
+  if (!record.keys || typeof record.keys !== "object") {
+    return false;
+  }
+  const keys = record.keys as Record<string, unknown>;
+  return typeof keys.p256dh === "string" && keys.p256dh.length > 0
+    && typeof keys.auth === "string" && keys.auth.length > 0;
+}
+
+export function getWebPushPublicKey(): string | null {
+  const key = (process.env.WEB_PUSH_VAPID_PUBLIC_KEY ?? process.env.NEXT_PUBLIC_WEB_PUSH_VAPID_PUBLIC_KEY ?? "").trim();
+  return key.length > 0 ? key : null;
+}
+
+export function getWebPushVapidSubject(): string | null {
+  const subject = (process.env.WEB_PUSH_VAPID_SUBJECT ?? "").trim();
+  return subject.length > 0 ? subject : null;
+}
+
+function ensureVapidConfigured(): boolean {
+  if (vapidConfigured) {
+    return true;
+  }
+  const publicKey = getWebPushPublicKey();
+  const privateKey = (process.env.WEB_PUSH_VAPID_PRIVATE_KEY ?? "").trim();
+  const subject = getWebPushVapidSubject();
+  if (!publicKey || !privateKey || !subject) {
+    return false;
+  }
+  webpush.setVapidDetails(subject, publicKey, privateKey);
+  vapidConfigured = true;
+  return true;
+}
+
+function isExpiredSubscriptionError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const statusCode = (error as { statusCode?: number }).statusCode;
+  return statusCode === 404 || statusCode === 410;
+}
+
+export async function sendWebPushToUser(params: {
+  recipientUserId: string;
+  payload: WebPushPayload;
+}): Promise<void> {
+  if (!ensureVapidConfigured()) {
+    return;
+  }
+
+  const subscriptions = await db
+    .select({
+      id: webPushSubscriptions.id,
+      endpoint: webPushSubscriptions.endpoint,
+      p256dh: webPushSubscriptions.p256dh,
+      auth: webPushSubscriptions.auth,
+    })
+    .from(webPushSubscriptions)
+    .where(and(
+      eq(webPushSubscriptions.userId, params.recipientUserId),
+      eq(webPushSubscriptions.enabled, true),
+    ));
+
+  const body = JSON.stringify({
+    title: params.payload.title,
+    body: params.payload.body,
+    type: params.payload.type,
+    url: params.payload.url ?? "/app",
+  });
+
+  for (let i = 0; i < subscriptions.length; i += PUSH_SEND_CONCURRENCY) {
+    const batch = subscriptions.slice(i, i + PUSH_SEND_CONCURRENCY);
+    await Promise.all(batch.map(async (row) => {
+      try {
+        await webpush.sendNotification(
+          {
+            endpoint: row.endpoint,
+            keys: { p256dh: row.p256dh, auth: row.auth },
+          },
+          body,
+        );
+        const now = new Date();
+        await db
+          .update(webPushSubscriptions)
+          .set({ lastUsedAt: now, updatedAt: now })
+          .where(eq(webPushSubscriptions.id, row.id));
+      } catch (error) {
+        if (isExpiredSubscriptionError(error)) {
+          await db
+            .update(webPushSubscriptions)
+            .set({ enabled: false, updatedAt: new Date() })
+            .where(eq(webPushSubscriptions.id, row.id));
+          return;
+        }
+        console.warn("Web Push notification failed", { subscriptionId: row.id, error });
+      }
+    }));
+  }
+}


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #347

## Summary

Adds browser Web Push alongside the existing #345 notification foundation so opted-in web users receive the same daily reminder as iOS (APNs), with click-through to `/app`.

## What changed

- **`public/sw.js`** — registers at `/`, handles `push` + `notificationclick` (deep link via payload `url`, default `/app`)
- **`web_push_subscriptions` table** + migration `drizzle/web_push_subscriptions_347_incremental.sql`
- **`src/lib/web-push.ts`** — VAPID send helper, expired subscription cleanup
- **`/api/notifications/push/subscription`** — GET public key, POST/DELETE subscription (mirrors device-token pattern)
- **Web Settings** — `WebNotificationSettings` in Settings: push opt-in, daily reminder time/frequency, Safari iOS PWA note
- **Scheduler fan-out** — `sendDailyReminderNotification` now sends APNs **and** Web Push (V1: both channels if enabled)

## Ops / env (required for sends)

Generate once locally (`npx web-push generate-vapid-keys`) and set in Vercel (never commit private key):

- `WEB_PUSH_VAPID_PUBLIC_KEY`
- `WEB_PUSH_VAPID_PRIVATE_KEY`
- `WEB_PUSH_VAPID_SUBJECT` (e.g. `mailto:ops@still-point.me`)

Public key is also exposed to the client via `NEXT_PUBLIC_WEB_PUSH_VAPID_PUBLIC_KEY` in `next.config.ts`.

## Verification

- `npm run test:unit` — 103 passed
- `npm run build` — success

## Manual QA (pre-merge)

Browser matrix from #347 AC still needs human verification on Preview with VAPID keys set:

- Chrome / Firefox / Safari desktop
- Chrome Android
- Safari iOS (home-screen PWA)

## #292 / routes note

No open #292 work found in-repo. Web already uses REST under `/api/*` (same shape as iOS `APIClient`). Service worker is static at `/sw.js` and does not conflict with `/app`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7d97700-f97a-4820-a2cf-1eb02b8a11a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7d97700-f97a-4820-a2cf-1eb02b8a11a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Add browser push notifications for daily reminders**

### What Changed
- Users can now turn on web push notifications in Settings, choose reminder time and frequency, and see a note when iPhone and iPad need the app added to the Home Screen
- Daily reminders are now sent to both iOS devices and web browsers when both are enabled
- Clicking a web notification opens the app directly to the reminder screen
- Subscription setup and removal are now handled for browsers, with support for saving new endpoints and disabling old ones when they expire

### Impact
`✅ Daily reminders on desktop browsers`
`✅ Fewer missed reminders for users with both phone and web notifications`
`✅ Clearer iPhone push setup guidance`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser Web Push support so users can receive notifications in supported browsers
  * Settings UI to enable/disable web push and manage daily reminders (on/off, time, frequency) per device/browser
  * Web behavior mirrors iOS daily reminders; per-device/browser opt-out supported; iOS/Safari may require PWA install

* **Documentation**
  * Added Web Push configuration and setup guidance, including required environment variables and operational notes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->