### PR TITLE
feat(auth): last used tag for OAuth login methods on web

### DIFF
--- a/src/app/api/auth/oauth-complete/route.ts
+++ b/src/app/api/auth/oauth-complete/route.ts
@@ -5,6 +5,7 @@ import { clearAuthJsCookies } from "@/lib/authJsCookies";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { createToken, setAuthCookie } from "@/lib/auth";
+import { isOAuthProvider } from "@/lib/lastAuthProvider";
 
 /** Sanitize a `?return=` param into a same-origin path. Anything other
  *  than a leading single `/` (no protocol-relative `//`, no full URL) is
@@ -28,10 +29,12 @@ export async function GET(request: NextRequest) {
   const requestUrl = new URL(request.url);
   const successTarget = sanitizeReturnTarget(requestUrl.searchParams.get("return"));
   let errorPath: string | null = null;
+  let completedProvider: string | null = null;
 
   try {
     const session = await auth();
     const userId = session?.userId;
+    completedProvider = session?.authProvider ?? null;
 
     if (!userId) {
       errorPath = "/app?error=oauth_session_missing";
@@ -60,6 +63,12 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  const finalPath = errorPath ?? successTarget;
-  return NextResponse.redirect(new URL(finalPath, request.url));
+  const finalUrl = new URL(errorPath ?? successTarget, request.url);
+  // Only on success: tell the client which provider just completed so it
+  // can record the "last used" login method (#337). Allowlisted so an
+  // unexpected provider string never lands in the redirect URL.
+  if (!errorPath && isOAuthProvider(completedProvider)) {
+    finalUrl.searchParams.set("auth_provider", completedProvider);
+  }
+  return NextResponse.redirect(finalUrl);
 }

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -14,6 +14,7 @@ import { FriendsView } from "@/components/FriendsView";
 import { BuddySessionHub } from "@/components/BuddySessionHub";
 import { BuddySessionRoom, type BuddyPersonalRecordPayload } from "@/components/BuddySessionRoom";
 import { useIsMobile } from "@/lib/useIsMobile";
+import { isOAuthProvider, saveLastAuthProvider } from "@/lib/lastAuthProvider";
 import { api, ApiError } from "@/lib/api";
 import type { SessionType } from "@/lib/constants";
 
@@ -115,6 +116,21 @@ export default function StillPoint() {
       cancelled = true;
     };
   }, [authRetryKey]);
+
+  // The oauth-complete bridge appends ?auth_provider=... only after a
+  // successful OAuth login (#337). Persist it as the "last used" method
+  // and strip the param so reloads/shared links don't carry it.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const provider = params.get("auth_provider");
+    if (provider === null) return;
+    if (isOAuthProvider(provider)) {
+      saveLastAuthProvider(provider);
+    }
+    params.delete("auth_provider");
+    const next = params.toString();
+    window.history.replaceState({}, "", `${window.location.pathname}${next ? `?${next}` : ""}`);
+  }, []);
 
   useEffect(() => {
     if (!user || !authChecked) return;

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -14,7 +14,6 @@ import { FriendsView } from "@/components/FriendsView";
 import { BuddySessionHub } from "@/components/BuddySessionHub";
 import { BuddySessionRoom, type BuddyPersonalRecordPayload } from "@/components/BuddySessionRoom";
 import { useIsMobile } from "@/lib/useIsMobile";
-import { isOAuthProvider, saveLastAuthProvider } from "@/lib/lastAuthProvider";
 import { api, ApiError } from "@/lib/api";
 import type { SessionType } from "@/lib/constants";
 
@@ -116,21 +115,6 @@ export default function StillPoint() {
       cancelled = true;
     };
   }, [authRetryKey]);
-
-  // The oauth-complete bridge appends ?auth_provider=... only after a
-  // successful OAuth login (#337). Persist it as the "last used" method
-  // and strip the param so reloads/shared links don't carry it.
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const provider = params.get("auth_provider");
-    if (provider === null) return;
-    if (isOAuthProvider(provider)) {
-      saveLastAuthProvider(provider);
-    }
-    params.delete("auth_provider");
-    const next = params.toString();
-    window.history.replaceState({}, "", `${window.location.pathname}${next ? `?${next}` : ""}`);
-  }, []);
 
   useEffect(() => {
     if (!user || !authChecked) return;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Newsreader, JetBrains_Mono } from "next/font/google";
+import { LastAuthProviderCapture } from "@/components/LastAuthProviderCapture";
 import "./globals.css";
 
 const newsreader = Newsreader({
@@ -45,6 +46,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${newsreader.variable} ${jetbrainsMono.variable}`}>
+        <LastAuthProviderCapture />
         <div style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}>
           <main style={{ flex: 1 }}>{children}</main>
           <footer

--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { signIn } from "next-auth/react";
+import { loadLastAuthProvider, type OAuthProvider } from "@/lib/lastAuthProvider";
 
 type AuthScreenProps = {
   onLogin: (user: { id: string; email: string; username: string; isPublic: boolean; currentDay: number }) => void;
@@ -19,6 +20,33 @@ const OAUTH_ERROR_MESSAGES: Record<string, string> = {
   Configuration: "Sign-in is temporarily unavailable.",
 };
 
+function LastUsedTag({ onDark }: { onDark: boolean }) {
+  return (
+    <span
+      style={{
+        position: "absolute",
+        top: "50%",
+        right: "12px",
+        transform: "translateY(-50%)",
+        fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+        fontSize: "8px",
+        letterSpacing: "0.12em",
+        textTransform: "uppercase",
+        lineHeight: 1,
+        padding: "4px 7px",
+        borderRadius: "10px",
+        whiteSpace: "nowrap",
+        pointerEvents: "none",
+        color: onDark ? "rgba(255, 255, 255, 0.65)" : "var(--fg-3)",
+        border: onDark ? "1px solid rgba(255, 255, 255, 0.25)" : "1px solid var(--border-2)",
+        background: onDark ? "rgba(255, 255, 255, 0.08)" : "var(--overlay-bg)",
+      }}
+    >
+      last used
+    </span>
+  );
+}
+
 export function AuthScreen({ onLogin }: AuthScreenProps) {
   const [mode, setMode] = useState<"login" | "signup">("login");
   const [email, setEmail] = useState("");
@@ -26,6 +54,13 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  // Read in an effect (not the initializer) so server and first client
+  // render agree — localStorage is only available after hydration.
+  const [lastProvider, setLastProvider] = useState<OAuthProvider | null>(null);
+
+  useEffect(() => {
+    setLastProvider(loadLastAuthProvider());
+  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -145,6 +180,7 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
             alignItems: "center",
             justifyContent: "center",
             gap: "10px",
+            position: "relative",
           }}
           onMouseEnter={e => {
             e.currentTarget.style.borderColor = "var(--border-3)";
@@ -154,7 +190,7 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
             e.currentTarget.style.borderColor = "var(--border-2)";
             e.currentTarget.style.background = "var(--surface-1)";
           }}
-          aria-label="Continue with Google"
+          aria-label={lastProvider === "google" ? "Continue with Google (last used)" : "Continue with Google"}
         >
           <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
             <path fill="#4285F4" d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z"/>
@@ -163,6 +199,7 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
             <path fill="#EA4335" d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.962L3.964 7.294C4.672 5.167 6.656 3.58 9 3.58z"/>
           </svg>
           Continue with Google
+          {lastProvider === "google" && <LastUsedTag onDark={false} />}
         </button>
 
         <button
@@ -188,6 +225,7 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
             alignItems: "center",
             justifyContent: "center",
             gap: "10px",
+            position: "relative",
           }}
           onMouseEnter={e => {
             e.currentTarget.style.background = "#1a1a1a";
@@ -197,12 +235,13 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
             e.currentTarget.style.background = "#000000";
             e.currentTarget.style.borderColor = "#000000";
           }}
-          aria-label="Continue with Apple"
+          aria-label={lastProvider === "apple" ? "Continue with Apple (last used)" : "Continue with Apple"}
         >
           <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor">
             <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
           </svg>
           Continue with Apple
+          {lastProvider === "apple" && <LastUsedTag onDark />}
         </button>
 
         <p style={{

--- a/src/components/LastAuthProviderCapture.tsx
+++ b/src/components/LastAuthProviderCapture.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { isOAuthProvider, saveLastAuthProvider } from "@/lib/lastAuthProvider";
+
+/** The oauth-complete bridge appends ?auth_provider=... only after a
+ *  successful OAuth login (#337). Its `return` target can be any
+ *  same-origin path (deep links, subroutes), so this capture lives in
+ *  the root layout rather than the /app page: wherever the redirect
+ *  lands, persist the provider as the "last used" method and strip the
+ *  param so reloads/shared links don't carry it. */
+export function LastAuthProviderCapture() {
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const provider = params.get("auth_provider");
+    if (provider === null) return;
+    if (isOAuthProvider(provider)) {
+      saveLastAuthProvider(provider);
+    }
+    params.delete("auth_provider");
+    const next = params.toString();
+    window.history.replaceState({}, "", `${window.location.pathname}${next ? `?${next}` : ""}`);
+  }, []);
+
+  return null;
+}

