### PR TITLE
feat(iOS): Multi-buddy calendar views (unified + per-buddy) (#358)

### DIFF
--- a/ios/PARITY_CHECKLIST.md
+++ b/ios/PARITY_CHECKLIST.md
@@ -1,6 +1,6 @@
 # iOS vs Web Feature Parity Checklist (Issue #210)
 
-Last updated: 2026-04-24  
+Last updated: 2026-06-03  
 Release owner: iOS release DRI
 
 ## Core product parity
@@ -16,6 +16,7 @@ Release owner: iOS release DRI
 | Thought journal | Implemented | Implemented | ✅ Complete | iOS `ThoughtJournalView` maps to web `ThoughtJournal`. |
 | Public board + visibility toggle | Implemented | Implemented | ✅ Complete | iOS `SettingsView` includes `isPublic` toggle and board read. |
 | Buddy session create/join/wait/start/leave/complete | Implemented | Implemented | ✅ Complete | iOS uses same buddy session API contract as web. |
+| Buddy calendar (unified + per-buddy, filters, pagination) | Implemented | Implemented | ✅ Complete | iOS `BuddyCalendarView` mirrors web `BuddyCalendarView`; entry via `BuddySessionHubView` until Friends tab ships. |
 | Buddy invite deep links | Implemented | Implemented | ✅ Complete | iOS handles `stillpoint://buddy` and web invite URL forms. |
 | Account deletion flow | Implemented | Implemented | ✅ Complete | iOS Settings includes two-step destructive confirmation. |
 

--- a/ios/StillPoint.xcodeproj/project.pbxproj
+++ b/ios/StillPoint.xcodeproj/project.pbxproj
@@ -46,6 +46,10 @@
 		DB99CD9DA2E6BB2A49B63025 /* PublicBoardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BD7D2C82C908604A0C3D914 /* PublicBoardView.swift */; };
 		E1FBFCD4730D9BC4E924C938 /* StillPointApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CEC6DBFFB1C10CFDDA8424 /* StillPointApp.swift */; };
 		F370AA8F6AA102355FC599C9 /* BlockGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EAF998E3470CBB4056699F /* BlockGridView.swift */; };
+		17A346000000000000000001 /* BuddyCalendarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A346000000000000000011 /* BuddyCalendarViewModel.swift */; };
+		17A346000000000000000002 /* BuddyCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A346000000000000000012 /* BuddyCalendarView.swift */; };
+		17A346000000000000000003 /* SessionStateBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A346000000000000000013 /* SessionStateBadge.swift */; };
+		17A346000000000000000004 /* BuddyFilterChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A346000000000000000014 /* BuddyFilterChips.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -91,6 +95,10 @@
 		DAAF68030111C6FA73098D17 /* BuddySessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddySessionViewModel.swift; sourceTree = "<group>"; };
 		FDE2D028ACC5D7FEFD82703D /* SessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionViewModel.swift; sourceTree = "<group>"; };
 		09E9BBE4830753E3B8FCC1C0 /* BuddyActiveSessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyActiveSessionView.swift; sourceTree = "<group>"; };
+		17A346000000000000000011 /* BuddyCalendarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyCalendarViewModel.swift; sourceTree = "<group>"; };
+		17A346000000000000000012 /* BuddyCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyCalendarView.swift; sourceTree = "<group>"; };
+		17A346000000000000000013 /* SessionStateBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStateBadge.swift; sourceTree = "<group>"; };
+		17A346000000000000000014 /* BuddyFilterChips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyFilterChips.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -110,6 +118,7 @@
 			children = (
 				A00D7B1EDF2C56A1B6EB4C28 /* AuthView.swift */,
 				9AEB18D5D4C55CB98F814D43 /* BuddySession */,
+				17A346000000000000000010 /* BuddyCalendar */,
 				7D13B1D65F99CF21AA713D32 /* CompletionView.swift */,
 				C7766937C968433C205A250C /* HistoryView.swift */,
 				23FA6DAE71EE23FAF8EE0F12 /* HomeView.swift */,
@@ -209,6 +218,16 @@
 			path = BuddySession;
 			sourceTree = "<group>";
 		};
