### PR TITLE
fix(tests): update notification-scheduler test mock for #360 delivered contract

### DIFF
--- a/src/lib/notification-scheduler.test.ts
+++ b/src/lib/notification-scheduler.test.ts
@@ -1,9 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 let preferenceRows: Array<Record<string, unknown>> = [];
-let limitQueryResults: Array<Array<{ id: string }>> = [];
-let limitQueryIndex = 0;
-let dbSelectCall = 0;
 
 const insertReturning = vi.fn();
 const insertOnConflict = vi.fn(() => ({ returning: insertReturning }));
@@ -14,23 +11,11 @@ const dbDelete = vi.fn(() => ({ where: deleteWhere }));
 const sendDailyReminderNotification = vi.fn();
 const sendMissADayNotification = vi.fn();
 
-const dbSelect = vi.fn(() => {
-  dbSelectCall += 1;
-  if (dbSelectCall === 1) {
-    return {
-      from: vi.fn(() => ({
-        where: vi.fn(() => Promise.resolve(preferenceRows)),
-      })),
-    };
-  }
-  return {
-    from: vi.fn(() => ({
-      where: vi.fn(() => ({
-        limit: vi.fn(() => Promise.resolve(nextLimitResult())),
-      })),
-    })),
-  };
-});
+const dbSelect = vi.fn(() => ({
+  from: vi.fn(() => ({
+    where: vi.fn(() => Promise.resolve(preferenceRows)),
+  })),
+}));
 
 vi.mock("@/db", () => ({
   db: {
@@ -78,27 +63,14 @@ const basePrefs = {
   missADayEnabled: false,
 };
 
-function queueLimitResults(...results: Array<Array<{ id: string }>>) {
-  limitQueryResults = results;
-  limitQueryIndex = 0;
-}
-
-function nextLimitResult(): Array<{ id: string }> {
-  const result = limitQueryResults[limitQueryIndex] ?? [];
-  limitQueryIndex += 1;
-  return result;
-}
-
 describe("notification scheduler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
-    dbSelectCall = 0;
     preferenceRows = [basePrefs];
-    queueLimitResults([]);
     sendDailyReminderNotification.mockReset();
     sendMissADayNotification.mockReset();
-    sendDailyReminderNotification.mockResolvedValue(undefined);
+    sendDailyReminderNotification.mockResolvedValue({ delivered: true });
     sendMissADayNotification.mockResolvedValue({ delivered: true });
     insertReturning.mockReset();
     insertReturning.mockResolvedValue([{ id: "dispatch-1" }]);
@@ -128,14 +100,10 @@ describe("notification scheduler", () => {
   });
 
   test("dispatchDueNotifications sends daily reminder when window matches", async () => {
-    queueLimitResults([]);
-
     const { dispatchDueNotifications } = await import("./notification-scheduler");
     const now = new Date("2026-05-29T09:02:00.000Z");
 
     const first = await dispatchDueNotifications(now);
-    dbSelectCall = 0;
-    queueLimitResults([{ id: "existing-dispatch" }]);
     insertReturning.mockResolvedValueOnce([]);
     const second = await dispatchDueNotifications(now);
 
@@ -146,7 +114,6 @@ describe("notification scheduler", () => {
 
   test("dispatchDueNotifications sends miss-a-day when yesterday was missed", async () => {
     preferenceRows = [{ ...basePrefs, missADayEnabled: true, dailyReminderEnabled: false }];
-    queueLimitResults([]);
     userCompletedSessionOnDate.mockResolvedValue(false);
 
     const { dispatchDueNotifications } = await import("./notification-scheduler");
@@ -159,7 +126,6 @@ describe("notification scheduler", () => {
 
   test("dispatchDueNotifications skips miss-a-day when user meditated today", async () => {
     preferenceRows = [{ ...basePrefs, missADayEnabled: true, dailyReminderEnabled: false }];
-    queueLimitResults([]);
     userCompletedSessionOnDate.mockImplementation(async (_userId, date) => date === "2026-05-29");
 
     const { dispatchDueNotifications } = await import("./notification-scheduler");

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from "node:url";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
@@ -9,5 +9,7 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    // keep stale agent worktree checkouts out of local runs
+    exclude: [...configDefaults.exclude, "**/.claude/**"],
   },
 });


### PR DESCRIPTION
## **User description**
Closes #385

## What changed

- `src/lib/notification-scheduler.test.ts`: the `beforeEach` mock for `sendDailyReminderNotification` now resolves `{ delivered: true }` instead of `undefined`, matching the `Promise<{ delivered: boolean }>` contract introduced in #360 (and consistent with the existing `sendMissADayNotification` mock).
- Same file: removed the dead limit-query mock scaffolding (`limitQueryResults`, `limitQueryIndex`, `queueLimitResults`, `nextLimitResult`, the `dbSelectCall` counter and its mid-test reset, and the second `dbSelect` branch). It was orphaned when #360 deleted `hasDispatchForLocalDate`, the only consumer of the `.limit()` select chain, and it was the first red herring when diagnosing this failure.
- `vitest.config.ts`: added `exclude: [...configDefaults.exclude, "**/.claude/**"]` so stale agent worktree checkouts under `.claude/worktrees/` no longer pollute local `npm run test:unit` runs (CI doesn't run test:unit; clean checkouts are unaffected).

## Why

`npm run test:unit` had one deterministic failure on `main`: #360 changed the scheduler to destructure `const { delivered } = await sendDailyReminderNotification(...)` and only count `sent` when delivered, but the test mock still resolved `undefined`. The destructure threw a `TypeError`, the scheduler's per-user catch swallowed it as `skipped += 1`, and `first.sent` stayed `0`. Since test:unit isn't in CI, it sat unnoticed.

## Benefit

`test:unit` is green again and trustworthy: the mock reflects the real delivery contract, the test file no longer carries misleading dead scaffolding, and local runs are deterministic even with agent worktrees present. No production code changed — the delivered-gated rollback behavior from #360 is intentional and untouched.

## Test plan

- [x] `npx vitest run src/lib/notification-scheduler.test.ts` passes 6/6 in this branch
- [x] Full `npm run test:unit` passes (25 files / 118 tests)
- [x] No remaining references to removed helpers (`grep -E "queueLimitResults|nextLimitResult|limitQuery|dbSelectCall"` is empty)
- [x] A test file planted under `.claude/**` is NOT collected by `npm run test:unit` (verified with a temporary failing fixture)
- [x] Running vitest from inside a worktree under `<root>/.claude/worktrees/` still collects its own `src` tests (exclude matches root-relative paths only)
- [x] `src/lib/notification-scheduler.ts` is unchanged in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix the notification scheduler test setup and keep local test runs clean**

### What Changed
- The daily reminder test now matches the real delivery result, so the scheduler test no longer fails when it expects a delivery status.
- Removed unused test setup left over from an older notification check, which makes the scheduler tests easier to follow.
- Local Vitest runs now ignore stale `.claude` worktrees, preventing unrelated files from showing up in unit test runs.

### Impact
`✅ Reliable notification scheduler tests`
`✅ Fewer false test failures`
`✅ Cleaner local unit test runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
