### PR TITLE
Duolingo-style daily app-lock + home pill & onboarding (closes #348)

### DIFF
--- a/ios/StillPointApp/Managers/AppBlockingManager.swift
+++ b/ios/StillPointApp/Managers/AppBlockingManager.swift
@@ -5,104 +5,111 @@ import Foundation
 @Observable
 @MainActor
 final class AppBlockingManager {
-    static let unlockWindow: TimeInterval = 2 * 60 * 60
-
-    var unlockUntil: Date?
+    var unlockedForDate: Date?
     var lastErrorMessage: String?
     var isApplyingShield = false
     private(set) var didUnlockFromLastCompletedSession = false
 
     private let defaults: UserDefaults
-    private let unlockUntilKey = "appBlocking.unlockUntil.v1"
+    private let unlockedForDateKey = "appBlocking.unlockedForDate.v1"
     private let uiTestSelectionEnabled: Bool
-    private var unlockTimer: Timer?
+    private var midnightTimer: Timer?
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
-        self.unlockUntil = defaults.object(forKey: unlockUntilKey) as? Date
+        self.unlockedForDate = defaults.object(forKey: unlockedForDateKey) as? Date
         self.uiTestSelectionEnabled = ProcessInfo.processInfo.environment["SP_UI_TEST_APP_BLOCKING_SELECTED"] == "1"
-        scheduleUnlockExpiryTimer()
+        refreshShielding()
     }
 
     var isAuthorizationApproved: Bool { uiTestSelectionEnabled }
     var hasSelection: Bool { uiTestSelectionEnabled }
     var selectedItemCount: Int { uiTestSelectionEnabled ? 1 : 0 }
 
+    /// Unlocked when a qualifying session was completed earlier *today* (local calendar day).
     var isUnlocked: Bool {
-        guard let unlockUntil else { return false }
-        return unlockUntil > Date()
+        guard let unlockedForDate else { return false }
+        return Calendar.current.isDateInToday(unlockedForDate)
     }
 
     var statusText: String {
         guard hasSelection else {
             return "Choose the apps you want Still Point to hold during practice."
         }
-        if isUnlocked, let unlockUntil {
-            return "Unlocked until \(Self.timeFormatter.string(from: unlockUntil))."
+        if isUnlocked {
+            return "Unlocked for the rest of today."
         }
-        return "Selected apps stay blocked until you complete a session."
+        return "Blocked until you complete today's sit."
     }
-
-    var unlockWindowText: String { "2 hours" }
 
     func requestAuthorizationIfNeeded() async {}
     func persistSelectionAndRefreshShielding() {}
+
+    /// Called when a session ends *without* a qualifying completion (e.g. ended early).
+    /// In the daily-lock model this neither grants nor revokes today's unlock — if a
+    /// qualifying session was already completed today the apps stay unlocked until
+    /// midnight; otherwise they remain blocked.
     func prepareForSession() {
         didUnlockFromLastCompletedSession = false
-        unlockUntil = nil
-        defaults.removeObject(forKey: unlockUntilKey)
-        scheduleUnlockExpiryTimer()
+        refreshShielding()
     }
 
     func unlockAfterCompletedSession() {
         didUnlockFromLastCompletedSession = false
         guard hasSelection else { return }
-        unlockUntil = Date().addingTimeInterval(Self.unlockWindow)
+        unlockedForDate = Date()
         didUnlockFromLastCompletedSession = true
-        defaults.set(unlockUntil, forKey: unlockUntilKey)
-        scheduleUnlockExpiryTimer()
+        defaults.set(unlockedForDate, forKey: unlockedForDateKey)
+        scheduleMidnightResetTimer()
     }
 
     func lockNow() {
         didUnlockFromLastCompletedSession = false
-        unlockUntil = nil
-        defaults.removeObject(forKey: unlockUntilKey)
-        scheduleUnlockExpiryTimer()
+        unlockedForDate = nil
+        defaults.removeObject(forKey: unlockedForDateKey)
+        scheduleMidnightResetTimer()
     }
 
     func refreshShielding() {
-        guard hasSelection else {
-            unlockUntil = nil
+        // Daily reset: an unlock only counts for the calendar day it was earned.
+        // When the app foregrounds (or the midnight timer fires) on a new day, the
+        // stale date is cleared and the apps re-lock.
+        if let unlockedForDate, !Calendar.current.isDateInToday(unlockedForDate) {
+            self.unlockedForDate = nil
             didUnlockFromLastCompletedSession = false
-            defaults.removeObject(forKey: unlockUntilKey)
-            scheduleUnlockExpiryTimer()
-            return
+            defaults.removeObject(forKey: unlockedForDateKey)
         }
 
-        if let unlockUntil, unlockUntil <= Date() {
-            self.unlockUntil = nil
+        if !hasSelection {
+            unlockedForDate = nil
             didUnlockFromLastCompletedSession = false
-            defaults.removeObject(forKey: unlockUntilKey)
+            defaults.removeObject(forKey: unlockedForDateKey)
         }
-        scheduleUnlockExpiryTimer()
+        scheduleMidnightResetTimer()
     }
 
-    private func scheduleUnlockExpiryTimer() {
-        unlockTimer?.invalidate()
-        guard let unlockUntil, unlockUntil > Date() else { return }
-        unlockTimer = Timer.scheduledTimer(withTimeInterval: unlockUntil.timeIntervalSinceNow, repeats: false) { [weak self] _ in
+    /// Schedule a one-shot timer for the next local midnight so apps re-lock even
+    /// if the app stays foregrounded across the day boundary. Only needed while unlocked.
+    private func scheduleMidnightResetTimer() {
+        midnightTimer?.invalidate()
+        midnightTimer = nil
+        guard isUnlocked, let nextMidnight = Self.nextLocalMidnight() else { return }
+        let interval = nextMidnight.timeIntervalSinceNow
+        guard interval > 0 else { return }
+        midnightTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: false) { [weak self] _ in
             Task { @MainActor in
                 self?.refreshShielding()
             }
         }
     }
 
-    private static let timeFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.timeStyle = .short
-        formatter.dateStyle = .none
-        return formatter
-    }()
+    private static func nextLocalMidnight() -> Date? {
+        Calendar.current.nextDate(
+            after: Date(),
+            matching: DateComponents(hour: 0, minute: 0, second: 0),
+            matchingPolicy: .nextTime
+        )
+    }
 }
 
 #else
@@ -113,11 +120,9 @@ import ManagedSettings
 @Observable
 @MainActor
 final class AppBlockingManager {
-    static let unlockWindow: TimeInterval = 2 * 60 * 60
-
     var selection: FamilyActivitySelection
     var authorizationStatus: AuthorizationStatus
-    var unlockUntil: Date?
+    var unlockedForDate: Date?
     var lastErrorMessage: String?
     var isApplyingShield = false
     private(set) var didUnlockFromLastCompletedSession = false
@@ -125,10 +130,10 @@ final class AppBlockingManager {
     private let defaults: UserDefaults
     private let store: ManagedSettingsStore?
     private let selectionKey = "appBlocking.selection.v1"
-    private let unlockUntilKey = "appBlocking.unlockUntil.v1"
+    private let unlockedForDateKey = "appBlocking.unlockedForDate.v1"
     private let uiTestMode: Bool
     private let uiTestSelectionEnabled: Bool
-    private var unlockTimer: Timer?
+    private var midnightTimer: Timer?
 
     init(defaults: UserDefaults = .standard) {
         let environment = ProcessInfo.processInfo.environment
@@ -136,7 +141,7 @@ final class AppBlockingManager {
         let uiTestSelectionEnabled = environment["SP_UI_TEST_APP_BLOCKING_SELECTED"] == "1"
         self.defaults = defaults
         self.selection = Self.loadSelection(defaults: defaults, key: selectionKey)
-        self.unlockUntil = defaults.object(forKey: unlockUntilKey) as? Date
+        self.unlockedForDate = defaults.object(forKey: unlockedForDateKey) as? Date
         self.authorizationStatus = uiTestMode ? .notDetermined : AuthorizationCenter.shared.authorizationStatus
         self.uiTestMode = uiTestMode
         self.uiTestSelectionEnabled = uiTestSelectionEnabled
@@ -161,23 +166,20 @@ final class AppBlockingManager {
         return realSelectedItemCount
     }
 
+    /// Unlocked when a qualifying session was completed earlier *today* (local calendar day).
     var isUnlocked: Bool {
-        guard let unlockUntil else { return false }
-        return unlockUntil > Date()
+        guard let unlockedForDate else { return false }
+        return Calendar.current.isDateInToday(unlockedForDate)
     }
 
     var statusText: String {
         guard hasSelection else {
             return "Choose the apps you want Still Point to hold during practice."
         }
-        if isUnlocked, let unlockUntil {
-            return "Unlocked until \(Self.timeFormatter.string(from: unlockUntil))."
+        if isUnlocked {
+            return "Unlocked for the rest of today."
         }
-        return "Selected apps stay blocked until you complete a session."
-    }
-
-    var unlockWindowText: String {
-        "2 hours"
+        return "Blocked until you complete today's sit."
     }
 
     func requestAuthorizationIfNeeded() async {
@@ -195,33 +197,36 @@ final class AppBlockingManager {
 
     func persistSelectionAndRefreshShielding() {
         saveSelection()
+        // Note: if the user has already unlocked for today, refreshShielding() leaves
+        // newly added apps unshielded — they "earned" today already and only start
+        // blocking tomorrow. Adding apps while still blocked shields them immediately.
         refreshShielding()
     }
 
+    /// Called when a session ends *without* a qualifying completion (e.g. ended early).
+    /// In the daily-lock model this neither grants nor revokes today's unlock — if a
+    /// qualifying session was already completed today the apps stay unlocked until
+    /// midnight; otherwise they remain blocked.
     func prepareForSession() {
         didUnlockFromLastCompletedSession = false
-        unlockUntil = nil
-        defaults.removeObject(forKey: unlockUntilKey)
-        scheduleUnlockExpiryTimer()
         refreshShielding()
     }
 
     func unlockAfterCompletedSession() {
         didUnlockFromLastCompletedSession = false
         guard hasSelection else { return }
-        unlockUntil = Date().addingTimeInterval(Self.unlockWindow)
+        unlockedForDate = Date()
         didUnlockFromLastCompletedSession = true
-        defaults.set(unlockUntil, forKey: unlockUntilKey)
+        defaults.set(unlockedForDate, forKey: unlockedForDateKey)
         lastErrorMessage = nil
         clearShielding()
-        scheduleUnlockExpiryTimer()
+        scheduleMidnightResetTimer()
     }
 
     func lockNow() {
         didUnlockFromLastCompletedSession = false
-        unlockUntil = nil
-        defaults.removeObject(forKey: unlockUntilKey)
-        scheduleUnlockExpiryTimer()
+        unlockedForDate = nil
+        defaults.removeObject(forKey: unlockedForDateKey)
         refreshShielding()
     }
 
@@ -230,23 +235,26 @@ final class AppBlockingManager {
             authorizationStatus = AuthorizationCenter.shared.authorizationStatus
         }
 
-        if let unlockUntil, unlockUntil <= Date() {
-            self.unlockUntil = nil
+        // Daily reset: an unlock only counts for the calendar day it was earned.
+        // When the app foregrounds (or the midnight timer fires) on a new day, the
+        // stale date is cleared and the apps re-lock.
+        if let unlockedForDate, !Calendar.current.isDateInToday(unlockedForDate) {
+            self.unlockedForDate = nil
             didUnlockFromLastCompletedSession = false
-            defaults.removeObject(forKey: unlockUntilKey)
+            defaults.removeObject(forKey: unlockedForDateKey)
         }
 
         if !hasSelection {
-            unlockUntil = nil
+            unlockedForDate = nil
             didUnlockFromLastCompletedSession = false
-            defaults.removeObject(forKey: unlockUntilKey)
-            scheduleUnlockExpiryTimer()
+            defaults.removeObject(forKey: unlockedForDateKey)
+            scheduleMidnightResetTimer()
             clearShielding()
             return
         }
 
         guard !isUnlocked else {
-            scheduleUnlockExpiryTimer()
+            scheduleMidnightResetTimer()
             clearShielding()
             return
         }
@@ -257,7 +265,7 @@ final class AppBlockingManager {
         }
 
         applyShielding()
-        scheduleUnlockExpiryTimer()
+        scheduleMidnightResetTimer()
     }
 
     private var realSelectedItemCount: Int {
@@ -293,14 +301,27 @@ final class AppBlockingManager {
         store?.clearAllSettings()
     }
 
-    private func scheduleUnlockExpiryTimer() {
-        unlockTimer?.invalidate()
-        guard let unlockUntil, unlockUntil > Date() else { return }
-        unlockTimer = Timer.scheduledTimer(withTimeInterval: unlockUntil.timeIntervalSinceNow, repeats: false) { [weak self] _ in
+    /// Schedule a one-shot timer for the next local midnight so apps re-lock even
+    /// if the app stays foregrounded across the day boundary. Only needed while unlocked.
+    private func scheduleMidnightResetTimer() {
+        midnightTimer?.invalidate()
+        midnightTimer = nil
+        guard isUnlocked, let nextMidnight = Self.nextLocalMidnight() else { return }
+        let interval = nextMidnight.timeIntervalSinceNow
+        guard interval > 0 else { return }
+        midnightTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: false) { [weak self] _ in
             Task { @MainActor in
                 self?.refreshShielding()
             }
         }
+    }
+
+    private static func nextLocalMidnight() -> Date? {
+        Calendar.current.nextDate(
+            after: Date(),
+            matching: DateComponents(hour: 0, minute: 0, second: 0),
+            matchingPolicy: .nextTime
+        )
     }
 
     private func saveSelection() {
@@ -321,13 +342,6 @@ final class AppBlockingManager {
         }
         return decoded
     }
-
-    private static let timeFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.timeStyle = .short
-        formatter.dateStyle = .none
-        return formatter
-    }()
 }
 
 #endif

--- a/ios/StillPointApp/Navigation/MainTabView.swift
+++ b/ios/StillPointApp/Navigation/MainTabView.swift
@@ -1,16 +1,10 @@
 import SwiftUI
 
 struct MainTabView: View {
-    let appVM: AppViewModel
-    @State private var selectedTab = 0
-
-    init(appVM: AppViewModel) {
-        self.appVM = appVM
-        self._selectedTab = State(initialValue: Self.initialSelectedTab())
-    }
+    @Bindable var appVM: AppViewModel
 
     var body: some View {
-        TabView(selection: $selectedTab) {
+        TabView(selection: $appVM.selectedTab) {
             HomeView(appVM: appVM)
                 .tabItem {
                     Label("HOME", systemImage: "house")
@@ -51,18 +45,6 @@ struct MainTabView: View {
     }
 
     private static var tabBarConfigured = false
-
-    private static func initialSelectedTab() -> Int {
-        if truthy(ProcessInfo.processInfo.environment["SP_UI_TEST_FORCE_PROGRESS_TAB"]) {
-            return 1
-        }
-        return 0
-    }
-
-    private static func truthy(_ value: String?) -> Bool {
-        guard let value else { return false }
-        return ["1", "true", "yes", "on"].contains(value.lowercased())
-    }
 
     private static func configureTabBarAppearance() {
         guard !tabBarConfigured else { return }

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -178,6 +178,9 @@ final class AppViewModel {
     func didLogin(user: UserDTO) {
         currentUser = user
         currentView = .home
+        // Reset to Home so a prior session's tab (e.g. Settings) doesn't leak
+        // across auth transitions now that selectedTab lives on the view model.
+        selectedTab = 0
         authStatusMessage = nil
         PushNotificationCoordinator.shared.registerIfAlreadyAuthorized()
         Task {
@@ -292,6 +295,7 @@ final class AppViewModel {
 
     func returnHome() async {
         currentView = .home
+        selectedTab = 0
         if let user = try? await APIClient.shared.me() {
             currentUser = user
         }

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -57,6 +57,9 @@ final class AppViewModel {
     private static let diagLog = Logger(subsystem: "com.brettonauerbach.stillpoint", category: "e2e-diag")
 
     var currentView: AppView = .auth
+    /// Selected tab in `MainTabView`, lifted here so non-tab views (e.g. the Home
+    /// app-gate pill) can navigate to a tab. 0 = Home … 4 = Settings.
+    var selectedTab: Int = AppViewModel.defaultSelectedTab()
     var currentUser: UserDTO?
     var isLoading = true
     var authStatusMessage: String?
@@ -167,6 +170,11 @@ final class AppViewModel {
         return ["1", "true", "yes", "on"].contains(value.lowercased())
     }
 
+    /// Initial tab index. Honors SP_UI_TEST_FORCE_PROGRESS_TAB (Progress = 1).
+    private static func defaultSelectedTab() -> Int {
+        truthy(ProcessInfo.processInfo.environment["SP_UI_TEST_FORCE_PROGRESS_TAB"]) ? 1 : 0
+    }
+
     func didLogin(user: UserDTO) {
         currentUser = user
         currentView = .home
@@ -263,7 +271,9 @@ final class AppViewModel {
         bonusSeconds: Int = 0,
         unlockAppGate: Bool
     ) {
-        if unlockAppGate && sessionType == .standard {
+        // Daily-lock model (#348): any naturally-completed session — quick-minute
+        // or standard — unlocks the gated apps for the rest of the day.
+        if unlockAppGate {
             appBlockingManager.unlockAfterCompletedSession()
         } else {
             appBlockingManager.prepareForSession()

--- a/ios/StillPointApp/Views/AppBlockingSettingsView.swift
+++ b/ios/StillPointApp/Views/AppBlockingSettingsView.swift
@@ -26,7 +26,7 @@ struct AppBlockingSettingsView: View {
                     .foregroundStyle(Color(SPColor.fg2))
                     .accessibilityIdentifier("appBlocking.statusText")
 
-                Text("A completed timer unlocks them for \(manager.unlockWindowText). Ending early keeps the gate closed.")
+                Text("A completed session unlocks them for the rest of the day; they re-lock at midnight. Ending early keeps the gate closed.")
                     .font(SPFont.serif(13, weight: .light))
                     .foregroundStyle(Color(SPColor.fg4))
             }

--- a/ios/StillPointApp/Views/HomeView.swift
+++ b/ios/StillPointApp/Views/HomeView.swift
@@ -5,6 +5,7 @@ struct HomeView: View {
     let appVM: AppViewModel
 
     @State private var breatheAnimation = false
+    @State private var showAppGateOnboarding = false
 
     var body: some View {
         ScrollView {
@@ -37,6 +38,8 @@ struct HomeView: View {
                     .font(SPFont.mono(14, weight: .light))
                     .foregroundStyle(Color(SPColor.fg3))
                     .tracking(2)
+
+                appGatePill
 
                 Spacer().frame(height: SPSpacing.s4)
 
@@ -114,6 +117,55 @@ struct HomeView: View {
             .safeAreaPadding(.bottom, SPSpacing.s4)
         }
         .stillPointBackground()
+        .onAppear {
+            maybePresentAppGateOnboarding()
+        }
+        .sheet(isPresented: $showAppGateOnboarding) {
+            AppGateOnboardingSheet(appVM: appVM, isPresented: $showAppGateOnboarding)
+        }
+    }
+
+    /// Persistent app-gate status indicator. Hidden until the user has picked apps
+    /// to block; tapping jumps to the Settings tab where the gate is configured.
+    @ViewBuilder
+    private var appGatePill: some View {
+        let manager = appVM.appBlockingManager
+        if manager.hasSelection {
+            Button {
+                appVM.selectedTab = 4
+            } label: {
+                HStack(spacing: SPSpacing.s2) {
+                    Image(systemName: manager.isUnlocked ? "lock.open" : "lock")
+                        .font(.system(size: 11, weight: .medium))
+                    Text(manager.isUnlocked ? "Apps unlocked until midnight" : "Apps locked — meditate to unlock")
+                        .font(SPFont.mono(11, weight: .medium))
+                        .tracking(1)
+                }
+                .foregroundStyle(manager.isUnlocked ? SPColor.greenText : SPColor.amberText)
+                .padding(.horizontal, SPSpacing.s3)
+                .padding(.vertical, SPSpacing.s2)
+                .background(manager.isUnlocked ? SPColor.greenBgFaint : SPColor.amberBgFaint)
+                .clipShape(Capsule())
+                .overlay(
+                    Capsule().stroke(manager.isUnlocked ? SPColor.greenBorderSubtle : SPColor.amberBorderSubtle)
+                )
+            }
+            .accessibilityIdentifier("home.appGatePill")
+            .accessibilityLabel(manager.isUnlocked ? "Apps unlocked until midnight" : "Apps locked, meditate to unlock")
+        }
+    }
+
+    /// First-run prompt asking whether to set up the app gate. Shown at most once,
+    /// and never during UI tests (it would block the home screen).
+    private func maybePresentAppGateOnboarding() {
+        guard ProcessInfo.processInfo.environment["SP_UI_TEST_MODE"] != "1" else { return }
+        let key = "appBlocking.onboardingShown.v1"
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: key) else { return }
+        defaults.set(true, forKey: key)
+        if !appVM.appBlockingManager.hasSelection {
+            showAppGateOnboarding = true
+        }
     }
 
     private var faqSection: some View {
@@ -132,7 +184,7 @@ struct HomeView: View {
             )
             faqItem(
                 q: "How does the app gate work?",
-                a: "In Settings, choose apps for Still Point to hold. They stay blocked until you complete the timer, then open for two hours. Ending early keeps them blocked."
+                a: "In Settings, choose apps for Still Point to hold. They stay blocked until you complete today's session, then open for the rest of the day and re-lock at midnight. Ending early keeps them blocked."
             )
             faqItem(
                 q: "This app is incredibly boring. What's the point?",
@@ -150,5 +202,58 @@ struct HomeView: View {
                 .font(SPFont.serif(15, weight: .light))
                 .foregroundStyle(Color(SPColor.fg3))
         }
+    }
+}
+
+private struct AppGateOnboardingSheet: View {
+    let appVM: AppViewModel
+    @Binding var isPresented: Bool
+
+    var body: some View {
+        VStack(spacing: SPSpacing.s4) {
+            Spacer()
+            Image(systemName: "lock.shield")
+                .font(.system(size: 44, weight: .light))
+                .foregroundStyle(SPColor.greenText)
+            Text("Block distracting apps until you meditate?")
+                .font(SPFont.serifItalic(24, weight: .light))
+                .foregroundStyle(Color(SPColor.fg))
+                .multilineTextAlignment(.center)
+            Text("Pick a few apps for Still Point to hold. They stay blocked until you complete today's session, then open for the rest of the day and re-lock at midnight.")
+                .font(SPFont.serif(15, weight: .light))
+                .foregroundStyle(Color(SPColor.fg3))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, SPSpacing.s4)
+            Spacer()
+            VStack(spacing: SPSpacing.s2) {
+                Button {
+                    isPresented = false
+                    appVM.selectedTab = 4
+                } label: {
+                    Text("Choose apps")
+                        .font(SPFont.mono(13, weight: .medium))
+                        .foregroundStyle(Color(SPColor.bg))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, SPSpacing.s3)
+                        .background(SPColor.green)
+                        .clipShape(Capsule())
+                }
+                .accessibilityIdentifier("onboarding.appGate.chooseApps")
+
+                Button {
+                    isPresented = false
+                } label: {
+                    Text("Not now")
+                        .font(SPFont.mono(12, weight: .medium))
+                        .foregroundStyle(Color(SPColor.fg3))
+                        .padding(.vertical, SPSpacing.s2)
+                }
+                .accessibilityIdentifier("onboarding.appGate.notNow")
+            }
+            .padding(.horizontal, SPSpacing.s4)
+            .padding(.bottom, SPSpacing.s4)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .stillPointBackground()
     }
 }

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -165,7 +165,7 @@ struct SessionView: View {
                     sessionType: vm.sessionType,
                     duration: vm.plannedSeconds,
                     bonusSeconds: vm.bonusSeconds,
-                    unlockAppGate: vm.completedNaturally && vm.sessionType == .standard
+                    unlockAppGate: vm.completedNaturally
                 )
             }
         } message: {
@@ -552,7 +552,7 @@ struct SessionView: View {
                 sessionType: session.sessionType,
                 duration: vm.plannedSeconds,
                 bonusSeconds: vm.bonusSeconds,
-                unlockAppGate: vm.completedNaturally && session.sessionType == .standard
+                unlockAppGate: vm.completedNaturally
             )
         }
     }


### PR DESCRIPTION
## **User description**
## Summary

Refactors the iOS app-blocking gate (#348) from the old "2-hour unlock window" to a Duolingo-style daily lock, and adds the two UI surfaces from the locked product decisions.

**What changed**
- **Daily lock model:** blocked apps stay locked until you complete today's session, then unlock for the rest of the day and re-lock at local midnight. `AppBlockingManager` tracks `unlockedForDate` (calendar date) instead of `unlockUntil` (timestamp), checks `Calendar.current.isDateInToday`, and re-locks via a next-local-midnight timer + foreground refresh. The 2-hour window + expiry timer are gone. Applied to both the simulator stub and the device (FamilyControls) branch.
- **Any session unlocks:** quick-minute (#239) and standard sessions both qualify (was standard-only).
- **Home status pill:** persistent, tappable lock-status indicator ("Apps locked — meditate to unlock" / "Apps unlocked until midnight") that opens the Settings app-gate.
- **Onboarding ask:** first-run prompt ("Block distracting apps until you meditate?") that routes into Settings. Suppressed in UI-test mode.
- **Copy:** Settings + FAQ updated to the daily-lock model.

**Why / benefit:** the daily lock is a stronger commitment device than the 2-hour window, and the home pill + onboarding make the gate discoverable and its state always visible.

**Decisions** (locked with the issue author): full replacement (no feature flag), any session counts, onboarding ask, home pill. See #348.

Closes #348

## Notes
- Phase 1 (on-device verification of the old PR #271 behavior) is handled separately by the author.
- Local `xcodebuild` can't parse this project on Xcode 26.5 (objectVersion 77 — fails on untouched `main` too), so compile validation relies on CI's iOS build.

## Test plan

**Automated (CI):**
- [x] iOS build compiles (`build`)
- [x] `ios-e2e-critical` green (incl. `testCompletedSessionUnlocksConfiguredAppGate`)
- [x] `ios-e2e-smoke` green

**On-device (manual — requires a real iPhone with Screen Time; cannot be checked from code):**
- [ ] Blocked apps are locked before today's session
- [ ] Completing a **standard** session unlocks apps for the rest of the day
- [ ] Completing a **quick-minute** session also unlocks apps
- [ ] Apps re-lock the next morning (local-midnight reset; verify across-midnight while foregrounded too)
- [ ] Turning app-blocking off mid-day unblocks immediately
- [ ] Adding an app mid-day after meditating does NOT block it until tomorrow
- [ ] Home pill shows correct state and opens Settings on tap
- [ ] First-run onboarding ask appears and routes to app selection

**Code-verifiable:**
- [x] `unlockUntil` / 2-hour logic fully removed; `unlockedForDate` + `isDateInToday` drive state
- [x] Settings + FAQ copy reflect the daily model
- [x] Onboarding suppressed under `SP_UI_TEST_MODE` (no interference with UI tests)


___

## **CodeAnt-AI Description**
**Switch app blocking to a daily unlock that resets at midnight**

### What Changed
- Blocked apps now stay unlocked for the rest of the day after a completed session, then lock again at local midnight instead of after two hours
- Any completed session can unlock the app gate, including quick-minute sessions and standard sessions
- The home screen now shows a tappable lock status pill that opens the app gate settings, and first-time users see an onboarding prompt to set it up
- Settings and FAQ text now explain the new daily-lock behavior, and ending a session early no longer clears an unlock earned earlier that day

### Impact
`✅ Longer daily app lockouts`
`✅ Fewer unwanted re-locks after a completed session`
`✅ Easier access to app-gate setup from home`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added app-gate onboarding flow to introduce feature to new users
  * Added visual status indicator on home screen showing app-gate unlock state

* **Improvements**
  * Changed app-unlock behavior from fixed-duration window to daily reset at midnight—apps unlock after completing a session and automatically re-lock at the next day
  * Updated messaging throughout the app to reflect the new daily reset model

<!-- end of auto-generated comment: release notes by coderabbit.ai -->