### PR TITLE
feat(web): keep screen awake during session (Wake Lock API parity with iOS)

### DIFF
--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -12,8 +12,7 @@ import { ThoughtCapture } from "./ThoughtCapture";
 import { loadSoundPrefs, saveSoundPrefs, unlockAudioContext, type SoundPrefs } from "@/lib/audio";
 import { computeClearPercentFromLog } from "@/lib/mindStateSession";
 import { useMindStateHold } from "@/lib/useMindStateHold";
-import { useWakeLock } from "@/lib/useWakeLock";
-import { loadWakeLockPrefs } from "@/lib/wakeLockPrefs";
+import { useKeepScreenAwakePref, useWakeLock } from "@/lib/useWakeLock";
 
 /** Payload for the shared `/app` completion screen after a buddy sit (#119). */
 export type BuddyPersonalRecordPayload = {
@@ -164,9 +163,15 @@ export function BuddySessionRoom({
 
   const buddyHoldActive = snap?.state === "active";
 
-  /** Opt-in Settings pref read once per room mount; leaving `active` (complete/abandon/exit) releases the lock. */
-  const [keepScreenAwakePref] = useState(() => loadWakeLockPrefs().keepScreenAwakeDuringSession);
-  useWakeLock(keepScreenAwakePref && buddyHoldActive);
+  /** Flipped at the start of leave() so the wake lock releases before the async exit finishes. */
+  const [exitingRoom, setExitingRoom] = useState(false);
+  /**
+   * Live opt-in Settings pref (toggle-off releases). Local terminal transitions
+   * (own timer finished, leaving the room) release immediately instead of
+   * waiting for the next polled snapshot to stop being `active`.
+   */
+  const keepScreenAwakePref = useKeepScreenAwakePref();
+  useWakeLock(keepScreenAwakePref && buddyHoldActive && !localTimerCompleted && !exitingRoom);
 
   const { holdKindRef, resetHoldTracking } = useMindStateHold({
     enabled: buddyHoldActive,
@@ -211,6 +216,7 @@ export function BuddySessionRoom({
     setIsSavingPersonalRecord(false);
     setLocalTimerCompleted(false);
     localTimerCompletedRef.current = false;
+    setExitingRoom(false);
     setAudioBlocked(false);
     setPersonalRecordError(null);
     setDailyMeetingToken(null);
@@ -409,6 +415,7 @@ export function BuddySessionRoom({
 
   const leave = async (opts?: { ignoreLeaveApiErrors?: boolean }) => {
     const ignoreLeaveApiErrors = opts?.ignoreLeaveApiErrors !== false;
+    setExitingRoom(true);
     try {
       await api.leaveBuddySession(sessionId);
       onExit();
@@ -417,6 +424,7 @@ export function BuddySessionRoom({
         onExit();
         return;
       }
+      setExitingRoom(false);
       throw err;
     }
   };

--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -12,6 +12,8 @@ import { ThoughtCapture } from "./ThoughtCapture";
 import { loadSoundPrefs, saveSoundPrefs, unlockAudioContext, type SoundPrefs } from "@/lib/audio";
 import { computeClearPercentFromLog } from "@/lib/mindStateSession";
 import { useMindStateHold } from "@/lib/useMindStateHold";
+import { useWakeLock } from "@/lib/useWakeLock";
+import { loadWakeLockPrefs } from "@/lib/wakeLockPrefs";
 
 /** Payload for the shared `/app` completion screen after a buddy sit (#119). */
 export type BuddyPersonalRecordPayload = {
@@ -161,6 +163,10 @@ export function BuddySessionRoom({
   }, [finalizeActiveBuddyHold]);
 
   const buddyHoldActive = snap?.state === "active";
+
+  /** Opt-in Settings pref read once per room mount; leaving `active` (complete/abandon/exit) releases the lock. */
+  const [keepScreenAwakePref] = useState(() => loadWakeLockPrefs().keepScreenAwakeDuringSession);
+  useWakeLock(keepScreenAwakePref && buddyHoldActive);
 
   const { holdKindRef, resetHoldTracking } = useMindStateHold({
     enabled: buddyHoldActive,

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -7,6 +7,8 @@ import { ThoughtCapture } from "./ThoughtCapture";
 import { loadSoundPrefs, saveSoundPrefs, type SoundPrefs } from "@/lib/audio";
 import { computeClearPercentFromLog } from "@/lib/mindStateSession";
 import { useMindStateHold } from "@/lib/useMindStateHold";
+import { useWakeLock } from "@/lib/useWakeLock";
+import { loadWakeLockPrefs } from "@/lib/wakeLockPrefs";
 
 type MindState = "clear" | "thinking" | "hyperfocus";
 
@@ -70,6 +72,9 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   /** True after user pauses once this sit — keeps tracking UI (and ThoughtCapture) mounted while paused. */
   const [wasPausedInSession, setWasPausedInSession] = useState(false);
+  /** Opt-in Settings pref read once per sit; pause/complete/abandon drop `isActive` and release the lock. */
+  const [keepScreenAwakePref] = useState(() => loadWakeLockPrefs().keepScreenAwakeDuringSession);
+  useWakeLock(keepScreenAwakePref && isActive);
 
   useEffect(() => {
     const resetTimer = () => {

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -7,8 +7,7 @@ import { ThoughtCapture } from "./ThoughtCapture";
 import { loadSoundPrefs, saveSoundPrefs, type SoundPrefs } from "@/lib/audio";
 import { computeClearPercentFromLog } from "@/lib/mindStateSession";
 import { useMindStateHold } from "@/lib/useMindStateHold";
-import { useWakeLock } from "@/lib/useWakeLock";
-import { loadWakeLockPrefs } from "@/lib/wakeLockPrefs";
+import { useKeepScreenAwakePref, useWakeLock } from "@/lib/useWakeLock";
 
 type MindState = "clear" | "thinking" | "hyperfocus";
 
@@ -72,8 +71,8 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   /** True after user pauses once this sit — keeps tracking UI (and ThoughtCapture) mounted while paused. */
   const [wasPausedInSession, setWasPausedInSession] = useState(false);
-  /** Opt-in Settings pref read once per sit; pause/complete/abandon drop `isActive` and release the lock. */
-  const [keepScreenAwakePref] = useState(() => loadWakeLockPrefs().keepScreenAwakeDuringSession);
+  /** Live opt-in Settings pref; pause/complete/abandon drop `isActive` and toggle-off releases too. */
+  const keepScreenAwakePref = useKeepScreenAwakePref();
   useWakeLock(keepScreenAwakePref && isActive);
 
   useEffect(() => {

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { DeleteAccountSection } from "@/components/DeleteAccountSection";
 import { api } from "@/lib/api";
 import {
@@ -9,6 +9,11 @@ import {
   USERNAME_ERROR,
   isValidUsername,
 } from "@/lib/username";
+import {
+  isWakeLockSupported,
+  loadWakeLockPrefs,
+  saveWakeLockPrefs,
+} from "@/lib/wakeLockPrefs";
 
 type User = {
   id: string;
@@ -32,6 +37,10 @@ export function SettingsView({
   onLogout,
 }: SettingsViewProps) {
   const [toggling, setToggling] = useState(false);
+  // Both stay false during SSR/hydration; the Session card only appears after
+  // mount when the browser actually supports the Screen Wake Lock API (#317).
+  const [wakeLockSupported, setWakeLockSupported] = useState(false);
+  const [keepScreenAwake, setKeepScreenAwake] = useState(false);
   const [editingUsername, setEditingUsername] = useState(false);
   const [usernameInput, setUsernameInput] = useState(user.username);
   const [savingUsername, setSavingUsername] = useState(false);
@@ -105,6 +114,17 @@ export function SettingsView({
     } finally {
       setToggling(false);
     }
+  };
+
+  useEffect(() => {
+    setWakeLockSupported(isWakeLockSupported());
+    setKeepScreenAwake(loadWakeLockPrefs().keepScreenAwakeDuringSession);
+  }, []);
+
+  const handleKeepScreenAwakeToggle = () => {
+    const next = !keepScreenAwake;
+    setKeepScreenAwake(next);
+    saveWakeLockPrefs({ keepScreenAwakeDuringSession: next });
   };
 
   const handleLogout = async () => {
@@ -302,6 +322,61 @@ export function SettingsView({
             →
           </span>
         </Link>
+
+        {/* Session: keep screen awake (hidden when the Wake Lock API is unsupported) */}
+        {wakeLockSupported && (
+          <div style={{
+            padding: "16px 20px",
+            background: "var(--surface-1)",
+            borderRadius: "10px",
+            display: "flex", alignItems: "center", justifyContent: "space-between",
+          }}>
+            <div>
+              <div style={{
+                fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                fontSize: "12px", color: "var(--fg)", marginBottom: "4px",
+              }}>
+                Keep screen on during session
+              </div>
+              <div style={{
+                fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+                fontSize: "13px", fontStyle: "italic",
+                color: "var(--fg-3)",
+              }}>
+                Prevents the screen from sleeping while a sit timer is running
+              </div>
+            </div>
+            <button
+              type="button"
+              aria-label={
+                keepScreenAwake
+                  ? "Disable keeping screen on during session"
+                  : "Enable keeping screen on during session"
+              }
+              aria-pressed={keepScreenAwake}
+              onClick={handleKeepScreenAwakeToggle}
+              style={{
+                width: "48px", height: "26px",
+                borderRadius: "13px", border: "none",
+                background: keepScreenAwake
+                  ? "var(--accent-green-bg)"
+                  : "var(--surface-3)",
+                position: "relative", cursor: "pointer",
+                transition: "background 0.3s",
+                flexShrink: 0, marginLeft: "16px",
+              }}
+            >
+              <div style={{
+                width: "20px", height: "20px",
+                borderRadius: "10px",
+                background: keepScreenAwake ? "var(--accent-green)" : "var(--border-3)",
+                position: "absolute", top: "3px",
+                left: keepScreenAwake ? "25px" : "3px",
+                transition: "all 0.3s",
+              }} />
+            </button>
+          </div>
+        )}
 
         {/* Public board toggle */}
         <div style={{

--- a/src/lib/useWakeLock.ts
+++ b/src/lib/useWakeLock.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { isWakeLockSupported } from "@/lib/wakeLockPrefs";
+
+/**
+ * Holds a Screen Wake Lock (`navigator.wakeLock.request("screen")`) while
+ * `enabled` is true — web parity with iOS `SessionIdleTimerController` (#317).
+ *
+ * Callers pass a single boolean derived from existing session state (e.g.
+ * `prefOn && isActive`); all acquire/release/re-acquire complexity lives here:
+ * - Acquires when `enabled` flips true (and the document is visible).
+ * - Releases when `enabled` flips false (pause, complete, abandon, toggle-off)
+ *   or on unmount (navigation away).
+ * - Browsers auto-release the lock when the page is hidden; a `visibilitychange`
+ *   listener re-acquires it when the page becomes visible again.
+ * - No-ops when the Wake Lock API is unsupported.
+ */
+export function useWakeLock(enabled: boolean): void {
+  const sentinelRef = useRef<WakeLockSentinel | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !isWakeLockSupported()) return;
+
+    let cancelled = false;
+
+    const acquire = async () => {
+      if (cancelled || document.visibilityState !== "visible") return;
+      if (sentinelRef.current && !sentinelRef.current.released) return;
+      try {
+        const sentinel = await navigator.wakeLock.request("screen");
+        if (cancelled) {
+          void sentinel.release().catch(() => {});
+          return;
+        }
+        sentinelRef.current = sentinel;
+      } catch {
+        // Best-effort: the browser can refuse (e.g. battery saver). The sit
+        // continues without a wake lock, matching iOS opt-in semantics.
+      }
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") void acquire();
+    };
+
+    void acquire();
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      const sentinel = sentinelRef.current;
+      sentinelRef.current = null;
+      if (sentinel && !sentinel.released) {
+        void sentinel.release().catch(() => {});
+      }
+    };
+  }, [enabled]);
+}

--- a/src/lib/useWakeLock.ts
+++ b/src/lib/useWakeLock.ts
@@ -1,7 +1,24 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { isWakeLockSupported } from "@/lib/wakeLockPrefs";
+import { useEffect, useRef, useSyncExternalStore } from "react";
+import {
+  isWakeLockSupported,
+  loadWakeLockPrefs,
+  subscribeWakeLockPrefs,
+} from "@/lib/wakeLockPrefs";
+
+/**
+ * Live view of the opt-in "keep screen awake" preference. Re-renders when the
+ * Settings toggle saves (same tab) or another tab writes the pref (`storage`
+ * event), so an already-mounted session releases its lock on toggle-off.
+ */
+export function useKeepScreenAwakePref(): boolean {
+  return useSyncExternalStore(
+    subscribeWakeLockPrefs,
+    () => loadWakeLockPrefs().keepScreenAwakeDuringSession,
+    () => false,
+  );
+}
 
 /**
  * Holds a Screen Wake Lock (`navigator.wakeLock.request("screen")`) while
@@ -23,13 +40,20 @@ export function useWakeLock(enabled: boolean): void {
     if (!enabled || !isWakeLockSupported()) return;
 
     let cancelled = false;
+    // Serializes overlapping acquire() calls (e.g. mount + a quick
+    // visibilitychange): without this, a slow request resolving late could
+    // overwrite or orphan an already-stored sentinel.
+    let acquireInFlight = false;
 
     const acquire = async () => {
-      if (cancelled || document.visibilityState !== "visible") return;
+      if (cancelled || acquireInFlight || document.visibilityState !== "visible") return;
       if (sentinelRef.current && !sentinelRef.current.released) return;
+      acquireInFlight = true;
       try {
         const sentinel = await navigator.wakeLock.request("screen");
-        if (cancelled) {
+        if (cancelled || (sentinelRef.current && !sentinelRef.current.released)) {
+          // Effect torn down (or another sentinel won) while the request was
+          // in flight — release immediately so no lock is orphaned.
           void sentinel.release().catch(() => {});
           return;
         }
@@ -37,6 +61,8 @@ export function useWakeLock(enabled: boolean): void {
       } catch {
         // Best-effort: the browser can refuse (e.g. battery saver). The sit
         // continues without a wake lock, matching iOS opt-in semantics.
+      } finally {
+        acquireInFlight = false;
       }
     };
 

--- a/src/lib/wakeLockPrefs.test.ts
+++ b/src/lib/wakeLockPrefs.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  isWakeLockSupported,
+  loadWakeLockPrefs,
+  saveWakeLockPrefs,
+} from "./wakeLockPrefs";
+
+const STORAGE_KEY = "stillpoint_wake_lock_prefs";
+
+function stubBrowserStorage(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial));
+  const localStorageMock = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  };
+  vi.stubGlobal("window", { localStorage: localStorageMock });
+  vi.stubGlobal("localStorage", localStorageMock);
+  return store;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("loadWakeLockPrefs", () => {
+  it("returns opt-out default without window (SSR guard)", () => {
+    expect(loadWakeLockPrefs()).toEqual({ keepScreenAwakeDuringSession: false });
+  });
+
+  it("returns default when nothing is stored", () => {
+    stubBrowserStorage();
+    expect(loadWakeLockPrefs()).toEqual({ keepScreenAwakeDuringSession: false });
+  });
+
+  it("reads a stored opt-in", () => {
+    stubBrowserStorage({
+      [STORAGE_KEY]: JSON.stringify({ keepScreenAwakeDuringSession: true }),
+    });
+    expect(loadWakeLockPrefs()).toEqual({ keepScreenAwakeDuringSession: true });
+  });
+
+  it("falls back to defaults on corrupt JSON", () => {
+    stubBrowserStorage({ [STORAGE_KEY]: "{not json" });
+    expect(loadWakeLockPrefs()).toEqual({ keepScreenAwakeDuringSession: false });
+  });
+});
+
+describe("saveWakeLockPrefs", () => {
+  it("is a no-op without window (SSR guard)", () => {
+    expect(() =>
+      saveWakeLockPrefs({ keepScreenAwakeDuringSession: true }),
+    ).not.toThrow();
+  });
+
+  it("round-trips through storage", () => {
+    const store = stubBrowserStorage();
+    saveWakeLockPrefs({ keepScreenAwakeDuringSession: true });
+    expect(JSON.parse(store.get(STORAGE_KEY) ?? "")).toEqual({
+      keepScreenAwakeDuringSession: true,
+    });
+    expect(loadWakeLockPrefs()).toEqual({ keepScreenAwakeDuringSession: true });
+  });
+});
+
+describe("isWakeLockSupported", () => {
+  it("is false without navigator (SSR guard)", () => {
+    expect(isWakeLockSupported()).toBe(false);
+  });
+
+  it("is false when navigator lacks wakeLock", () => {
+    vi.stubGlobal("navigator", {});
+    expect(isWakeLockSupported()).toBe(false);
+  });
+
+  it("is true when navigator.wakeLock exists", () => {
+    vi.stubGlobal("navigator", { wakeLock: { request: () => {} } });
+    expect(isWakeLockSupported()).toBe(true);
+  });
+});

--- a/src/lib/wakeLockPrefs.test.ts
+++ b/src/lib/wakeLockPrefs.test.ts
@@ -3,6 +3,7 @@ import {
   isWakeLockSupported,
   loadWakeLockPrefs,
   saveWakeLockPrefs,
+  subscribeWakeLockPrefs,
 } from "./wakeLockPrefs";
 
 const STORAGE_KEY = "stillpoint_wake_lock_prefs";
@@ -15,7 +16,11 @@ function stubBrowserStorage(initial: Record<string, string> = {}) {
       store.set(key, value);
     },
   };
-  vi.stubGlobal("window", { localStorage: localStorageMock });
+  vi.stubGlobal("window", {
+    localStorage: localStorageMock,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
   vi.stubGlobal("localStorage", localStorageMock);
   return store;
 }
@@ -45,6 +50,17 @@ describe("loadWakeLockPrefs", () => {
     stubBrowserStorage({ [STORAGE_KEY]: "{not json" });
     expect(loadWakeLockPrefs()).toEqual({ keepScreenAwakeDuringSession: false });
   });
+
+  it.each([
+    ["non-object JSON", JSON.stringify("true")],
+    ["null", JSON.stringify(null)],
+    ["string instead of boolean", JSON.stringify({ keepScreenAwakeDuringSession: "true" })],
+    ["number instead of boolean", JSON.stringify({ keepScreenAwakeDuringSession: 1 })],
+    ["missing field", JSON.stringify({ other: true })],
+  ])("falls back to defaults for %s", (_label, raw) => {
+    stubBrowserStorage({ [STORAGE_KEY]: raw });
+    expect(loadWakeLockPrefs()).toEqual({ keepScreenAwakeDuringSession: false });
+  });
 });
 
 describe("saveWakeLockPrefs", () => {
@@ -61,6 +77,33 @@ describe("saveWakeLockPrefs", () => {
       keepScreenAwakeDuringSession: true,
     });
     expect(loadWakeLockPrefs()).toEqual({ keepScreenAwakeDuringSession: true });
+  });
+});
+
+describe("subscribeWakeLockPrefs", () => {
+  it("notifies subscribers on save and stops after unsubscribe", () => {
+    stubBrowserStorage();
+    const listener = vi.fn();
+    const unsubscribe = subscribeWakeLockPrefs(listener);
+
+    saveWakeLockPrefs({ keepScreenAwakeDuringSession: true });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    saveWakeLockPrefs({ keepScreenAwakeDuringSession: false });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers a cross-tab storage listener while subscribed", () => {
+    stubBrowserStorage();
+    const win = window as unknown as {
+      addEventListener: ReturnType<typeof vi.fn>;
+      removeEventListener: ReturnType<typeof vi.fn>;
+    };
+    const unsubscribe = subscribeWakeLockPrefs(() => {});
+    expect(win.addEventListener).toHaveBeenCalledWith("storage", expect.any(Function));
+    unsubscribe();
+    expect(win.removeEventListener).toHaveBeenCalledWith("storage", expect.any(Function));
   });
 });
 

--- a/src/lib/wakeLockPrefs.ts
+++ b/src/lib/wakeLockPrefs.ts
@@ -20,7 +20,10 @@ export function loadWakeLockPrefs(): WakeLockPrefs {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return DEFAULTS;
-    return { ...DEFAULTS, ...JSON.parse(raw) };
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return DEFAULTS;
+    const value = (parsed as Record<string, unknown>).keepScreenAwakeDuringSession;
+    return typeof value === "boolean" ? { keepScreenAwakeDuringSession: value } : DEFAULTS;
   } catch {
     return DEFAULTS;
   }
@@ -33,4 +36,36 @@ export function saveWakeLockPrefs(prefs: WakeLockPrefs): void {
   } catch {
     // Best-effort persistence: ignore storage write failures.
   }
+  notifyWakeLockPrefsListeners();
+}
+
+type WakeLockPrefsListener = () => void;
+
+const listeners = new Set<WakeLockPrefsListener>();
+
+function onStorageEvent(e: StorageEvent): void {
+  // key === null means the whole storage area was cleared.
+  if (e.key === STORAGE_KEY || e.key === null) notifyWakeLockPrefsListeners();
+}
+
+function notifyWakeLockPrefsListeners(): void {
+  for (const listener of [...listeners]) listener();
+}
+
+/**
+ * Subscribe to wake-lock preference changes: same-tab saves via
+ * `saveWakeLockPrefs` and cross-tab changes via the `storage` event.
+ * Returns an unsubscribe function (`useSyncExternalStore`-compatible).
+ */
+export function subscribeWakeLockPrefs(listener: WakeLockPrefsListener): () => void {
+  if (typeof window !== "undefined" && listeners.size === 0) {
+    window.addEventListener("storage", onStorageEvent);
+  }
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+    if (typeof window !== "undefined" && listeners.size === 0) {
+      window.removeEventListener("storage", onStorageEvent);
+    }
+  };
 }

--- a/src/lib/wakeLockPrefs.ts
+++ b/src/lib/wakeLockPrefs.ts
@@ -1,0 +1,36 @@
+export type WakeLockPrefs = {
+  /** Opt-in: keep the screen awake while a sit timer is running (parity with iOS #306). */
+  keepScreenAwakeDuringSession: boolean;
+};
+
+const STORAGE_KEY = "stillpoint_wake_lock_prefs";
+
+const DEFAULTS: WakeLockPrefs = {
+  keepScreenAwakeDuringSession: false,
+};
+
+/** True when the browser exposes the Screen Wake Lock API (secure contexts only). */
+export function isWakeLockSupported(): boolean {
+  return typeof navigator !== "undefined" && "wakeLock" in navigator;
+}
+
+export function loadWakeLockPrefs(): WakeLockPrefs {
+  if (typeof window === "undefined") return DEFAULTS;
+
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULTS;
+    return { ...DEFAULTS, ...JSON.parse(raw) };
+  } catch {
+    return DEFAULTS;
+  }
+}
+
+export function saveWakeLockPrefs(prefs: WakeLockPrefs): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+  } catch {
+    // Best-effort persistence: ignore storage write failures.
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #317

Follow-up from PR #306 (iOS half). Adds the web half of the opt-in "Keep screen on during session" preference using the Screen Wake Lock API.

## Implementation

- `src/lib/wakeLockPrefs.ts` — `loadWakeLockPrefs`/`saveWakeLockPrefs` persisted in `localStorage` (`stillpoint_wake_lock_prefs`) with SSR guards and stored-payload type validation; `isWakeLockSupported()`; `subscribeWakeLockPrefs()` for same-tab + cross-tab change notification.
- `src/lib/useWakeLock.ts` — single reusable hook; `useKeepScreenAwakePref()` for live pref reads. Acquire/release/`visibilitychange` re-acquire; overlapping `acquire()` calls serialized with in-flight guard; late-resolving sentinel released if superseded or torn down.
- `SettingsView` — toggle hidden when `'wakeLock' in navigator` is false.
- `SessionView` — `useWakeLock(pref && isActive)`.
- `BuddySessionRoom` — `useWakeLock(pref && active && !localTimerCompleted && !exitingRoom)`; `leave()` sets `exitingRoom` before async exit.

## Review feedback (all addressed)

| Source | Issue | Fix |
|--------|-------|-----|
| Bugbot | Overlapping acquire orphans wake lock | `acquireInFlight` + release late sentinel if another won (`c1e3f87`) |
| CodeRabbit | Buddy lock waits on polled snapshot | `localTimerCompleted` + `exitingRoom` in predicate |
| CodeRabbit | Pref changes don't propagate to mounted sessions | `subscribeWakeLockPrefs` + `useKeepScreenAwakePref` |
| CodeRabbit | Unvalidated localStorage payload | Parse `unknown`, require boolean field |

Rebased onto latest `main` (`a5435fa`); all review threads resolved; CI green.

## Test plan

- [x] Settings toggle persisted in localStorage
- [x] Acquire on active session; release on pause/complete/abandon/toggle-off/navigation
- [x] Re-acquire on `visibilitychange` return
- [x] Toggle hidden when API unsupported
- [x] Solo + buddy sessions
- [x] Toggle-off/on propagates to running session in another window (manual)
- [x] `npm run test:unit` — 16 wakeLockPrefs tests
- [x] `npm run build`
- [x] PR CI (build, web/mobile e2e, e2e-policy, CodeRabbit)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-708fc7b4-c359-4381-aabe-ab0057290f7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-708fc7b4-c359-4381-aabe-ab0057290f7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “keep screen awake during session” setting, displayed only when supported and saved persistently with cross-tab syncing.
  * Sessions (and buddy holds) can now hold a screen wake-lock when the setting is enabled, and it’s released when leaving or when the session/timer ends.
  * Automatically re-acquires the wake-lock when returning to the visible tab.
* **Tests**
  * Added coverage for preference load/save behavior (including SSR safety), cross-tab subscription updates, and wake-lock support detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->