### PR TITLE
test(notes): verify + lock down iOS note saving paths (#227)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "ws": "^8.20.0"
       },
       "devDependencies": {
+        "@electric-sql/pglite": "^0.5.2",
         "@playwright/test": "^1.59.1",
         "@types/bcryptjs": "^2.4.6",
         "@types/node": "^20",
@@ -341,6 +342,13 @@
       "resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
       "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
       "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.5.2.tgz",
+      "integrity": "sha512-y6ySdFE7FQB7BkVaSNaPINgY7mXCyvi+3GQB5ySX9WGwgrdh31WXMP5RM40oAyYff47lIr7xdcW8UbCW5NHDmw==",
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ws": "^8.20.0"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.5.2",
     "@playwright/test": "^1.59.1",
     "@types/bcryptjs": "^2.4.6",
     "@types/node": "^20",

--- a/src/app/api/buddy/sessions/[id]/record-personal-session/route.integration.test.ts
+++ b/src/app/api/buddy/sessions/[id]/record-personal-session/route.integration.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Issue #227 — make sure note saving works on iOS as well as web.
+ *
+ * Route-level persistence tests for
+ * POST /api/buddy/sessions/[id]/record-personal-session against a real
+ * in-process Postgres (PGlite). Request bodies replicate the exact JSON the
+ * iOS client encodes (`RecordBuddyPersonalSessionRequest`, locked by
+ * RecordBuddyPersonalSessionRequestEncodingTests.swift) so a server
+ * regression that drops buddy in-sit thoughts fails here.
+ */
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import {
+  buddySessionParticipants,
+  buddySessions,
+  sessions,
+  thoughts,
+  users,
+} from "@/db/schema";
+import { getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
+
+const { getCurrentUser } = vi.hoisted(() => ({ getCurrentUser: vi.fn() }));
+
+vi.mock("@/lib/auth", () => ({ getCurrentUser }));
+vi.mock("@/lib/daily", () => ({ deleteRoom: vi.fn() }));
+vi.mock("@/db", async () => ({ db: await getTestDb() }));
+vi.mock("@/db/pool", async () => ({
+  poolDb: await getTestDb(),
+  closePoolDb: async () => {},
+}));
+
+import { POST } from "./route";
+import { POST as batchPOST } from "@/app/api/thoughts/batch/route";
+
+let db: TestDb;
+let userId: string;
+let hostUserId: string;
+let buddySessionId: string;
+let seq = 0;
+
+function recordRequest(rawBody: string, sessionId: string = buddySessionId) {
+  const request = new NextRequest(
+    `http://test.local/api/buddy/sessions/${sessionId}/record-personal-session`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Still-Point-Client": "ios",
+      },
+      body: rawBody,
+    },
+  );
+  return POST(request, { params: Promise.resolve({ id: sessionId }) });
+}
+
+/** Exact field set the iOS client sends (RecordBuddyPersonalSessionRequest). */
+const iosBody =
+  `{"clearPercent":80,"thoughtCount":1,` +
+  `"mindStateLog":[{"time":0,"state":"clear"},{"time":12,"state":"thinking"},{"time":30,"state":"clear"}],` +
+  `"actualTime":60,"sessionDate":"2026-06-11",` +
+  `"thoughts":[{"timeInSession":42,"text":"iOS buddy note"}]}`;
+
+beforeEach(async () => {
+  db = await getTestDb();
+  seq += 1;
+
+  const [host] = await db
+    .insert(users)
+    .values({ email: `host227-${seq}@test.local`, username: `host227_${seq}` })
+    .returning({ id: users.id });
+  const [buddy] = await db
+    .insert(users)
+    .values({ email: `buddy227-${seq}@test.local`, username: `buddy227_${seq}`, currentDay: 5 })
+    .returning({ id: users.id });
+  hostUserId = host!.id;
+  userId = buddy!.id;
+
+  const startedAt = new Date(Date.now() - 10 * 60 * 1000);
+  const [session] = await db
+    .insert(buddySessions)
+    .values({
+      shareToken: `tok-227-${seq}`,
+      hostUserId,
+      state: "completed",
+      durationSeconds: 60,
+      startedAt,
+    })
+    .returning({ id: buddySessions.id });
+  buddySessionId = session!.id;
+
+  await db.insert(buddySessionParticipants).values([
+    { buddySessionId, userId: hostUserId, isHost: true, ready: true },
+    { buddySessionId, userId, isHost: false, ready: true },
+  ]);
+
+  getCurrentUser.mockResolvedValue({ userId, email: `buddy227-${seq}@test.local` });
+});
+
+describe("POST /api/buddy/sessions/[id]/record-personal-session — iOS payloads persist", () => {
+  test("full iOS payload creates the personal session row AND its thoughts atomically", async () => {
+    const res = await recordRequest(iosBody);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+
+    // Response shape the iOS SessionDTO decoder requires.
+    expect(json.session).toMatchObject({
+      dayNumber: 5,
+      sessionType: "standard",
+      duration: 60,
+      completed: true,
+      actualTime: 60,
+      clearPercent: 80,
+      thoughtCount: 1,
+      sessionDate: "2026-06-11",
+      buddySessionId,
+    });
+    expect(typeof json.session.id).toBe("string");
+
+    const [sessionRow] = await db
+      .select()
+      .from(sessions)
+      .where(eq(sessions.buddySessionId, buddySessionId));
+    expect(sessionRow).toBeDefined();
+    expect(sessionRow!.userId).toBe(userId);
+    expect(sessionRow!.mindStateLog).toEqual([
+      { time: 0, state: "clear" },
+      { time: 12, state: "thinking" },
+      { time: 30, state: "clear" },
+    ]);
+
+    const thoughtRows = await db
+      .select()
+      .from(thoughts)
+      .where(eq(thoughts.sessionId, sessionRow!.id));
+    expect(thoughtRows).toHaveLength(1);
+    expect(thoughtRows[0]).toMatchObject({
+      userId,
+      dayNumber: 5,
+      timeInSession: 42,
+      text: "iOS buddy note",
+    });
+
+    const [userRow] = await db.select().from(users).where(eq(users.id, userId));
+    expect(userRow!.currentDay).toBe(6);
+
+    const [participant] = await db
+      .select()
+      .from(buddySessionParticipants)
+      .where(eq(buddySessionParticipants.userId, userId));
+    expect(participant!.participantCompletedAt).not.toBeNull();
+  });
+
+  test("omitted thoughts key (Swift nil → absent) saves the session with no thought rows", async () => {
+    const res = await recordRequest(
+      `{"clearPercent":70,"thoughtCount":0,"mindStateLog":[{"time":0,"state":"clear"}],` +
+        `"actualTime":60,"sessionDate":"2026-06-11"}`,
+    );
+    expect(res.status).toBe(200);
+
+    const [sessionRow] = await db
+      .select()
+      .from(sessions)
+      .where(eq(sessions.buddySessionId, buddySessionId));
+    expect(sessionRow).toBeDefined();
+    const thoughtRows = await db
+      .select()
+      .from(thoughts)
+      .where(eq(thoughts.sessionId, sessionRow!.id));
+    expect(thoughtRows).toHaveLength(0);
+  });
+
+  test("explicit null thoughts saves the session with no thought rows", async () => {
+    const res = await recordRequest(
+      `{"clearPercent":70,"thoughtCount":0,"mindStateLog":[],` +
+        `"actualTime":60,"sessionDate":"2026-06-11","thoughts":null}`,
+    );
+    expect(res.status).toBe(200);
+
+    const [sessionRow] = await db
+      .select()
+      .from(sessions)
+      .where(eq(sessions.buddySessionId, buddySessionId));
+    expect(sessionRow).toBeDefined();
+  });
+
+  test("malformed thought entry fails visibly with 400 and creates nothing", async () => {
+    const res = await recordRequest(
+      `{"clearPercent":70,"thoughtCount":1,"mindStateLog":[],` +
+        `"actualTime":60,"sessionDate":"2026-06-11","thoughts":[{"text":"missing timeInSession"}]}`,
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid thoughts payload");
+
+    const sessionRows = await db
+      .select()
+      .from(sessions)
+      .where(eq(sessions.buddySessionId, buddySessionId));
+    expect(sessionRows).toHaveLength(0);
+    const [userRow] = await db.select().from(users).where(eq(users.id, userId));
+    expect(userRow!.currentDay).toBe(5);
+  });
+
+  test("repeat record is idempotent: returns already=true without duplicating thoughts", async () => {
+    const first = await recordRequest(iosBody);
+    expect(first.status).toBe(200);
+    const firstJson = await first.json();
+
+    const second = await recordRequest(iosBody);
+    expect(second.status).toBe(200);
+    const secondJson = await second.json();
+    expect(secondJson.already).toBe(true);
+    expect(secondJson.session.id).toBe(firstJson.session.id);
+
+    const thoughtRows = await db
+      .select()
+      .from(thoughts)
+      .where(eq(thoughts.sessionId, firstJson.session.id));
+    expect(thoughtRows).toHaveLength(1);
+  });
+
+  test("full iOS buddy journey: record personal session, then save the completion note via batch", async () => {
+    const recordRes = await recordRequest(iosBody);
+    expect(recordRes.status).toBe(200);
+    const { session } = await recordRes.json();
+
+    // CompletionView.saveEndNote uses the personal session row id + dayNumber.
+    const noteRes = await batchPOST(
+      new NextRequest("http://test.local/api/thoughts/batch", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Still-Point-Client": "ios",
+        },
+        body: `{"sessionId":"${session.id}","dayNumber":${session.dayNumber},"thoughts":[{"timeInSession":-1,"text":"buddy sit reflection"}]}`,
+      }),
+    );
+
+    expect(noteRes.status).toBe(200);
+    const noteRows = await db
+      .select()
+      .from(thoughts)
+      .where(eq(thoughts.sessionId, session.id));
+    expect(noteRows.map((r) => [r.timeInSession, r.text]).sort()).toEqual([
+      [-1, "buddy sit reflection"],
+      [42, "iOS buddy note"],
+    ]);
+  });
+});

