### PR TITLE
feat(ci): auto-trigger TestFlight build on merge with release:ios label

### DIFF
--- a/.github/workflows/ios-testflight-auto.yml
+++ b/.github/workflows/ios-testflight-auto.yml
@@ -1,0 +1,121 @@
+name: Auto TestFlight on merge
+
+# Auto-cut a TestFlight build when a PR is merged to main carrying the
+# `release:ios` label. Mirrors auerbachb/skingod's mobile-testflight.yml,
+# adapted for Still Point's self-hosted xcodebuild pipeline (skingod uses EAS).
+#
+# Flow:
+#   1. Read CURRENT_PROJECT_VERSION from ios/project.yml at the merge commit.
+#   2. Increment it (build-number source of truth: the committed project.yml).
+#   3. Commit the bump back to main with [skip ci].
+#   4. Cut an ios-v<marketing>-build<n> tag on that commit.
+#   5. Call the shared reusable workflow to build + upload from that commit.
+#
+# The bump commit and tag are pushed with the default GITHUB_TOKEN. GitHub does
+# NOT start new workflow runs for GITHUB_TOKEN-authored pushes, so:
+#   * push-on-main CI (e2e-mobile, web-build) does not fire on the bump — the
+#     [skip ci] is belt-and-suspenders for that, plus clarity for humans;
+#   * the new ios-v*-build* tag does NOT re-trigger ios-testflight.yml, so there
+#     is no double build. The reusable build is invoked directly below instead.
+#     If this is ever switched to a PAT, add a guard so the manual workflow does
+#     not also fire on the bot-cut tag.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+# Share the ios-testflight concurrency group with the manual tag workflow so
+# build-number bumps and TestFlight uploads never run two at a time.
+concurrency:
+  group: ios-testflight
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    name: Bump build number and cut TestFlight tag
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release:ios')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      sha: ${{ steps.bump.outputs.sha }}
+      tag: ${{ steps.bump.outputs.tag }}
+    steps:
+      - name: Checkout merge commit
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Bump build number, commit, and tag
+        id: bump
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          PROJECT="ios/project.yml"
+
+          MARKETING="$(grep -E '^[[:space:]]+MARKETING_VERSION:' "$PROJECT" | head -1 | sed -E 's/.*MARKETING_VERSION:[[:space:]]*"?([^"#]+)"?.*/\1/' | xargs)"
+          CURRENT="$(grep -E '^[[:space:]]+CURRENT_PROJECT_VERSION:' "$PROJECT" | head -1 | sed -E 's/.*CURRENT_PROJECT_VERSION:[[:space:]]*"?([0-9]+)"?.*/\1/' | xargs)"
+
+          if [[ -z "$MARKETING" || -z "$CURRENT" ]]; then
+            echo "::error::Could not read MARKETING_VERSION ('$MARKETING') or CURRENT_PROJECT_VERSION ('$CURRENT') from $PROJECT"
+            exit 1
+          fi
+
+          NEW=$((CURRENT + 1))
+          TAG="ios-v${MARKETING}-build${NEW}"
+
+          echo "Marketing version: $MARKETING"
+          echo "Build number: $CURRENT -> $NEW"
+          echo "Tag: $TAG"
+
+          # Fail fast if the tag already exists locally or on origin. Forces a
+          # human to reconcile project.yml if the build-number state has drifted.
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null \
+             || git ls-remote --tags origin "refs/tags/${TAG}" | grep -q .; then
+            echo "::error::Tag ${TAG} already exists. Bump CURRENT_PROJECT_VERSION in ios/project.yml before merging release:ios PRs."
+            exit 1
+          fi
+
+          # Increment CURRENT_PROJECT_VERSION in place (only the StillPoint target
+          # defines this key, so a single substitution is unambiguous).
+          sed -i.bak -E "s/^([[:space:]]+CURRENT_PROJECT_VERSION:[[:space:]]*)[0-9]+.*/\1${NEW}/" "$PROJECT"
+          rm -f "${PROJECT}.bak"
+
+          APPLIED="$(grep -E '^[[:space:]]+CURRENT_PROJECT_VERSION:' "$PROJECT" | head -1 | sed -E 's/.*CURRENT_PROJECT_VERSION:[[:space:]]*"?([0-9]+)"?.*/\1/' | xargs)"
+          if [[ "$APPLIED" != "$NEW" ]]; then
+            echo "::error::Failed to update CURRENT_PROJECT_VERSION to ${NEW} (got '${APPLIED}')."
+            exit 1
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add "$PROJECT"
+          git commit -m "chore(ios): bump build to ${NEW} for TestFlight [skip ci]"
+          git tag -a "${TAG}" -m "Automated TestFlight release ${TAG}"
+
+          # Push the bump to main, then the tag. main is a fast-forward from the
+          # merge commit; if another commit landed first the push is rejected and
+          # the job fails before the tag is pushed (no orphan tag, no double bump).
+          git push origin HEAD:main
+          git push origin "refs/tags/${TAG}"
+
+          {
+            echo "sha=$(git rev-parse HEAD)"
+            echo "tag=${TAG}"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: tag
+    # Build the freshly tagged bump commit so the binary's CFBundleVersion
+    # matches the just-incremented CURRENT_PROJECT_VERSION.
+    uses: ./.github/workflows/ios-testflight-build.yml
+    with:
+      ref: ${{ needs.tag.outputs.sha }}
+    secrets: inherit

--- a/.github/workflows/ios-testflight-auto.yml
+++ b/.github/workflows/ios-testflight-auto.yml
@@ -38,6 +38,7 @@ jobs:
     name: Bump build number and cut TestFlight tag
     if: >-
       github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
       contains(github.event.pull_request.labels.*.name, 'release:ios')
     runs-on: ubuntu-latest
     permissions:
@@ -100,11 +101,12 @@ jobs:
           git commit -m "chore(ios): bump build to ${NEW} for TestFlight [skip ci]"
           git tag -a "${TAG}" -m "Automated TestFlight release ${TAG}"
 
-          # Push the bump to main, then the tag. main is a fast-forward from the
-          # merge commit; if another commit landed first the push is rejected and
-          # the job fails before the tag is pushed (no orphan tag, no double bump).
-          git push origin HEAD:main
-          git push origin "refs/tags/${TAG}"
+          # Push the bump commit and the tag together atomically: with --atomic
+          # both refs update or neither does, so main can never gain a higher
+          # CURRENT_PROJECT_VERSION without the matching tag. main is a
+          # fast-forward from the merge commit; if another commit landed first the
+          # whole push is rejected and the job fails (no partial state, no double bump).
+          git push --atomic origin HEAD:main "refs/tags/${TAG}"
 
           {
             echo "sha=$(git rev-parse HEAD)"

--- a/.github/workflows/ios-testflight-build.yml
+++ b/.github/workflows/ios-testflight-build.yml
@@ -1,0 +1,240 @@
+name: Build & Upload to TestFlight (reusable)
+
+# Reusable workflow: builds Still Point in Release configuration and uploads it
+# to App Store Connect / TestFlight. Single source of truth for the build +
+# upload logic, called by:
+#   - ios-testflight.yml      (manual ios-v*-build* tag push — escape hatch)
+#   - ios-testflight-auto.yml (PR merged to main with the release:ios label)
+#
+# The heavy App Store release gates (PARITY/QA checklists, App Store dry-run
+# evidence) are intentionally NOT here: TestFlight IS the testing surface, so
+# gating it on a completed QA pass is circular. Those gates still guard the
+# App Store release path in ios-app-store-release.yml (untouched). The cheap
+# Release-config UI smoke gate is kept — it catches build-broken-on-Release
+# before a slot is burned.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Commit ref (SHA or tag) to build from"
+        type: string
+        required: true
+    secrets:
+      BUILD_CERTIFICATE_BASE64:
+        required: true
+      BUILD_PROVISION_PROFILE_BASE64:
+        required: true
+      P12_PASSWORD:
+        required: true
+      APPSTORE_API_KEY_ID:
+        required: true
+      APPSTORE_API_ISSUER_ID:
+        required: true
+      APPSTORE_API_PRIVATE_KEY:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  pre-flight-tests:
+    name: Release-config UI smoke gate
+    runs-on: macos-26
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install XcodeGen
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if brew install xcodegen; then
+              exit 0
+            fi
+            if [[ "$attempt" -lt 3 ]]; then
+              sleep $((attempt * 10))
+            fi
+          done
+          echo "Failed to install xcodegen after 3 attempts."
+          exit 1
+
+      - name: Generate Xcode project
+        working-directory: ios
+        run: xcodegen generate
+
+      - name: Run iOS smoke lane in Release configuration
+        # iOS UI tests run fully in-app via SP_UI_TEST_MODE=1 (set in
+        # StillPointAppUITests.makeApp); no real backend is reached, so
+        # we deliberately omit E2E_BASE_URL and credentials here.
+        env:
+          E2E_ENV: ci
+          E2E_SECRETS_REQUIRED: "false"
+          IOS_TEST_CONFIGURATION: "Release"
+        run: npm run e2e:ios:smoke
+
+      - name: Upload simulator diagnostic reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-testflight-preflight-diagreports
+          path: ~/Library/Logs/DiagnosticReports/**
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload xcresult bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-testflight-preflight-xcresult
+          path: artifacts/e2e/ios/**
+          if-no-files-found: warn
+          retention-days: 14
+
+  build-and-upload:
+    needs: pre-flight-tests
+    runs-on: macos-26
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Verify Xcode and iOS SDK versions
+        shell: bash
+        run: |
+          xcodebuild -version
+          SDK_VERSION="$(xcrun --sdk iphoneos --show-sdk-version)"
+          echo "iPhoneOS SDK: ${SDK_VERSION}"
+          [[ "${SDK_VERSION%%.*}" -ge 26 ]]
+
+      - name: Install XcodeGen (retry on transient Homebrew failures)
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if brew install xcodegen; then
+              exit 0
+            fi
+
+            if [[ "$attempt" -lt 3 ]]; then
+              sleep $((attempt * 10))
+            fi
+          done
+
+          echo "Failed to install xcodegen after 3 attempts."
+          exit 1
+
+      - name: Generate Xcode project
+        working-directory: ios
+        run: xcodegen generate
+
+      - name: Install Apple certificate and provisioning profile
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
+        run: |
+          # Create variables
+          CERTIFICATE_PATH="$RUNNER_TEMP/build_certificate.p12"
+          PP_PATH="$RUNNER_TEMP/build_pp.mobileprovision"
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+          KEYCHAIN_PASSWORD=$(openssl rand -hex 16)
+
+          # Import certificate and provisioning profile from secrets
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o "$CERTIFICATE_PATH"
+          echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o "$PP_PATH"
+
+          # Create temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import certificate to keychain
+          security import "$CERTIFICATE_PATH" -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          # Word-splitting on the existing-keychains list is intentional: each path
+          # must reach -s as its own argument so the new keychain is appended, not
+          # made the sole search-list entry.
+          # shellcheck disable=SC2046
+          security list-keychain -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+
+          # Apply provisioning profile and extract UUID for manual signing
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          PP_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< "$(/usr/bin/security cms -D -i "$PP_PATH")")
+          cp "$PP_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/"${PP_UUID}".mobileprovision
+          # Export the installed profile's UUID so the always()-cleanup step can
+          # remove the actual UUID-named file (not the raw build_pp name).
+          echo "PP_UUID=${PP_UUID}" >> "$GITHUB_ENV"
+
+      - name: Build archive
+        working-directory: ios
+        env:
+          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
+        run: |
+          # Extract provisioning profile UUID for manual signing
+          PP_PATH="$RUNNER_TEMP/build_pp.mobileprovision"
+          echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o "$PP_PATH"
+          PP_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< "$(/usr/bin/security cms -D -i "$PP_PATH")")
+
+          xcodebuild archive \
+            -project StillPoint.xcodeproj \
+            -scheme StillPoint \
+            -configuration Release \
+            -archivePath "$RUNNER_TEMP/StillPoint.xcarchive" \
+            -destination 'generic/platform=iOS' \
+            CODE_SIGN_STYLE=Manual \
+            DEVELOPMENT_TEAM=T5UU4BP6AV \
+            PROVISIONING_PROFILE_SPECIFIER="$PP_UUID" \
+            CODE_SIGN_IDENTITY="Apple Distribution"
+
+      - name: Upload to App Store Connect
+        env:
+          APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+          APPSTORE_API_ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+          APPSTORE_API_PRIVATE_KEY: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
+        run: |
+          # Write API key to file for authentication
+          mkdir -p ~/.private_keys
+          printf '%s\n' "$APPSTORE_API_PRIVATE_KEY" > "$HOME/.private_keys/AuthKey_${APPSTORE_API_KEY_ID}.p8"
+
+          # Export and upload in one step using xcodebuild
+          # The ExportOptions.plist has destination=upload and method=app-store-connect
+          # which makes xcodebuild upload directly to App Store Connect / TestFlight
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/StillPoint.xcarchive" \
+            -exportOptionsPlist ios/ExportOptions.plist \
+            -exportPath "$RUNNER_TEMP/export" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$HOME/.private_keys/AuthKey_${APPSTORE_API_KEY_ID}.p8" \
+            -authenticationKeyID "$APPSTORE_API_KEY_ID" \
+            -authenticationKeyIssuerID "$APPSTORE_API_ISSUER_ID"
+
+      - name: Clean up keychain, provisioning profile, and API key
+        if: always()
+        run: |
+          security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db" 2>/dev/null || true
+          rm -f "$RUNNER_TEMP/build_certificate.p12" 2>/dev/null || true
+          rm -f "$RUNNER_TEMP/build_pp.mobileprovision" 2>/dev/null || true
+          if [[ -n "${PP_UUID:-}" ]]; then
+            rm -f ~/Library/MobileDevice/Provisioning\ Profiles/"${PP_UUID}".mobileprovision 2>/dev/null || true
+          fi
+          rm -rf ~/.private_keys 2>/dev/null || true

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -1,251 +1,31 @@
 name: Build & Upload to TestFlight
 
+# Manual escape-hatch path: push an ios-v<marketing>-build<n> tag (e.g.
+# ios-v1.0.3-build11) to build and upload to TestFlight. The automatic
+# PR-merge + release:ios label path lives in ios-testflight-auto.yml. Both call
+# the shared reusable workflow ios-testflight-build.yml, so the build/upload
+# logic has a single source of truth.
+#
+# Semver-only tags (ios-v1.0.0) trigger App Store release — see
+# ios-app-store-release.yml.
+
 on:
   push:
     tags:
-      # TestFlight binary uploads use extended tags, e.g. ios-v1.0.3-build10.
-      # Semver-only tags (ios-v1.0.0) trigger App Store release — see ios-app-store-release.yml.
       - 'ios-v*-build*'
 
 permissions:
   contents: read
 
+# Shared with ios-testflight-auto.yml so the two TestFlight paths never upload
+# (or bump build numbers) two at a time.
 concurrency:
   group: ios-testflight
   cancel-in-progress: false
 
 jobs:
-  pre-flight-tests:
-    name: Release-config UI smoke gate
-    runs-on: macos-26
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install XcodeGen
-        env:
-          HOMEBREW_NO_AUTO_UPDATE: "1"
-        shell: bash
-        run: |
-          for attempt in 1 2 3; do
-            if brew install xcodegen; then
-              exit 0
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              sleep $((attempt * 10))
-            fi
-          done
-          echo "Failed to install xcodegen after 3 attempts."
-          exit 1
-
-      - name: Generate Xcode project
-        working-directory: ios
-        run: xcodegen generate
-
-      - name: Run iOS smoke lane in Release configuration
-        # iOS UI tests run fully in-app via SP_UI_TEST_MODE=1 (set in
-        # StillPointAppUITests.makeApp); no real backend is reached, so
-        # we deliberately omit E2E_BASE_URL and credentials here.
-        env:
-          E2E_ENV: ci
-          E2E_SECRETS_REQUIRED: "false"
-          IOS_TEST_CONFIGURATION: "Release"
-        run: npm run e2e:ios:smoke
-
-      - name: Upload simulator diagnostic reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ios-testflight-preflight-diagreports
-          path: ~/Library/Logs/DiagnosticReports/**
-          if-no-files-found: ignore
-          retention-days: 14
-
-      - name: Upload xcresult bundle
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ios-testflight-preflight-xcresult
-          path: artifacts/e2e/ios/**
-          if-no-files-found: warn
-          retention-days: 14
-
-  build-and-upload:
-    needs: pre-flight-tests
-    runs-on: macos-26
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Validate release-readiness artifacts
-        shell: bash
-        run: |
-          set -euo pipefail
-          if ! test -f ios/PARITY_CHECKLIST.md; then
-            echo "::error file=.github/workflows/ios-testflight.yml::Missing ios/PARITY_CHECKLIST.md"
-            exit 1
-          fi
-
-          if ! test -f ios/QA_CHECKLIST.md; then
-            echo "::error file=.github/workflows/ios-testflight.yml::Missing ios/QA_CHECKLIST.md"
-            exit 1
-          fi
-
-          if ! grep -qE '^- \[[xX]\] Feature parity checklist between iOS and web is completed\.$' ios/PARITY_CHECKLIST.md; then
-            echo "::error file=.github/workflows/ios-testflight.yml::Missing PARITY_CHECKLIST entry: Feature parity checklist between iOS and web is completed"
-            exit 1
-          fi
-
-          if ! grep -qE '^- \[[xX]\] All critical parity gaps are fixed or explicitly deferred with owner/date\.$' ios/PARITY_CHECKLIST.md; then
-            echo "::error file=.github/workflows/ios-testflight.yml::Missing PARITY_CHECKLIST entry: All critical parity gaps are fixed or explicitly deferred with owner/date"
-            exit 1
-          fi
-
-          if ! grep -qE '^- \[[xX]\] Regression/QA pass for release candidate is completed\.$' ios/QA_CHECKLIST.md; then
-            echo "::error file=.github/workflows/ios-testflight.yml::Missing QA_CHECKLIST entry: Regression/QA pass for release candidate is completed"
-            exit 1
-          fi
-
-          if ! grep -qE '^- \[[xX]\] App Store metadata/versioning/release notes are finalized\.$' ios/QA_CHECKLIST.md; then
-            echo "::error file=.github/workflows/ios-testflight.yml::Missing QA_CHECKLIST entry: App Store metadata/versioning/release notes are finalized"
-            exit 1
-          fi
-
-      - name: Generate App Store submission dry-run evidence
-        run: npm run ios:app-store:dry-run -- --release-owner "GitHub Actions preflight"
-
-      - name: Upload App Store submission dry-run evidence
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ios-app-store-dry-run
-          path: artifacts/ios-app-store-dry-run/**
-          if-no-files-found: error
-          retention-days: 30
-
-      - name: Verify Xcode and iOS SDK versions
-        shell: bash
-        run: |
-          xcodebuild -version
-          SDK_VERSION="$(xcrun --sdk iphoneos --show-sdk-version)"
-          echo "iPhoneOS SDK: ${SDK_VERSION}"
-          [[ "${SDK_VERSION%%.*}" -ge 26 ]]
-
-      - name: Install XcodeGen (retry on transient Homebrew failures)
-        env:
-          HOMEBREW_NO_AUTO_UPDATE: "1"
-        shell: bash
-        run: |
-          for attempt in 1 2 3; do
-            if brew install xcodegen; then
-              exit 0
-            fi
-
-            if [[ "$attempt" -lt 3 ]]; then
-              sleep $((attempt * 10))
-            fi
-          done
-
-          echo "Failed to install xcodegen after 3 attempts."
-          exit 1
-
-      - name: Generate Xcode project
-        working-directory: ios
-        run: xcodegen generate
-
-      - name: Install Apple certificate and provisioning profile
-        env:
-          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
-        run: |
-          # Create variables
-          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-          PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-          KEYCHAIN_PASSWORD=$(openssl rand -hex 16)
-          PP_INSTALL_PATH=~/Library/MobileDevice/Provisioning\ Profiles/build_pp.mobileprovision
-
-          # Import certificate and provisioning profile from secrets
-          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
-          echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
-
-          # Create temporary keychain
-          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-
-          # Import certificate to keychain
-          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH $(security list-keychains -d user | tr -d '"')
-
-          # Apply provisioning profile and extract UUID for manual signing
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          PP_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< "$(/usr/bin/security cms -D -i $PP_PATH)")
-          cp "$PP_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/${PP_UUID}.mobileprovision
-
-      - name: Build archive
-        working-directory: ios
-        env:
-          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
-        run: |
-          # Extract provisioning profile UUID for manual signing
-          PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
-          echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
-          PP_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< "$(/usr/bin/security cms -D -i $PP_PATH)")
-
-          xcodebuild archive \
-            -project StillPoint.xcodeproj \
-            -scheme StillPoint \
-            -configuration Release \
-            -archivePath $RUNNER_TEMP/StillPoint.xcarchive \
-            -destination 'generic/platform=iOS' \
-            CODE_SIGN_STYLE=Manual \
-            DEVELOPMENT_TEAM=T5UU4BP6AV \
-            PROVISIONING_PROFILE_SPECIFIER="$PP_UUID" \
-            CODE_SIGN_IDENTITY="Apple Distribution"
-
-      - name: Upload to App Store Connect
-        env:
-          APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
-          APPSTORE_API_ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
-          APPSTORE_API_PRIVATE_KEY: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
-        run: |
-          # Write API key to file for authentication
-          mkdir -p ~/.private_keys
-          printf '%s\n' "$APPSTORE_API_PRIVATE_KEY" > ~/.private_keys/AuthKey_${APPSTORE_API_KEY_ID}.p8
-
-          # Export and upload in one step using xcodebuild
-          # The ExportOptions.plist has destination=upload and method=app-store-connect
-          # which makes xcodebuild upload directly to App Store Connect / TestFlight
-          xcodebuild -exportArchive \
-            -archivePath $RUNNER_TEMP/StillPoint.xcarchive \
-            -exportOptionsPlist ios/ExportOptions.plist \
-            -exportPath $RUNNER_TEMP/export \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath ~/.private_keys/AuthKey_${APPSTORE_API_KEY_ID}.p8 \
-            -authenticationKeyID "$APPSTORE_API_KEY_ID" \
-            -authenticationKeyIssuerID "$APPSTORE_API_ISSUER_ID"
-
-      - name: Clean up keychain, provisioning profile, and API key
-        if: always()
-        run: |
-          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db 2>/dev/null || true
-          rm -f $RUNNER_TEMP/build_certificate.p12 2>/dev/null || true
-          rm -f $RUNNER_TEMP/build_pp.mobileprovision 2>/dev/null || true
-          rm -f ~/Library/MobileDevice/Provisioning\ Profiles/build_pp.mobileprovision 2>/dev/null || true
-          rm -rf ~/.private_keys 2>/dev/null || true
+  build:
+    uses: ./.github/workflows/ios-testflight-build.yml
+    with:
+      ref: ${{ github.sha }}
+    secrets: inherit

--- a/ios/RELEASING.md
+++ b/ios/RELEASING.md
@@ -2,10 +2,25 @@
 
 ## Release-readiness artifacts (Issue #210)
 
-Treat these files as required merge artifacts for iOS release candidates:
+Treat these files as required merge artifacts for iOS release candidates. They gate the **App Store release** path (`ios-app-store-release.yml`); the TestFlight paths below do **not** enforce them, because TestFlight is itself the testing surface.
 
 - `ios/PARITY_CHECKLIST.md` - feature parity status vs web, including deferred gaps with owner/date.
 - `ios/QA_CHECKLIST.md` - regression/QA sign-off, release metadata completion, and submission evidence.
+
+## Release paths
+
+Still Point has three iOS release paths. Pick by intent:
+
+| Path | Trigger | Workflow | Use when |
+|------|---------|----------|----------|
+| **Auto TestFlight** (recommended) | Merge a PR to `main` carrying the **`release:ios`** label | [`ios-testflight-auto.yml`](../.github/workflows/ios-testflight-auto.yml) → [`ios-testflight-build.yml`](../.github/workflows/ios-testflight-build.yml) | You want the merged code on TestFlight. Label the PR, merge it — the build number auto-increments. |
+| **Manual TestFlight tag** (escape hatch) | Push an `ios-v<marketing>-build<n>` tag | [`ios-testflight.yml`](../.github/workflows/ios-testflight.yml) → [`ios-testflight-build.yml`](../.github/workflows/ios-testflight-build.yml) | You need to cut a specific commit/build by hand, or replay a build without merging a PR. |
+| **App Store release** | Push a strict semver `ios-vMAJOR.MINOR.PATCH` tag (no `-build`) | [`ios-app-store-release.yml`](../.github/workflows/ios-app-store-release.yml) | You're shipping metadata + binary to the App Store for the version in `ios/project.yml`. |
+
+Both TestFlight paths share the reusable build/upload workflow and run only the
+**Release-config UI smoke gate**; the parity/QA-checklist and App Store dry-run gates
+are reserved for the App Store release path. The `release:ios` label gate keeps
+auto-builds intentional, so doc-only or translation PRs don't burn a TestFlight slot.
 
 ## Prerequisites
 
@@ -34,26 +49,47 @@ Before your first TestFlight release, configure a tester group and handle encryp
 
 ## Releasing to TestFlight
 
-1. Complete and commit `ios/PARITY_CHECKLIST.md` and `ios/QA_CHECKLIST.md`.
-2. Update the version in `ios/project.yml`:
+### Automatic: label a PR (recommended)
+
+1. Add the **`release:ios`** label to the PR you want to ship.
+2. Merge the PR to `main`. [`ios-testflight-auto.yml`](../.github/workflows/ios-testflight-auto.yml) fires on the merge and:
+   - reads `CURRENT_PROJECT_VERSION` from `ios/project.yml` and increments it by 1,
+   - commits the bump back to `main` with `[skip ci]`,
+   - cuts an `ios-v<MARKETING_VERSION>-build<new>` tag on that commit,
+   - calls the reusable workflow to build (Release config) and upload to TestFlight.
+3. The build appears in TestFlight ~15–30 min after the run finishes.
+
+`MARKETING_VERSION` is **never** auto-bumped — that's a human decision. Bump it in
+`ios/project.yml` in an ordinary PR when you want a new marketing version; the next
+labeled merge tags against it. If the computed `ios-v<marketing>-build<n>` tag already
+exists (build-number state drifted), the run **fails fast** — bump
+`CURRENT_PROJECT_VERSION` in `ios/project.yml` and re-merge. Unlabeled PR merges do
+nothing (no quota burn).
+
+### Manual tag (escape hatch)
+
+Cut a build by hand without a labeled-PR merge. TestFlight does not require the
+parity/QA checklists — those gate the App Store release path.
+
+1. Bump `CURRENT_PROJECT_VERSION` in `ios/project.yml` so it is strictly greater than the last uploaded build:
    ```yaml
    MARKETING_VERSION: "1.0.3"
-   CURRENT_PROJECT_VERSION: 10
+   CURRENT_PROJECT_VERSION: 11
    ```
-3. Commit release artifacts + version bump:
+2. Commit the build-number bump:
    ```bash
-   git add ios/project.yml ios/PARITY_CHECKLIST.md ios/QA_CHECKLIST.md ios/RELEASING.md
-   git commit -m "Finalize iOS 1.0.3 (build 10) release readiness"
+   git add ios/project.yml
+   git commit -m "Bump iOS to 1.0.3 (build 11) for TestFlight"
    ```
-4. Tag and push using the **TestFlight** tag pattern (`ios-v{version}-build{number}`):
+3. Tag and push using the **TestFlight** tag pattern (`ios-v{version}-build{number}`):
    ```bash
-   git tag ios-v1.0.3-build10
-   git push origin ios-v1.0.3-build10
+   git tag ios-v1.0.3-build11
+   git push origin ios-v1.0.3-build11
    ```
-5. The [Build & Upload to TestFlight](../.github/workflows/ios-testflight.yml) workflow (`ios-v*-build*` tags) builds and uploads to TestFlight automatically.
-6. After Apple processes the build (~15 minutes), it appears in the TestFlight app.
-7. Record the processed build number and processing timestamp in `ios/QA_CHECKLIST.md`.
-8. Before App Store submission, run the automation dry run and save its artifact:
+4. The [Build & Upload to TestFlight](../.github/workflows/ios-testflight.yml) workflow (`ios-v*-build*` tags) builds and uploads to TestFlight automatically.
+5. After Apple processes the build (~15 minutes), it appears in the TestFlight app.
+6. Record the processed build number and processing timestamp in `ios/QA_CHECKLIST.md`.
+7. Before App Store submission, run the automation dry run and save its artifact:
    ```bash
    npm run ios:app-store:dry-run
    ```
@@ -102,9 +138,10 @@ After the intended TestFlight build is processed and valid, use the delegate-rea
 
 ## Version numbering
 
-- `MARKETING_VERSION` - user-facing version (e.g., `1.0.0`, `1.0.3`).
-- `CURRENT_PROJECT_VERSION` - build number; increment every upload (`1`, `2`, `3`, ...).
-- **TestFlight:** push a tag matching `ios-v*-build*` (e.g. `ios-v1.0.3-build10`) to trigger [`.github/workflows/ios-testflight.yml`](../.github/workflows/ios-testflight.yml).
+- `MARKETING_VERSION` - user-facing version (e.g., `1.0.0`, `1.0.3`). Human-bumped only.
+- `CURRENT_PROJECT_VERSION` - build number; must be strictly increasing per marketing version. The **Auto TestFlight** path increments this for you and commits it back to `main`; on the manual paths you bump it yourself.
+- **Auto TestFlight:** merge a PR labeled **`release:ios`** to trigger [`.github/workflows/ios-testflight-auto.yml`](../.github/workflows/ios-testflight-auto.yml), which bumps the build number, tags `ios-v<marketing>-build<n>`, and calls [`.github/workflows/ios-testflight-build.yml`](../.github/workflows/ios-testflight-build.yml).
+- **Manual TestFlight:** push a tag matching `ios-v*-build*` (e.g. `ios-v1.0.3-build11`) to trigger [`.github/workflows/ios-testflight.yml`](../.github/workflows/ios-testflight.yml).
 - **App Store automation:** push a strict semver tag `ios-vMAJOR.MINOR.PATCH` that **equals** `MARKETING_VERSION` to trigger [`.github/workflows/ios-app-store-release.yml`](../.github/workflows/ios-app-store-release.yml).
 - Uploaded app version is controlled by `ios/project.yml`, not the tag string (except the App Store workflow enforces tag ↔ `MARKETING_VERSION` match).
 - Re-uploads for the same marketing version require a new TestFlight tag and incremented build number, e.g. `ios-v<marketing-version>-build<next-build>`.


### PR DESCRIPTION
## **User description**
## What & why

Code keeps merging to `main` but TestFlight builds go stale because someone has to remember to cut an `ios-v*-build*` tag by hand. This adds a label-gated auto path: merge a PR carrying the **`release:ios`** label and a TestFlight build is cut automatically. Mirrors `auerbachb/skingod`'s `mobile-testflight.yml`, adapted for our self-hosted `xcodebuild` pipeline (skingod uses EAS).

Closes #366

## Changes

- **New `ios-testflight-build.yml`** — reusable (`workflow_call`) build + upload workflow. Single source of truth for the Release-config smoke gate, `xcodebuild archive`, and ASC upload. Takes a `ref` input + the six signing secrets.
- **New `ios-testflight-auto.yml`** — triggers on `pull_request: closed`, gated on `merged == true && contains(labels, 'release:ios')`. Reads `CURRENT_PROJECT_VERSION` from `ios/project.yml`, increments it, commits the bump back to `main` with `[skip ci]`, cuts `ios-v<marketing>-build<n>`, then calls the reusable build.
- **`ios-testflight.yml`** — manual `ios-v*-build*` tag escape hatch preserved; now just calls the reusable workflow.
- **`ios/RELEASING.md`** — documents the three release paths (label-merge → TestFlight, manual tag → TestFlight, semver tag → App Store).
- **`release:ios` label** — created on the repo (`#FBCA04`).

## Key design decisions

- **Build number = committed `project.yml`** (issue's Option 1). Verified `main` is **unprotected** (no branch protection / rulesets), so the bot can push the bump directly; the auto workflow grants `contents: write` only on the `tag` job (default token is read-only).
- **No double build.** The bump/tag are pushed with `GITHUB_TOKEN`, and GitHub does not start new workflow runs for `GITHUB_TOKEN` pushes — so the new `ios-v*-build*` tag does **not** re-trigger `ios-testflight.yml`, and the push-on-main CI (`e2e-mobile`, `web-build`) doesn't fire (the `[skip ci]` is belt-and-suspenders). Documented inline in case anyone swaps to a PAT later.
- **Heavy gates dropped from TestFlight, kept for App Store.** TestFlight is the testing surface, so the parity/QA-checklist + dry-run gates would be circular here. They still guard `ios-app-store-release.yml` (untouched). Confirmed the App Store dry-run script (`scripts/ios-app-store-dry-run.mjs`) still passes: its A4 check only needs `ios-testflight.yml` to keep the `ios-v*-build*` trigger (kept), and B2 finds all six secrets in the untouched App Store workflow.
- **Concurrency.** Both TestFlight callers share `group: ios-testflight`, serializing build-number bumps and uploads.
- Validated with `actionlint` + `shellcheck` (clean) and a clean local CodeRabbit pass.

## Test plan

- [x] Merging a PR to `main` with the `release:ios` label triggers a TestFlight build (`tag` job `if` gate + `build` calls the reusable workflow).
- [x] Build number auto-increments without manual intervention (bump step reads `CURRENT_PROJECT_VERSION`, `+1`, fails fast if the tag exists).
- [ ] Resulting build appears in TestFlight within ~30 min of merge.
- [x] PRs **without** the label do NOT trigger a build (`build` job `needs: tag`; `tag` is skipped → `build` skipped).
- [x] The manual `ios-v*-build*` tag path still works (`ios-testflight.yml` keeps its tag trigger, delegates to the reusable workflow).
- [x] The App Store release path (`ios-v*.*.*` → `ios-app-store-release.yml`) is untouched (no diff to that file; dry-run A4/B2 still green).
- [x] Documented in `ios/RELEASING.md` (three-path overview table + per-path steps).
- [x] `release:ios` label exists on the repo.

### End-to-end verification (post-merge)

The final AC — *first successful auto-TestFlight build verified end-to-end* — can only run **after this PR lands**, since the auto workflow must be on `main`. Plan: open a trivial PR (comment typo), add `release:ios`, merge, watch `ios-testflight-auto.yml` cut `ios-v1.0.3-build11`, and confirm the build lands in TestFlight (~30 min). Will coordinate timing with @auerbachb.


___

## **CodeAnt-AI Description**
**Auto-run TestFlight builds when a labeled PR is merged**

### What Changed
- Merging a PR to `main` with the `release:ios` label now automatically bumps the iOS build number, creates the TestFlight tag, and uploads a new build
- TestFlight builds no longer require release checklists or a manual tag for the common release path; those checks now stay with the App Store release flow
- Manual `ios-v*-build*` tags still work as an escape hatch, and both TestFlight paths now share the same build-and-upload flow
- Release notes now document the three iOS release paths and when to use each one

### Impact
`✅ Fewer manual TestFlight releases`
`✅ Faster handoff from merged code to device testing`
`✅ Clearer iOS release flow`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>