### PR TITLE
docs(db): prod hygiene audit for social + buddy tables (#143)

### DIFF
--- a/docs/db-audit-social-buddy.sql
+++ b/docs/db-audit-social-buddy.sql
@@ -1,0 +1,181 @@
+-- ============================================================================
+-- Read-only DB audit: social + buddy tables (#143)
+-- ============================================================================
+-- SAFETY: Every statement below is a catalog/statistics SELECT. No DDL, no
+-- DML, and no reads of user row data (privacy: only pg_catalog /
+-- information_schema / pg_stat views are touched). Safe to run against
+-- production at any time.
+--
+-- HOW TO RUN
+--   psql:                 psql "$POSTGRES_URL" -f docs/db-audit-social-buddy.sql
+--   single-statement      run each statement individually, in order; every
+--   runners (e.g. Neon    statement is self-contained (the in-scope table
+--   MCP run_sql):         list is repeated inline rather than parameterized).
+--
+-- SCOPE (from src/db/schema.ts)
+--   social:   friend_requests, friendships
+--   buddy:    buddy_sessions, buddy_session_participants,
+--             buddy_session_calendar_events
+--   adjacent: sessions (FK buddy_session_id), users (FK target for all)
+--
+-- INTERPRETATION NOTES
+--   * pg_stat_* counters are cumulative since the stats reset reported in
+--     Section 0 (NULL = never reset, i.e. since branch creation).
+--   * Do NOT use EXPLAIN as index evidence on these tables: they are small
+--     enough that the planner prefers seq scans regardless of index
+--     presence. Index need is judged from catalog state + app query
+--     patterns, not planner choices.
+--   * idx_scan = 0 means "not used since stats reset", which on a young or
+--     low-traffic deployment is weak evidence on its own. Combine with the
+--     structural checks in Sections 7-8 before acting.
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- Section 0: Context — database + stats epoch
+-- ----------------------------------------------------------------------------
+SELECT current_database() AS database, stats_reset
+FROM pg_stat_database WHERE datname = current_database();
+
+-- ----------------------------------------------------------------------------
+-- Section 1: Table sizes + tuple estimates
+-- ----------------------------------------------------------------------------
+SELECT c.relname AS table_name,
+       pg_total_relation_size(c.oid) AS total_bytes,
+       pg_relation_size(c.oid) AS heap_bytes,
+       pg_indexes_size(c.oid) AS index_bytes,
+       s.n_live_tup, s.n_dead_tup
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+LEFT JOIN pg_stat_user_tables s ON s.relid = c.oid
+WHERE n.nspname = 'public' AND c.relkind = 'r'
+  AND c.relname IN ('friend_requests','friendships','buddy_sessions','buddy_session_participants','buddy_session_calendar_events','sessions','users')
+ORDER BY c.relname;
+
+-- ----------------------------------------------------------------------------
+-- Section 2: Index definitions
+-- ----------------------------------------------------------------------------
+SELECT tablename, indexname, indexdef
+FROM pg_indexes
+WHERE schemaname = 'public'
+  AND tablename IN ('friend_requests','friendships','buddy_sessions','buddy_session_participants','buddy_session_calendar_events','sessions','users')
+ORDER BY tablename, indexname;
+
+-- ----------------------------------------------------------------------------
+-- Section 3: Index flags — uniqueness, primary, validity, partial predicate
+-- (indisvalid = false would indicate a broken/aborted concurrent build)
+-- ----------------------------------------------------------------------------
+SELECT t.relname AS table_name, i.relname AS index_name,
+       x.indisunique, x.indisprimary, x.indisvalid,
+       pg_get_expr(x.indpred, x.indrelid) AS partial_predicate
+FROM pg_index x
+JOIN pg_class i ON i.oid = x.indexrelid
+JOIN pg_class t ON t.oid = x.indrelid
+JOIN pg_namespace n ON n.oid = t.relnamespace
+WHERE n.nspname = 'public'
+  AND t.relname IN ('friend_requests','friendships','buddy_sessions','buddy_session_participants','buddy_session_calendar_events','sessions','users')
+ORDER BY t.relname, i.relname;
+
+-- ----------------------------------------------------------------------------
+-- Section 4: Constraint inventory — PK (p), FK (f), UNIQUE (u), CHECK (c)
+-- (convalidated = false would indicate a NOT VALID constraint awaiting
+-- VALIDATE CONSTRAINT)
+-- ----------------------------------------------------------------------------
+SELECT t.relname AS table_name, con.conname, con.contype, con.convalidated,
+       pg_get_constraintdef(con.oid) AS definition
+FROM pg_constraint con
+JOIN pg_class t ON t.oid = con.conrelid
+JOIN pg_namespace n ON n.oid = t.relnamespace
+WHERE n.nspname = 'public'
+  AND t.relname IN ('friend_requests','friendships','buddy_sessions','buddy_session_participants','buddy_session_calendar_events','sessions','users')
+ORDER BY t.relname, con.contype, con.conname;
+
+-- ----------------------------------------------------------------------------
+-- Section 5: Index usage statistics
+-- ----------------------------------------------------------------------------
+SELECT s.relname AS table_name, s.indexrelname AS index_name,
+       s.idx_scan, s.idx_tup_read, s.idx_tup_fetch,
+       pg_relation_size(s.indexrelid) AS index_bytes
+FROM pg_stat_user_indexes s
+WHERE s.schemaname = 'public'
+  AND s.relname IN ('friend_requests','friendships','buddy_sessions','buddy_session_participants','buddy_session_calendar_events','sessions','users')
+ORDER BY s.relname, s.idx_scan DESC;
+
+-- ----------------------------------------------------------------------------
+-- Section 6: Table scan + write patterns
+-- ----------------------------------------------------------------------------
+SELECT relname AS table_name, seq_scan, seq_tup_read, idx_scan, idx_tup_fetch,
+       n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd,
+       last_autovacuum, last_autoanalyze
+FROM pg_stat_user_tables
+WHERE schemaname = 'public'
+  AND relname IN ('friend_requests','friendships','buddy_sessions','buddy_session_participants','buddy_session_calendar_events','sessions','users')
+ORDER BY relname;
+
+-- ----------------------------------------------------------------------------
+-- Section 7: FK leading-column index coverage (single-column FKs)
+-- An FK whose referencing column is not the LEADING column of some valid,
+-- non-partial index forces a table scan on every parent-row DELETE/UPDATE
+-- (cascade or SET NULL). Partial indexes are excluded: they cannot serve
+-- cascade probes for rows outside their predicate.
+-- NOTE: pg_index.indkey is an int2vector (0-based subscripts);
+-- pg_constraint.conkey is int2[] (1-based) — hence indkey[0] vs conkey[1].
+-- ----------------------------------------------------------------------------
+SELECT t.relname AS table_name, con.conname,
+       a.attname AS fk_column,
+       EXISTS (
+         SELECT 1 FROM pg_index x
+         WHERE x.indrelid = con.conrelid
+           AND x.indisvalid
+           AND x.indpred IS NULL
+           AND x.indkey[0] = con.conkey[1]
+       ) AS fk_leading_col_indexed
+FROM pg_constraint con
+JOIN pg_class t ON t.oid = con.conrelid
+JOIN pg_namespace n ON n.oid = t.relnamespace
+JOIN pg_attribute a ON a.attrelid = con.conrelid AND a.attnum = con.conkey[1]
+WHERE con.contype = 'f'
+  AND n.nspname = 'public'
+  AND t.relname IN ('friend_requests','friendships','buddy_sessions','buddy_session_participants','buddy_session_calendar_events','sessions','users')
+  AND array_length(con.conkey, 1) = 1
+ORDER BY t.relname, con.conname;
+
+-- ----------------------------------------------------------------------------
+-- Section 8: Redundant prefix-duplicate index detection
+-- Flags a plain (non-unique, non-primary, non-partial, non-expression) index
+-- whose key columns are an exact positional prefix of another non-partial,
+-- non-expression index on the same table. Such an index adds write cost with
+-- no read benefit. Caveats: (a) two identical plain duplicates flag each
+-- other (two rows); (b) this is an equality/prefix heuristic — confirm
+-- against app query patterns before dropping anything.
+-- ----------------------------------------------------------------------------
+SELECT t.relname AS table_name,
+       i2.relname AS redundant_index,
+       i1.relname AS covering_index,
+       pg_get_indexdef(x2.indexrelid) AS redundant_def,
+       pg_get_indexdef(x1.indexrelid) AS covering_def
+FROM pg_index x1
+JOIN pg_index x2 ON x1.indrelid = x2.indrelid AND x1.indexrelid <> x2.indexrelid
+JOIN pg_class i1 ON i1.oid = x1.indexrelid
+JOIN pg_class i2 ON i2.oid = x2.indexrelid
+JOIN pg_class t ON t.oid = x1.indrelid
+JOIN pg_namespace n ON n.oid = t.relnamespace
+WHERE n.nspname = 'public'
+  AND t.relname IN ('friend_requests','friendships','buddy_sessions','buddy_session_participants','buddy_session_calendar_events','sessions','users')
+  AND x1.indpred IS NULL AND x2.indpred IS NULL
+  AND x1.indexprs IS NULL AND x2.indexprs IS NULL
+  AND NOT x2.indisunique
+  AND NOT x2.indisprimary
+  AND x2.indnkeyatts <= x1.indnkeyatts
+  AND (SELECT bool_and(x1.indkey[g.i] = x2.indkey[g.i])
+       FROM generate_series(0, x2.indnkeyatts - 1) AS g(i))
+ORDER BY t.relname, i2.relname;
+
+-- ----------------------------------------------------------------------------
+-- Section 9: Column inventory (drift check vs src/db/schema.ts)
+-- information_schema is read-only views over pg_catalog.
+-- ----------------------------------------------------------------------------
+SELECT table_name, column_name, data_type, is_nullable, column_default
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name IN ('friend_requests','friendships','buddy_sessions','buddy_session_participants','buddy_session_calendar_events','sessions','users')
+ORDER BY table_name, ordinal_position;

--- a/docs/db-audit-social-buddy.sql
+++ b/docs/db-audit-social-buddy.sql
@@ -142,11 +142,15 @@ ORDER BY t.relname, con.conname;
 -- ----------------------------------------------------------------------------
 -- Section 8: Redundant prefix-duplicate index detection
 -- Flags a plain (non-unique, non-primary, non-partial, non-expression) index
--- whose key columns are an exact positional prefix of another non-partial,
--- non-expression index on the same table. Such an index adds write cost with
--- no read benefit. Caveats: (a) two identical plain duplicates flag each
--- other (two rows); (b) this is an equality/prefix heuristic — confirm
--- against app query patterns before dropping anything.
+-- whose key columns are an exact positional prefix of another VALID index of
+-- the same access method on the same table. The prefix comparison matches
+-- column numbers AND per-column operator class, collation, and sort options
+-- (indclass / indcollation / indoption), so a specialized index (e.g.
+-- text_pattern_ops or DESC) is never mistaken for a duplicate, and an
+-- invalid/aborted index can never pose as the covering index. Such a
+-- redundant index adds write cost with no read benefit. Caveats: (a) two
+-- identical plain duplicates flag each other (two rows); (b) this remains a
+-- heuristic — confirm against app query patterns before dropping anything.
 -- ----------------------------------------------------------------------------
 SELECT t.relname AS table_name,
        i2.relname AS redundant_index,
@@ -161,12 +165,18 @@ JOIN pg_class t ON t.oid = x1.indrelid
 JOIN pg_namespace n ON n.oid = t.relnamespace
 WHERE n.nspname = 'public'
   AND t.relname IN ('friend_requests','friendships','buddy_sessions','buddy_session_participants','buddy_session_calendar_events','sessions','users')
+  AND x1.indisvalid AND x2.indisvalid
+  AND i1.relam = i2.relam
   AND x1.indpred IS NULL AND x2.indpred IS NULL
   AND x1.indexprs IS NULL AND x2.indexprs IS NULL
   AND NOT x2.indisunique
   AND NOT x2.indisprimary
   AND x2.indnkeyatts <= x1.indnkeyatts
-  AND (SELECT bool_and(x1.indkey[g.i] = x2.indkey[g.i])
+  AND (SELECT bool_and(
+         x1.indkey[g.i] = x2.indkey[g.i]
+         AND x1.indclass[g.i] = x2.indclass[g.i]
+         AND x1.indcollation[g.i] = x2.indcollation[g.i]
+         AND x1.indoption[g.i] = x2.indoption[g.i])
        FROM generate_series(0, x2.indnkeyatts - 1) AS g(i))
 ORDER BY t.relname, i2.relname;
 

--- a/docs/db-hygiene-report-social-buddy.md
+++ b/docs/db-hygiene-report-social-buddy.md
@@ -1,0 +1,113 @@
+# Prod DB hygiene report: social + buddy tables (#143)
+
+| | |
+|---|---|
+| **Audited** | 2026-06-11 |
+| **Environment** | Neon project `noisy-cell-87641627`, branch `production` (`br-rough-salad-aixcbca7`, the project default), database `neondb` |
+| **Method** | Catalog-only read-only SQL — [`docs/db-audit-social-buddy.sql`](./db-audit-social-buddy.sql), run statement-by-statement. **Zero DDL/DML applied; no user row data read** (only `pg_catalog` / `information_schema` / `pg_stat` views). |
+| **Stats epoch** | `pg_stat_database.stats_reset` is `NULL` → counters are cumulative since branch creation (2026-02-26). |
+| **Outcome** | 2 migration candidates → filed as #383 and #384. #147 (already filed) confirmed still needed. No schema drift between prod and `src/db/schema.ts`. |
+
+> **EXPLAIN was deliberately not used as index evidence.** Every table in scope is small enough that the planner seq-scans regardless of index presence, so planner output proves nothing here. Index conclusions below come from catalog state (what exists) + app query patterns (what the code asks for) + FK mechanics (what cascades need).
+
+## 1. Tables in scope (from `src/db/schema.ts`)
+
+| Table | Category | Why in scope |
+|---|---|---|
+| `friend_requests` | social | friend request inbox/outbox + status lifecycle |
+| `friendships` | social | accepted-friend pairs, ordered `(user1_id < user2_id)` |
+| `buddy_sessions` | buddy | shared sit lifecycle (`waiting → ready_check → active → completed/abandoned`) |
+| `buddy_session_participants` | buddy (membership) | per-user membership/heartbeat rows |
+| `buddy_session_calendar_events` | buddy (membership) | per-user Google Calendar sync state (#204) |
+| `sessions` | adjacent | personal sits; `buddy_session_id` FK provenance (#119) |
+| `users` | adjacent | FK target of every table above (host / from / to / member) |
+
+Out of scope: auth/notification tables (`oauth_accounts`, `device_tokens`, `notification_*`, `web_push_subscriptions`, `password_reset_tokens`, `google_oauth_tokens`, `thoughts`, `account_deletion_log`).
+
+## 2. Size snapshot (Section 1 of the script)
+
+| Table | live tuples | dead tuples | total bytes |
+|---|---:|---:|---:|
+| `buddy_session_calendar_events` | 0 | 0 | 40,960 |
+| `buddy_session_participants` | 14 | 7 | 73,728 |
+| `buddy_sessions` | 8 | 10 | 65,536 |
+| `friend_requests` | 4 | 5 | 106,496 |
+| `friendships` | 4 | 0 | 40,960 |
+| `sessions` | 114 | 0 | 122,880 |
+| `users` | 28 | 32 | 81,920 |
+
+Everything is tiny (≤120 KB). Findings below are **structural hygiene** — they matter for correctness-of-scale and cascade behavior, not for present-day latency.
+
+## 3. Catalog state vs `schema.ts` — drift check
+
+**No drift found.** All 25 indexes present in prod match `schema.ts` declarations one-for-one (names, columns, uniqueness, partial predicates); every index is `indisvalid = true`; all 27 constraints (PK/FK/UNIQUE/CHECK) are `convalidated = true` with definitions matching the schema (Sections 2–4, 9 of the script). Column inventory (types, nullability, defaults) matches for all 7 tables, including the deliberate mixed timestamp style (`timestamptz` on buddy tables, `timestamp` on the older social/users/sessions tables) — that mix mirrors `schema.ts` itself, so it is a schema-design note, not prod drift.
+
+One cosmetic asymmetry, not drift: `buddy_session_calendar_events_session_user` exists as a `UNIQUE` **constraint** (with its backing index) while the equivalent `buddy_session_participants_session_user` is a bare unique **index** — both declared via `uniqueIndex()` in `schema.ts`, both enforcing identical uniqueness. No action needed.
+
+## 4. Per-table coverage assessment
+
+Query patterns were mapped from the app code (API routes, `src/lib/buddySession.ts`, `src/lib/buddyCalendar.ts`, `src/lib/google.ts`, notification cron).
+
+### 4.1 `friend_requests` — ✅ healthy
+- Hot paths: inbox/outbox lists `WHERE to_user_id|from_user_id = ? AND status='pending'` ([route.ts:21,33](../src/app/api/friends/requests/route.ts)) → matched exactly by the #146 partial indexes `idx_friend_requests_{to,from}_pending_created (…, created_at DESC) WHERE status='pending'`.
+- Duplicate-pair guard: unique partial `friend_requests_pending_user_pair (LEAST(from,to), GREATEST(from,to)) WHERE status='pending'` enforces one pending request per unordered pair — present and validated.
+- The full (non-partial) `idx_friend_requests_from` / `idx_friend_requests_to` show `idx_scan = 0`, but they are **not** drop candidates: the partial pending indexes cannot serve the `users → friend_requests` `ON DELETE CASCADE` probes for non-pending rows, so the full indexes are the FK-support indexes (both flagged ✅ by the Section 7 coverage query).
+- Integrity: `no_self` CHECK + status CHECK present. Terminal rows (accepted/rejected/cancelled) accumulate indefinitely, but the partial indexes keep hot paths immune to that growth — no action needed.
+
+### 4.2 `friendships` — ✅ healthy
+- PK `(user1_id, user2_id)` serves the pair lookups (request-send guard, buddy-join friendship gate, calendar `assertFriendship`) and the `user1_id` UNION half of `GET /api/friends`; `idx_friendships_user2` serves the `user2_id` half and the `user2_id` FK cascade. Both sides ✅ in Section 7.
+- `friendships_user_order` CHECK (`user1_id < user2_id`) enforces canonical pair ordering. Stats confirm index use (`idx_scan` 59 + 11). The earlier redundant `idx_friendships_user1` was already dropped (#148).
+
+### 4.3 `buddy_sessions` — ✅ healthy
+- All hot operations are PK point lookups: the polling heartbeat (`GET /api/buddy/sessions/[id]` → reconcile + snapshot) and every state transition filter `WHERE id = ?` (often `AND state = …` as an optimistic guard — fine on top of a PK probe). `buddy_sessions_pkey` shows 2,162 scans, by far the hottest index in scope — correctly backed.
+- `share_token` unique index backs the one-shot join lookup; `idx_buddy_sessions_host` backs the `host_user_id` FK cascade (✅ Section 7).
+- State CHECK present. Calendar-view ordering (`COALESCE(started_at, scheduled_start_at, created_at)`) is applied to an already-narrowed id set from participant subqueries; no index need at any plausible scale.
+
+### 4.4 `buddy_session_participants` — ⚠️ two findings
+- Hot paths are covered: the per-heartbeat membership gate `WHERE buddy_session_id = ? AND user_id = ?` and the participant-list reads `WHERE buddy_session_id = ?` are both served by the unique `buddy_session_participants_session_user (buddy_session_id, user_id)` (left-prefix); the per-heartbeat `last_seen_at` update targets the row PK. (Stats show 9,530 seq scans — that is the planner preferring seq scans on a 14-row table, expected and not evidence of a gap; see the EXPLAIN note above.)
+- **Finding A — no `user_id`-leading index** (the only ❌ row in the Section 7 FK-coverage query). `user_id` is the *second* column of the unique index, which cannot serve: (a) the calendar-view subqueries `WHERE user_id = <viewer>` / `<buddy>` run on every calendar page load ([buddyCalendar.ts:88,111](../src/lib/buddyCalendar.ts)), and (b) the `users → buddy_session_participants` `ON DELETE CASCADE` probe on account deletion. Every sibling membership table has this index; this is the one gap. → **filed as #383**.
+- **Finding B — host-row uniqueness is app-enforced only.** Nothing in the catalog prevents two `is_host = true` rows (or zero) per session. → **already filed as #147** (partial unique index on `(buddy_session_id) WHERE is_host`); this audit confirms the constraint is absent in prod. Note for #147 implementation: this pass was catalog-only, so run a duplicate-host precheck (count of sessions with ≠1 host row) before adding the constraint, and dedupe if needed.
+
+### 4.5 `buddy_session_calendar_events` — ⚠️ one finding
+- The feature is freshly deployed: 0 rows, all-zero stats. The unique `(buddy_session_id, user_id)` backs both the idempotency check and the `onConflictDoUpdate` target in [google.ts:423,451](../src/lib/google.ts); `idx_buddy_session_calendar_events_user` backs the `user_id` FK cascade. Status CHECK + both FK cascades validated.
+- **Finding C — `idx_buddy_session_calendar_events_session (buddy_session_id)` is an exact leading prefix** of the unique `(buddy_session_id, user_id)` index (both plain btree, non-partial) — the only row flagged by the Section 8 redundancy query. It adds write cost on every row touch and can never beat the composite for reads. Same cleanup as the #148 `friendships` precedent. → **filed as #384**.
+
+### 4.6 `sessions` (buddy-adjacent paths) — ✅ healthy
+- `(user_id, buddy_session_id)` idempotency check + recovery read are served by the partial unique `sessions_user_buddy_session_unique … WHERE buddy_session_id IS NOT NULL` (also the integrity guarantee: one personal row per user per shared sit). `idx_sessions_buddy_session` is the non-partial FK-support index for the `buddy_sessions → sessions` `ON DELETE SET NULL` (✅ Section 7) — not redundant with the partial unique (different leading column, and partials can't serve cascades).
+- `idx_sessions_user (user_id, day_number)` backs the per-user list/day lookups and the cron streak reads (leading-column match; the `session_date` filter is applied on top — acceptable, see §5.3).
+
+### 4.7 `users` (adjacent) — ✅ healthy
+- PK (2,052 scans — auth on every request), `email` unique (login/signup), `lower(username)` unique (#8) all present and valid. `idx_users_public` backs the board's `is_public = true` filter; low selectivity but harmless at this scale.
+
+## 5. Migration candidates
+
+### Filed from this audit
+| # | Change | Driver |
+|---|---|---|
+| **#383** | `CREATE INDEX idx_buddy_session_participants_user ON buddy_session_participants (user_id)` (new incremental migration + `schema.ts`) | Only failing row of the FK-coverage check; calendar-view subqueries filter `user_id` alone per page load; account-deletion cascade support. |
+| **#384** | `DROP INDEX idx_buddy_session_calendar_events_session` (new incremental migration + `schema.ts`) | Exact redundant prefix of the unique `(buddy_session_id, user_id)` index; pure write overhead. Keep the `user_id` index (FK support). |
+
+### Pre-existing, confirmed by this audit
+| # | Change | Audit confirmation |
+|---|---|---|
+| **#147** | Partial unique index enforcing one `is_host = true` row per `buddy_session_id` | No such constraint exists in prod; host integrity is currently application-convention only. Referenced, not re-filed. |
+
+### Considered and rejected (explicitly *not* filing)
+- **Drop `idx_friend_requests_from` / `idx_friend_requests_to`** (0 scans): rejected — they are the FK cascade-support indexes; the pending partial indexes can't cover non-pending rows.
+- **Make `idx_sessions_buddy_session` partial (`WHERE buddy_session_id IS NOT NULL`)**: technically sound (cascade probes only ever target non-NULL values; most rows are solo sits with NULL) but the saving is a few KB and it adds an applied-migration churn risk for nothing at current scale. Revisit only if `sessions` reaches millions of rows.
+- **Partial/drop `idx_users_public`**: low-selectivity boolean index, but it serves the board query and costs ~16 KB. Not worth a migration.
+- **Composite heartbeat index `(buddy_session_id, user_id, left_at …)` variants**: the existing unique composite already serves every observed filter shape as a left-prefix.
+- **CHECK tightening (e.g. `left_at >= joined_at`)**: no observed integrity violations possible through current code paths; not worth constraint churn.
+
+## 6. Verification that this pass was read-only
+
+- Every statement in [`db-audit-social-buddy.sql`](./db-audit-social-buddy.sql) is a `SELECT` against `pg_catalog`, `pg_stat_*`, or `information_schema` — no DDL/DML keywords appear anywhere in the script.
+- Neon MCP `run_sql` was used statement-by-statement against the default (`production`) branch; the preview branch was not touched.
+- Post-audit, the `schema_migrations` ledger and all object definitions are byte-identical to the pre-audit state (nothing in the session issued writes; catalog SELECTs cannot mutate).
+
+## 7. Re-running this audit
+
+1. Run [`docs/db-audit-social-buddy.sql`](./db-audit-social-buddy.sql) section-by-section (each statement is self-contained; psql can run the whole file).
+2. Compare Sections 2–4 output against `src/db/schema.ts` for drift.
+3. Treat Section 7 `false` rows and Section 8 rows as the candidate queue; validate each against current app query patterns before filing migrations.
+4. Remember the stats caveats in the script header (cumulative counters, planner seq-scan preference on small tables).


### PR DESCRIPTION
## **User description**
Closes #143

## What changed

- `docs/db-audit-social-buddy.sql` — standalone read-only audit script (10 catalog-only `SELECT`s: sizes, index defs/flags, constraints, usage stats, FK leading-column coverage, redundant prefix-duplicate detection, column drift check). Safe to re-run against production anytime; each statement is self-contained for single-statement runners like Neon `run_sql`.
- `docs/db-hygiene-report-social-buddy.md` — findings from running that script against the Neon `production` branch on 2026-06-11, plus per-table coverage assessment against actual app query patterns.

## Why

#143 asked for a prod hygiene pass over the social + buddy tables before any DDL: validate index/constraint coverage, find gaps and redundancies, and file migrations separately rather than applying anything inline.

## Findings (benefit)

- **Zero drift**: prod catalog matches `src/db/schema.ts` exactly (25 indexes, 27 constraints, all valid/validated).
- **2 migration candidates filed**: #383 (add `buddy_session_participants(user_id)` index — the one FK without leading-column coverage, also used by calendar subqueries) and #384 (drop `idx_buddy_session_calendar_events_session`, an exact redundant prefix of the unique `(buddy_session_id, user_id)` index).
- **#147 confirmed** still needed (host-row uniqueness absent in prod) — referenced, not duplicated.
- 5 considered-and-rejected candidates documented with reasons, so the next audit doesn't re-litigate them.
- **Zero DDL/DML applied**; no user row data read (catalog/stats views only).

## Test plan

- [x] Report includes full table list in scope from schema (`docs/db-hygiene-report-social-buddy.md` §1: 7 tables from `src/db/schema.ts`)
- [x] Report includes read-only SQL audit script used for inventory (`docs/db-audit-social-buddy.sql`, linked from report header + §7)
- [x] Report identifies concrete migration candidates (or explicitly states none) (§5: two candidates + one pre-existing + rejected list)
- [x] A separate GitHub issue exists for each needed migration, each with rationale and acceptance criteria (#383, #384)
- [x] No production schema changes were applied during this pass (report §6; script is 10 catalog `SELECT`s — no DDL/DML keywords at any statement start)


___

## **CodeAnt-AI Description**
Review the social and buddy tables in production and document the findings

### What Changed
- Added a read-only production database audit script that checks table sizes, indexes, constraints, index usage, foreign key coverage, redundant indexes, and column definitions for the social and buddy tables
- Added a hygiene report summarizing the production findings, confirming no schema drift, and recording the migration candidates filed from the audit
- Documented which indexes and constraints are intentionally kept, which gaps were found, and how to rerun the audit safely without changing data

### Impact
`✅ Clearer database maintenance reviews`
`✅ Safer production audits`
`✅ Faster follow-up on index and constraint cleanup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

