### PR TITLE
fix(ios): show quick sits in history journey, collapse long missed-day gaps

### DIFF
--- a/ios/StillPointApp/ViewModels/HistoryViewModel.swift
+++ b/ios/StillPointApp/ViewModels/HistoryViewModel.swift
@@ -8,14 +8,14 @@ final class HistoryViewModel {
     var stats: StatsDTO?
     var isLoading = false
     var errorMessage: String?
-    /// Expanded standard session (by row id).
+    /// Expanded session (by row id).
     var expandedSessionId: String?
     var sessionThoughts: [String: [ThoughtDTO]] = [:]
 
-    /// Standard sits only, ordered for the Journey list (missed gaps + per-day session indices).
+    /// All sits (standard + quick), ordered for the Journey list with collapsed missed-day gaps.
     var journeyRows: [HistoryJourneyListRow] = []
 
-    /// Longest actualTime across standard sessions in the journey (floor 60).
+    /// Longest actualTime across sessions in the journey (floor 60).
     var maxDuration: Int = 60
 
     func load() async {
@@ -57,10 +57,20 @@ final class HistoryViewModel {
     // MARK: - Private
 
     private func buildJourney() {
-        let standard = sessions.filter { $0.sessionType == .standard }
-        journeyRows = HistoryJourney.buildRows(fromStandardSessions: standard)
+        // Today in device-local time, matching how `sessionDate` is stamped at creation,
+        // so the gap between the last session and today renders (#379).
+        let today = Self.localIsoDateFormatter.string(from: Date())
+        journeyRows = HistoryJourney.buildRows(fromSessions: sessions, todayIsoDate: today)
 
-        let sessionTimes = standard.map { $0.actualTime ?? $0.duration }
+        let sessionTimes = sessions.map { $0.actualTime ?? $0.duration }
         maxDuration = max(sessionTimes.max() ?? 60, 60)
     }
+
+    private static let localIsoDateFormatter: DateFormatter = {
+        let df = DateFormatter()
+        df.dateFormat = "yyyy-MM-dd"
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.calendar = Calendar(identifier: .gregorian)
+        return df
+    }()
 }

--- a/ios/StillPointApp/Views/HistoryView.swift
+++ b/ios/StillPointApp/Views/HistoryView.swift
@@ -81,7 +81,9 @@ struct HistoryView: View {
                             switch row {
                             case .missed(let date):
                                 missedRow(date: date)
-                            case .standardSession(let session, let sessionIndex):
+                            case .missedRange(let startDate, _, let dayCount):
+                                missedRangeRow(startDate: startDate, dayCount: dayCount)
+                            case .session(let session, let sessionIndex):
                                 let showDate = prevDate.map { $0 != session.sessionDate } ?? true
                                 sessionRow(session: session, sessionIndexInDay: sessionIndex, showDateColumn: showDate)
                             }
@@ -107,7 +109,9 @@ struct HistoryView: View {
             switch vm.journeyRows[i] {
             case .missed(let date):
                 return date
-            case .standardSession(let session, _):
+            case .missedRange(_, let endDate, _):
+                return endDate
+            case .session(let session, _):
                 return session.sessionDate
             }
             i -= 1
@@ -146,10 +150,10 @@ struct HistoryView: View {
                         .frame(width: 56, alignment: .trailing)
                         .lineLimit(1)
 
-                    // Session label within the day
-                    Text("Session \(sessionIndexInDay)")
+                    // Session label within the day (quick sits visually distinct)
+                    Text(session.sessionType == .quick ? "Quick \(sessionIndexInDay)" : "Session \(sessionIndexInDay)")
                         .font(SPFont.mono(11, weight: .medium))
-                        .foregroundStyle(Color(SPColor.fg3))
+                        .foregroundStyle(session.sessionType == .quick ? SPColor.amberText : SPColor.fg3)
                         .frame(width: 72, alignment: .trailing)
 
                     // Proportional bar
@@ -266,6 +270,46 @@ struct HistoryView: View {
         }
         .padding(.vertical, 2)
         .opacity(0.35)
+    }
+
+    // MARK: - Missed Range Row
+
+    /// Compact summary for a collapsed run of consecutive missed days (#379).
+    private func missedRangeRow(startDate: String, dayCount: Int) -> some View {
+        HStack(spacing: 8) {
+            // Date label (first missed day of the range)
+            Text(shortDateLabel(startDate))
+                .font(SPFont.mono(10))
+                .foregroundStyle(Color(SPColor.fg4))
+                .frame(width: 56, alignment: .trailing)
+                .lineLimit(1)
+
+            // Em-dash instead of session label
+            Text("\u{2014}")
+                .font(SPFont.mono(11, weight: .medium))
+                .foregroundStyle(Color(SPColor.fg3))
+                .frame(width: 72, alignment: .trailing)
+
+            // Dashed border container
+            RoundedRectangle(cornerRadius: 3)
+                .stroke(SPColor.border2, style: StrokeStyle(lineWidth: 1, dash: [4]))
+                .frame(height: 16)
+                .overlay(alignment: .leading) {
+                    Text(dayCount == 1 ? "1 day missed" : "\(dayCount) days missed")
+                        .font(SPFont.mono(10))
+                        .foregroundStyle(Color(SPColor.fg4))
+                        .italic()
+                        .padding(.leading, 8)
+                        .lineLimit(1)
+                }
+
+            // Empty metadata spacer
+            Color.clear
+                .frame(width: 100)
+        }
+        .padding(.vertical, 2)
+        .opacity(0.35)
+        .accessibilityIdentifier("history.missedRange.\(startDate)")
     }
 
     // MARK: - Today Preview

--- a/ios/StillPointShared/Sources/StillPointShared/HistoryJourney.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/HistoryJourney.swift
@@ -55,6 +55,14 @@ public enum SessionCalendar {
 // MARK: - Streak / aggregate stats (matches web `calculateSessionStats`)
 
 public enum SessionStatistics {
+    /// Aggregates standard sessions only — quick sits are intentionally excluded (#379).
+    ///
+    /// Streak and the per-session averages measure the progressive daily practice:
+    /// quick sits never advance `currentDay` (see `StillPoint.shouldAdvanceDay`) and
+    /// run a fixed 60s, so counting them would extend streaks without the daily sit
+    /// and skew averages calibrated to the growing durations. This matches the web
+    /// app's `calculateSessionStats`. Quick sits still appear in the history journey
+    /// (`HistoryJourney.buildRows`).
     public static func calculateStats(for sessions: [SessionDTO]) -> StatsDTO {
         let standard = sessions.filter { $0.sessionType == .standard }
         guard !standard.isEmpty else {
@@ -119,19 +127,29 @@ public enum SessionStatistics {
     }
 }
 
-// MARK: - History journey rows (standard sessions; quick excluded by caller)
+// MARK: - History journey rows (all session types)
 
 public enum HistoryJourneyListRow: Sendable {
     case missed(date: String)
-    case standardSession(session: SessionDTO, sessionIndexInDay: Int)
+    /// Collapsed run of `dayCount` consecutive missed days, `startDate`...`endDate` inclusive.
+    case missedRange(startDate: String, endDate: String, dayCount: Int)
+    case session(session: SessionDTO, sessionIndexInDay: Int)
 }
 
-/// Max consecutive missed-day rows between two sessions (matches web `MAX_MISSED_GAP_ROWS`).
 public enum HistoryJourney {
-    public static let maxMissedGapRows = 366
+    /// Gaps of this many consecutive missed days or more collapse into one `.missedRange`
+    /// row; shorter gaps keep per-day `.missed` rows (#379). The web journey still emits
+    /// per-day rows — see the issue for the parity follow-up.
+    public static let collapseGapThresholdDays = 3
 
-    /// `sessions` should be standard-only; sorted by `sessionDate` then `createdAt` / `id`.
-    public static func buildRows(fromStandardSessions sessions: [SessionDTO]) -> [HistoryJourneyListRow] {
+    /// Builds journey rows from all sessions (standard and quick), sorted by
+    /// `sessionDate` then `createdAt` / `id`.
+    ///
+    /// `sessionIndexInDay` counts per session type within a calendar day, so standard
+    /// numbering is unaffected by interleaved quick sits. Pass `todayIsoDate` (caller's
+    /// local calendar day, same convention used to stamp `sessionDate`) to also emit
+    /// gap rows between the last session and today; today itself is never missed.
+    public static func buildRows(fromSessions sessions: [SessionDTO], todayIsoDate: String? = nil) -> [HistoryJourneyListRow] {
         let sorted = sessions.sorted {
             if $0.sessionDate != $1.sessionDate { return $0.sessionDate < $1.sessionDate }
             let a = $0.createdAt ?? ""
@@ -140,26 +158,41 @@ public enum HistoryJourney {
             return $0.id < $1.id
         }
         var rows: [HistoryJourneyListRow] = []
-        var perDayIndex: [String: Int] = [:]
+        var perDayTypeIndex: [String: Int] = [:]
 
         for i in sorted.indices {
             if i > 0 {
-                let prev = sorted[i - 1]
-                let daysBetween = SessionCalendar.daysBetweenInclusive(fromIso: prev.sessionDate, toIso: sorted[i].sessionDate)
-                let missedCount = max(0, daysBetween - 1)
-                let toEmit = min(missedCount, maxMissedGapRows)
-                if toEmit > 0 {
-                    for gap in 1...toEmit {
-                        let missedDate = SessionCalendar.addDays(toIsoDate: prev.sessionDate, deltaDays: gap)
-                        rows.append(.missed(date: missedDate))
-                    }
-                }
+                appendGapRows(after: sorted[i - 1].sessionDate, before: sorted[i].sessionDate, into: &rows)
             }
             let cur = sorted[i]
-            let n = (perDayIndex[cur.sessionDate] ?? 0) + 1
-            perDayIndex[cur.sessionDate] = n
-            rows.append(.standardSession(session: cur, sessionIndexInDay: n))
+            let key = "\(cur.sessionDate)|\(cur.sessionType.rawValue)"
+            let n = (perDayTypeIndex[key] ?? 0) + 1
+            perDayTypeIndex[key] = n
+            rows.append(.session(session: cur, sessionIndexInDay: n))
+        }
+
+        if let todayIsoDate, let last = sorted.last {
+            appendGapRows(after: last.sessionDate, before: todayIsoDate, into: &rows)
         }
         return rows
+    }
+
+    /// Emits rows for the missed days strictly between `fromIso` and `toIso`: per-day
+    /// `.missed` rows for short gaps, a single `.missedRange` at the collapse threshold.
+    private static func appendGapRows(after fromIso: String, before toIso: String, into rows: inout [HistoryJourneyListRow]) {
+        let daysBetween = SessionCalendar.daysBetweenInclusive(fromIso: fromIso, toIso: toIso)
+        let missedCount = max(0, daysBetween - 1)
+        guard missedCount > 0 else { return }
+        if missedCount >= collapseGapThresholdDays {
+            rows.append(.missedRange(
+                startDate: SessionCalendar.addDays(toIsoDate: fromIso, deltaDays: 1),
+                endDate: SessionCalendar.addDays(toIsoDate: fromIso, deltaDays: missedCount),
+                dayCount: missedCount
+            ))
+        } else {
+            for gap in 1...missedCount {
+                rows.append(.missed(date: SessionCalendar.addDays(toIsoDate: fromIso, deltaDays: gap)))
+            }
+        }
     }
 }

--- a/ios/StillPointShared/Tests/StillPointSharedTests/HistoryJourneyTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/HistoryJourneyTests.swift
@@ -2,37 +2,39 @@ import XCTest
 import StillPointShared
 
 final class HistoryJourneyTests: XCTestCase {
+    private func makeSession(
+        id: String,
+        type: SessionType = .standard,
+        date: String,
+        createdAt: String? = nil,
+        completed: Bool = true,
+        thoughtCount: Int = 0
+    ) -> SessionDTO {
+        SessionDTO(
+            id: id,
+            dayNumber: 1,
+            sessionType: type,
+            duration: 60,
+            completed: completed,
+            actualTime: 60,
+            clearPercent: 50,
+            thoughtCount: thoughtCount,
+            mindStateLog: nil,
+            sessionDate: date,
+            createdAt: createdAt,
+            buddySessionId: nil
+        )
+    }
+
+    // MARK: - Session ordering / per-day indices
+
     func testSequentialSessionLabelsSameDay() {
-        let rows = HistoryJourney.buildRows(fromStandardSessions: [
-            SessionDTO(
-                id: "a",
-                dayNumber: 1,
-                sessionType: .standard,
-                duration: 60,
-                completed: true,
-                actualTime: 60,
-                clearPercent: 50,
-                thoughtCount: 0,
-                mindStateLog: nil,
-                sessionDate: "2026-04-28",
-                buddySessionId: nil
-            ),
-            SessionDTO(
-                id: "b",
-                dayNumber: 1,
-                sessionType: .standard,
-                duration: 60,
-                completed: true,
-                actualTime: 60,
-                clearPercent: 50,
-                thoughtCount: 0,
-                mindStateLog: nil,
-                sessionDate: "2026-04-28",
-                buddySessionId: nil
-            ),
+        let rows = HistoryJourney.buildRows(fromSessions: [
+            makeSession(id: "a", date: "2026-04-28"),
+            makeSession(id: "b", date: "2026-04-28"),
         ])
-        guard case .standardSession(_, let n1) = rows[0],
-              case .standardSession(_, let n2) = rows[1] else {
+        guard case .session(_, let n1) = rows[0],
+              case .session(_, let n2) = rows[1] else {
             return XCTFail("expected two session rows")
         }
         XCTAssertEqual(n1, 1)
@@ -40,38 +42,12 @@ final class HistoryJourneyTests: XCTestCase {
     }
 
     func testSameDaySessionsOrderedByCreatedAt() {
-        let rows = HistoryJourney.buildRows(fromStandardSessions: [
-            SessionDTO(
-                id: "later-id",
-                dayNumber: 1,
-                sessionType: .standard,
-                duration: 60,
-                completed: true,
-                actualTime: 60,
-                clearPercent: 50,
-                thoughtCount: 0,
-                mindStateLog: nil,
-                sessionDate: "2026-04-28",
-                createdAt: "2026-04-28T12:00:00.000Z",
-                buddySessionId: nil
-            ),
-            SessionDTO(
-                id: "earlier-id",
-                dayNumber: 1,
-                sessionType: .standard,
-                duration: 60,
-                completed: true,
-                actualTime: 60,
-                clearPercent: 50,
-                thoughtCount: 0,
-                mindStateLog: nil,
-                sessionDate: "2026-04-28",
-                createdAt: "2026-04-28T10:00:00.000Z",
-                buddySessionId: nil
-            ),
+        let rows = HistoryJourney.buildRows(fromSessions: [
+            makeSession(id: "later-id", date: "2026-04-28", createdAt: "2026-04-28T12:00:00.000Z"),
+            makeSession(id: "earlier-id", date: "2026-04-28", createdAt: "2026-04-28T10:00:00.000Z"),
         ])
-        guard case .standardSession(let first, let n1) = rows[0],
-              case .standardSession(let second, let n2) = rows[1] else {
+        guard case .session(let first, let n1) = rows[0],
+              case .session(let second, let n2) = rows[1] else {
             return XCTFail("expected two session rows")
         }
         XCTAssertEqual(first.id, "earlier-id")
@@ -80,35 +56,176 @@ final class HistoryJourneyTests: XCTestCase {
         XCTAssertEqual(n2, 2)
     }
 
+    // MARK: - Quick sessions in the journey (#379)
+
+    func testQuickOnlySessionsProduceRows() {
+        let rows = HistoryJourney.buildRows(fromSessions: [
+            makeSession(id: "q1", type: .quick, date: "2026-06-10"),
+        ])
+        XCTAssertEqual(rows.count, 1)
+        guard case .session(let session, let n) = rows[0] else {
+            return XCTFail("expected a session row for a quick sit")
+        }
+        XCTAssertEqual(session.sessionType, .quick)
+        XCTAssertEqual(n, 1)
+    }
+
+    func testQuickAndStandardMixUsesPerTypeIndices() {
+        let rows = HistoryJourney.buildRows(fromSessions: [
+            makeSession(id: "s1", date: "2026-06-10", createdAt: "2026-06-10T08:00:00.000Z"),
+            makeSession(id: "q1", type: .quick, date: "2026-06-10", createdAt: "2026-06-10T09:00:00.000Z"),
+            makeSession(id: "s2", date: "2026-06-10", createdAt: "2026-06-10T10:00:00.000Z"),
+        ])
+        XCTAssertEqual(rows.count, 3)
+        guard case .session(let first, let n1) = rows[0],
+              case .session(let second, let n2) = rows[1],
+              case .session(let third, let n3) = rows[2] else {
+            return XCTFail("expected three session rows")
+        }
+        // Chronological interleaving preserved...
+        XCTAssertEqual(first.id, "s1")
+        XCTAssertEqual(second.id, "q1")
+        XCTAssertEqual(third.id, "s2")
+        // ...while standard numbering ignores the quick sit in between.
+        XCTAssertEqual(n1, 1)
+        XCTAssertEqual(n2, 1)
+        XCTAssertEqual(n3, 2)
+    }
+
+    // MARK: - Gap collapsing (#379)
+
+    func testShortGapEmitsPerDayMissedRows() {
+        let rows = HistoryJourney.buildRows(fromSessions: [
+            makeSession(id: "a", date: "2026-06-01"),
+            makeSession(id: "b", date: "2026-06-04"),
+        ])
+        XCTAssertEqual(rows.count, 4)
+        guard case .missed(let d1) = rows[1], case .missed(let d2) = rows[2] else {
+            return XCTFail("expected two per-day missed rows for a 2-day gap")
+        }
+        XCTAssertEqual(d1, "2026-06-02")
+        XCTAssertEqual(d2, "2026-06-03")
+    }
+
+    func testThreeMissedDaysCollapseToRange() {
+        let rows = HistoryJourney.buildRows(fromSessions: [
+            makeSession(id: "a", date: "2026-06-01"),
+            makeSession(id: "b", date: "2026-06-05"),
+        ])
+        XCTAssertEqual(rows.count, 3)
+        guard case .missedRange(let start, let end, let count) = rows[1] else {
+            return XCTFail("expected a collapsed missed range at the 3-day threshold")
+        }
+        XCTAssertEqual(start, "2026-06-02")
+        XCTAssertEqual(end, "2026-06-04")
+        XCTAssertEqual(count, 3)
+    }
+
+    func testThirtyDayGapCollapsesToSingleRange() {
+        let rows = HistoryJourney.buildRows(fromSessions: [
+            makeSession(id: "a", date: "2026-04-01"),
+            makeSession(id: "b", date: "2026-05-01"),
+        ])
+        XCTAssertEqual(rows.count, 3, "prior session must stay reachable: session, one range row, session")
+        guard case .session(let first, _) = rows[0],
+              case .missedRange(let start, let end, let count) = rows[1],
+              case .session(let second, _) = rows[2] else {
+            return XCTFail("expected session, missedRange, session")
+        }
+        XCTAssertEqual(first.id, "a")
+        XCTAssertEqual(second.id, "b")
+        XCTAssertEqual(start, "2026-04-02")
+        XCTAssertEqual(end, "2026-04-30")
+        XCTAssertEqual(count, 29)
+    }
+
+    func testGapSpanningQuickAndStandardSessions() {
+        let rows = HistoryJourney.buildRows(fromSessions: [
+            makeSession(id: "s1", date: "2026-04-01"),
+            makeSession(id: "q1", type: .quick, date: "2026-05-06"),
+        ])
+        XCTAssertEqual(rows.count, 3)
+        guard case .missedRange(_, _, let count) = rows[1],
+              case .session(let last, _) = rows[2] else {
+            return XCTFail("expected missedRange then quick session")
+        }
+        XCTAssertEqual(count, 34)
+        XCTAssertEqual(last.sessionType, .quick)
+    }
+
+    // MARK: - Gap adjacent to today (#379)
+
+    func testLongGapAdjacentToTodayCollapses() {
+        let rows = HistoryJourney.buildRows(
+            fromSessions: [makeSession(id: "a", date: "2026-05-01")],
+            todayIsoDate: "2026-06-11"
+        )
+        XCTAssertEqual(rows.count, 2)
+        guard case .missedRange(let start, let end, let count) = rows[1] else {
+            return XCTFail("expected trailing missedRange before today")
+        }
+        XCTAssertEqual(start, "2026-05-02")
+        XCTAssertEqual(end, "2026-06-10", "today itself is never emitted as missed")
+        XCTAssertEqual(count, 40)
+    }
+
+    func testShortGapAdjacentToTodayEmitsPerDayRows() {
+        let rows = HistoryJourney.buildRows(
+            fromSessions: [makeSession(id: "a", date: "2026-06-09")],
+            todayIsoDate: "2026-06-11"
+        )
+        XCTAssertEqual(rows.count, 2)
+        guard case .missed(let date) = rows[1] else {
+            return XCTFail("expected one trailing missed row")
+        }
+        XCTAssertEqual(date, "2026-06-10")
+    }
+
+    func testNoTrailingGapWhenSessionIsToday() {
+        let rows = HistoryJourney.buildRows(
+            fromSessions: [makeSession(id: "a", date: "2026-06-11")],
+            todayIsoDate: "2026-06-11"
+        )
+        XCTAssertEqual(rows.count, 1)
+        guard case .session = rows[0] else {
+            return XCTFail("expected only the session row")
+        }
+    }
+
+    func testNoTrailingGapWhenSessionWasYesterday() {
+        let rows = HistoryJourney.buildRows(
+            fromSessions: [makeSession(id: "a", date: "2026-06-10")],
+            todayIsoDate: "2026-06-11"
+        )
+        XCTAssertEqual(rows.count, 1)
+    }
+
+    func testEmptySessionsProduceNoRows() {
+        XCTAssertTrue(HistoryJourney.buildRows(fromSessions: [], todayIsoDate: "2026-06-11").isEmpty)
+    }
+
+    // MARK: - Stats (quick sits intentionally excluded — #379)
+
     func testStreakCountsUniqueCalendarDays() {
         let stats = SessionStatistics.calculateStats(for: [
-            SessionDTO(
-                id: "1",
-                dayNumber: 1,
-                sessionType: .standard,
-                duration: 60,
-                completed: true,
-                actualTime: 60,
-                clearPercent: 80,
-                thoughtCount: 0,
-                mindStateLog: nil,
-                sessionDate: "2026-04-28",
-                buddySessionId: nil
-            ),
-            SessionDTO(
-                id: "2",
-                dayNumber: 2,
-                sessionType: .standard,
-                duration: 70,
-                completed: true,
-                actualTime: 70,
-                clearPercent: 90,
-                thoughtCount: 0,
-                mindStateLog: nil,
-                sessionDate: "2026-04-28",
-                buddySessionId: nil
-            ),
+            makeSession(id: "1", date: "2026-04-28"),
+            makeSession(id: "2", date: "2026-04-28"),
         ])
         XCTAssertEqual(stats.streak, 1)
+    }
+
+    func testStatsExcludeQuickSits() {
+        let quickOnly = SessionStatistics.calculateStats(for: [
+            makeSession(id: "q1", type: .quick, date: "2026-06-10", thoughtCount: 5),
+        ])
+        XCTAssertEqual(quickOnly.streak, 0)
+        XCTAssertEqual(quickOnly.avgThoughtsPerSession, 0)
+
+        let mixed = SessionStatistics.calculateStats(for: [
+            makeSession(id: "s1", date: "2026-06-10", thoughtCount: 10),
+            makeSession(id: "q1", type: .quick, date: "2026-06-11", thoughtCount: 5),
+        ])
+        XCTAssertEqual(mixed.streak, 1, "quick sit on a later day must not extend the streak")
+        XCTAssertEqual(mixed.avgThoughtsPerSession, 10, "average must count standard sessions only")
     }
 }


### PR DESCRIPTION
## **User description**
## What changed
- `HistoryJourney.buildRows(fromSessions:todayIsoDate:)` now takes **all** sessions (standard + quick) and emits generalized `.session` rows with per-type day indices, so quick sits appear without disturbing standard "Session N" numbering
- Gaps of **3+ consecutive missed days** collapse into a single `.missedRange` row rendered as a compact **"N days missed"** summary; 1-2 day gaps keep per-day rows
- New optional `todayIsoDate` renders the previously invisible gap between the last session and today (today itself is never "missed")
- `HistoryView` renders quick sits with an amber "Quick N" label; `HistoryViewModel` passes all sessions plus device-local today (same convention used to stamp `sessionDate`)
- Stats still **exclude** quick sits — locked decision; rationale documented on `SessionStatistics.calculateStats` (quick sits don't advance `currentDay`, fixed 60s would skew streak/averages)
- Removed `maxMissedGapRows` (dead once gaps collapse — per-day emission is now bounded by the threshold)

## Why
After a month-long break the Journey emitted ~30 per-day "missed" rows that buried prior sessions, and quick sits never appeared at all — quick-only users saw "No sessions yet".

## Benefit
History stays readable and complete after any gap; every sit shows up immediately after completion. Unblocks #83 (history redesign wave 2).

## Web parity (AC item)
Verified by code inspection: web has the same pre-fix behavior (`src/components/HistoryView.tsx:84` filters quick sits out; `src/lib/historyJourney.ts` emits per-day missed rows capped at 366; no today-adjacent gap). Documented and filed as follow-up #381 — web and iOS are separate codebases, so this is a manual port.

## Test plan
- [x] A `.quick` session appears in the history log immediately after completion (`testQuickOnlySessionsProduceRows`, `testQuickAndStandardMixUsesPerTypeIndices`; ViewModel no longer filters)
- [x] After a 30+ day gap, prior sessions remain visible and reachable (`testThirtyDayGapCollapsesToSingleRange` asserts session-range-session)
- [x] Long gaps render as a compact "N days missed" summary row, not endless per-day rows (`testThreeMissedDaysCollapseToRange`, `missedRangeRow` in HistoryView)
- [x] Stats counters: quick-sit exclusion is explicit and documented (doc comment on `calculateStats` + `testStatsExcludeQuickSits`)
- [x] `HistoryJourneyTests` covers quick+standard mix, 30-day gap, gap adjacent to today — 15 tests, all green locally via `swift test` (52/52 package-wide)
- [x] Web History behavior documented; follow-up filed (#381)

## Notes for review
- Wave-1 collision: #374 also edits `HistoryJourney.swift`/`HistoryViewModel.swift` — this PR lands first per issue plan; #374 rebases.
- Local xcodebuild can't parse the app project (objectVersion-77 / Xcode 26.5), so app-target compilation is verified by CI; the shared package was tested locally.

Closes #379


___

## **CodeAnt-AI Description**
**Show quick sits in History and collapse long gaps into one summary row**

### What Changed
- Quick sits now appear in the History journey with their own label and numbering, instead of being hidden
- Standard and quick sits keep separate per-day numbering, so quick sits no longer interrupt standard session counts
- Missed-day gaps of 3 or more days now collapse into a single “N days missed” row, including the gap between the last session and today
- Short gaps of 1-2 days still show as individual missed days
- History stats still ignore quick sits, so streaks and averages remain based on standard sessions only

### Impact
`✅ Quick sits show up immediately in history`
`✅ Less scrolling through long breaks`
`✅ Clearer streak and average stats`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>