### PR TITLE
fix(migrations): checksum reconcile helper + migration runbook

### DIFF
--- a/drizzle/README.md
+++ b/drizzle/README.md
@@ -1,0 +1,90 @@
+# Database migrations
+
+Migrations live here as `*_incremental.sql` files and are applied by
+[`scripts/apply-migrations.ts`](../scripts/apply-migrations.ts) (`npm run db:migrate`),
+which runs as part of the Vercel build command on **every** deploy (preview and
+production).
+
+## How the runner works
+
+- It applies every `*.sql` file in this directory **except** the numbered
+  `0000_*.sql` drizzle-kit output (those are for local drift detection only and
+  are not idempotent against an existing DB).
+- Files are expected to be **idempotent** (`CREATE TABLE IF NOT EXISTS`,
+  `CREATE INDEX IF NOT EXISTS`, `DO $$ ... $$` existence guards, etc.).
+- When a file is first applied, its SHA-256 is recorded in the
+  `schema_migrations` ledger (`filename`, `checksum`, `applied_at`).
+- On later runs: a file whose checksum matches the ledger is skipped; a file not
+  in the ledger is applied and recorded.
+- **If a file's content changes after it was applied, the runner fails the build:**
+
+  ```
+  [migrate] <file>.sql has been edited since it was applied (checksum mismatch).
+  Restore the original content, or write a new migration file.
+  ```
+
+  This guard is intentional - it stops silent schema drift. **Do not weaken it**
+  in `apply-migrations.ts` to make CI pass.
+
+## The golden rule: migrations are append-only once applied
+
+Once a migration has been applied to **any** long-lived branch, treat it as
+immutable. Need a schema change? **Add a new `*_incremental.sql` file** rather
+than editing an existing one.
+
+### Why editing an applied file breaks deploys
+
+Vercel previews deploy against a **single, long-lived shared Neon `preview`
+branch**, and production deploys against the `production` branch. Each branch
+keeps its own `schema_migrations` ledger. If a migration is applied on one branch
+and then edited before it reaches another, the branches disagree:
+
+- The branch that recorded the **old** content fails the checksum guard on the
+  next deploy.
+- "Restore the original content" is **not** always safe - another branch may have
+  already recorded the **new** content, so reverting just moves the breakage.
+
+> Incident #368: `web_push_subscriptions_347_incremental.sql` was applied to the
+> shared `preview` branch under its original #347 content, then a review fix
+> (#360) hardened the FK-existence guard before it merged to `main`. `production`
+> first saw the file with the new content (so it was fine), but `preview` still
+> held the old checksum and every PR preview deploy failed.
+
+## If you must change an already-applied migration
+
+Only do this when the new content is **schema-equivalent** to what was applied
+(e.g. hardening an idempotency guard) - i.e. re-running it would produce the
+exact same schema. If the change alters the schema, write a **new** migration
+file instead.
+
+1. **Verify equivalence.** Confirm the new file produces the same tables /
+   columns / constraints / indexes as the version already applied.
+2. **Reconcile the ledger on every branch that applied the old content** -
+   typically both `production` and `preview`. Use the helper (dry-run first):
+
+   ```bash
+   # point POSTGRES_URL at the branch you are reconciling
+   POSTGRES_URL='<branch connection string>' npm run db:reconcile -- web_push_subscriptions_347_incremental.sql
+   # review the drift, then write it:
+   POSTGRES_URL='<branch connection string>' npm run db:reconcile -- web_push_subscriptions_347_incremental.sql --apply
+   ```
+
+   The helper updates the **ledger only** - it never runs DDL. It shares the
+   migrator's advisory lock, so it cannot race a concurrent deploy.
+
+3. **Preview shortcut.** Because `preview` is a disposable mirror of
+   `production`, you can instead reset it from its parent in the Neon console (or
+   via the API: `reset_from_parent`), which brings its ledger and data back in
+   line with `production` in one step. (This discards preview-only data - use the
+   "preserve under name" option if you might need it back.)
+
+## `db:reconcile` helper
+
+[`scripts/reconcile-migration-checksum.ts`](../scripts/reconcile-migration-checksum.ts)
+(`npm run db:reconcile`) compares the recorded checksum to the current file
+content on the branch addressed by `POSTGRES_URL`:
+
+- **Dry-run by default** - nothing is written without `--apply`.
+- Takes an explicit `<file.sql>` or `--all`; refuses to run without `POSTGRES_URL`.
+- Uses the same checksum and advisory lock as the migrator, so its view always
+  matches what the migrator would compute.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build:turbo": "next build --turbopack",
     "build:verify": "bash ./scripts/verify-build.sh",
     "db:migrate": "tsx scripts/apply-migrations.ts",
+    "db:reconcile": "tsx scripts/reconcile-migration-checksum.ts",
     "test:unit": "vitest run src",
     "start": "next start",
     "db:seed": "tsx scripts/seed.ts",

--- a/scripts/reconcile-migration-checksum.ts
+++ b/scripts/reconcile-migration-checksum.ts
@@ -1,0 +1,196 @@
+import { loadEnvConfig } from "@next/env";
+import { Pool, neonConfig } from "@neondatabase/serverless";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import ws from "ws";
+
+loadEnvConfig(process.cwd());
+
+const MIGRATIONS_DIR = path.join(process.cwd(), "drizzle");
+
+// Same key as scripts/apply-migrations.ts so a reconcile can never race a
+// concurrent migration run on the same branch (the lock is session-scoped).
+const ADVISORY_LOCK_KEY = 7195279_0001;
+
+function usage(message?: string): never {
+  if (message) console.error(`[reconcile] ${message}\n`);
+  console.error(
+    "Reconcile the schema_migrations checksum ledger to match the current\n" +
+      "migration file content on the branch addressed by POSTGRES_URL.\n\n" +
+      "Usage:\n" +
+      "  POSTGRES_URL=... npm run db:reconcile -- <file.sql>            # dry-run one file\n" +
+      "  POSTGRES_URL=... npm run db:reconcile -- --all                 # dry-run every file\n" +
+      "  POSTGRES_URL=... npm run db:reconcile -- <file.sql> --apply    # write\n\n" +
+      "Dry-run is the default; nothing is written without --apply.\n" +
+      "This updates the LEDGER ONLY - it never runs DDL. Reconcile a migration\n" +
+      "ONLY after verifying its new content produces the same schema as what was\n" +
+      "already applied (e.g. an idempotent-guard tweak). See drizzle/README.md.",
+  );
+  process.exit(2);
+}
+
+function listIncrementalFiles(): string[] {
+  // Mirror apply-migrations.ts: managed files are *.sql that are not the
+  // numbered `0000_*` drizzle-kit output.
+  return fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql"))
+    .filter((f) => !/^\d{4}_/.test(f))
+    .sort();
+}
+
+function checksumOf(file: string): string {
+  // Identical to the runner: sha256 of the raw file body (pre any BEGIN/COMMIT
+  // stripping, which only affects the executed SQL, not the checksum).
+  const body = fs.readFileSync(path.join(MIGRATIONS_DIR, file), "utf8");
+  return crypto.createHash("sha256").update(body).digest("hex");
+}
+
+function isUndefinedTable(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: string }).code === "42P01"
+  );
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const apply = argv.includes("--apply");
+  const all = argv.includes("--all");
+  const positionals = argv.filter((a) => !a.startsWith("--"));
+
+  if (all && positionals.length > 0) usage("Pass either --all or a filename, not both.");
+  if (!all && positionals.length === 0) usage("Specify a migration filename or --all.");
+  if (positionals.length > 1) usage("Specify exactly one migration filename.");
+
+  const url = process.env.POSTGRES_URL;
+  if (!url) usage("POSTGRES_URL is required (point it at the branch you want to reconcile).");
+
+  if (!fs.existsSync(MIGRATIONS_DIR)) {
+    console.error(`[reconcile] ${MIGRATIONS_DIR} not found.`);
+    process.exit(1);
+  }
+
+  let targets: string[];
+  if (all) {
+    targets = listIncrementalFiles();
+  } else {
+    // Accept "drizzle/foo.sql" or "foo.sql".
+    const name = path.basename(positionals[0]);
+    if (/^\d{4}_/.test(name)) usage(`Numbered migrations are not managed by the runner: ${name}`);
+    if (!fs.existsSync(path.join(MIGRATIONS_DIR, name))) usage(`No such migration file: drizzle/${name}`);
+    targets = [name];
+  }
+
+  neonConfig.webSocketConstructor = ws;
+  const pool = new Pool({ connectionString: url });
+  console.log(`[reconcile] Connecting to host=${new URL(url).host}`);
+  console.log(`[reconcile] Mode: ${apply ? "APPLY (will write)" : "dry-run (no writes)"}`);
+
+  // pg_advisory_lock is session-scoped: the lock and every query must run on the
+  // same checked-out client (matches apply-migrations.ts).
+  const client = await pool.connect();
+  let lockHeld = false;
+  let drift = 0;
+  let reconciled = 0;
+
+  try {
+    await client.query(`SELECT pg_advisory_lock($1)`, [ADVISORY_LOCK_KEY]);
+    lockHeld = true;
+
+    const ledger = new Map<string, string>();
+    try {
+      const { rows } = await client.query<{ filename: string; checksum: string }>(
+        `SELECT filename, checksum FROM schema_migrations`,
+      );
+      for (const row of rows) ledger.set(row.filename, row.checksum);
+    } catch (err) {
+      if (isUndefinedTable(err)) {
+        console.log(
+          "[reconcile] No schema_migrations table on this branch - nothing applied yet, nothing to reconcile.",
+        );
+        return;
+      }
+      throw err;
+    }
+
+    for (const file of targets) {
+      const fileChecksum = checksumOf(file);
+      const recorded = ledger.get(file);
+
+      if (recorded === undefined) {
+        if (!all) {
+          console.log(
+            `[reconcile] ${file}: not applied on this branch - the migrator will apply it on the next run. Nothing to reconcile.`,
+          );
+        }
+        continue;
+      }
+      if (recorded === fileChecksum) {
+        if (!all) console.log(`[reconcile] ${file}: in sync (${fileChecksum}).`);
+        continue;
+      }
+
+      drift++;
+      console.log(`[reconcile] ${file}: DRIFT`);
+      console.log(`             recorded: ${recorded}`);
+      console.log(`             file:     ${fileChecksum}`);
+
+      if (!apply) {
+        console.log("             -> would reconcile (re-run with --apply).");
+        continue;
+      }
+
+      await client.query("BEGIN");
+      try {
+        // Ledger-only update - touches no schema object. The `AND checksum = $3`
+        // guard makes this a no-op if a concurrent deploy/reconcile already moved
+        // the row, so we never clobber an unexpected value.
+        const res = await client.query(
+          `UPDATE schema_migrations SET checksum = $2 WHERE filename = $1 AND checksum = $3`,
+          [file, fileChecksum, recorded],
+        );
+        await client.query("COMMIT");
+        if (res.rowCount === 1) {
+          reconciled++;
+          console.log("             -> reconciled.");
+        } else {
+          console.log("             -> skipped (ledger changed under us; re-run to re-check).");
+        }
+      } catch (err) {
+        await client.query("ROLLBACK");
+        throw err;
+      }
+    }
+
+    console.log(
+      `[reconcile] done. drift=${drift} ${apply ? `reconciled=${reconciled}` : "(dry-run; no writes)"}`,
+    );
+    if (!apply && drift > 0) {
+      console.log(
+        "[reconcile] Re-run with --apply to write. ONLY do this after confirming the new file",
+      );
+      console.log(
+        "[reconcile] content yields the same schema as what was applied. See drizzle/README.md.",
+      );
+    }
+  } finally {
+    if (lockHeld) {
+      try {
+        await client.query(`SELECT pg_advisory_unlock($1)`, [ADVISORY_LOCK_KEY]);
+      } catch {
+        // best-effort; the session ending also releases it.
+      }
+    }
+    client.release();
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## **User description**
Closes #368

## What changed

- **`scripts/reconcile-migration-checksum.ts`** (`npm run db:reconcile`): operator helper to reconcile the `schema_migrations` checksum ledger to the current migration file content on the branch addressed by `POSTGRES_URL`. Dry-run by default; `--apply` required to write; takes an explicit `<file.sql>` or `--all`. Ledger-only (never runs DDL), and shares the migrator's advisory-lock key so it cannot race a deploy. Checksum logic is identical to `apply-migrations.ts` (sha256 of the raw file body).
- **`drizzle/README.md`**: migration runbook. Documents how the runner + checksum ledger work, the append-only rule, why editing an applied file breaks the shared preview branch, the prod+preview reconcile procedure, and the rule that the guard must never be weakened.
- **`package.json`**: `db:reconcile` script alias.

The checksum guard in `apply-migrations.ts` is intentionally left **unchanged**.

## Why

The migrator throws when an applied `*_incremental.sql` file changes (checksum mismatch). `web_push_subscriptions_347_incremental.sql` was applied to the long-lived shared **preview** Neon branch under its original #347 content, then a review fix in #360 hardened the FK-existence guard before it merged to `main`. `production` first saw the file with the new content (so it stayed healthy), but `preview` still held the old checksum, so every PR preview deploy failed.

## Operational note (already done, not in this diff)

The immediate unblock was applied out-of-band: the Neon `preview` branch was reset from its parent (`production`) so its ledger matches `main` again; prior state preserved as branch `preview-pre-reset-20260609`. Production was never touched (verified: its ledger already matched `main`). This PR is the durable follow-up so the next occurrence has a documented, auditable procedure.

## Test plan

- [x] `drizzle/README.md` documents the append-only rule, the prod+preview reconcile procedure, and the "never weaken the guard" rule
- [x] `scripts/reconcile-migration-checksum.ts` exists; dry-run is the default and `--apply` is required to write
- [x] Helper refuses to run without `POSTGRES_URL` and requires an explicit filename or `--all`
- [x] Helper's checksum computation matches `apply-migrations.ts` (sha256 of the raw file body)
- [x] `apply-migrations.ts` checksum guard is unchanged (not weakened)
- [x] New script typechecks cleanly


___

## **CodeAnt-AI Description**
Add a safe way to repair migration checksum mismatches and document the recovery process

### What Changed
- Added a dry-run migration checksum check that can reconcile a single file or all applied migrations on a branch
- The reconcile tool writes only the migration ledger, requires an explicit apply step, and will not run schema changes
- Documented the append-only migration rule, why edited migrations can break deploys, and the steps to recover safely
- Added a package script so the reconcile helper can be run with a simple command

### Impact
`✅ Fewer preview deploy failures after migration edits`
`✅ Safer recovery from checksum mismatches`
`✅ Clearer migration rollback and repair steps`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