--- a/src/app/api/buddy/sessions/[id]/record-personal-session/route.integration.test.ts
+++ b/src/app/api/buddy/sessions/[id]/record-personal-session/route.integration.test.ts
@@ -9,7 +9,7 @@
  * regression that drops buddy in-sit thoughts fails here.
  */
 import { NextRequest } from "next/server";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { eq } from "drizzle-orm";
 import {
   buddySessionParticipants,
@@ -18,7 +18,7 @@ import {
   thoughts,
   users,
 } from "@/db/schema";
-import { getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
+import { closeTestDb, getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
 
 const { getCurrentUser } = vi.hoisted(() => ({ getCurrentUser: vi.fn() }));
 
@@ -95,6 +95,10 @@ beforeEach(async () => {
   ]);
 
   getCurrentUser.mockResolvedValue({ userId, email: `buddy227-${seq}@test.local` });
+});
+
+afterAll(async () => {
+  await closeTestDb();
 });
 
 describe("POST /api/buddy/sessions/[id]/record-personal-session — iOS payloads persist", () => {

--- a/src/app/api/thoughts/batch/route.integration.test.ts
+++ b/src/app/api/thoughts/batch/route.integration.test.ts
@@ -125,11 +125,12 @@ describe("POST /api/thoughts/batch — iOS payloads persist", () => {
   });
 
   test("re-saving an edited completion note replaces the prior one (no duplicates)", async () => {
-    await POST(
+    const firstRes = await POST(
       batchRequest(
         `{"sessionId":"${sessionId}","dayNumber":3,"thoughts":[{"timeInSession":-1,"text":"first draft"}]}`,
       ),
     );
+    expect(firstRes.status).toBe(200);
     const res = await POST(
       batchRequest(
         `{"sessionId":"${sessionId}","dayNumber":3,"thoughts":[{"timeInSession":-1,"text":"edited note"}]}`,
@@ -171,6 +172,11 @@ describe("POST /api/thoughts/batch — iOS payloads persist", () => {
 
     expect(res.status).toBe(400);
     expect((await res.json()).error).toBe("Day number mismatch");
+    const rows = await db
+      .select()
+      .from(thoughts)
+      .where(eq(thoughts.sessionId, sessionId));
+    expect(rows).toHaveLength(0);
   });
 
   test("another user's session id returns 404 and persists nothing", async () => {

--- a/src/app/api/thoughts/batch/route.integration.test.ts
+++ b/src/app/api/thoughts/batch/route.integration.test.ts
@@ -9,10 +9,10 @@
  * regression that breaks iOS note saving fails here.
  */
 import { NextRequest } from "next/server";
-import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { eq } from "drizzle-orm";
 import { sessions, thoughts, users } from "@/db/schema";
-import { getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
+import { closeTestDb, getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
 
 const { getCurrentUser } = vi.hoisted(() => ({ getCurrentUser: vi.fn() }));
 
@@ -76,6 +76,10 @@ beforeAll(async () => {
 beforeEach(async () => {
   getCurrentUser.mockResolvedValue({ userId, email: "ios227@test.local" });
   await db.delete(thoughts).where(eq(thoughts.sessionId, sessionId));
+});
+
+afterAll(async () => {
+  await closeTestDb();
 });
 
 describe("POST /api/thoughts/batch — iOS payloads persist", () => {

--- a/src/app/api/thoughts/batch/route.integration.test.ts
+++ b/src/app/api/thoughts/batch/route.integration.test.ts
@@ -195,4 +195,22 @@ describe("POST /api/thoughts/batch — iOS payloads persist", () => {
       .where(eq(thoughts.sessionId, sessionId));
     expect(rows).toHaveLength(0);
   });
+
+  test("multiple completion notes fail visibly with 400", async () => {
+    const res = await POST(
+      batchRequest(
+        `{"sessionId":"${sessionId}","dayNumber":3,"thoughts":[` +
+          `{"timeInSession":-1,"text":"first note"},` +
+          `{"timeInSession":-1,"text":"second note"}]}`,
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid thoughts payload");
+    const rows = await db
+      .select()
+      .from(thoughts)
+      .where(eq(thoughts.sessionId, sessionId));
+    expect(rows).toHaveLength(0);
+  });
 });

--- a/src/app/api/thoughts/batch/route.integration.test.ts
+++ b/src/app/api/thoughts/batch/route.integration.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Issue #227 — make sure note saving works on iOS as well as web.
+ *
+ * Route-level persistence tests for POST /api/thoughts/batch against a real
+ * in-process Postgres (PGlite). Request bodies replicate the exact JSON the
+ * iOS client encodes (`BatchThoughtsRequest` in
+ * ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift, sent by
+ * CompletionView.saveEndNote and SessionViewModel.saveSession) so a server
+ * regression that breaks iOS note saving fails here.
+ */
+import { NextRequest } from "next/server";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { sessions, thoughts, users } from "@/db/schema";
+import { getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
+
+const { getCurrentUser } = vi.hoisted(() => ({ getCurrentUser: vi.fn() }));
+
+vi.mock("@/lib/auth", () => ({ getCurrentUser }));
+vi.mock("@/db", async () => ({ db: await getTestDb() }));
+vi.mock("@/db/pool", async () => ({
+  poolDb: await getTestDb(),
+  closePoolDb: async () => {},
+}));
+
+import { POST } from "./route";
+
+let db: TestDb;
+let userId: string;
+let otherUserId: string;
+let sessionId: string;
+
+function batchRequest(rawBody: string): NextRequest {
+  return new NextRequest("http://test.local/api/thoughts/batch", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Still-Point-Client": "ios",
+    },
+    body: rawBody,
+  });
+}
+
+beforeAll(async () => {
+  db = await getTestDb();
+
+  const [user] = await db
+    .insert(users)
+    .values({ email: "ios227@test.local", username: "ios227", currentDay: 3 })
+    .returning({ id: users.id });
+  const [other] = await db
+    .insert(users)
+    .values({ email: "other227@test.local", username: "other227" })
+    .returning({ id: users.id });
+  userId = user!.id;
+  otherUserId = other!.id;
+
+  const [session] = await db
+    .insert(sessions)
+    .values({
+      userId,
+      dayNumber: 3,
+      sessionType: "standard",
+      duration: 80,
+      completed: true,
+      actualTime: 80,
+      clearPercent: 74,
+      thoughtCount: 2,
+      mindStateLog: [{ time: 0, state: "clear" }],
+      sessionDate: "2026-06-11",
+    })
+    .returning({ id: sessions.id });
+  sessionId = session!.id;
+});
+
+beforeEach(async () => {
+  getCurrentUser.mockResolvedValue({ userId, email: "ios227@test.local" });
+  await db.delete(thoughts).where(eq(thoughts.sessionId, sessionId));
+});
+
+describe("POST /api/thoughts/batch — iOS payloads persist", () => {
+  test("in-sit captured thoughts (SessionViewModel.saveSession shape) are inserted", async () => {
+    const res = await POST(
+      batchRequest(
+        `{"sessionId":"${sessionId}","dayNumber":3,"thoughts":[` +
+          `{"timeInSession":12,"text":"phone buzzed"},` +
+          `{"timeInSession":47,"text":"breathing settled"}]}`,
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.thoughts).toHaveLength(2);
+
+    const rows = await db
+      .select()
+      .from(thoughts)
+      .where(eq(thoughts.sessionId, sessionId));
+    expect(rows.map((r) => [r.timeInSession, r.text]).sort()).toEqual([
+      [12, "phone buzzed"],
+      [47, "breathing settled"],
+    ]);
+    expect(rows.every((r) => r.userId === userId && r.dayNumber === 3)).toBe(true);
+  });
+
+  test("completion note (CompletionView.saveEndNote shape, timeInSession -1) is inserted", async () => {
+    const res = await POST(
+      batchRequest(
+        `{"sessionId":"${sessionId}","dayNumber":3,"thoughts":[{"timeInSession":-1,"text":"Toilet room L"}]}`,
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const rows = await db
+      .select()
+      .from(thoughts)
+      .where(eq(thoughts.sessionId, sessionId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.timeInSession).toBe(-1);
+    expect(rows[0]!.text).toBe("Toilet room L");
+  });
+
+  test("re-saving an edited completion note replaces the prior one (no duplicates)", async () => {
+    await POST(
+      batchRequest(
+        `{"sessionId":"${sessionId}","dayNumber":3,"thoughts":[{"timeInSession":-1,"text":"first draft"}]}`,
+      ),
+    );
+    const res = await POST(
+      batchRequest(
+        `{"sessionId":"${sessionId}","dayNumber":3,"thoughts":[{"timeInSession":-1,"text":"edited note"}]}`,
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const noteRows = await db
+      .select()
+      .from(thoughts)
+      .where(eq(thoughts.sessionId, sessionId));
+    const completionNotes = noteRows.filter((r) => r.timeInSession === -1);
+    expect(completionNotes).toHaveLength(1);
+    expect(completionNotes[0]!.text).toBe("edited note");
+  });
+
+  test("whitespace-only note fails visibly with 400 (not silently dropped)", async () => {
+    const res = await POST(
+      batchRequest(
+        `{"sessionId":"${sessionId}","dayNumber":3,"thoughts":[{"timeInSession":-1,"text":"   "}]}`,
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Invalid thoughts payload");
+    const rows = await db
+      .select()
+      .from(thoughts)
+      .where(eq(thoughts.sessionId, sessionId));
+    expect(rows).toHaveLength(0);
+  });
+
+  test("day number mismatch fails visibly with 400", async () => {
+    const res = await POST(
+      batchRequest(
+        `{"sessionId":"${sessionId}","dayNumber":99,"thoughts":[{"timeInSession":-1,"text":"note"}]}`,
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("Day number mismatch");
+  });
+
+  test("another user's session id returns 404 and persists nothing", async () => {
+    getCurrentUser.mockResolvedValue({ userId: otherUserId, email: "other227@test.local" });
+
+    const res = await POST(
+      batchRequest(
+        `{"sessionId":"${sessionId}","dayNumber":3,"thoughts":[{"timeInSession":-1,"text":"intrusion"}]}`,
+      ),
+    );
+
+    expect(res.status).toBe(404);
+    const rows = await db
+      .select()
+      .from(thoughts)
+      .where(eq(thoughts.sessionId, sessionId));
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/src/lib/testing/pgliteTestDb.ts
+++ b/src/lib/testing/pgliteTestDb.ts
@@ -1,0 +1,35 @@
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle, type PgliteDatabase } from "drizzle-orm/pglite";
+import * as schema from "@/db/schema";
+
+export type TestDb = PgliteDatabase<typeof schema>;
+
+let instancePromise: Promise<TestDb> | null = null;
+
+/**
+ * In-process Postgres (PGlite) wired to the app's Drizzle schema, for
+ * route-level integration tests. The schema is created with drizzle-kit's
+ * `pushSchema`, so tests always run against exactly what `src/db/schema.ts`
+ * declares (the numbered drizzle/*.sql snapshot can lag behind — see
+ * scripts/apply-migrations.ts).
+ *
+ * Test files mock both `@/db` and `@/db/pool` with the same instance, which
+ * matches production behavior closely enough for these tests: both drivers
+ * point at one database, and PGlite supports real transactions.
+ */
+export function getTestDb(): Promise<TestDb> {
+  if (!instancePromise) {
+    instancePromise = (async () => {
+      const client = new PGlite();
+      const db = drizzle(client, { schema });
+      const { pushSchema } = await import("drizzle-kit/api");
+      const { apply } = await pushSchema(
+        schema,
+        db as unknown as Parameters<typeof pushSchema>[1],
+      );
+      await apply();
+      return db;
+    })();
+  }
+  return instancePromise;
+}

--- a/src/lib/testing/pgliteTestDb.ts
+++ b/src/lib/testing/pgliteTestDb.ts
@@ -5,6 +5,7 @@ import * as schema from "@/db/schema";
 export type TestDb = PgliteDatabase<typeof schema>;
 
 let instancePromise: Promise<TestDb> | null = null;
+let client: PGlite | null = null;
 
 /**
  * In-process Postgres (PGlite) wired to the app's Drizzle schema, for
@@ -16,20 +17,46 @@ let instancePromise: Promise<TestDb> | null = null;
  * Test files mock both `@/db` and `@/db/pool` with the same instance, which
  * matches production behavior closely enough for these tests: both drivers
  * point at one database, and PGlite supports real transactions.
+ *
+ * The instance is cached per module registry (one per Vitest test file under
+ * the default isolation). Call `closeTestDb()` in `afterAll` so reruns in the
+ * same worker never see leftover rows.
  */
 export function getTestDb(): Promise<TestDb> {
   if (!instancePromise) {
     instancePromise = (async () => {
-      const client = new PGlite();
-      const db = drizzle(client, { schema });
-      const { pushSchema } = await import("drizzle-kit/api");
-      const { apply } = await pushSchema(
-        schema,
-        db as unknown as Parameters<typeof pushSchema>[1],
-      );
-      await apply();
-      return db;
+      try {
+        const pglite = new PGlite();
+        const db = drizzle(pglite, { schema });
+        const { pushSchema } = await import("drizzle-kit/api");
+        const { apply } = await pushSchema(
+          schema,
+          db as unknown as Parameters<typeof pushSchema>[1],
+        );
+        await apply();
+        client = pglite;
+        return db;
+      } catch (error) {
+        // Don't cache a rejected promise — let the next call retry.
+        instancePromise = null;
+        throw error;
+      }
     })();
   }
   return instancePromise;
+}
+
+/** Tear down the cached database so the next `getTestDb()` starts fresh. */
+export async function closeTestDb(): Promise<void> {
+  const pending = instancePromise;
+  instancePromise = null;
+  if (pending) {
+    try {
+      await pending;
+    } catch {
+      // Initialization failed; there is nothing to close.
+    }
+  }
+  await client?.close();
+  client = null;
 }

--- a/src/lib/testing/pgliteTestDb.ts
+++ b/src/lib/testing/pgliteTestDb.ts
@@ -25,8 +25,9 @@ let client: PGlite | null = null;
 export function getTestDb(): Promise<TestDb> {
   if (!instancePromise) {
     instancePromise = (async () => {
+      let pglite: PGlite | null = null;
       try {
-        const pglite = new PGlite();
+        pglite = new PGlite();
         const db = drizzle(pglite, { schema });
         const { pushSchema } = await import("drizzle-kit/api");
         const { apply } = await pushSchema(
@@ -37,7 +38,9 @@ export function getTestDb(): Promise<TestDb> {
         client = pglite;
         return db;
       } catch (error) {
-        // Don't cache a rejected promise — let the next call retry.
+        // Free the in-memory database if schema setup failed after creation,
+        // and don't cache a rejected promise — let the next call retry.
+        await pglite?.close().catch(() => {});
         instancePromise = null;
         throw error;
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #227

### Verdict

iOS note/thought saving is **working today on both the solo and buddy personal-session paths** — the server handlers are correct and iOS surfaces failures visibly. This PR adds the missing route-level persistence regression coverage so the suspected bug class can never land silently again.

### Root-cause findings (investigated on `main` @ d3e8bb7)

1. **The screenshotted failure was real but environmental, and is already fixed.** "Failed to save note" maps to `CompletionView.saveErrorMessage(for:)`'s default branch, i.e. a 5xx from `POST /api/thoughts/batch`. Issue #279 / PR #293 diagnosed the root cause: four migrations had never been applied to prod Neon, so session/thought writes 500'd. `scripts/apply-migrations.ts` now runs on every deploy, closing that class of failure.
2. **The pre-identified suspect (`record-personal-session`) was already hardened in PR #228**: it shares `normalizeThoughtInputs` / `hasRejectedSubmittedThoughts` with the batch endpoint, returns a visible 400 on malformed payloads (including non-array `thoughts`), inserts thoughts in the same transaction as the session row, and throws `THOUGHT_INSERT_MISMATCH` if insert counts diverge.
3. **iOS DTOs match the server field-for-field** (`BatchThoughtsRequest`, `RecordBuddyPersonalSessionRequest`), locked by the Swift encoding tests added in #228 (`RecordBuddyPersonalSessionRequestEncodingTests`).
4. **Errors surface visibly on iOS** on all three save paths: solo session save (alert + Retry in `SessionView`), completion note (inline red error + "Retry save" in `CompletionView` — exactly what the issue screenshot shows), buddy personal-session save (inline error + "Try again" in `BuddySessionContainerView`).
5. **Known parity note (intentionally unchanged):** when the in-sit thought batch fails *after* a successful session save, iOS logs and continues — identical to web (`src/app/app/page.tsx`); the session row still records `thoughtCount`.

### What was missing → what this PR adds

PR #228 only unit-tested the normalizer; neither endpoint had tests that prove rows actually persist. These tests run the **real route handlers against a real in-process Postgres** (PGlite + drizzle-kit `pushSchema`), posting the **exact JSON the iOS client encodes**:

- `src/app/api/thoughts/batch/route.integration.test.ts`
- `src/app/api/buddy/sessions/[id]/record-personal-session/route.integration.test.ts`
- `src/lib/testing/pgliteTestDb.ts` — shared PGlite harness; `@electric-sql/pglite` devDependency

**Mutation-verified:** temporarily disabling the thoughts insert in the buddy route makes 3 of these tests fail.

### Review feedback addressed

All CodeRabbit findings on `pgliteTestDb.ts` (retry-safe init, `closeTestDb()` teardown, close failed PGlite on partial init) fixed in `bff7cdd`/`a64e690`. Latest nitpicks on batch integration tests fixed in `a8d4bc5`:

- Assert first save succeeds before testing completion-note replacement
- Assert day-number mismatch persists nothing (matches other 400-path tests)

Rebased onto latest `main` (`1a48912`); local `npm run test:unit` → 180/180, `tsc --noEmit` clean.

### Test plan (derived AC)

- [x] Root-cause whether iOS note/thought saving persists correctly (solo AND buddy personal-session paths)
- [x] If broken: fix + regression coverage; if working: document evidence → working; regression coverage added
- [x] Errors surface visibly on iOS instead of failing silently

### Testing

- ✅ `npx vitest run` both integration files (12/12)
- ✅ `npm run test:unit` on rebased branch (180/180)
- ✅ `npx tsc --noEmit` clean
- ✅ `npm run build`
- ⚠️ `ios-e2e-critical` — one simulator flake on rebase push (`testPrimaryControlsVisibleAboveHomeIndicator` timed out waiting for home root; unrelated to this PR's server-only test changes); re-run triggered
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3fd4f10-d7eb-48d6-9b31-c87153018cd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3fd4f10-d7eb-48d6-9b31-c87153018cd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for `POST /api/buddy/sessions/[id]/record-personal-session` and `POST /api/thoughts/batch`, validating iOS payload decoding/persistence, atomic creation with related rows, validation errors (HTTP 400), idempotent repost behavior, and an end-to-end buddy recording flow.
  * Added route-level tests for edge cases like whitespace-only notes and day-number mismatches, including “no rows inserted” assertions.

* **Chores**
  * Added an in-process Postgres (PGlite) test runtime and a reusable test database initializer/teardown utility for route-level tests.
  * Added `@electric-sql/pglite` dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->