### PR TITLE
ci(migrations): nightly auto-reset of preview Neon branch

### DIFF
--- a/.github/workflows/neon-preview-reset.yml
+++ b/.github/workflows/neon-preview-reset.yml
@@ -1,0 +1,47 @@
+name: Reset Preview DB Branch
+
+# Keeps the shared Neon `preview` branch in sync with `production` so its
+# schema_migrations ledger cannot drift far enough to break PR preview deploys
+# (see drizzle/README.md and issue #372). The preview branch is a disposable
+# mirror of production, so resetting it nightly is safe; any preview-only data
+# is discarded and new migrations simply re-apply on the next preview deploy.
+#
+# Requires the repo secret NEON_API_KEY (a Neon API key with access to the
+# project). Until that secret is added the job no-ops (passes) rather than
+# failing every night.
+
+on:
+  schedule:
+    - cron: "0 7 * * *" # 07:00 UTC nightly (~02:00-03:00 ET), low-traffic
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+# Never let two resets overlap.
+concurrency:
+  group: neon-preview-reset
+  cancel-in-progress: false
+
+jobs:
+  reset-preview:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Reset preview branch from production
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: noisy-cell-87641627
+          PREVIEW_BRANCH: preview
+        run: |
+          if [ -z "$NEON_API_KEY" ]; then
+            echo "::notice::NEON_API_KEY secret not set - skipping preview reset. Add the secret to enable nightly resets."
+            exit 0
+          fi
+          # neonctl reads NEON_API_KEY from the environment. --parent resets the
+          # branch to production's current state; we intentionally do NOT pass
+          # --preserve-under-name so nightly runs don't accumulate backup branches.
+          npx -y neonctl@2.22.0 branches reset "$PREVIEW_BRANCH" \
+            --project-id "$NEON_PROJECT_ID" \
+            --parent
+          echo "Preview branch '$PREVIEW_BRANCH' reset from production."

--- a/drizzle/README.md
+++ b/drizzle/README.md
@@ -50,6 +50,14 @@ and then edited before it reaches another, the branches disagree:
 > first saw the file with the new content (so it was fine), but `preview` still
 > held the old checksum and every PR preview deploy failed.
 
+**Safety net:** the shared `preview` branch is automatically reset from
+`production` every night by
+[`.github/workflows/neon-preview-reset.yml`](../.github/workflows/neon-preview-reset.yml)
+(issue #372), so most preview drift self-heals within a day. This requires the
+`NEON_API_KEY` repo secret; until it is set the workflow no-ops. `production` is
+never auto-reset, so an intentionally edited applied migration there still needs
+a manual reconcile (below).
+
 ## If you must change an already-applied migration
 
 Only do this when the new content is **schema-equivalent** to what was applied
@@ -72,11 +80,13 @@ file instead.
    The helper updates the **ledger only** - it never runs DDL. It shares the
    migrator's advisory lock, so it cannot race a concurrent deploy.
 
-3. **Preview shortcut.** Because `preview` is a disposable mirror of
-   `production`, you can instead reset it from its parent in the Neon console (or
-   via the API: `reset_from_parent`), which brings its ledger and data back in
-   line with `production` in one step. (This discards preview-only data - use the
-   "preserve under name" option if you might need it back.)
+3. **Preview shortcut.** The nightly workflow above usually heals preview on its
+   own, but to fix it immediately: because `preview` is a disposable mirror of
+   `production`, you can reset it from its parent in the Neon console (or via the
+   API: `reset_from_parent`, or `neonctl branches reset preview --parent`), which
+   brings its ledger and data back in line with `production` in one step. (This
+   discards preview-only data - use the "preserve under name" option if you might
+   need it back.)
 
 ## `db:reconcile` helper
 


### PR DESCRIPTION
## **User description**
Closes #372

## What changed

- **`.github/workflows/neon-preview-reset.yml`** (new): a `schedule` (nightly, 07:00 UTC / ~02:00-03:00 ET) + `workflow_dispatch` workflow that resets the shared Neon `preview` branch from its parent (`production`) via `neonctl branches reset preview --parent`. It keeps preview's `schema_migrations` ledger aligned with production so it cannot drift far enough to break PR preview deploys.
  - Guarded to **no-op (pass)** when the `NEON_API_KEY` secret is absent, so it never fails nightly before setup.
  - Intentionally omits `--preserve-under-name` so nightly runs do not accumulate backup branches.
  - `concurrency` group prevents overlapping resets; `permissions: contents: read` only.
- **`drizzle/README.md`**: documents the nightly auto-reset safety net and the secret requirement.

## Why

Follows the #368/#370 incident: the long-lived shared preview branch holds its own checksum ledger, which drifts whenever a migration file is edited after it has been previewed. PR #370 added recovery tooling (`npm run db:reconcile`) and a runbook; this closes the loop by making preview self-heal so the failure class stops recurring without manual intervention.

## ⚠️ Required setup (manual, one-time)

The workflow does nothing until a **`NEON_API_KEY`** repository secret is added (Settings to Secrets and variables to Actions). Create a Neon API key with access to project `noisy-cell-87641627` and store it as `NEON_API_KEY`. Until then the job passes with a "skipping" notice. After adding it, you can verify via **Actions to Reset Preview DB Branch to Run workflow** (the `workflow_dispatch` trigger).

> Note: the `schedule` trigger only becomes active once this workflow is on `main`, and scheduled/dispatch workflows do not run as a check on this PR, so there is no preview-reset check-run here by design.

## Test plan

- [x] `.github/workflows/neon-preview-reset.yml` added with `schedule` (nightly) + `workflow_dispatch` triggers
- [x] Job resets `preview` from `production` via `neonctl branches reset preview --parent --project-id noisy-cell-87641627`
- [x] Job no-ops (exit 0 with a notice) when `NEON_API_KEY` is absent
- [x] `--preserve-under-name` is NOT used (no backup-branch accumulation)
- [x] `concurrency` prevents overlapping resets; `permissions` is read-only
- [x] Workflow YAML validates (actionlint clean)
- [x] `drizzle/README.md` documents the auto-reset + the `NEON_API_KEY` requirement


___

## **CodeAnt-AI Description**
**Automatically reset the shared preview database branch each night**

### What Changed
- The shared `preview` database branch now resets from `production` every night, so migration drift usually fixes itself before it breaks PR preview deploys.
- The reset can also be run manually from GitHub Actions.
- If the required Neon API key is missing, the workflow skips instead of failing.
- The migration guide now explains the nightly reset and how to recover preview immediately when needed.

### Impact
`✅ Fewer preview deploy failures`
`✅ Shorter recovery after migration drift`
`✅ No nightly action failures before setup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated nightly reset of preview database branch to maintain synchronization with production branch, with built-in safeguards for missing credentials and concurrent execution prevention

* **Documentation**
  * Updated documentation to explain the automated preview branch reset behavior, provide manual recovery and reset procedures, and clarify data handling during maintenance windows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