--- a/src/lib/auth-config.ts
+++ b/src/lib/auth-config.ts
@@ -7,6 +7,10 @@ import { resolveOAuthUserId } from "@/lib/oauth-user-resolution";
 declare module "next-auth" {
   interface Session {
     userId?: string;
+    /** OAuth provider used for this sign-in (e.g. "google", "apple");
+     *  threaded through the JWT so oauth-complete can tell the client
+     *  which provider just succeeded (#337). */
+    authProvider?: string;
   }
 }
 
@@ -86,14 +90,21 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       user.id = userId;
       return true;
     },
-    async jwt({ token, user }) {
+    async jwt({ token, user, account }) {
       if (user?.id) token.userId = user.id;
+      // `account` is only defined on the sign-in invocation, which is
+      // exactly when we want to record which provider completed login.
+      if (account?.provider) token.authProvider = account.provider;
       return token;
     },
     async session({ session, token }) {
       const tokenUserId = (token as { userId?: unknown }).userId;
       if (typeof tokenUserId === "string") {
         session.userId = tokenUserId;
+      }
+      const tokenAuthProvider = (token as { authProvider?: unknown }).authProvider;
+      if (typeof tokenAuthProvider === "string") {
+        session.authProvider = tokenAuthProvider;
       }
       return session;
     },

--- a/src/lib/lastAuthProvider.test.ts
+++ b/src/lib/lastAuthProvider.test.ts
@@ -1,7 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { isOAuthProvider, loadLastAuthProvider, saveLastAuthProvider } from "./lastAuthProvider";
-
-const STORAGE_KEY = "stillpoint_last_auth_provider";
+import { isOAuthProvider, loadLastAuthProvider, saveLastAuthProvider, STORAGE_KEY } from "./lastAuthProvider";
 
 function stubBrowserStorage(initial: Record<string, string> = {}) {
   const store = new Map(Object.entries(initial));

--- a/src/lib/lastAuthProvider.test.ts
+++ b/src/lib/lastAuthProvider.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isOAuthProvider, loadLastAuthProvider, saveLastAuthProvider } from "./lastAuthProvider";
+
+const STORAGE_KEY = "stillpoint_last_auth_provider";
+
+function stubBrowserStorage(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial));
+  const localStorageStub = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  };
+  vi.stubGlobal("window", { localStorage: localStorageStub });
+  vi.stubGlobal("localStorage", localStorageStub);
+  return store;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("isOAuthProvider", () => {
+  it("accepts known providers", () => {
+    expect(isOAuthProvider("google")).toBe(true);
+    expect(isOAuthProvider("apple")).toBe(true);
+  });
+
+  it("rejects unknown values", () => {
+    expect(isOAuthProvider("facebook")).toBe(false);
+    expect(isOAuthProvider("")).toBe(false);
+    expect(isOAuthProvider(null)).toBe(false);
+    expect(isOAuthProvider(undefined)).toBe(false);
+  });
+});
+
+describe("loadLastAuthProvider", () => {
+  it("returns null during SSR (no window)", () => {
+    expect(loadLastAuthProvider()).toBeNull();
+  });
+
+  it("returns null when nothing is stored", () => {
+    stubBrowserStorage();
+    expect(loadLastAuthProvider()).toBeNull();
+  });
+
+  it("returns a stored valid provider", () => {
+    stubBrowserStorage({ [STORAGE_KEY]: "google" });
+    expect(loadLastAuthProvider()).toBe("google");
+  });
+
+  it("returns null for a tampered/unknown stored value", () => {
+    stubBrowserStorage({ [STORAGE_KEY]: "github" });
+    expect(loadLastAuthProvider()).toBeNull();
+  });
+
+  it("returns null when localStorage throws", () => {
+    const throwingStorage = {
+      getItem: () => {
+        throw new Error("denied");
+      },
+    };
+    vi.stubGlobal("window", { localStorage: throwingStorage });
+    vi.stubGlobal("localStorage", throwingStorage);
+    expect(loadLastAuthProvider()).toBeNull();
+  });
+});
+
+describe("saveLastAuthProvider", () => {
+  it("is a no-op during SSR (no window)", () => {
+    expect(() => saveLastAuthProvider("google")).not.toThrow();
+  });
+
+  it("persists the provider and round-trips through load", () => {
+    const store = stubBrowserStorage();
+    saveLastAuthProvider("apple");
+    expect(store.get(STORAGE_KEY)).toBe("apple");
+    expect(loadLastAuthProvider()).toBe("apple");
+  });
+
+  it("overwrites a previously stored provider", () => {
+    const store = stubBrowserStorage({ [STORAGE_KEY]: "google" });
+    saveLastAuthProvider("apple");
+    expect(store.get(STORAGE_KEY)).toBe("apple");
+  });
+
+  it("ignores storage write failures", () => {
+    const throwingStorage = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("quota exceeded");
+      },
+    };
+    vi.stubGlobal("window", { localStorage: throwingStorage });
+    vi.stubGlobal("localStorage", throwingStorage);
+    expect(() => saveLastAuthProvider("google")).not.toThrow();
+  });
+});