+		17A346000000000000000010 /* BuddyCalendar */ = {
+			isa = PBXGroup;
+			children = (
+				17A346000000000000000012 /* BuddyCalendarView.swift */,
+				17A346000000000000000014 /* BuddyFilterChips.swift */,
+				17A346000000000000000013 /* SessionStateBadge.swift */,
+			);
+			path = BuddyCalendar;
+			sourceTree = "<group>";
+		};
 		70234ED5699E0294984184EC = {
 			isa = PBXGroup;
 			children = (
@@ -242,6 +261,7 @@
 				DAAF68030111C6FA73098D17 /* BuddySessionViewModel.swift */,
 				0D22599DCB705628A5CB6F51 /* BoardViewModel.swift */,
 				1F75039BBEED880C73680860 /* HistoryViewModel.swift */,
+				17A346000000000000000011 /* BuddyCalendarViewModel.swift */,
 				FDE2D028ACC5D7FEFD82703D /* SessionViewModel.swift */,
 				42927B68B0A976D71FE0637F /* ThoughtJournalViewModel.swift */,
 				17A345000000000000000001 /* NotificationPreferencesViewModel.swift */,
@@ -349,6 +369,10 @@
 				760C4A2F57E6B207F729ABEA /* BuddyActiveSessionView.swift in Sources */,
 				25295F15540B9986B15EB839 /* BuddySessionContainerView.swift in Sources */,
 				3F95AB4ED8A3AB01D8D2B042 /* BuddySessionHubView.swift in Sources */,
+				17A346000000000000000001 /* BuddyCalendarViewModel.swift in Sources */,
+				17A346000000000000000002 /* BuddyCalendarView.swift in Sources */,
+				17A346000000000000000003 /* SessionStateBadge.swift in Sources */,
+				17A346000000000000000004 /* BuddyFilterChips.swift in Sources */,
 				42BF1908A778629F7C747264 /* BuddySessionViewModel.swift in Sources */,
 				16697A0A2D8E95D300EEA791 /* BuddyVideoWebView.swift in Sources */,
 				4FF6F665DB343AF63E7E1718 /* BuddyWaitingRoomView.swift in Sources */,

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -8,6 +8,8 @@ enum AppView: Equatable {
     case home
     case session(type: SessionType)
     case buddyHub
+    case buddyCalendar
+    case buddyCalendarWithBuddy(buddyId: String, buddyUsername: String)
     case buddySession(sessionId: String)
     case completion(
         sessionId: String,
@@ -28,6 +30,7 @@ enum AppView: Equatable {
         switch (lhs, rhs) {
         case (.auth, .auth), (.home, .home),
              (.buddyHub, .buddyHub),
+             (.buddyCalendar, .buddyCalendar),
              (.history, .history), (.journal, .journal), (.board, .board),
              (.settings, .settings):
             return true
@@ -35,6 +38,8 @@ enum AppView: Equatable {
             return lhsType == rhsType
         case let (.buddySession(lhsSessionId), .buddySession(rhsSessionId)):
             return lhsSessionId == rhsSessionId
+        case let (.buddyCalendarWithBuddy(lhsId, lhsName), .buddyCalendarWithBuddy(rhsId, rhsName)):
+            return lhsId == rhsId && lhsName == rhsName
         case (.completion, .completion):
             return true
         default:
@@ -151,6 +156,8 @@ final class AppViewModel {
         case .home: return "home"
         case .session: return "session"
         case .buddyHub: return "buddyHub"
+        case .buddyCalendar: return "buddyCalendar"
+        case .buddyCalendarWithBuddy: return "buddyCalendarWithBuddy"
         case .buddySession: return "buddySession"
         case .completion: return "completion"
         case .history: return "history"
@@ -192,6 +199,18 @@ final class AppViewModel {
 
     func beginBuddySession() {
         buddyInviteError = nil
+        currentView = .buddyHub
+    }
+
+    func openBuddyCalendar() {
+        currentView = .buddyCalendar
+    }
+
+    func openBuddyCalendarForBuddy(buddyId: String, username: String) {
+        currentView = .buddyCalendarWithBuddy(buddyId: buddyId, buddyUsername: username)
+    }
+
+    func closeBuddyCalendar() {
         currentView = .buddyHub
     }
 

--- a/ios/StillPointApp/ViewModels/BuddyCalendarViewModel.swift
+++ b/ios/StillPointApp/ViewModels/BuddyCalendarViewModel.swift
@@ -13,6 +13,7 @@ final class BuddyCalendarViewModel {
     var isLoading = false
     var isLoadingMore = false
     var errorMessage: String?
+    var loadMoreErrorMessage: String?
     var fromDate = ""
     var toDate = ""
     var hasMore = false
@@ -67,6 +68,7 @@ final class BuddyCalendarViewModel {
         currentMode = mode
         isLoading = true
         errorMessage = nil
+        loadMoreErrorMessage = nil
         sessions = []
         hasMore = false
         defer { isLoading = false }
@@ -88,6 +90,7 @@ final class BuddyCalendarViewModel {
     func loadMore(mode: BuddyCalendarMode) async {
         guard hasMore, !isLoading, !isLoadingMore else { return }
         isLoadingMore = true
+        loadMoreErrorMessage = nil
         defer { isLoadingMore = false }
 
         do {
@@ -97,9 +100,9 @@ final class BuddyCalendarViewModel {
             toDate = response.toDate
             hasMore = response.hasMore
         } catch let error as APIError {
-            errorMessage = message(for: error)
+            loadMoreErrorMessage = message(for: error)
         } catch {
-            errorMessage = "Could not load more sessions. Try again."
+            loadMoreErrorMessage = "Could not load more sessions. Try again."
         }
     }
 

--- a/ios/StillPointApp/ViewModels/BuddyCalendarViewModel.swift
+++ b/ios/StillPointApp/ViewModels/BuddyCalendarViewModel.swift
@@ -80,6 +80,8 @@ final class BuddyCalendarViewModel {
             toDate = response.toDate
             hasMore = response.hasMore
             _ = viewerUserId
+        } catch is CancellationError {
+            // SwiftUI cancelled this task (e.g. mode change or view dismissal) — not a user-facing error
         } catch let error as APIError {
             errorMessage = message(for: error)
         } catch {
@@ -95,10 +97,13 @@ final class BuddyCalendarViewModel {
 
         do {
             let response = try await fetchCalendar(mode: mode, offset: sessions.count)
+            guard currentMode == mode else { return }
             sessions.append(contentsOf: response.sessions)
             fromDate = response.fromDate
             toDate = response.toDate
             hasMore = response.hasMore
+        } catch is CancellationError {
+            // SwiftUI cancelled this task — not a user-facing error
         } catch let error as APIError {
             loadMoreErrorMessage = message(for: error)
         } catch {

--- a/ios/StillPointApp/ViewModels/BuddyCalendarViewModel.swift
+++ b/ios/StillPointApp/ViewModels/BuddyCalendarViewModel.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+import StillPointShared
+
+enum BuddyCalendarMode: Equatable {
+    case unified
+    case perBuddy(buddyId: String, buddyUsername: String)
+}
+
+@MainActor
+@Observable
+final class BuddyCalendarViewModel {
+    var sessions: [BuddyCalendarSession] = []
+    var isLoading = false
+    var isLoadingMore = false
+    var errorMessage: String?
+    var fromDate = ""
+    var toDate = ""
+    var hasMore = false
+    var hiddenBuddyIds: Set<String> = []
+
+    private var currentMode: BuddyCalendarMode = .unified
+
+    var allBuddyIds: [String] {
+        guard case .unified = currentMode else { return [] }
+        var ids = Set<String>()
+        for session in sessions {
+            for id in session.buddyIds {
+                ids.insert(id)
+            }
+        }
+        return ids.sorted { username(for: $0).localizedCaseInsensitiveCompare(username(for: $1)) == .orderedAscending }
+    }
+
+    var showBuddyFilters: Bool {
+        guard case .unified = currentMode else { return false }
+        return allBuddyIds.count >= 3
+    }
+
+    var visibleSessions: [BuddyCalendarSession] {
+        guard showBuddyFilters, !hiddenBuddyIds.isEmpty else { return sessions }
+        return sessions.filter { session in
+            !session.buddyIds.contains(where: { hiddenBuddyIds.contains($0) })
+        }
+    }
+
+    var sessionsByDate: [(date: String, sessions: [BuddyCalendarSession])] {
+        var groups: [String: [BuddyCalendarSession]] = [:]
+        for session in visibleSessions {
+            groups[session.calendarDate, default: []].append(session)
+        }
+        return groups
+            .map { (date: $0.key, sessions: $0.value) }
+            .sorted { $0.date > $1.date }
+    }
+
+    func username(for buddyId: String) -> String {
+        for session in sessions {
+            if let participant = session.participants.first(where: { $0.userId == buddyId }) {
+                return participant.username
+            }
+        }
+        return "Buddy"
+    }
+
+    func load(mode: BuddyCalendarMode, viewerUserId: String?) async {
+        guard !isLoading else { return }
+        currentMode = mode
+        isLoading = true
+        errorMessage = nil
+        sessions = []
+        hasMore = false
+        defer { isLoading = false }
+
+        do {
+            let response = try await fetchCalendar(mode: mode, offset: 0)
+            sessions = response.sessions
+            fromDate = response.fromDate
+            toDate = response.toDate
+            hasMore = response.hasMore
+            _ = viewerUserId
+        } catch let error as APIError {
+            errorMessage = message(for: error)
+        } catch {
+            errorMessage = "Could not load buddy calendar. Check your connection and try again."
+        }
+    }
+
+    func loadMore(mode: BuddyCalendarMode) async {
+        guard hasMore, !isLoading, !isLoadingMore else { return }
+        isLoadingMore = true
+        defer { isLoadingMore = false }
+
+        do {
+            let response = try await fetchCalendar(mode: mode, offset: sessions.count)
+            sessions.append(contentsOf: response.sessions)
+            fromDate = response.fromDate
+            toDate = response.toDate
+            hasMore = response.hasMore
+        } catch let error as APIError {
+            errorMessage = message(for: error)
+        } catch {
+            errorMessage = "Could not load more sessions. Try again."
+        }
+    }
+
+    func toggleBuddyVisibility(buddyId: String) {
+        if hiddenBuddyIds.contains(buddyId) {
+            hiddenBuddyIds.remove(buddyId)
+        } else {
+            hiddenBuddyIds.insert(buddyId)
+        }
+    }
+
+    // MARK: - Private
+
+    private func fetchCalendar(mode: BuddyCalendarMode, offset: Int) async throws -> BuddyCalendarListResponse {
+        switch mode {
+        case .unified:
+            return try await APIClient.shared.getBuddyCalendar(offset: offset)
+        case .perBuddy(let buddyId, _):
+            return try await APIClient.shared.getBuddyCalendarForBuddy(buddyId: buddyId, offset: offset)
+        }
+    }
+
+    private func message(for error: APIError) -> String {
+        switch error.status {
+        case 401:
+            return "Please sign in to view your buddy calendar."
+        case 403:
+            return "You are not friends with this user."
+        case 400:
+            return error.message.isEmpty ? "Invalid date range." : error.message
+        case 500...599:
+            return "Server error. Please try again."
+        default:
+            return error.message.isEmpty ? "Could not load buddy calendar." : error.message
+        }
+    }
+}

--- a/ios/StillPointApp/Views/BuddyCalendar/BuddyCalendarView.swift
+++ b/ios/StillPointApp/Views/BuddyCalendar/BuddyCalendarView.swift
@@ -129,7 +129,7 @@ struct BuddyCalendarView: View {
             }
             .padding(.top, SPSpacing.s6)
         } else if vm.visibleSessions.isEmpty {
-            Text(emptyMessage)
+            Text(vm.showBuddyFilters && !vm.hiddenBuddyIds.isEmpty ? "All buddies are hidden — tap a chip above to show sessions." : emptyMessage)
                 .font(SPFont.serifItalic(15))
                 .foregroundStyle(Color(SPColor.fg4))
                 .multilineTextAlignment(.center)
@@ -208,7 +208,7 @@ struct BuddyCalendarView: View {
         let accent = primaryId.map { buddyColorFromUserId($0) } ?? Color(SPColor.fg3)
         let label = buddyLabel(session: session, focusBuddyId: focusBuddyId)
         let time = formatTime(session.startedAt) ?? formatTime(session.scheduledStartAt)
-        let durationMin = max(1, Int((Double(session.durationSeconds) / 60.0).rounded()))
+        let durationMin = session.durationSeconds > 0 ? max(1, Int((Double(session.durationSeconds) / 60.0).rounded())) : nil
 
         return VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .top) {
@@ -221,7 +221,7 @@ struct BuddyCalendarView: View {
                 SessionStateBadge(state: session.state)
             }
 
-            Text("\(durationMin) min\(time.map { " · \($0)" } ?? "")")
+            Text([durationMin.map { "\($0) min" }, time].compactMap { $0 }.joined(separator: " · "))
                 .font(SPFont.mono(11))
                 .foregroundStyle(Color(SPColor.fg3))
 
@@ -282,20 +282,31 @@ struct BuddyCalendarView: View {
         return session.buddyIds.first(where: { $0 != viewerId }) ?? session.buddyIds.first
     }
 
+    private static let isoTimeFormatterFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static let isoTimeFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    private static let displayTimeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.timeStyle = .short
+        f.dateStyle = .none
+        return f
+    }()
+
     private func formatTime(_ iso: String?) -> String? {
         guard let iso, !iso.isEmpty else { return nil }
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        var date = formatter.date(from: iso)
-        if date == nil {
-            formatter.formatOptions = [.withInternetDateTime]
-            date = formatter.date(from: iso)
-        }
+        let date = Self.isoTimeFormatterFractional.date(from: iso)
+            ?? Self.isoTimeFormatter.date(from: iso)
         guard let date else { return nil }
-        let display = DateFormatter()
-        display.timeStyle = .short
-        display.dateStyle = .none
-        return display.string(from: date)
+        return Self.displayTimeFormatter.string(from: date)
     }
 
     private static let isoDateFormatter: DateFormatter = {

--- a/ios/StillPointApp/Views/BuddyCalendar/BuddyCalendarView.swift
+++ b/ios/StillPointApp/Views/BuddyCalendar/BuddyCalendarView.swift
@@ -165,6 +165,13 @@ struct BuddyCalendarView: View {
                 .foregroundStyle(SPColor.green)
             }
 
+            if let loadMoreError = vm.loadMoreErrorMessage {
+                Text(loadMoreError)
+                    .font(SPFont.mono(11))
+                    .foregroundStyle(SPColor.dangerMuted)
+                    .multilineTextAlignment(.center)
+            }
+
             Text("More sessions available in this range.")
                 .font(SPFont.mono(10))
                 .foregroundStyle(Color(SPColor.fg4))

--- a/ios/StillPointApp/Views/BuddyCalendar/BuddyCalendarView.swift
+++ b/ios/StillPointApp/Views/BuddyCalendar/BuddyCalendarView.swift
@@ -1,0 +1,312 @@
+import SwiftUI
+import StillPointShared
+
+struct BuddyCalendarView: View {
+    let appVM: AppViewModel
+    let mode: BuddyCalendarMode
+
+    @State private var vm = BuddyCalendarViewModel()
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: SPSpacing.s5) {
+                header
+
+                subtitle
+
+                if !vm.fromDate.isEmpty, !vm.toDate.isEmpty {
+                    Text("\(vm.fromDate) — \(vm.toDate)")
+                        .font(SPFont.mono(11))
+                        .foregroundStyle(Color(SPColor.fg4))
+                        .multilineTextAlignment(.center)
+                }
+
+                if vm.showBuddyFilters {
+                    BuddyFilterChips(
+                        buddyIds: vm.allBuddyIds,
+                        hiddenBuddyIds: vm.hiddenBuddyIds,
+                        usernameForBuddy: { vm.username(for: $0) },
+                        onToggle: { vm.toggleBuddyVisibility(buddyId: $0) }
+                    )
+                }
+
+                content
+
+                if vm.hasMore, !vm.isLoading {
+                    loadMoreSection
+                }
+
+                Spacer().frame(height: SPSpacing.s6)
+            }
+            .padding(.horizontal, SPSpacing.s4)
+            .padding(.top, SPSpacing.s3)
+        }
+        .stillPointBackground()
+        .task(id: mode) {
+            await vm.load(mode: mode, viewerUserId: appVM.currentUser?.id)
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            Button {
+                withAnimation {
+                    switch mode {
+                    case .unified:
+                        appVM.closeBuddyCalendar()
+                    case .perBuddy:
+                        appVM.openBuddyCalendar()
+                    }
+                }
+            } label: {
+                Text("← Back")
+                    .font(SPFont.mono(12, weight: .medium))
+                    .foregroundStyle(Color(SPColor.fg3))
+            }
+            .accessibilityIdentifier("buddyCalendar.backButton")
+
+            Spacer()
+
+            Text(title)
+                .font(SPFont.serifItalic(24, weight: .light))
+                .foregroundStyle(Color(SPColor.fg))
+                .multilineTextAlignment(.trailing)
+
+            Spacer()
+
+            Color.clear.frame(width: 56)
+        }
+    }
+
+    private var title: String {
+        switch mode {
+        case .unified:
+            return "Buddy calendar"
+        case .perBuddy(_, let username):
+            return username
+        }
+    }
+
+    @ViewBuilder
+    private var subtitle: some View {
+        switch mode {
+        case .unified:
+            Text("Shared buddy sits from the last 90 days. Solo history is unchanged on Progress.")
+                .font(SPFont.mono(11))
+                .foregroundStyle(Color(SPColor.fg3))
+                .multilineTextAlignment(.center)
+        case .perBuddy(_, let username):
+            Text("Shared sits with \(username) only — not their solo sessions.")
+                .font(SPFont.mono(11))
+                .foregroundStyle(Color(SPColor.fg3))
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        if vm.isLoading {
+            ProgressView()
+                .tint(SPColor.green)
+                .padding(.top, SPSpacing.s6)
+        } else if let errorMessage = vm.errorMessage {
+            VStack(spacing: SPSpacing.s3) {
+                Text(errorMessage)
+                    .font(SPFont.serif(15))
+                    .foregroundStyle(SPColor.dangerMuted)
+                    .multilineTextAlignment(.center)
+                    .accessibilityIdentifier("buddyCalendar.errorMessage")
+
+                Button("Retry") {
+                    Task { await vm.load(mode: mode, viewerUserId: appVM.currentUser?.id) }
+                }
+                .font(SPFont.mono(13, weight: .medium))
+                .foregroundStyle(SPColor.green)
+            }
+            .padding(.top, SPSpacing.s6)
+        } else if vm.visibleSessions.isEmpty {
+            Text(emptyMessage)
+                .font(SPFont.serifItalic(15))
+                .foregroundStyle(Color(SPColor.fg4))
+                .multilineTextAlignment(.center)
+                .padding(.top, SPSpacing.s6)
+        } else {
+            VStack(spacing: SPSpacing.s3) {
+                ForEach(vm.sessionsByDate, id: \.date) { group in
+                    dateSection(date: group.date, sessions: group.sessions)
+                }
+            }
+        }
+    }
+
+    private var emptyMessage: String {
+        switch mode {
+        case .unified:
+            return "No shared buddy sits in this period yet."
+        case .perBuddy(_, let username):
+            return "No shared sits with \(username) in this period."
+        }
+    }
+
+    private var loadMoreSection: some View {
+        VStack(spacing: SPSpacing.s2) {
+            if vm.isLoadingMore {
+                ProgressView()
+                    .tint(SPColor.green)
+            } else {
+                Button("Load more") {
+                    Task { await vm.loadMore(mode: mode) }
+                }
+                .font(SPFont.mono(12, weight: .medium))
+                .foregroundStyle(SPColor.green)
+            }
+
+            Text("More sessions available in this range.")
+                .font(SPFont.mono(10))
+                .foregroundStyle(Color(SPColor.fg4))
+                .multilineTextAlignment(.center)
+        }
+        .padding(.top, SPSpacing.s2)
+    }
+
+    // MARK: - Date sections
+
+    private func dateSection(date: String, sessions: [BuddyCalendarSession]) -> some View {
+        HStack(alignment: .top, spacing: SPSpacing.s2) {
+            Text(shortDateLabel(date))
+                .font(SPFont.mono(10))
+                .foregroundStyle(Color(SPColor.fg3))
+                .frame(width: 60, alignment: .trailing)
+                .lineLimit(2)
+                .padding(.top, 10)
+
+            VStack(spacing: SPSpacing.s2) {
+                ForEach(sessions, id: \.id) { session in
+                    sessionCard(session)
+                }
+            }
+        }
+    }
+
+    private func sessionCard(_ session: BuddyCalendarSession) -> some View {
+        let focusBuddyId: String? = {
+            if case .perBuddy(let buddyId, _) = mode { return buddyId }
+            return nil
+        }()
+        let primaryId = primaryBuddyId(session: session, focusBuddyId: focusBuddyId)
+        let accent = primaryId.map { buddyColorFromUserId($0) } ?? Color(SPColor.fg3)
+        let label = buddyLabel(session: session, focusBuddyId: focusBuddyId)
+        let time = formatTime(session.startedAt) ?? formatTime(session.scheduledStartAt)
+        let durationMin = max(1, Int((Double(session.durationSeconds) / 60.0).rounded()))
+
+        return VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .top) {
+                Text(label)
+                    .font(SPFont.serif(16, weight: .regular))
+                    .foregroundStyle(Color(SPColor.fg))
+
+                Spacer(minLength: 8)
+
+                SessionStateBadge(state: session.state)
+            }
+
+            Text("\(durationMin) min\(time.map { " · \($0)" } ?? "")")
+                .font(SPFont.mono(11))
+                .foregroundStyle(Color(SPColor.fg3))
+
+            if case .unified = mode, session.buddyIds.count == 1, let buddyId = session.buddyIds.first {
+                Button {
+                    withAnimation {
+                        appVM.openBuddyCalendarForBuddy(
+                            buddyId: buddyId,
+                            username: vm.username(for: buddyId)
+                        )
+                    }
+                } label: {
+                    Text("View with \(vm.username(for: buddyId))")
+                        .font(SPFont.mono(10, weight: .medium))
+                        .foregroundStyle(Color(SPColor.fg3))
+                        .underline()
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, SPSpacing.s3)
+        .padding(.vertical, SPSpacing.s2)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(SPColor.surface1))
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(SPColor.border2)
+        )
+        .overlay(alignment: .leading) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(accent)
+                .frame(width: 3)
+                .padding(.vertical, 4)
+                .padding(.leading, 4)
+        }
+        .accessibilityIdentifier("buddyCalendar.session.\(session.id)")
+    }
+
+    // MARK: - Session helpers
+
+    private func buddyLabel(session: BuddyCalendarSession, focusBuddyId: String?) -> String {
+        let viewerId = appVM.currentUser?.id
+        let others = session.participants.filter { $0.userId != viewerId }
+        if let focusBuddyId, let focus = others.first(where: { $0.userId == focusBuddyId }) {
+            return focus.username
+        }
+        if others.isEmpty { return "Buddy sit" }
+        if others.count == 1 { return others[0].username }
+        return others.map(\.username).joined(separator: ", ")
+    }
+
+    private func primaryBuddyId(session: BuddyCalendarSession, focusBuddyId: String?) -> String? {
+        if let focusBuddyId, session.buddyIds.contains(focusBuddyId) {
+            return focusBuddyId
+        }
+        let viewerId = appVM.currentUser?.id
+        return session.buddyIds.first(where: { $0 != viewerId }) ?? session.buddyIds.first
+    }
+
+    private func formatTime(_ iso: String?) -> String? {
+        guard let iso, !iso.isEmpty else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        var date = formatter.date(from: iso)
+        if date == nil {
+            formatter.formatOptions = [.withInternetDateTime]
+            date = formatter.date(from: iso)
+        }
+        guard let date else { return nil }
+        let display = DateFormatter()
+        display.timeStyle = .short
+        display.dateStyle = .none
+        return display.string(from: date)
+    }
+
+    private static let isoDateFormatter: DateFormatter = {
+        let df = DateFormatter()
+        df.dateFormat = "yyyy-MM-dd"
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.calendar = Calendar(identifier: .gregorian)
+        return df
+    }()
+
+    private static let displayDateFormatter: DateFormatter = {
+        let df = DateFormatter()
+        df.dateFormat = "EEE MMM d"
+        return df
+    }()
+
+    private func shortDateLabel(_ isoDate: String) -> String {
+        guard let date = Self.isoDateFormatter.date(from: isoDate) else { return isoDate }
+        return Self.displayDateFormatter.string(from: date)
+    }
+}

--- a/ios/StillPointApp/Views/BuddyCalendar/BuddyFilterChips.swift
+++ b/ios/StillPointApp/Views/BuddyCalendar/BuddyFilterChips.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+import StillPointShared
+
+struct BuddyFilterChips: View {
+    let buddyIds: [String]
+    let hiddenBuddyIds: Set<String>
+    let usernameForBuddy: (String) -> String
+    let onToggle: (String) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: SPSpacing.s2) {
+            Text("SHOW BUDDIES")
+                .font(SPFont.mono(11, weight: .medium))
+                .foregroundStyle(Color(SPColor.fg4))
+                .tracking(2)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: SPSpacing.s1) {
+                    ForEach(buddyIds, id: \.self) { buddyId in
+                        chip(for: buddyId)
+                    }
+                }
+            }
+        }
+        .padding(SPSpacing.s3)
+        .background(Color(SPColor.surface1))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .overlay(RoundedRectangle(cornerRadius: 10).stroke(SPColor.border2))
+    }
+
+    private func chip(for buddyId: String) -> some View {
+        let hidden = hiddenBuddyIds.contains(buddyId)
+        let accent = buddyColorFromUserId(buddyId)
+        let name = usernameForBuddy(buddyId)
+
+        return Button {
+            onToggle(buddyId)
+        } label: {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(accent)
+                    .frame(width: 8, height: 8)
+                    .opacity(hidden ? 0.35 : 1)
+
+                Text(name)
+                    .font(SPFont.mono(11))
+                    .strikethrough(hidden)
+                    .foregroundStyle(hidden ? Color(SPColor.fg3) : Color(SPColor.fg))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(hidden ? Color.clear : accent.opacity(0.08))
+            .clipShape(Capsule())
+            .overlay(
+                Capsule()
+                    .stroke(hidden ? SPColor.border2 : accent, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(name), \(hidden ? "hidden" : "visible")")
+    }
+}

--- a/ios/StillPointApp/Views/BuddyCalendar/SessionStateBadge.swift
+++ b/ios/StillPointApp/Views/BuddyCalendar/SessionStateBadge.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct SessionStateBadge: View {
+    let state: String
+
+    var body: some View {
+        Text(label)
+            .font(SPFont.mono(10, weight: .medium))
+            .foregroundStyle(foreground)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(background)
+            .clipShape(Capsule())
+    }
+
+    private var label: String {
+        switch state {
+        case "completed":
+            return "Completed"
+        case "active":
+            return "In progress"
+        case "abandoned":
+            return "Abandoned"
+        case "waiting", "ready_check":
+            return "Scheduled"
+        default:
+            return state
+        }
+    }
+
+    private var foreground: Color {
+        switch state {
+        case "completed", "active":
+            return SPColor.greenText
+        case "abandoned":
+            return Color(SPColor.fg4)
+        default:
+            return Color(SPColor.fg3)
+        }
+    }
+
+    private var background: Color {
+        switch state {
+        case "completed", "active":
+            return SPColor.greenBgFaint
+        case "abandoned":
+            return Color(SPColor.surface1)
+        default:
+            return Color(SPColor.surface2)
+        }
+    }
+}

--- a/ios/StillPointApp/Views/BuddySession/BuddySessionHubView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddySessionHubView.swift
@@ -51,6 +51,23 @@ struct BuddySessionHubView: View {
 
                 Button {
                     withAnimation {
+                        appVM.openBuddyCalendar()
+                    }
+                } label: {
+                    Text("View buddy calendar")
+                        .font(SPFont.mono(12, weight: .medium))
+                        .foregroundStyle(Color(SPColor.fg))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, SPSpacing.s2)
+                        .background(SPColor.surface1)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                        .overlay(RoundedRectangle(cornerRadius: 10).stroke(SPColor.border2))
+                }
+                .accessibilityIdentifier("buddy.viewCalendarButton")
+                .padding(.top, SPSpacing.s2)
+
+                Button {
+                    withAnimation {
                         appVM.leaveBuddySession()
                     }
                 } label: {

--- a/ios/StillPointApp/Views/RootView.swift
+++ b/ios/StillPointApp/Views/RootView.swift
@@ -27,6 +27,17 @@ struct RootView: View {
                 BuddySessionHubView(appVM: appVM)
                     .transition(.opacity)
 
+            case .buddyCalendar:
+                BuddyCalendarView(appVM: appVM, mode: .unified)
+                    .transition(.opacity)
+
+            case .buddyCalendarWithBuddy(let buddyId, let buddyUsername):
+                BuddyCalendarView(
+                    appVM: appVM,
+                    mode: .perBuddy(buddyId: buddyId, buddyUsername: buddyUsername)
+                )
+                .transition(.opacity)
+
             case .buddySession(let sessionId):
                 BuddySessionContainerView(appVM: appVM, sessionId: sessionId)
                     .id(sessionId)
@@ -138,6 +149,10 @@ struct RootView: View {
             return "session"
         case .buddyHub:
             return "buddyHub"
+        case .buddyCalendar:
+            return "buddyCalendar"
+        case .buddyCalendarWithBuddy:
+            return "buddyCalendarWithBuddy"
         case .buddySession:
             return "buddySession"
         case .completion:

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -389,6 +389,51 @@ public actor APIClient {
         return response.session
     }
 
+    /// Unified multi-buddy calendar (`GET /api/buddy/sessions/calendar`).
+    public func getBuddyCalendar(
+        from: String? = nil,
+        to: String? = nil,
+        limit: Int? = nil,
+        offset: Int? = nil
+    ) async throws -> BuddyCalendarListResponse {
+        try await get(buddyCalendarPath("/api/buddy/sessions/calendar", from: from, to: to, limit: limit, offset: offset))
+    }
+
+    /// Per-buddy shared calendar (`GET /api/buddy/sessions/calendar/{buddyId}`).
+    public func getBuddyCalendarForBuddy(
+        buddyId: String,
+        from: String? = nil,
+        to: String? = nil,
+        limit: Int? = nil,
+        offset: Int? = nil
+    ) async throws -> BuddyCalendarListResponse {
+        try await get(
+            buddyCalendarPath(
+                "/api/buddy/sessions/calendar/\(buddyId)",
+                from: from,
+                to: to,
+                limit: limit,
+                offset: offset
+            )
+        )
+    }
+
+    private func buddyCalendarPath(
+        _ base: String,
+        from: String?,
+        to: String?,
+        limit: Int?,
+        offset: Int?
+    ) -> String {
+        var parts: [String] = []
+        if let from { parts.append("from=\(from.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? from)") }
+        if let to { parts.append("to=\(to.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? to)") }
+        if let limit { parts.append("limit=\(limit)") }
+        if let offset { parts.append("offset=\(offset)") }
+        guard !parts.isEmpty else { return base }
+        return "\(base)?\(parts.joined(separator: "&"))"
+    }
+
     // MARK: - HTTP Helpers
 
     private func get<T: Decodable>(_ path: String) async throws -> T {

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -492,7 +492,9 @@ public actor APIClient {
     }
 
     private func makeRequest(method: String, path: String) -> URLRequest {
-        let url = baseURL.appendingPathComponent(path)
+        // Use URL(string:relativeTo:) instead of appendingPathComponent so query strings
+        // in `path` (e.g. "/api/foo?offset=0") are preserved rather than percent-encoded.
+        let url = URL(string: path, relativeTo: baseURL)?.absoluteURL ?? baseURL.appendingPathComponent(path)
         var request = URLRequest(url: url)
         request.httpMethod = method
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/ios/StillPointShared/Sources/StillPointShared/BuddyCalendarColors.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/BuddyCalendarColors.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Client-safe buddy accent colors (#350). Matches `src/lib/buddyCalendarColors.ts`.
+public let BUDDY_CALENDAR_PALETTE: [String] = [
+    "#5B8C7A",
+    "#7A6B8C",
+    "#8C7A5B",
+    "#5B6F8C",
+    "#8C5B6B",
+    "#6B8C5B",
+    "#8C6B5B",
+    "#5B8C8C",
+]
+
+/// Deterministic accent color from buddy user id (stable across unified + per-buddy views).
+public func buddyColorFromUserId(_ userId: String) -> Color {
+    var hash: UInt32 = 0
+    for byte in userId.utf8 {
+        hash = hash &* 31 &+ UInt32(byte)
+    }
+    let index = Int(hash % UInt32(BUDDY_CALENDAR_PALETTE.count))
+    return colorFromHex(BUDDY_CALENDAR_PALETTE[index])
+}
+
+private func colorFromHex(_ hex: String) -> Color {
+    var cleaned = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+    if cleaned.hasPrefix("#") {
+        cleaned.removeFirst()
+    }
+    guard cleaned.count == 6, let value = UInt64(cleaned, radix: 16) else {
+        return Color.gray
+    }
+    let r = Double((value >> 16) & 0xFF) / 255.0
+    let g = Double((value >> 8) & 0xFF) / 255.0
+    let b = Double(value & 0xFF) / 255.0
+    return Color(red: r, green: g, blue: b)
+}

--- a/ios/StillPointShared/Sources/StillPointShared/BuddyCalendarColors.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/BuddyCalendarColors.swift
@@ -12,14 +12,18 @@ public let BUDDY_CALENDAR_PALETTE: [String] = [
     "#5B8C8C",
 ]
 
-/// Deterministic accent color from buddy user id (stable across unified + per-buddy views).
-public func buddyColorFromUserId(_ userId: String) -> Color {
+/// Deterministic palette index from buddy user id.
+func buddyColorIndexFromUserId(_ userId: String) -> Int {
     var hash: UInt32 = 0
     for byte in userId.utf8 {
         hash = hash &* 31 &+ UInt32(byte)
     }
-    let index = Int(hash % UInt32(BUDDY_CALENDAR_PALETTE.count))
-    return colorFromHex(BUDDY_CALENDAR_PALETTE[index])
+    return Int(hash % UInt32(BUDDY_CALENDAR_PALETTE.count))
+}
+
+/// Deterministic accent color from buddy user id (stable across unified + per-buddy views).
+public func buddyColorFromUserId(_ userId: String) -> Color {
+    return colorFromHex(BUDDY_CALENDAR_PALETTE[buddyColorIndexFromUserId(userId)])
 }
 
 private func colorFromHex(_ hex: String) -> Color {

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -193,6 +193,31 @@ public struct BuddyParticipantDTO: Codable, Sendable {
     public let participantCompletedAt: String?
 }
 
+// MARK: - Buddy Calendar API Types (#350 / #358)
+
+public struct BuddyCalendarParticipant: Codable, Sendable {
+    public let userId: String
+    public let username: String
+}
+
+public struct BuddyCalendarSession: Codable, Sendable {
+    public let id: String
+    public let state: String
+    public let durationSeconds: Int
+    public let calendarDate: String
+    public let scheduledStartAt: String?
+    public let startedAt: String?
+    public let participants: [BuddyCalendarParticipant]
+    public let buddyIds: [String]
+}
+
+public struct BuddyCalendarListResponse: Codable, Sendable {
+    public let sessions: [BuddyCalendarSession]
+    public let fromDate: String
+    public let toDate: String
+    public let hasMore: Bool
+}
+
 public struct BuddySnapshotDTO: Codable, Sendable {
     public let id: String
     public let state: String

--- a/ios/StillPointShared/Tests/StillPointSharedTests/BuddyCalendarColorsTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/BuddyCalendarColorsTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import StillPointShared
+
+final class BuddyCalendarColorsTests: XCTestCase {
+    func testStableColorForSameUserId() {
+        let id = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+        let a = buddyColorHexFromUserId(id)
+        let b = buddyColorHexFromUserId(id)
+        XCTAssertEqual(a, b)
+    }
+
+    func testDifferentColorsForDifferentUserIds() {
+        let a = "00000000-0000-4000-8000-000000000001"
+        let b = "00000000-0000-4000-8000-000000000002"
+        XCTAssertNotEqual(buddyColorHexFromUserId(a), buddyColorHexFromUserId(b))
+    }
+
+    func testPaletteHasEightEntries() {
+        XCTAssertEqual(BUDDY_CALENDAR_PALETTE.count, 8)
+    }
+}
+
+/// Compare palette indices without depending on SwiftUI `Color` equality.
+private func buddyColorHexFromUserId(_ userId: String) -> String {
+    var hash: UInt32 = 0
+    for byte in userId.utf8 {
+        hash = hash &* 31 &+ UInt32(byte)
+    }
+    let index = Int(hash % UInt32(BUDDY_CALENDAR_PALETTE.count))
+    return BUDDY_CALENDAR_PALETTE[index]
+}

--- a/ios/StillPointShared/Tests/StillPointSharedTests/BuddyCalendarColorsTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/BuddyCalendarColorsTests.swift
@@ -7,10 +7,12 @@ final class BuddyCalendarColorsTests: XCTestCase {
         XCTAssertEqual(buddyColorIndexFromUserId(id), buddyColorIndexFromUserId(id))
     }
 
-    func testDifferentColorsForDifferentUserIds() {
-        let a = "00000000-0000-4000-8000-000000000001"
-        let b = "00000000-0000-4000-8000-000000000002"
-        XCTAssertNotEqual(buddyColorIndexFromUserId(a), buddyColorIndexFromUserId(b))
+    func testKnownFixtureIndices() {
+        // Hardcoded expected indices for stability — computed from the djb2-style hash mod 8.
+        // These pin the exact algorithm; update here if the hash function intentionally changes.
+        XCTAssertEqual(buddyColorIndexFromUserId("00000000-0000-4000-8000-000000000001"), 5)
+        XCTAssertEqual(buddyColorIndexFromUserId("00000000-0000-4000-8000-000000000002"), 6)
+        XCTAssertEqual(buddyColorIndexFromUserId("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"), 4)
     }
 
     func testPaletteHasEightEntries() {

--- a/ios/StillPointShared/Tests/StillPointSharedTests/BuddyCalendarColorsTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/BuddyCalendarColorsTests.swift
@@ -4,28 +4,23 @@ import XCTest
 final class BuddyCalendarColorsTests: XCTestCase {
     func testStableColorForSameUserId() {
         let id = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
-        let a = buddyColorHexFromUserId(id)
-        let b = buddyColorHexFromUserId(id)
-        XCTAssertEqual(a, b)
+        XCTAssertEqual(buddyColorIndexFromUserId(id), buddyColorIndexFromUserId(id))
     }
 
     func testDifferentColorsForDifferentUserIds() {
         let a = "00000000-0000-4000-8000-000000000001"
         let b = "00000000-0000-4000-8000-000000000002"
-        XCTAssertNotEqual(buddyColorHexFromUserId(a), buddyColorHexFromUserId(b))
+        XCTAssertNotEqual(buddyColorIndexFromUserId(a), buddyColorIndexFromUserId(b))
     }
 
     func testPaletteHasEightEntries() {
         XCTAssertEqual(BUDDY_CALENDAR_PALETTE.count, 8)
     }
-}
 
-/// Compare palette indices without depending on SwiftUI `Color` equality.
-private func buddyColorHexFromUserId(_ userId: String) -> String {
-    var hash: UInt32 = 0
-    for byte in userId.utf8 {
-        hash = hash &* 31 &+ UInt32(byte)
+    func testIndexInPaletteBounds() {
+        let id = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+        let index = buddyColorIndexFromUserId(id)
+        XCTAssertGreaterThanOrEqual(index, 0)
+        XCTAssertLessThan(index, BUDDY_CALENDAR_PALETTE.count)
     }
-    let index = Int(hash % UInt32(BUDDY_CALENDAR_PALETTE.count))
-    return BUDDY_CALENDAR_PALETTE[index]
 }


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements iOS parity for multi-buddy calendar views (#358), mirroring the merged web implementation (#350).

## Changes

### Data layer (`StillPointShared`)
- `BuddyCalendarParticipant`, `BuddyCalendarSession`, `BuddyCalendarListResponse` DTOs
- `APIClient.getBuddyCalendar` and `getBuddyCalendarForBuddy` for the calendar REST endpoints
- `BuddyCalendarColors.swift` with deterministic `buddyColorFromUserId` (same 8-color palette and hash as web)
- Unit tests for color stability

### UI & navigation (`StillPointApp`)
- `BuddyCalendarView` with `.unified` and `.perBuddy` modes (single component, web-aligned)
- `BuddyCalendarViewModel` — loading, buddy filter chips (3+ buddies), date grouping, `hasMore` pagination
- `BuddyFilterChips`, `SessionStateBadge`
- `AppView` routes: `buddyCalendar`, `buddyCalendarWithBuddy`
- Entry point: **View buddy calendar** on `BuddySessionHubView` (interim until Friends tab)

### Docs
- `ios/PARITY_CHECKLIST.md` — buddy calendar marked complete

## Acceptance criteria

- [x] Unified buddy calendar shows shared sessions (server default 90-day window)
- [x] Each event shows participating buddy name(s)
- [x] Per-buddy view filters to that buddy’s shared sessions
- [x] Hide/filter chips when 3+ buddies (hidden buddy sessions omitted)
- [x] No changes to solo `HistoryView` / progress
- [x] `hasMore` honored via **Load more** when additional pages exist

## Error handling

Maps API errors: 401 (auth), 403 (not friends), 400 (bad range), 5xx (retry message + Retry button).

## Notes

- Local `coderabbit review --prompt-only` could not run in this environment (CLI auth unavailable); GitHub CodeRabbit will review on PR.
- Swift/Xcode build not run on Linux agent; CI should validate iOS target.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa886906-c212-4d12-8110-7ac5173f0c19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa886906-c212-4d12-8110-7ac5173f0c19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Buddy calendar screen: unified and per-buddy views, sessions grouped by date, date-range header, “Load more” pagination, empty/error states with Retry
  * Buddy filter chips to show/hide buddies, deterministic buddy color accents, session state badges, and quick access from session hub

* **Documentation**
  * Parity checklist updated to reflect buddy calendar implementation status

* **Tests**
  * Unit tests validating buddy color stability and palette size
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Add unified and per-buddy calendar views for iOS, with filtering and paging

### What Changed
- Added a new buddy calendar screen from Buddy Session Hub, with a unified view and a per-buddy view for shared sessions
- Sessions are grouped by date, show state badges, duration, time, and buddy-specific labels, and can open a per-buddy calendar from a single-buddy entry
- Added buddy filter chips in the unified view to hide or show buddies, plus a message when all buddies are hidden
- Added Load more for older sessions, with retry support when loading the first page or additional pages fails
- Kept calendar colors stable for each buddy and updated the iOS parity checklist to mark buddy calendar support complete

### Impact
`✅ Easier review of shared buddy sessions`
`✅ Faster switching between all-buddy and single-buddy views`
`✅ Fewer empty or misleading calendar states`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
