### PR TITLE
fix(ios): consolidate push deep-link handler wiring in RootView + OS-denied push Settings alert

### DIFF
--- a/ios/StillPointApp/PushNotificationCoordinator.swift
+++ b/ios/StillPointApp/PushNotificationCoordinator.swift
@@ -93,6 +93,11 @@ final class PushNotificationCoordinator: NSObject, UIApplicationDelegate, UNUser
         queueOrDeliverDeepLink(from: response.notification.request.content.userInfo)
     }
 
+    func getAuthorizationStatus() async -> UNAuthorizationStatus {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        return settings.authorizationStatus
+    }
+
     private func queueOrDeliverDeepLink(from userInfo: [AnyHashable: Any]) {
         guard let url = deepLinkURL(from: userInfo) else { return }
         DispatchQueue.main.async { [weak self] in

--- a/ios/StillPointApp/ViewModels/NotificationPreferencesViewModel.swift
+++ b/ios/StillPointApp/ViewModels/NotificationPreferencesViewModel.swift
@@ -42,6 +42,7 @@ final class NotificationPreferencesViewModel {
 
     func persistPushEnabledChange(wasEnabled: Bool, isEnabled: Bool) async {
         pushEnabled = isEnabled
+        var osPermissionDenied = false
         if isEnabled && !wasEnabled {
             // iOS never re-prompts once the user denied notification
             // permission, so requesting authorization again is a silent
@@ -49,7 +50,7 @@ final class NotificationPreferencesViewModel {
             // the system Settings app instead (issue #363).
             let status = await PushNotificationCoordinator.shared.getAuthorizationStatus()
             if status == .denied {
-                showPushPermissionDeniedAlert = true
+                osPermissionDenied = true
             } else {
                 PushNotificationCoordinator.shared.requestAuthorizationAndRegister()
             }
@@ -58,6 +59,13 @@ final class NotificationPreferencesViewModel {
             pushEnabled: isEnabled,
             tz: TimeZone.current.identifier
         ))
+        // Surface the Settings alert only after the server save succeeded.
+        // On failure, `persist` reverts the toggle and shows its own error,
+        // which the alert's "push is enabled for your account" wording
+        // would contradict.
+        if osPermissionDenied && errorMessage == nil && pushEnabled {
+            showPushPermissionDeniedAlert = true
+        }
     }
 
     func persistDailyReminderEnabled(_ enabled: Bool) async {

--- a/ios/StillPointApp/ViewModels/NotificationPreferencesViewModel.swift
+++ b/ios/StillPointApp/ViewModels/NotificationPreferencesViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import StillPointShared
+import UserNotifications
 
 @MainActor
 @Observable
@@ -15,6 +16,10 @@ final class NotificationPreferencesViewModel {
     var isLoading = false
     var isSaving = false
     var errorMessage: String?
+
+    /// True when the user enabled push server-side but OS-level notification
+    /// permission is denied. Drives the "Open Settings" alert (issue #363).
+    var showPushPermissionDeniedAlert = false
 
     var reminderTime = Calendar.current.date(from: DateComponents(hour: 9, minute: 0)) ?? Date()
     var quietStartTime = Calendar.current.date(from: DateComponents(hour: 22, minute: 0)) ?? Date()
@@ -38,7 +43,16 @@ final class NotificationPreferencesViewModel {
     func persistPushEnabledChange(wasEnabled: Bool, isEnabled: Bool) async {
         pushEnabled = isEnabled
         if isEnabled && !wasEnabled {
-            PushNotificationCoordinator.shared.requestAuthorizationAndRegister()
+            // iOS never re-prompts once the user denied notification
+            // permission, so requesting authorization again is a silent
+            // no-op. Detect the denied state up front and route the user to
+            // the system Settings app instead (issue #363).
+            let status = await PushNotificationCoordinator.shared.getAuthorizationStatus()
+            if status == .denied {
+                showPushPermissionDeniedAlert = true
+            } else {
+                PushNotificationCoordinator.shared.requestAuthorizationAndRegister()
+            }
         }
         await persist(patch: NotificationPreferencesPatch(
             pushEnabled: isEnabled,

--- a/ios/StillPointApp/Views/NotificationsSettingsView.swift
+++ b/ios/StillPointApp/Views/NotificationsSettingsView.swift
@@ -1,8 +1,10 @@
 import SwiftUI
 import StillPointShared
+import UIKit
 
 struct NotificationsSettingsView: View {
     @Bindable var notificationPrefs: NotificationPreferencesViewModel
+    @Environment(\.openURL) private var openURL
 
     var body: some View {
         ScrollView {
@@ -71,6 +73,19 @@ struct NotificationsSettingsView: View {
         .tint(SPColor.green)
         .disabled(notificationPrefs.isSaving)
         .accessibilityIdentifier("notifications.pushToggle")
+        .alert(
+            "Notifications are off in iOS Settings",
+            isPresented: $notificationPrefs.showPushPermissionDeniedAlert
+        ) {
+            Button("Open Settings") {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    openURL(url)
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Push is enabled for your account, but iOS notification permission for Still Point is turned off. Allow notifications in Settings to receive them on this device.")
+        }
     }
 
     @ViewBuilder

--- a/ios/StillPointApp/Views/RootView.swift
+++ b/ios/StillPointApp/Views/RootView.swift
@@ -110,9 +110,6 @@ struct RootView: View {
         .animation(.easeInOut(duration: 0.3), value: appVM.currentView)
         .animation(.easeInOut(duration: 0.2), value: appVM.isLoading)
         .onAppear {
-            PushNotificationCoordinator.shared.deepLinkHandler = { url in
-                appVM.handleIncomingURL(url)
-            }
             SessionIdleTimerController.syncSceneForegroundActive(
                 appVM: appVM,
                 isForegroundActive: scenePhase == .active
@@ -137,6 +134,22 @@ struct RootView: View {
         .onOpenURL { url in
             appVM.handleIncomingURL(url)
         }
+        // Single authoritative wiring point for push-notification deep links
+        // (issue #363). Do not assign `deepLinkHandler` anywhere else: the
+        // coordinator is a shared singleton, so a second assignment is
+        // last-writer-wins and fragile under multiple WindowGroup scenes.
+        //
+        // - Warm routing: a tapped push reaches the coordinator's
+        //   `userNotificationCenter(_:didReceive:)`, which invokes this
+        //   handler directly.
+        // - Cold-start routing: a launch push arrives in
+        //   `didFinishLaunchingWithOptions` before this `.task` runs; the
+        //   coordinator queues it and its `deepLinkHandler.didSet` delivers
+        //   the pending URL as soon as the handler is assigned here.
+        //
+        // `handlePushDeepLink` currently forwards to `handleIncomingURL`
+        // (the same path `onOpenURL` uses) but stays a distinct entry point
+        // for future push-specific logic (analytics, badge clearing).
         .task {
             PushNotificationCoordinator.shared.deepLinkHandler = { url in
                 appVM.handlePushDeepLink(url)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #363

Follow-up from PR #356 (non-blocking review suggestions deferred at merge).

## Changes

### 1. Single deep-link routing path in `RootView` (primary)
- Removed the `.onAppear` assignment of `PushNotificationCoordinator.shared.deepLinkHandler` (which routed via `handleIncomingURL`).
- The `.task` assignment via `appVM.handlePushDeepLink` is now the **single, documented** wiring point. A doc comment explains warm vs cold-start delivery and warns against assigning the singleton's handler elsewhere (last-writer-wins under multiple `WindowGroup` scenes).
- `handlePushDeepLink` still forwards to `handleIncomingURL`, but stays a distinct entry point for future push-specific logic (analytics, badge clearing).
- No new queuing logic: the coordinator's existing `deepLinkHandler.didSet` → `deliverPendingDeepLinkIfNeeded()` covers cold start (launch push arrives in `didFinishLaunchingWithOptions` before the `.task` runs).

### 2. OS-authorization recheck (optional AC)
- `NotificationPreferencesViewModel.persistPushEnabledChange` checks `getAuthorizationStatus()` before requesting authorization. iOS never re-prompts once denied, so on `.denied` it surfaces an alert instead of a silent no-op request; otherwise behavior is unchanged.
- `NotificationsSettingsView` (where the push toggle lives; `SettingsView` only links to it) shows a modal alert with **Open Settings** (via `UIApplication.openSettingsURLString`) / **Cancel**.
- The server preference is still persisted, so pushes resume as soon as OS permission is granted — the alert only surfaces the mismatch.
- `@MainActor` defer-flag gotcha respected: the new `await` happens before `persist()`; no guard-flag/defer interleaving introduced.

## Review feedback resolution
- **Cursor Bugbot (low severity, "Alert shown before save completes")** — fixed in `e4efa23`: the denied-state alert is shown only after `persist()` returns, and suppressed when the save failed or the toggle was reverted (`errorMessage == nil && pushEnabled` guard). Thread resolved.
- **CodeRabbit** — review completed, no actionable comments.

## Rebase / CI follow-up (`966452f`)
- Rebased onto current `main` (includes PR #406 dead-symbol sweep).
- PR #406 removed `getAuthorizationStatus()` from `PushNotificationCoordinator` as unused; restored it since `NotificationPreferencesViewModel` now depends on it for the OS-denied alert path.

## Test plan (mirrors AC)

- [x] **Single, documented deep-link routing path** — `rg "deepLinkHandler\s*="` returns exactly one assignment (RootView's `.task`); documented inline.
- [x] **Cold-start and warm routing for `stillpoint://home` and `stillpoint://session/quick`** — verified with a compiled harness (7/7 checks pass on original implementation).
- [x] **OS-revoked mismatch affordance** — enable toggle → `getAuthorizationStatus()` → `.denied` → save succeeds → alert; on save failure alert suppressed.
- [x] CI on HEAD `966452f`: `build`, `e2e-policy`, all `e2e-web`/`e2e-mobile` lanes, `ios-e2e-critical` (7m29s), `ios-e2e-smoke` (14m48s).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce0b1518-9bc0-4df6-b88f-92761ed662ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce0b1518-9bc0-4df6-b88f-92761ed662ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-app alert that appears when push notifications are enabled on the server but iOS notification permission is denied, with an **“Open Settings”** action to send users to iOS Settings.

* **Bug Fixes**
  * Improved push deep-link routing consistency by consolidating deep-link handler setup so cold vs. warm start behavior follows the same path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->