--- a/src/lib/lastAuthProvider.ts
+++ b/src/lib/lastAuthProvider.ts
@@ -2,7 +2,7 @@ export const OAUTH_PROVIDERS = ["google", "apple"] as const;
 
 export type OAuthProvider = (typeof OAUTH_PROVIDERS)[number];
 
-const STORAGE_KEY = "stillpoint_last_auth_provider";
+export const STORAGE_KEY = "stillpoint_last_auth_provider";
 
 export function isOAuthProvider(value: unknown): value is OAuthProvider {
   return typeof value === "string" && (OAUTH_PROVIDERS as readonly string[]).includes(value);

--- a/src/lib/lastAuthProvider.ts
+++ b/src/lib/lastAuthProvider.ts
@@ -1,0 +1,29 @@
+export const OAUTH_PROVIDERS = ["google", "apple"] as const;
+
+export type OAuthProvider = (typeof OAUTH_PROVIDERS)[number];
+
+const STORAGE_KEY = "stillpoint_last_auth_provider";
+
+export function isOAuthProvider(value: unknown): value is OAuthProvider {
+  return typeof value === "string" && (OAUTH_PROVIDERS as readonly string[]).includes(value);
+}
+
+export function loadLastAuthProvider(): OAuthProvider | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return isOAuthProvider(raw) ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveLastAuthProvider(provider: OAuthProvider): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, provider);
+  } catch {
+    // Best-effort persistence: ignore storage write failures.
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #337

## Implementation Plan (as locked in the issue)
Track the provider via Auth.js JWT/session callbacks → `oauth-complete` redirect query param → client saves to localStorage and strips the param. Chosen over save-on-click or a temp cookie so only **completed** logins are counted, following Auth.js patterns.

## Changes
- `src/lib/auth-config.ts` — `jwt` callback records `account.provider` (only defined on the sign-in invocation); `session` callback exposes it as `session.authProvider`.
- `src/app/api/auth/oauth-complete/route.ts` — on **success only**, appends `?auth_provider=<provider>` (allowlisted to `google`/`apple`) to the post-OAuth redirect.
- `src/components/LastAuthProviderCapture.tsx` (new) — mounted in the root layout; detects `auth_provider`, persists it via `saveLastAuthProvider`, and strips the param with `history.replaceState` (other params preserved). Lives in the layout (not the `/app` page) so redirects landing on any same-origin path — deep links, subroutes — are captured.
- `src/lib/lastAuthProvider.ts` (new) — localStorage helper following the `displayPrefs.ts` pattern: SSR guards, try/catch, value allowlist on read, exported `STORAGE_KEY`.
- `src/components/AuthScreen.tsx` — renders a "last used" pill on the matching OAuth button (light variant on the Google button, dark variant on the black Apple button); aria-labels updated; state read in an effect to avoid hydration mismatch.
- `src/lib/lastAuthProvider.test.ts` (new) — 11 unit tests covering SSR guards, round-trip, tamper rejection, and storage failures.

## Review feedback resolved
- **Cursor Bugbot (medium): "Subroute OAuth skips persistence"** — fixed in `a076da1` by hoisting the capture from the `/app` page mount effect into `LastAuthProviderCapture` in the root layout. Verified with a Playwright check landing on `/app/settings/notifications?auth_provider=apple`: param stripped, provider persisted, tag correct back on `/app` (11/11 checks pass; see demo video). Outdated review thread resolved.
- **CodeRabbit nitpick: duplicated `STORAGE_KEY` in test** — fixed in `56bda3a` by exporting the key from `lastAuthProvider.ts` and importing it in the test.
- codeant-ai comment about a missing PR Review subscription is informational (account/billing), not actionable in code.

## Demo

[subroute_oauth_tag_fix_demo.mp4](https://cursor.com/agents/bc-7c5e353e-cf7a-4279-81f0-02c2be389e40/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsubroute_oauth_tag_fix_demo.mp4)

Demo covers: clean first visit (no tag) → `/app?auth_provider=google` tags Google and strips the param → subroute landing `/app/settings/notifications?auth_provider=apple` strips the param and moves the tag to Apple → `/app` shows Apple tagged, Google clean → reload persists.

[Google last used tag](https://cursor.com/agents/bc-7c5e353e-cf7a-4279-81f0-02c2be389e40/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgoogle_last_used_tag.webp)
[Subroute landing: Apple tagged, param stripped](https://cursor.com/agents/bc-7c5e353e-cf7a-4279-81f0-02c2be389e40/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsubroute_landing_apple_tag.webp)

## Test plan (derived AC)
- [x] "Last used" tag renders on the matching OAuth button on AuthScreen after a successful OAuth login (verified the bridge pipeline client-side: `/app?auth_provider=google` → tag on Google button, param stripped from URL)
- [x] Tag survives reload (localStorage) and only reflects successful logins — the param is only appended on the `oauth-complete` success path; abandoned attempts redirect with `?error=` and never set it
- [x] No tag shown for first-time visitors; tag updates when the user switches providers (verified Google → Apple switch; bogus `auth_provider` values are ignored)
- [x] Redirects landing on subroutes (e.g. `/app/settings/notifications`) also persist the provider and strip the param (Bugbot regression case)

## Testing
- `npm run test:unit` — 179/179 pass (rebased onto latest `main`)
- `npx tsc --noEmit` — passes
- `npm run build` — passes
- Playwright verification script (11/11 checks incl. subroute landing) + manual GUI demo on local dev server — see video above
- CI on latest commit (`56bda3a`): all checks green (build, e2e web smoke/critical/auth-db, e2e mobile ×3, e2e-policy, CodeRabbit, Vercel)

## Notes
- Real Google/Apple OAuth round-trips can't run in this environment (no provider credentials); the server-side threading is covered by code review + unit-tested allowlisting, and the client pipeline was exercised end-to-end from the redirect param onward.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c5e353e-cf7a-4279-81f0-02c2be389e40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c5e353e-cf7a-4279-81f0-02c2be389e40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added “last used” badges on the login screen’s Google and Apple OAuth buttons.
  * The app now remembers the last successful OAuth provider and automatically highlights it for faster access.

* **Other Updates**
  * The OAuth completion flow now preserves the successful provider and stores it on the client for future logins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->