### PR TITLE
feat(buddy): project scheduled calendar invite duration from min participant

### DIFF
--- a/src/lib/buddySession.duration.test.ts
+++ b/src/lib/buddySession.duration.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "vitest";
 import { BASE_DURATION } from "@/lib/constants";
-import { normalizedBuddySessionDurationSeconds } from "@/lib/buddySessionDuration";
+import {
+  calendarDaysUntilUTC,
+  normalizedBuddySessionDurationSeconds,
+  projectedCalendarDurationSeconds,
+} from "@/lib/buddySessionDuration";
 
 describe("normalizedBuddySessionDurationSeconds", () => {
   test("two participants uses the shorter current-day length", () => {
@@ -27,5 +31,77 @@ describe("normalizedBuddySessionDurationSeconds", () => {
 
   test("empty participant list defaults to base duration", () => {
     expect(normalizedBuddySessionDurationSeconds([])).toBe(BASE_DURATION);
+  });
+});
+
+describe("calendarDaysUntilUTC", () => {
+  test("same UTC date is 0 days regardless of time of day", () => {
+    expect(
+      calendarDaysUntilUTC(
+        new Date("2026-06-11T01:00:00Z"),
+        new Date("2026-06-11T23:30:00Z"),
+      ),
+    ).toBe(0);
+  });
+
+  test("crossing a single UTC midnight is 1 day (session tomorrow)", () => {
+    expect(
+      calendarDaysUntilUTC(
+        new Date("2026-06-11T23:00:00Z"),
+        new Date("2026-06-12T01:00:00Z"),
+      ),
+    ).toBe(1);
+  });
+
+  test("floors partial days to whole UTC date boundaries", () => {
+    expect(
+      calendarDaysUntilUTC(
+        new Date("2026-06-11T00:00:00Z"),
+        new Date("2026-06-16T23:59:59Z"),
+      ),
+    ).toBe(5);
+  });
+
+  test("clamps past sessions to 0", () => {
+    expect(
+      calendarDaysUntilUTC(
+        new Date("2026-06-16T00:00:00Z"),
+        new Date("2026-06-11T00:00:00Z"),
+      ),
+    ).toBe(0);
+  });
+});
+
+describe("projectedCalendarDurationSeconds", () => {
+  const syncAt = new Date("2026-06-11T12:00:00Z");
+  // 8am UTC, n whole calendar days after syncAt's UTC date.
+  const daysOut = (n: number) => new Date(Date.UTC(2026, 5, 11 + n, 8, 0, 0));
+
+  test("two participants: projects the minimum participant +10s/day (issue example)", () => {
+    // host day 10 (150s) + guest day 1 (60s) → min 60s; 5 days out → 60 + 5*10 = 110
+    expect(projectedCalendarDurationSeconds([10, 1], syncAt, daysOut(5))).toBe(110);
+  });
+
+  test("N participants: picks the global minimum, then projects", () => {
+    // days [4,2,6] → lengths [90,70,110] → min 70; 3 days out → 70 + 3*10 = 100
+    expect(projectedCalendarDurationSeconds([4, 2, 6], syncAt, daysOut(3))).toBe(100);
+  });
+
+  test("0 days out equals the live normalized minimum (no projection)", () => {
+    const sameDay = new Date("2026-06-11T23:00:00Z");
+    expect(projectedCalendarDurationSeconds([10, 1], syncAt, sameDay)).toBe(
+      normalizedBuddySessionDurationSeconds([10, 1]),
+    );
+    expect(projectedCalendarDurationSeconds([3, 3], syncAt, sameDay)).toBe(80);
+  });
+
+  test("many days out scales linearly at +10s/day", () => {
+    // days [10,11,12,13] → min 150; 30 days out → 150 + 30*10 = 450
+    expect(projectedCalendarDurationSeconds([10, 11, 12, 13], syncAt, daysOut(30))).toBe(450);
+  });
+
+  test("respects the 60s floor", () => {
+    expect(projectedCalendarDurationSeconds([1, 1], syncAt, daysOut(0))).toBe(BASE_DURATION);
+    expect(projectedCalendarDurationSeconds([], syncAt, daysOut(0))).toBe(BASE_DURATION);
   });
 });

--- a/src/lib/buddySessionDuration.ts
+++ b/src/lib/buddySessionDuration.ts
@@ -1,4 +1,6 @@
-import { BASE_DURATION, durationForDay } from "@/lib/constants";
+import { BASE_DURATION, INCREMENT, durationForDay } from "@/lib/constants";
+
+const MS_PER_DAY = 86_400_000;
 
 export function buddyDurationForDay(currentDay: number): number {
   return durationForDay(currentDay);
@@ -17,4 +19,39 @@ export function normalizedBuddySessionDurationSeconds(currentDays: number[]): nu
   }
   const lengths = currentDays.map((day) => buddyDurationForDay(day));
   return Math.max(BASE_DURATION, Math.min(...lengths));
+}
+
+/**
+ * Whole calendar days from `from` to `to`, measured at UTC day granularity (#361).
+ *
+ * Both instants are floored to their UTC calendar date, so the result is the number of date
+ * boundaries crossed: same UTC date → 0, the next UTC day → 1. Negative spans (a session already in
+ * the past) clamp to 0. UTC is intentional for v1 — day granularity tolerates user-timezone variance.
+ */
+export function calendarDaysUntilUTC(from: Date, to: Date): number {
+  const fromMidnight = Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate());
+  const toMidnight = Date.UTC(to.getUTCFullYear(), to.getUTCMonth(), to.getUTCDate());
+  return Math.max(0, Math.floor((toMidnight - fromMidnight) / MS_PER_DAY));
+}
+
+/**
+ * Projected buddy *calendar invite* length (#361).
+ *
+ * Scheduled buddy sits grow before they run: the shortest participant gains +10s per completed
+ * standard day. So when we write a calendar event for a future sit we show the length we expect the
+ * shortest participant to reach by `scheduledStartAt`, not today's length. Take the live minimum
+ * participant length now (`normalizedBuddySessionDurationSeconds`, #349) and advance it by +10s per
+ * whole UTC calendar day until the session, floored at 60s.
+ *
+ * 0 days out (same-day / immediate) projects +0s — identical to the live normalized length. This is
+ * an estimate for the invite only; the in-app timer is still normalized live at session start (#349).
+ */
+export function projectedCalendarDurationSeconds(
+  currentDays: number[],
+  syncAt: Date,
+  scheduledStartAt: Date,
+): number {
+  const base = normalizedBuddySessionDurationSeconds(currentDays);
+  const daysUntil = calendarDaysUntilUTC(syncAt, scheduledStartAt);
+  return Math.max(BASE_DURATION, base + daysUntil * INCREMENT);
 }

--- a/src/lib/google.ts
+++ b/src/lib/google.ts
@@ -5,11 +5,13 @@ import { db } from "@/db";
 import { poolDb } from "@/db/pool";
 import {
   buddySessionCalendarEvents,
+  buddySessionParticipants,
   buddySessions,
   googleOAuthTokens,
   users,
 } from "@/db/schema";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
+import { projectedCalendarDurationSeconds } from "@/lib/buddySessionDuration";
 
 const GOOGLE_AUTH_BASE = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
@@ -367,12 +369,13 @@ async function insertCalendarEvent(
   userId: string,
   session: typeof buddySessions.$inferSelect,
   accessToken: string,
+  durationSeconds: number,
 ): Promise<GoogleCalendarEventResponse> {
   if (!session.scheduledStartAt) {
     throw new GoogleCalendarUnavailableError("Cannot create a calendar event without scheduledStartAt.");
   }
   const start = session.scheduledStartAt;
-  const end = new Date(start.getTime() + session.durationSeconds * 1000);
+  const end = new Date(start.getTime() + durationSeconds * 1000);
   const eventId = googleCalendarEventId(session.id, userId);
   const headers = {
     Authorization: `Bearer ${accessToken}`,
@@ -413,6 +416,7 @@ export async function syncBuddySessionCalendarForUser(
   if (!session.scheduledStartAt) {
     return { status: "skipped", userId, reason: "not_scheduled" };
   }
+  const scheduledStartAt = session.scheduledStartAt;
   try {
     return await poolDb.transaction(async (tx) => {
       await tx.execute(
@@ -443,7 +447,25 @@ export async function syncBuddySessionCalendarForUser(
       }
       const accessToken = await getValidAccessToken(userId);
       if (!accessToken) return { status: "skipped", userId, reason: "not_connected" };
-      const event = await insertCalendarEvent(userId, session, accessToken);
+      // #361: project the invite duration from the shortest active participant at sync time
+      // (+10s/day until the session) so a future scheduled sit shows the length we expect it to
+      // reach, not today's length. The in-app timer is still normalized live at start (#349).
+      const participantDays = await tx
+        .select({ currentDay: users.currentDay })
+        .from(buddySessionParticipants)
+        .innerJoin(users, eq(buddySessionParticipants.userId, users.id))
+        .where(
+          and(
+            eq(buddySessionParticipants.buddySessionId, session.id),
+            isNull(buddySessionParticipants.leftAt),
+          ),
+        );
+      const calendarDurationSeconds = projectedCalendarDurationSeconds(
+        participantDays.map((row) => row.currentDay),
+        new Date(),
+        scheduledStartAt,
+      );
+      const event = await insertCalendarEvent(userId, session, accessToken, calendarDurationSeconds);
       if (!event.id) {
         throw new GoogleCalendarApiError("Google Calendar event response was incomplete", 200, event);
       }


### PR DESCRIPTION
## **User description**
## What

Scheduled buddy calendar invites now show a **projected** session length instead of today's length. When a Google Calendar event is written for a future scheduled buddy sit, we take the shortest active participant's current length and advance it **+10s per calendar day** until `scheduledStartAt` (floored at 60s).

Closes #361.

## Why

Buddy sits pace to the shortest participant (`min` of current lengths, #349). For a sit scheduled days out, that minimum participant will have grown by the time the session runs (+10s per completed standard day). Writing today's length into the invite under-states the block — the calendar event should communicate the length we expect on the session day.

Example: host day 10 (150s) + guest day 1 (60s), scheduled 5 days out → invite shows `60 + 5×10 = 110s`, not 60s.

## How

- **`src/lib/buddySessionDuration.ts`** (pure, unit-tested):
  - `calendarDaysUntilUTC(from, to)` — whole calendar days at UTC day granularity (floor, clamped ≥0). Integer math only.
  - `projectedCalendarDurationSeconds(currentDays, syncAt, scheduledStartAt)` — reuses the #349 `min`-with-60s-floor, then advances `+10s × daysUntil`, floored at 60s.
- **`src/lib/google.ts`** — on the calendar create path, query the shortest **active** participant (`leftAt IS NULL`) at sync time and feed the projected duration into `insertCalendarEvent` (which now takes an explicit `durationSeconds`).

## Behavior notes

- **Projection applies to scheduled sessions only.** Immediate-start sits have no `scheduledStartAt`, so calendar sync is still skipped entirely — unchanged.
- **0 days out (same-day) projects +0s** — identical to current behavior.
- Calendar duration is an **estimate** for the invite; the in-app timer is still normalized live at session start (#349).
- v1 keeps the existing **create-once-per-user** calendar behavior (patching already-created events when a later, lower-day guest joins is out of scope per the issue).

## Test plan

- [x] Scheduled buddy calendar events use projected duration from minimum participant at sync time (+10s/day until `scheduledStartAt`) — `projectedCalendarDurationSeconds` + `google.ts` integration
- [x] Floor remains 60 seconds — `respects the 60s floor` test
- [x] Unit tests for projection math (2 participants, N participants, 0 days out, many days out) — see `buddySession.duration.test.ts`
- [x] Existing immediate-start buddy calendar behavior unchanged or explicitly documented — sync still skipped when no `scheduledStartAt`; documented in code + above
- [x] `npm run test:unit` passes for the changed area (output pasted in PR comment)

> Note: `npm run test:unit` is not run in CI (CI runs e2e + build only), so unit results are pasted below.


___

## **CodeAnt-AI Description**
**Show projected session length in future buddy calendar invites**

### What Changed
- Calendar invites for scheduled buddy sits now use the expected session length on the session day, not the length from the day the invite was created.
- The invite length grows by 10 seconds for each full UTC day until the session starts, using the shortest active participant as the starting point.
- Same-day invites stay unchanged, and sessions without a scheduled start still do not create calendar events.
- Added coverage for date counting and projected invite length, including same-day, future-day, and floor behavior.

### Impact
`✅ More accurate calendar blocks`
`✅ Clearer future sit durations`
`✅ Fewer misleading invite lengths`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

