### PR TITLE
fix(ios): move Apple sign-in below the auth form

### DIFF
--- a/ios/StillPointApp/Views/AuthView.swift
+++ b/ios/StillPointApp/Views/AuthView.swift
@@ -52,43 +52,6 @@ struct AuthView: View {
                         .textInputAutocapitalization(.never)
                         .accessibilityIdentifier("auth.emailField")
 
-                    // `SignInWithAppleButton` sits in a UIKit bridge that can steal hit-testing /
-                    // layout from sibling fields on CI simulators. XCTest targets stable ids on the
-                    // email/password path — hide OAuth chrome under UI test mode only (#286 / CI).
-                    if !isUiTestMode {
-                        SignInWithAppleButton(.signIn) { request in
-                            request.requestedScopes = [.fullName, .email]
-                        } onCompletion: { result in
-                            switch result {
-                            case .success(let authorization):
-                                guard
-                                    let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
-                                    let body = AppleSignInController.nativeSignInRequest(from: credential)
-                                else {
-                                    vm.error = "Could not read Sign in with Apple credentials."
-                                    return
-                                }
-                                Task {
-                                    if let user = await vm.signInWithApple(using: body) {
-                                        appVM.didLogin(user: user)
-                                    }
-                                }
-                            case .failure(let error):
-                                if let authError = error as? ASAuthorizationError,
-                                   authError.code == .canceled {
-                                    return
-                                }
-                                vm.error = "Sign in with Apple failed. Please try again."
-                            }
-                        }
-                        .signInWithAppleButtonStyle(.black)
-                        .frame(height: 44)
-                        .clipShape(Capsule())
-                        .overlay(Capsule().stroke(SPColor.border2))
-                        .disabled(vm.isAuthInFlight)
-                        .opacity(vm.isAuthInFlight ? 0.5 : 1)
-                    }
-
                     if vm.isSignUp {
                         styledField("Username", text: $vm.username)
                             .textContentType(.username)
@@ -156,6 +119,57 @@ struct AuthView: View {
                         .accessibilityIdentifier("auth.forgotPasswordButton")
                         .disabled(vm.isRequestingPasswordReset)
                         .padding(.top, SPSpacing.s1)
+                    }
+
+                    // OAuth chrome lives at the bottom of the form so it never splits the
+                    // email/username/password fields. `SignInWithAppleButton` sits in a UIKit bridge
+                    // that can steal hit-testing / layout from sibling fields on CI simulators, so the
+                    // divider and button stay hidden under UI test mode — XCTest targets stable ids on
+                    // the email/password path (#286 / CI).
+                    if !isUiTestMode {
+                        HStack(spacing: SPSpacing.s3) {
+                            Rectangle()
+                                .fill(SPColor.border1)
+                                .frame(height: 1)
+                            Text("or")
+                                .font(SPFont.mono(12))
+                                .foregroundStyle(Color(SPColor.fg4))
+                            Rectangle()
+                                .fill(SPColor.border1)
+                                .frame(height: 1)
+                        }
+
+                        SignInWithAppleButton(.signIn) { request in
+                            request.requestedScopes = [.fullName, .email]
+                        } onCompletion: { result in
+                            switch result {
+                            case .success(let authorization):
+                                guard
+                                    let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+                                    let body = AppleSignInController.nativeSignInRequest(from: credential)
+                                else {
+                                    vm.error = "Could not read Sign in with Apple credentials."
+                                    return
+                                }
+                                Task {
+                                    if let user = await vm.signInWithApple(using: body) {
+                                        appVM.didLogin(user: user)
+                                    }
+                                }
+                            case .failure(let error):
+                                if let authError = error as? ASAuthorizationError,
+                                   authError.code == .canceled {
+                                    return
+                                }
+                                vm.error = "Sign in with Apple failed. Please try again."
+                            }
+                        }
+                        .signInWithAppleButtonStyle(.black)
+                        .frame(height: 44)
+                        .clipShape(Capsule())
+                        .overlay(Capsule().stroke(SPColor.border2))
+                        .disabled(vm.isAuthInFlight)
+                        .opacity(vm.isAuthInFlight ? 0.5 : 1)
                     }
                 }
                 .padding(.horizontal, SPSpacing.s4)


### PR DESCRIPTION
## **User description**
## What
Relocate the Sign in with Apple button from between the Email and Password fields to the bottom of the auth form, below the submit button, separated by an "or" divider.

## Why
The button rendered between the credential fields (Email -> [Apple button] -> Username/Password), visually splitting the inputs. Conventional SSO placement is below the primary form.

## How
- Removed the `SignInWithAppleButton` conditional block from between the Email and Username/Password fields.
- Re-added it at the bottom of the Form `VStack`, after the submit button and forgot-password link, so it renders in the same place in both login and sign-up modes.
- Added an "or" divider (`HStack` with two 1pt `Rectangle` rules around a centered `Text("or")`) using design-system tokens (`SPColor.border1`, `SPColor.fg4`, `SPFont.mono(12)`).
- Both the divider and the button stay wrapped in the same `if !isUiTestMode` guard, preserving the #286 CI hit-testing workaround.
- Button styling and in-flight disabled/opacity behavior are unchanged.

Closes #378

## Test plan
- [x] Email -> (Username in sign-up mode) -> Password render contiguously; no SSO button between credential fields in either mode
- [x] Apple button renders at the bottom of the form, below the submit button, separated by an "or" divider — consistent across login and sign-up modes
- [x] UI-test-mode hiding (#286 workaround) still applies to both the divider and the button; iOS e2e stays green
- [x] Button keeps existing styling (black capsule, 44pt height) and in-flight disabled/opacity behavior


___

## **CodeAnt-AI Description**
Move Apple sign-in to the bottom of the iPhone auth form

### What Changed
- The Sign in with Apple button no longer appears between the email and password fields
- On both login and sign-up screens, the Apple button now sits below the main form with an “or” divider above it
- The Apple sign-in area stays hidden in UI test mode to avoid blocking the normal email/password flow

### Impact
`✅ Clearer sign-in forms`
`✅ Fewer iOS test-time layout issues`
`✅ Less confusion during login and sign-up`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized Sign in with Apple authentication to appear at the bottom of the login form with an "or" separator for improved visual hierarchy and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
