### PR TITLE
feat(auth): Apple server-to-server notification endpoint

### DIFF
--- a/docs/mobile-oauth-integration.md
+++ b/docs/mobile-oauth-integration.md
@@ -49,9 +49,58 @@ The native client targets `https://still-point.me` by default (`APIClient`). Poi
 
 ---
 
+## Apple server-to-server notifications (#338)
+
+Apple notifies us when a user's relationship with Sign in with Apple changes outside the app: Apple ID deleted, consent revoked, or Hide My Email forwarding toggled.
+
+### Endpoint
+
+`POST /api/auth/apple/notifications`
+
+Public route — Apple's servers post here with no `sp_token`; middleware allows the path and the route authenticates the request by verifying the Apple-signed JWT itself.
+
+### Request body and verification
+
+Apple sends `{"payload": "<JWS>"}`. The route verifies the JWT via `src/lib/apple-auth.ts`:
+
+1. Signature against Apple's JWKS (`https://appleid.apple.com/auth/keys`, `jose` remote key set).
+2. Issuer `https://appleid.apple.com`.
+3. Audience must be one of our client IDs: the App ID bundle identifier (`AUTH_APPLE_IOS_AUDIENCE`, default `com.brettonauerbach.stillpoint` — notifications are configured on the App ID) or the web Services ID (`AUTH_APPLE_ID`).
+
+Requests that fail JWT verification return **401** and are not processed — they are not from Apple (or the audience is misconfigured, which should fail loudly rather than be silently swallowed). The JWT's `events` claim is a JSON string holding one event: `{ "type", "sub", "event_time", … }`.
+
+### Event handling (`src/lib/apple-notifications.ts`)
+
+| `events.type` | Action |
+| --- | --- |
+| `account-delete` / `account-deleted` | Deletes the app account via the **same transactional path as in-app deletion (#158)** — `deleteUserAccount()` cascades user data and writes `account_deletion_log`. (Apple's reference documents `account-deleted`; both spellings are accepted.) |
+| `consent-revoked` | Deletes the `oauth_accounts` Apple link so the next sign-in requires fresh consent. Active sessions are stateless `sp_token` JWTs that age out at the 7-day expiry; a token blocklist is explicitly out of scope. |
+| `email-disabled` | Sets `users.email_deliverable = false` — outbound mail to the (relay) address will bounce. |
+| `email-enabled` | Sets `users.email_deliverable = true`. |
+| anything else | Logged with `action_taken = ignored_unknown_event_type`, no state change. |
+
+**Idempotency:** every handler tolerates already-processed state (user already deleted, link already removed, flag already set), so the same notification posted twice produces the same end state. Apple does **not** document retry or delivery-guarantee semantics for these notifications — processing failures therefore return 500 **and** are logged (`console.error` → Vercel logs) for manual follow-up; if Apple or an operator redelivers, the idempotent handlers make that safe.
+
+**Audit log:** every verified notification — including duplicates and unknown types — appends a row to `apple_notification_log` (event type, Apple `sub`, Apple event time, JWT `jti`, affected user id, action taken, received time).
+
+### Operator setup (one-time, Apple Developer console)
+
+1. [developer.apple.com](https://developer.apple.com/account) → **Certificates, Identifiers & Profiles → Identifiers** → App ID `com.brettonauerbach.stillpoint`.
+2. **Sign in with Apple → Edit** → set **Server-to-Server Notification Endpoint** to `https://still-point.me/api/auth/apple/notifications` → Save.
+
+Notifications for the whole App ID group (including the web Services ID flow) are delivered to this endpoint.
+
+### End-to-end verification
+
+On a device signed in with Apple: **Settings → [your name] → Sign-In & Security → Sign in with Apple → Still Point → Stop Using Apple ID** (or [account.apple.com](https://account.apple.com) → Sign-In and Security). Within ~30s expect:
+
+- a `consent-revoked` row in `apple_notification_log` with `action_taken = apple_link_removed`, and the user's `oauth_accounts` Apple row gone;
+- for an Apple ID **account deletion**, an `account-delete`/`account-deleted` row with `action_taken = account_deleted`, the `users` row gone, and an `account_deletion_log` entry.
+
+---
+
 ## Follow-up work (not shipped here)
 
-- **#338** — Server-to-server Apple notifications (account deleted, consent revoked, email disabled).
 - **#339** — Register outbound email sources for Apple Private Email Relay deliverability.
 
 ---

--- a/docs/mobile-oauth-integration.md
+++ b/docs/mobile-oauth-integration.md
@@ -81,7 +81,9 @@ Requests that fail JWT verification return **401** and are not processed — the
 
 **Idempotency:** every handler tolerates already-processed state (user already deleted, link already removed, flag already set), so the same notification posted twice produces the same end state. Apple does **not** document retry or delivery-guarantee semantics for these notifications — processing failures therefore return 500 **and** are logged (`console.error` → Vercel logs) for manual follow-up; if Apple or an operator redelivers, the idempotent handlers make that safe.
 
-**Audit log:** every verified notification — including duplicates and unknown types — appends a row to `apple_notification_log` (event type, Apple `sub`, Apple event time, JWT `jti`, affected user id, action taken, received time).
+**Audit log:** every verified notification — including duplicates and unknown types — appends a row to `apple_notification_log` (event type, Apple `sub`, Apple event time, JWT `jti`, affected user id, action taken, received time). Logging is two-phase: the row is written as `received` **before** the handler runs, then finalized with the outcome (`account_deleted`, `noop_*`, `processing_failed`, …), so a mid-handling crash can never lose the receipt.
+
+**Event ordering:** Apple commonly sends `consent-revoked` immediately before `account-delete`. Since `consent-revoked` removes the `oauth_accounts` link, user resolution falls back to the most recent `apple_notification_log` row for the same `sub`, so the follow-up `account-delete` still finds and deletes the account. Events are otherwise applied last-write-wins — a deliberate tradeoff for these low-stakes flags (no per-subject ordering ledger); `event_time` is kept in the audit log for forensic reconstruction.
 
 ### Operator setup (one-time, Apple Developer console)
 

--- a/drizzle/apple_notification_log_incremental.sql
+++ b/drizzle/apple_notification_log_incremental.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS "apple_notification_log" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "event_type" varchar(50) NOT NULL,
+  "subject" varchar(255) NOT NULL,
+  "event_time" timestamp with time zone,
+  "jti" varchar(255),
+  "user_id" uuid,
+  "action_taken" varchar(64) NOT NULL,
+  "received_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "idx_apple_notification_log_subject"
+  ON "apple_notification_log" ("subject");
+
+CREATE INDEX IF NOT EXISTS "idx_apple_notification_log_user"
+  ON "apple_notification_log" ("user_id");

--- a/drizzle/users_email_deliverable_incremental.sql
+++ b/drizzle/users_email_deliverable_incremental.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "email_deliverable" boolean DEFAULT true NOT NULL;

--- a/src/app/api/auth/apple/notifications/route.test.ts
+++ b/src/app/api/auth/apple/notifications/route.test.ts
@@ -1,10 +1,16 @@
 import type { NextRequest } from "next/server";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-const { verifyAppleJwt, handleAppleNotificationEvent, logAppleNotification } = vi.hoisted(() => ({
+const {
+  verifyAppleJwt,
+  handleAppleNotificationEvent,
+  recordAppleNotificationReceipt,
+  finalizeAppleNotificationLog,
+} = vi.hoisted(() => ({
   verifyAppleJwt: vi.fn(),
   handleAppleNotificationEvent: vi.fn(),
-  logAppleNotification: vi.fn(),
+  recordAppleNotificationReceipt: vi.fn(),
+  finalizeAppleNotificationLog: vi.fn(),
 }));
 
 vi.mock("@/lib/apple-auth", () => ({
@@ -16,7 +22,8 @@ vi.mock("@/lib/apple-notifications", async (importOriginal) => {
   return {
     ...actual,
     handleAppleNotificationEvent,
-    logAppleNotification,
+    recordAppleNotificationReceipt,
+    finalizeAppleNotificationLog,
   };
 });
 
@@ -42,29 +49,32 @@ beforeEach(() => {
     actionTaken: "account_deleted",
     userId: "user-uuid-1",
   });
-  logAppleNotification.mockResolvedValue(undefined);
+  recordAppleNotificationReceipt.mockResolvedValue("log-uuid-1");
+  finalizeAppleNotificationLog.mockResolvedValue(undefined);
 });
 
 describe("POST /api/auth/apple/notifications", () => {
-  test("processes a verified notification and writes the audit log", async () => {
+  test("records a receipt, handles the event, and finalizes the audit row", async () => {
     const { POST } = await import("./route");
 
     const res = await POST(requestWithBody({ payload: "header.payload.sig" }));
 
     expect(res.status).toBe(200);
     expect(verifyAppleJwt).toHaveBeenCalledWith("header.payload.sig");
+    expect(recordAppleNotificationReceipt).toHaveBeenCalledWith({
+      eventType: "account-delete",
+      subject: "apple-sub-1",
+      eventTime: 1_718_000_000_000,
+      jti: "jti-abc",
+    });
     expect(handleAppleNotificationEvent).toHaveBeenCalledWith({
       type: "account-delete",
       sub: "apple-sub-1",
       event_time: 1_718_000_000_000,
     });
-    expect(logAppleNotification).toHaveBeenCalledWith({
-      eventType: "account-delete",
-      subject: "apple-sub-1",
-      eventTime: 1_718_000_000_000,
-      jti: "jti-abc",
-      userId: "user-uuid-1",
+    expect(finalizeAppleNotificationLog).toHaveBeenCalledWith("log-uuid-1", {
       actionTaken: "account_deleted",
+      userId: "user-uuid-1",
     });
   });
 
@@ -89,15 +99,15 @@ describe("POST /api/auth/apple/notifications", () => {
     expect(verifyAppleJwt).not.toHaveBeenCalled();
   });
 
-  test("returns 401 when JWT verification fails and never touches handlers", async () => {
+  test("returns 401 when JWT verification fails and never touches handlers or the log", async () => {
     verifyAppleJwt.mockRejectedValue(new Error("signature verification failed"));
     const { POST } = await import("./route");
 
     const res = await POST(requestWithBody({ payload: "forged.jwt.token" }));
 
     expect(res.status).toBe(401);
+    expect(recordAppleNotificationReceipt).not.toHaveBeenCalled();
     expect(handleAppleNotificationEvent).not.toHaveBeenCalled();
-    expect(logAppleNotification).not.toHaveBeenCalled();
   });
 
   test("returns 400 when the events claim is malformed", async () => {
@@ -107,17 +117,32 @@ describe("POST /api/auth/apple/notifications", () => {
     const res = await POST(requestWithBody({ payload: "tok" }));
 
     expect(res.status).toBe(400);
+    expect(recordAppleNotificationReceipt).not.toHaveBeenCalled();
     expect(handleAppleNotificationEvent).not.toHaveBeenCalled();
   });
 
-  test("returns 500 when handling fails so Apple retries", async () => {
+  test("returns 500 before side effects when the audit receipt cannot be written", async () => {
+    recordAppleNotificationReceipt.mockRejectedValue(new Error("db down"));
+    const { POST } = await import("./route");
+
+    const res = await POST(requestWithBody({ payload: "tok" }));
+
+    expect(res.status).toBe(500);
+    expect(handleAppleNotificationEvent).not.toHaveBeenCalled();
+    expect(finalizeAppleNotificationLog).not.toHaveBeenCalled();
+  });
+
+  test("returns 500 and finalizes the row as processing_failed when handling fails", async () => {
     handleAppleNotificationEvent.mockRejectedValue(new Error("db down"));
     const { POST } = await import("./route");
 
     const res = await POST(requestWithBody({ payload: "tok" }));
 
     expect(res.status).toBe(500);
-    expect(logAppleNotification).not.toHaveBeenCalled();
+    expect(finalizeAppleNotificationLog).toHaveBeenCalledWith("log-uuid-1", {
+      actionTaken: "processing_failed",
+      userId: null,
+    });
   });
 
   test("duplicate deliveries still return 200 and are audited", async () => {
@@ -130,7 +155,9 @@ describe("POST /api/auth/apple/notifications", () => {
     const res = await POST(requestWithBody({ payload: "tok" }));
 
     expect(res.status).toBe(200);
-    expect(logAppleNotification).toHaveBeenCalledWith(
+    expect(recordAppleNotificationReceipt).toHaveBeenCalled();
+    expect(finalizeAppleNotificationLog).toHaveBeenCalledWith(
+      "log-uuid-1",
       expect.objectContaining({ actionTaken: "noop_user_not_found", userId: null }),
     );
   });

--- a/src/app/api/auth/apple/notifications/route.test.ts
+++ b/src/app/api/auth/apple/notifications/route.test.ts
@@ -1,0 +1,137 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const { verifyAppleJwt, handleAppleNotificationEvent, logAppleNotification } = vi.hoisted(() => ({
+  verifyAppleJwt: vi.fn(),
+  handleAppleNotificationEvent: vi.fn(),
+  logAppleNotification: vi.fn(),
+}));
+
+vi.mock("@/lib/apple-auth", () => ({
+  verifyAppleJwt,
+}));
+
+vi.mock("@/lib/apple-notifications", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/apple-notifications")>();
+  return {
+    ...actual,
+    handleAppleNotificationEvent,
+    logAppleNotification,
+  };
+});
+
+function requestWithBody(body: unknown): NextRequest {
+  return { json: async () => body } as unknown as NextRequest;
+}
+
+const VALID_CLAIMS = {
+  iss: "https://appleid.apple.com",
+  aud: "com.brettonauerbach.stillpoint",
+  jti: "jti-abc",
+  events: JSON.stringify({
+    type: "account-delete",
+    sub: "apple-sub-1",
+    event_time: 1_718_000_000_000,
+  }),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  verifyAppleJwt.mockResolvedValue(VALID_CLAIMS);
+  handleAppleNotificationEvent.mockResolvedValue({
+    actionTaken: "account_deleted",
+    userId: "user-uuid-1",
+  });
+  logAppleNotification.mockResolvedValue(undefined);
+});
+
+describe("POST /api/auth/apple/notifications", () => {
+  test("processes a verified notification and writes the audit log", async () => {
+    const { POST } = await import("./route");
+
+    const res = await POST(requestWithBody({ payload: "header.payload.sig" }));
+
+    expect(res.status).toBe(200);
+    expect(verifyAppleJwt).toHaveBeenCalledWith("header.payload.sig");
+    expect(handleAppleNotificationEvent).toHaveBeenCalledWith({
+      type: "account-delete",
+      sub: "apple-sub-1",
+      event_time: 1_718_000_000_000,
+    });
+    expect(logAppleNotification).toHaveBeenCalledWith({
+      eventType: "account-delete",
+      subject: "apple-sub-1",
+      eventTime: 1_718_000_000_000,
+      jti: "jti-abc",
+      userId: "user-uuid-1",
+      actionTaken: "account_deleted",
+    });
+  });
+
+  test("returns 400 on unparseable JSON body", async () => {
+    const { POST } = await import("./route");
+    const req = {
+      json: async () => {
+        throw new Error("bad json");
+      },
+    } as unknown as NextRequest;
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect(verifyAppleJwt).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when payload is missing or not a string", async () => {
+    const { POST } = await import("./route");
+
+    expect((await POST(requestWithBody({}))).status).toBe(400);
+    expect((await POST(requestWithBody({ payload: 42 }))).status).toBe(400);
+    expect(verifyAppleJwt).not.toHaveBeenCalled();
+  });
+
+  test("returns 401 when JWT verification fails and never touches handlers", async () => {
+    verifyAppleJwt.mockRejectedValue(new Error("signature verification failed"));
+    const { POST } = await import("./route");
+
+    const res = await POST(requestWithBody({ payload: "forged.jwt.token" }));
+
+    expect(res.status).toBe(401);
+    expect(handleAppleNotificationEvent).not.toHaveBeenCalled();
+    expect(logAppleNotification).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when the events claim is malformed", async () => {
+    verifyAppleJwt.mockResolvedValue({ ...VALID_CLAIMS, events: "{{not-json" });
+    const { POST } = await import("./route");
+
+    const res = await POST(requestWithBody({ payload: "tok" }));
+
+    expect(res.status).toBe(400);
+    expect(handleAppleNotificationEvent).not.toHaveBeenCalled();
+  });
+
+  test("returns 500 when handling fails so Apple retries", async () => {
+    handleAppleNotificationEvent.mockRejectedValue(new Error("db down"));
+    const { POST } = await import("./route");
+
+    const res = await POST(requestWithBody({ payload: "tok" }));
+
+    expect(res.status).toBe(500);
+    expect(logAppleNotification).not.toHaveBeenCalled();
+  });
+
+  test("duplicate deliveries still return 200 and are audited", async () => {
+    handleAppleNotificationEvent.mockResolvedValue({
+      actionTaken: "noop_user_not_found",
+      userId: null,
+    });
+    const { POST } = await import("./route");
+
+    const res = await POST(requestWithBody({ payload: "tok" }));
+
+    expect(res.status).toBe(200);
+    expect(logAppleNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ actionTaken: "noop_user_not_found", userId: null }),
+    );
+  });
+});

--- a/src/app/api/auth/apple/notifications/route.ts
+++ b/src/app/api/auth/apple/notifications/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAppleJwt } from "@/lib/apple-auth";
 import {
+  finalizeAppleNotificationLog,
   handleAppleNotificationEvent,
-  logAppleNotification,
   parseAppleEventsClaim,
+  recordAppleNotificationReceipt,
 } from "@/lib/apple-notifications";
 
 /**
@@ -39,22 +40,37 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid events claim" }, { status: 400 });
   }
 
+  // Receipt first: the audit row exists before any side effect runs, so a
+  // mid-handling crash can never lose the record of a received notification.
+  let logId: string;
   try {
-    const result = await handleAppleNotificationEvent(event);
-    await logAppleNotification({
+    logId = await recordAppleNotificationReceipt({
       eventType: event.type,
       subject: event.sub,
       eventTime: event.event_time,
       jti: typeof claims.jti === "string" ? claims.jti : undefined,
-      userId: result.userId,
-      actionTaken: result.actionTaken,
     });
+  } catch (error) {
+    // Nothing has been applied yet — a redelivery starts clean.
+    console.error("apple notifications: audit receipt failed:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+
+  try {
+    const result = await handleAppleNotificationEvent(event);
+    await finalizeAppleNotificationLog(logId, result);
     return NextResponse.json({ received: true });
   } catch (error) {
     // Apple does not document retry semantics for these notifications, so the
     // 500 may be final — log loudly for manual follow-up. If Apple (or an
     // operator) redelivers, the idempotent handlers make that safe.
     console.error("apple notifications: processing failed:", error);
+    await finalizeAppleNotificationLog(logId, {
+      actionTaken: "processing_failed",
+      userId: null,
+    }).catch((finalizeError) => {
+      console.error("apple notifications: failed to finalize audit row:", finalizeError);
+    });
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/src/app/api/auth/apple/notifications/route.ts
+++ b/src/app/api/auth/apple/notifications/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyAppleJwt } from "@/lib/apple-auth";
+import {
+  handleAppleNotificationEvent,
+  logAppleNotification,
+  parseAppleEventsClaim,
+} from "@/lib/apple-notifications";
+
+/**
+ * Sign in with Apple server-to-server notifications (#338).
+ *
+ * Apple POSTs `{"payload": "<JWS>"}` when a user deletes their Apple ID,
+ * revokes consent, or toggles Hide My Email forwarding. The endpoint is on the
+ * middleware public list — the Apple-signed JWT (verified against Apple's JWKS
+ * with issuer + audience checks) is the authentication.
+ */
+export async function POST(request: NextRequest) {
+  let body: { payload?: unknown };
+  try {
+    body = (await request.json()) as { payload?: unknown };
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const payload = typeof body?.payload === "string" ? body.payload : "";
+  if (!payload) {
+    return NextResponse.json({ error: "payload required" }, { status: 400 });
+  }
+
+  let claims;
+  try {
+    claims = await verifyAppleJwt(payload);
+  } catch {
+    return NextResponse.json({ error: "Invalid notification token" }, { status: 401 });
+  }
+
+  const event = parseAppleEventsClaim(claims.events);
+  if (!event) {
+    return NextResponse.json({ error: "Invalid events claim" }, { status: 400 });
+  }
+
+  try {
+    const result = await handleAppleNotificationEvent(event);
+    await logAppleNotification({
+      eventType: event.type,
+      subject: event.sub,
+      eventTime: event.event_time,
+      jti: typeof claims.jti === "string" ? claims.jti : undefined,
+      userId: result.userId,
+      actionTaken: result.actionTaken,
+    });
+    return NextResponse.json({ received: true });
+  } catch (error) {
+    // Apple does not document retry semantics for these notifications, so the
+    // 500 may be final — log loudly for manual follow-up. If Apple (or an
+    // operator) redelivers, the idempotent handlers make that safe.
+    console.error("apple notifications: processing failed:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -150,6 +150,8 @@ export const appleNotificationLog = pgTable("apple_notification_log", {
   jti: varchar("jti", { length: 255 }),
   /** Affected app user when the Apple `sub` resolved to one. */
   userId: uuid("user_id"),
+  /** Two-phase: rows start as "received", then are finalized with the handler
+   *  outcome (account_deleted, apple_link_removed, noop_*, processing_failed, …). */
   actionTaken: varchar("action_taken", { length: 64 }).notNull(),
   receivedAt: timestamp("received_at", { withTimezone: true }).defaultNow().notNull(),
 }, (table) => ({

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -25,6 +25,9 @@ export const users = pgTable("users", {
   /** Nullable: OAuth-only accounts (#136) never have a password. */
   passwordHash: varchar("password_hash", { length: 255 }),
   isPublic: boolean("is_public").default(false).notNull(),
+  /** #338: flipped by Apple `email-disabled` / `email-enabled` relay notifications.
+   *  False means mail to this address (private relay) will bounce. */
+  emailDeliverable: boolean("email_deliverable").default(true).notNull(),
   currentDay: integer("current_day").default(1).notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
@@ -130,6 +133,28 @@ export const accountDeletionLog = pgTable("account_deletion_log", {
 }, (table) => ({
   emailHashIdx: index("idx_account_deletion_log_email_hash").on(table.emailHash),
   userIdx: index("idx_account_deletion_log_user").on(table.userId),
+}));
+
+/** #338: Audit log for Sign in with Apple server-to-server notifications.
+ *  One row per verified notification received, including repeat deliveries.
+ *  `user_id` has no FK so rows survive account deletion (same as account_deletion_log). */
+export const appleNotificationLog = pgTable("apple_notification_log", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  /** account-delete(d) | consent-revoked | email-disabled | email-enabled; unknown types are logged too. */
+  eventType: varchar("event_type", { length: 50 }).notNull(),
+  /** Apple `sub` of the affected Apple ID. */
+  subject: varchar("subject", { length: 255 }).notNull(),
+  /** Apple-reported event time (`events.event_time`, ms epoch). */
+  eventTime: timestamp("event_time", { withTimezone: true }),
+  /** JWT `jti` claim — correlates retried deliveries of the same notification. */
+  jti: varchar("jti", { length: 255 }),
+  /** Affected app user when the Apple `sub` resolved to one. */
+  userId: uuid("user_id"),
+  actionTaken: varchar("action_taken", { length: 64 }).notNull(),
+  receivedAt: timestamp("received_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  subjectIdx: index("idx_apple_notification_log_subject").on(table.subject),
+  userIdx: index("idx_apple_notification_log_user").on(table.userId),
 }));
 
 /** OAuth provider identities linked to a user (#136).

--- a/src/lib/apple-auth.test.ts
+++ b/src/lib/apple-auth.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { vi } from "vitest";
+import {
+  SignJWT,
+  createLocalJWKSet,
+  exportJWK,
+  generateKeyPair,
+  type JWTVerifyGetKey,
+} from "jose";
+import { APPLE_ISSUER, appleAudiences, verifyAppleJwt } from "./apple-auth";
+
+const BUNDLE_ID = "com.brettonauerbach.stillpoint";
+const TEST_KID = "test-key-1";
+
+async function makeAppleLikeKeys(): Promise<{
+  privateKey: CryptoKey;
+  jwks: JWTVerifyGetKey;
+}> {
+  const { publicKey, privateKey } = await generateKeyPair("ES256");
+  const jwk = await exportJWK(publicKey);
+  jwk.kid = TEST_KID;
+  jwk.alg = "ES256";
+  return { privateKey, jwks: createLocalJWKSet({ keys: [jwk] }) };
+}
+
+function signNotificationJwt(
+  privateKey: CryptoKey,
+  { issuer = APPLE_ISSUER, audience = BUNDLE_ID }: { issuer?: string; audience?: string } = {},
+): Promise<string> {
+  return new SignJWT({
+    events: JSON.stringify({
+      type: "email-disabled",
+      sub: "apple-sub-1",
+      event_time: 1_718_000_000_000,
+    }),
+  })
+    .setProtectedHeader({ alg: "ES256", kid: TEST_KID })
+    .setIssuer(issuer)
+    .setAudience(audience)
+    .setIssuedAt()
+    .setJti("jti-abc")
+    .sign(privateKey);
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("verifyAppleJwt", () => {
+  test("accepts a correctly signed JWT with Apple issuer and bundle-id audience", async () => {
+    const { privateKey, jwks } = await makeAppleLikeKeys();
+    const token = await signNotificationJwt(privateKey);
+
+    const payload = await verifyAppleJwt(token, { jwks });
+
+    expect(payload.iss).toBe(APPLE_ISSUER);
+    expect(payload.aud).toBe(BUNDLE_ID);
+    expect(payload.jti).toBe("jti-abc");
+    expect(typeof payload.events).toBe("string");
+  });
+
+  test("rejects a JWT signed by a different key (bad signature)", async () => {
+    const { jwks } = await makeAppleLikeKeys();
+    const { privateKey: otherPrivateKey } = await makeAppleLikeKeys();
+    const token = await signNotificationJwt(otherPrivateKey);
+
+    await expect(verifyAppleJwt(token, { jwks })).rejects.toThrow();
+  });
+
+  test("rejects a JWT with the wrong issuer", async () => {
+    const { privateKey, jwks } = await makeAppleLikeKeys();
+    const token = await signNotificationJwt(privateKey, { issuer: "https://evil.example.com" });
+
+    await expect(verifyAppleJwt(token, { jwks })).rejects.toThrow();
+  });
+
+  test("rejects a JWT with the wrong audience", async () => {
+    const { privateKey, jwks } = await makeAppleLikeKeys();
+    const token = await signNotificationJwt(privateKey, { audience: "com.someone.else" });
+
+    await expect(verifyAppleJwt(token, { jwks })).rejects.toThrow();
+  });
+
+  test("rejects a tampered JWT body", async () => {
+    const { privateKey, jwks } = await makeAppleLikeKeys();
+    const token = await signNotificationJwt(privateKey);
+    const [header, payload, signature] = token.split(".");
+    const forged = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+    forged.events = JSON.stringify({ type: "account-delete", sub: "attacker-sub" });
+    const tampered = [
+      header,
+      Buffer.from(JSON.stringify(forged)).toString("base64url"),
+      signature,
+    ].join(".");
+
+    await expect(verifyAppleJwt(tampered, { jwks })).rejects.toThrow();
+  });
+
+  test("accepts the web Services ID audience when AUTH_APPLE_ID is set", async () => {
+    vi.stubEnv("AUTH_APPLE_ID", "me.still-point.web");
+    const { privateKey, jwks } = await makeAppleLikeKeys();
+    const token = await signNotificationJwt(privateKey, { audience: "me.still-point.web" });
+
+    const payload = await verifyAppleJwt(token, { jwks });
+    expect(payload.aud).toBe("me.still-point.web");
+  });
+});
+
+describe("appleAudiences", () => {
+  test("defaults to the iOS bundle id", () => {
+    vi.stubEnv("AUTH_APPLE_ID", "");
+    expect(appleAudiences()).toEqual([BUNDLE_ID]);
+  });
+
+  test("includes AUTH_APPLE_ID and honors AUTH_APPLE_IOS_AUDIENCE override", () => {
+    vi.stubEnv("AUTH_APPLE_IOS_AUDIENCE", "com.example.alt");
+    vi.stubEnv("AUTH_APPLE_ID", "me.still-point.web");
+    expect(appleAudiences()).toEqual(["com.example.alt", "me.still-point.web"]);
+  });
+
+  test("does not duplicate when both env vars match", () => {
+    vi.stubEnv("AUTH_APPLE_IOS_AUDIENCE", "same.id");
+    vi.stubEnv("AUTH_APPLE_ID", "same.id");
+    expect(appleAudiences()).toEqual(["same.id"]);
+  });
+});

--- a/src/lib/apple-auth.ts
+++ b/src/lib/apple-auth.ts
@@ -18,8 +18,11 @@ function getAppleJwks(): JWTVerifyGetKey {
  *  (server-to-server notifications are configured on the App ID) plus the web
  *  Services ID (`AUTH_APPLE_ID`) when configured. */
 export function appleAudiences(): string[] {
-  const audiences = [process.env.AUTH_APPLE_IOS_AUDIENCE ?? "com.brettonauerbach.stillpoint"];
-  const servicesId = process.env.AUTH_APPLE_ID;
+  // Blank env values count as unset — `AUTH_APPLE_IOS_AUDIENCE=` in an env file
+  // must not make "" the only accepted audience and reject every notification.
+  const iosAudience = process.env.AUTH_APPLE_IOS_AUDIENCE?.trim();
+  const audiences = [iosAudience || "com.brettonauerbach.stillpoint"];
+  const servicesId = process.env.AUTH_APPLE_ID?.trim();
   if (servicesId && !audiences.includes(servicesId)) {
     audiences.push(servicesId);
   }

--- a/src/lib/apple-auth.ts
+++ b/src/lib/apple-auth.ts
@@ -1,0 +1,47 @@
+import { createRemoteJWKSet, jwtVerify, type JWTPayload, type JWTVerifyGetKey } from "jose";
+
+/** Issuer for every Sign in with Apple JWT (identity tokens and server-to-server notifications). */
+export const APPLE_ISSUER = "https://appleid.apple.com";
+export const APPLE_JWKS_URL = `${APPLE_ISSUER}/auth/keys`;
+
+let remoteJwks: JWTVerifyGetKey | null = null;
+
+/** Shared remote JWKS — jose caches the key set and refetches on rotation. */
+function getAppleJwks(): JWTVerifyGetKey {
+  if (!remoteJwks) {
+    remoteJwks = createRemoteJWKSet(new URL(APPLE_JWKS_URL));
+  }
+  return remoteJwks;
+}
+
+/** Client IDs Apple may use as `aud` for this app: the iOS App ID bundle identifier
+ *  (server-to-server notifications are configured on the App ID) plus the web
+ *  Services ID (`AUTH_APPLE_ID`) when configured. */
+export function appleAudiences(): string[] {
+  const audiences = [process.env.AUTH_APPLE_IOS_AUDIENCE ?? "com.brettonauerbach.stillpoint"];
+  const servicesId = process.env.AUTH_APPLE_ID;
+  if (servicesId && !audiences.includes(servicesId)) {
+    audiences.push(servicesId);
+  }
+  return audiences;
+}
+
+export type VerifyAppleJwtOptions = {
+  /** Override the accepted audiences (defaults to `appleAudiences()`). */
+  audience?: string | string[];
+  /** Test seam: local key set instead of Apple's remote JWKS. */
+  jwks?: JWTVerifyGetKey;
+};
+
+/** Verify an Apple-signed JWT — signature against Apple's JWKS, issuer, audience —
+ *  and return its payload. Throws on any verification failure. */
+export async function verifyAppleJwt(
+  token: string,
+  options: VerifyAppleJwtOptions = {},
+): Promise<JWTPayload> {
+  const { payload } = await jwtVerify(token, options.jwks ?? getAppleJwks(), {
+    issuer: APPLE_ISSUER,
+    audience: options.audience ?? appleAudiences(),
+  });
+  return payload;
+}

--- a/src/lib/apple-notifications.test.ts
+++ b/src/lib/apple-notifications.test.ts
@@ -1,32 +1,58 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const {
-  selectLimit,
+  linkLimit,
+  fallbackLimit,
   deleteReturning,
   updateSet,
   updateWhere,
+  updateReturning,
   insertValues,
+  insertReturning,
   deleteUserAccount,
 } = vi.hoisted(() => ({
-  selectLimit: vi.fn(),
+  /** select().from().where().limit() — oauth_accounts link lookup */
+  linkLimit: vi.fn(),
+  /** select().from().where().orderBy().limit() — audit-log fallback lookup */
+  fallbackLimit: vi.fn(),
   deleteReturning: vi.fn(),
   updateSet: vi.fn(),
   updateWhere: vi.fn(),
+  updateReturning: vi.fn(),
   insertValues: vi.fn(),
+  insertReturning: vi.fn(),
   deleteUserAccount: vi.fn(),
 }));
 
 vi.mock("@/db", () => ({
   db: {
-    select: () => ({ from: () => ({ where: () => ({ limit: selectLimit }) }) }),
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: linkLimit,
+          orderBy: () => ({ limit: fallbackLimit }),
+        }),
+      }),
+    }),
     delete: () => ({ where: () => ({ returning: deleteReturning }) }),
     update: () => ({
       set: (values: unknown) => {
         updateSet(values);
-        return { where: updateWhere };
+        return {
+          where: (...args: unknown[]) => {
+            updateWhere(...args);
+            const result = Promise.resolve(undefined);
+            return Object.assign(result, { returning: updateReturning });
+          },
+        };
       },
     }),
-    insert: () => ({ values: insertValues }),
+    insert: () => ({
+      values: (values: unknown) => {
+        insertValues(values);
+        return { returning: insertReturning };
+      },
+    }),
   },
 }));
 
@@ -35,17 +61,19 @@ vi.mock("@/lib/accountDeletion", () => ({
 }));
 
 import {
+  finalizeAppleNotificationLog,
   handleAppleNotificationEvent,
-  logAppleNotification,
   parseAppleEventsClaim,
+  recordAppleNotificationReceipt,
 } from "./apple-notifications";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  selectLimit.mockResolvedValue([{ userId: "user-uuid-1" }]);
+  linkLimit.mockResolvedValue([{ userId: "user-uuid-1" }]);
+  fallbackLimit.mockResolvedValue([]);
   deleteReturning.mockResolvedValue([{ id: "link-1" }]);
-  updateWhere.mockResolvedValue(undefined);
-  insertValues.mockResolvedValue(undefined);
+  updateReturning.mockResolvedValue([{ id: "user-uuid-1" }]);
+  insertReturning.mockResolvedValue([{ id: "log-uuid-1" }]);
   deleteUserAccount.mockResolvedValue(true);
 });
 
@@ -93,6 +121,17 @@ describe("handleAppleNotificationEvent", () => {
     expect(result).toEqual({ actionTaken: "account_deleted", userId: "user-uuid-1" });
   });
 
+  test("account-delete after consent-revoked still deletes via the audit-log fallback", async () => {
+    // consent-revoked removed the oauth link; the audit log still maps sub -> user.
+    linkLimit.mockResolvedValue([]);
+    fallbackLimit.mockResolvedValue([{ userId: "user-uuid-1" }]);
+
+    const result = await handleAppleNotificationEvent({ type: "account-delete", sub: "apple-sub-1" });
+
+    expect(deleteUserAccount).toHaveBeenCalledWith("user-uuid-1");
+    expect(result).toEqual({ actionTaken: "account_deleted", userId: "user-uuid-1" });
+  });
+
   test("account-delete is a noop when deleteUserAccount finds nothing", async () => {
     deleteUserAccount.mockResolvedValue(false);
     const result = await handleAppleNotificationEvent({ type: "account-delete", sub: "apple-sub-1" });
@@ -100,8 +139,9 @@ describe("handleAppleNotificationEvent", () => {
     expect(result).toEqual({ actionTaken: "noop_already_deleted", userId: "user-uuid-1" });
   });
 
-  test("account-delete with unknown sub does not call deleteUserAccount (idempotent repeat)", async () => {
-    selectLimit.mockResolvedValue([]);
+  test("account-delete with a never-seen sub does not call deleteUserAccount", async () => {
+    linkLimit.mockResolvedValue([]);
+    fallbackLimit.mockResolvedValue([]);
     const result = await handleAppleNotificationEvent({ type: "account-delete", sub: "gone-sub" });
 
     expect(deleteUserAccount).not.toHaveBeenCalled();
@@ -115,7 +155,7 @@ describe("handleAppleNotificationEvent", () => {
     expect(result).toEqual({ actionTaken: "apple_link_removed", userId: "user-uuid-1" });
   });
 
-  test("consent-revoked reports noop when the link is already gone (race)", async () => {
+  test("consent-revoked reports noop when the link is already gone", async () => {
     deleteReturning.mockResolvedValue([]);
     const result = await handleAppleNotificationEvent({ type: "consent-revoked", sub: "apple-sub-1" });
 
@@ -125,19 +165,25 @@ describe("handleAppleNotificationEvent", () => {
   test("email-disabled marks the user undeliverable", async () => {
     const result = await handleAppleNotificationEvent({ type: "email-disabled", sub: "apple-sub-1" });
 
-    expect(updateSet).toHaveBeenCalledWith(
-      expect.objectContaining({ emailDeliverable: false }),
-    );
+    expect(updateSet).toHaveBeenCalledWith(expect.objectContaining({ emailDeliverable: false }));
     expect(result).toEqual({ actionTaken: "email_marked_undeliverable", userId: "user-uuid-1" });
   });
 
   test("email-enabled marks the user deliverable again", async () => {
     const result = await handleAppleNotificationEvent({ type: "email-enabled", sub: "apple-sub-1" });
 
-    expect(updateSet).toHaveBeenCalledWith(
-      expect.objectContaining({ emailDeliverable: true }),
-    );
+    expect(updateSet).toHaveBeenCalledWith(expect.objectContaining({ emailDeliverable: true }));
     expect(result).toEqual({ actionTaken: "email_marked_deliverable", userId: "user-uuid-1" });
+  });
+
+  test("email-enabled for a fallback-resolved but deleted user is a noop", async () => {
+    linkLimit.mockResolvedValue([]);
+    fallbackLimit.mockResolvedValue([{ userId: "user-uuid-1" }]);
+    updateReturning.mockResolvedValue([]);
+
+    const result = await handleAppleNotificationEvent({ type: "email-enabled", sub: "apple-sub-1" });
+
+    expect(result).toEqual({ actionTaken: "noop_user_not_found", userId: "user-uuid-1" });
   });
 
   test("repeat email-disabled deliveries converge on the same state", async () => {
@@ -160,39 +206,64 @@ describe("handleAppleNotificationEvent", () => {
   });
 });
 
-describe("logAppleNotification", () => {
-  test("writes one audit row with event metadata", async () => {
-    await logAppleNotification({
+describe("recordAppleNotificationReceipt", () => {
+  test("inserts a received row and returns its id", async () => {
+    const id = await recordAppleNotificationReceipt({
       eventType: "consent-revoked",
       subject: "apple-sub-1",
       eventTime: 1_718_000_000_000,
       jti: "jti-abc",
-      userId: "user-uuid-1",
-      actionTaken: "apple_link_removed",
     });
 
+    expect(id).toBe("log-uuid-1");
     expect(insertValues).toHaveBeenCalledWith({
       eventType: "consent-revoked",
       subject: "apple-sub-1",
       eventTime: new Date(1_718_000_000_000),
       jti: "jti-abc",
-      userId: "user-uuid-1",
-      actionTaken: "apple_link_removed",
+      actionTaken: "received",
     });
   });
 
   test("tolerates missing event_time and jti", async () => {
-    await logAppleNotification({
+    await recordAppleNotificationReceipt({
       eventType: "email-enabled",
       subject: "apple-sub-1",
       eventTime: undefined,
       jti: undefined,
-      userId: null,
-      actionTaken: "noop_user_not_found",
     });
 
     expect(insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({ eventTime: null, jti: null, userId: null }),
+      expect.objectContaining({ eventTime: null, jti: null }),
     );
+  });
+
+  test("truncates an oversized external event type instead of failing the insert", async () => {
+    const longType = "x".repeat(80);
+    await recordAppleNotificationReceipt({
+      eventType: longType,
+      subject: "apple-sub-1",
+      eventTime: undefined,
+      jti: undefined,
+    });
+
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: "x".repeat(50) }),
+    );
+  });
+});
+
+describe("finalizeAppleNotificationLog", () => {
+  test("updates the receipt row with the handler outcome", async () => {
+    await finalizeAppleNotificationLog("log-uuid-1", {
+      actionTaken: "apple_link_removed",
+      userId: "user-uuid-1",
+    });
+
+    expect(updateSet).toHaveBeenCalledWith({
+      actionTaken: "apple_link_removed",
+      userId: "user-uuid-1",
+    });
+    expect(updateWhere).toHaveBeenCalled();
   });
 });

--- a/src/lib/apple-notifications.test.ts
+++ b/src/lib/apple-notifications.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const {
+  selectLimit,
+  deleteReturning,
+  updateSet,
+  updateWhere,
+  insertValues,
+  deleteUserAccount,
+} = vi.hoisted(() => ({
+  selectLimit: vi.fn(),
+  deleteReturning: vi.fn(),
+  updateSet: vi.fn(),
+  updateWhere: vi.fn(),
+  insertValues: vi.fn(),
+  deleteUserAccount: vi.fn(),
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    select: () => ({ from: () => ({ where: () => ({ limit: selectLimit }) }) }),
+    delete: () => ({ where: () => ({ returning: deleteReturning }) }),
+    update: () => ({
+      set: (values: unknown) => {
+        updateSet(values);
+        return { where: updateWhere };
+      },
+    }),
+    insert: () => ({ values: insertValues }),
+  },
+}));
+
+vi.mock("@/lib/accountDeletion", () => ({
+  deleteUserAccount,
+}));
+
+import {
+  handleAppleNotificationEvent,
+  logAppleNotification,
+  parseAppleEventsClaim,
+} from "./apple-notifications";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectLimit.mockResolvedValue([{ userId: "user-uuid-1" }]);
+  deleteReturning.mockResolvedValue([{ id: "link-1" }]);
+  updateWhere.mockResolvedValue(undefined);
+  insertValues.mockResolvedValue(undefined);
+  deleteUserAccount.mockResolvedValue(true);
+});
+
+describe("parseAppleEventsClaim", () => {
+  test("parses the documented JSON-string form", () => {
+    const event = parseAppleEventsClaim(
+      JSON.stringify({ type: "consent-revoked", sub: "apple-sub-1", event_time: 1_718_000_000_000 }),
+    );
+    expect(event).toEqual({
+      type: "consent-revoked",
+      sub: "apple-sub-1",
+      event_time: 1_718_000_000_000,
+    });
+  });
+
+  test("tolerates an already-decoded object", () => {
+    const event = parseAppleEventsClaim({ type: "account-delete", sub: "apple-sub-2" });
+    expect(event).toEqual({ type: "account-delete", sub: "apple-sub-2", event_time: undefined });
+  });
+
+  test.each([
+    ["not json", "{{nope"],
+    ["missing type", JSON.stringify({ sub: "s" })],
+    ["missing sub", JSON.stringify({ type: "account-delete" })],
+    ["array", JSON.stringify([{ type: "account-delete", sub: "s" }])],
+    ["null", null],
+    ["undefined", undefined],
+  ])("returns null for %s", (_label, claim) => {
+    expect(parseAppleEventsClaim(claim)).toBeNull();
+  });
+});
+
+describe("handleAppleNotificationEvent", () => {
+  test("account-delete reuses deleteUserAccount and reports account_deleted", async () => {
+    const result = await handleAppleNotificationEvent({ type: "account-delete", sub: "apple-sub-1" });
+
+    expect(deleteUserAccount).toHaveBeenCalledWith("user-uuid-1");
+    expect(result).toEqual({ actionTaken: "account_deleted", userId: "user-uuid-1" });
+  });
+
+  test("account-deleted (Apple's documented spelling) is handled identically", async () => {
+    const result = await handleAppleNotificationEvent({ type: "account-deleted", sub: "apple-sub-1" });
+
+    expect(deleteUserAccount).toHaveBeenCalledWith("user-uuid-1");
+    expect(result).toEqual({ actionTaken: "account_deleted", userId: "user-uuid-1" });
+  });
+
+  test("account-delete is a noop when deleteUserAccount finds nothing", async () => {
+    deleteUserAccount.mockResolvedValue(false);
+    const result = await handleAppleNotificationEvent({ type: "account-delete", sub: "apple-sub-1" });
+
+    expect(result).toEqual({ actionTaken: "noop_already_deleted", userId: "user-uuid-1" });
+  });
+
+  test("account-delete with unknown sub does not call deleteUserAccount (idempotent repeat)", async () => {
+    selectLimit.mockResolvedValue([]);
+    const result = await handleAppleNotificationEvent({ type: "account-delete", sub: "gone-sub" });
+
+    expect(deleteUserAccount).not.toHaveBeenCalled();
+    expect(result).toEqual({ actionTaken: "noop_user_not_found", userId: null });
+  });
+
+  test("consent-revoked deletes the apple oauth link", async () => {
+    const result = await handleAppleNotificationEvent({ type: "consent-revoked", sub: "apple-sub-1" });
+
+    expect(deleteReturning).toHaveBeenCalled();
+    expect(result).toEqual({ actionTaken: "apple_link_removed", userId: "user-uuid-1" });
+  });
+
+  test("consent-revoked reports noop when the link is already gone (race)", async () => {
+    deleteReturning.mockResolvedValue([]);
+    const result = await handleAppleNotificationEvent({ type: "consent-revoked", sub: "apple-sub-1" });
+
+    expect(result).toEqual({ actionTaken: "noop_link_already_removed", userId: "user-uuid-1" });
+  });
+
+  test("email-disabled marks the user undeliverable", async () => {
+    const result = await handleAppleNotificationEvent({ type: "email-disabled", sub: "apple-sub-1" });
+
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ emailDeliverable: false }),
+    );
+    expect(result).toEqual({ actionTaken: "email_marked_undeliverable", userId: "user-uuid-1" });
+  });
+
+  test("email-enabled marks the user deliverable again", async () => {
+    const result = await handleAppleNotificationEvent({ type: "email-enabled", sub: "apple-sub-1" });
+
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ emailDeliverable: true }),
+    );
+    expect(result).toEqual({ actionTaken: "email_marked_deliverable", userId: "user-uuid-1" });
+  });
+
+  test("repeat email-disabled deliveries converge on the same state", async () => {
+    const first = await handleAppleNotificationEvent({ type: "email-disabled", sub: "apple-sub-1" });
+    const second = await handleAppleNotificationEvent({ type: "email-disabled", sub: "apple-sub-1" });
+
+    expect(first.actionTaken).toBe("email_marked_undeliverable");
+    expect(second.actionTaken).toBe("email_marked_undeliverable");
+    expect(updateSet).toHaveBeenNthCalledWith(1, expect.objectContaining({ emailDeliverable: false }));
+    expect(updateSet).toHaveBeenNthCalledWith(2, expect.objectContaining({ emailDeliverable: false }));
+  });
+
+  test("unknown event types are ignored but reported", async () => {
+    const result = await handleAppleNotificationEvent({ type: "mystery-event", sub: "apple-sub-1" });
+
+    expect(result).toEqual({ actionTaken: "ignored_unknown_event_type", userId: "user-uuid-1" });
+    expect(deleteUserAccount).not.toHaveBeenCalled();
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(deleteReturning).not.toHaveBeenCalled();
+  });
+});
+
+describe("logAppleNotification", () => {
+  test("writes one audit row with event metadata", async () => {
+    await logAppleNotification({
+      eventType: "consent-revoked",
+      subject: "apple-sub-1",
+      eventTime: 1_718_000_000_000,
+      jti: "jti-abc",
+      userId: "user-uuid-1",
+      actionTaken: "apple_link_removed",
+    });
+
+    expect(insertValues).toHaveBeenCalledWith({
+      eventType: "consent-revoked",
+      subject: "apple-sub-1",
+      eventTime: new Date(1_718_000_000_000),
+      jti: "jti-abc",
+      userId: "user-uuid-1",
+      actionTaken: "apple_link_removed",
+    });
+  });
+
+  test("tolerates missing event_time and jti", async () => {
+    await logAppleNotification({
+      eventType: "email-enabled",
+      subject: "apple-sub-1",
+      eventTime: undefined,
+      jti: undefined,
+      userId: null,
+      actionTaken: "noop_user_not_found",
+    });
+
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ eventTime: null, jti: null, userId: null }),
+    );
+  });
+});

--- a/src/lib/apple-notifications.ts
+++ b/src/lib/apple-notifications.ts
@@ -1,0 +1,127 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db";
+import { appleNotificationLog, oauthAccounts, users } from "@/db/schema";
+import { deleteUserAccount } from "@/lib/accountDeletion";
+
+/** One event from the JWT `events` claim of an Apple server-to-server notification. */
+export type AppleNotificationEvent = {
+  type: string;
+  /** Apple `sub` of the affected Apple ID. */
+  sub: string;
+  /** ms epoch. */
+  event_time?: number;
+};
+
+/** Outcome of handling one event; persisted verbatim to `apple_notification_log.action_taken`. */
+export type AppleNotificationResult = {
+  actionTaken: string;
+  userId: string | null;
+};
+
+/** Parse the JWT `events` claim. Apple documents it as a JSON **string** holding a
+ *  single event object; an already-decoded object is tolerated. Returns null when
+ *  the claim is missing or malformed. */
+export function parseAppleEventsClaim(eventsClaim: unknown): AppleNotificationEvent | null {
+  let decoded: unknown = eventsClaim;
+  if (typeof eventsClaim === "string") {
+    try {
+      decoded = JSON.parse(eventsClaim);
+    } catch {
+      return null;
+    }
+  }
+  if (decoded === null || typeof decoded !== "object" || Array.isArray(decoded)) {
+    return null;
+  }
+  const candidate = decoded as Record<string, unknown>;
+  if (typeof candidate.type !== "string" || !candidate.type) return null;
+  if (typeof candidate.sub !== "string" || !candidate.sub) return null;
+  return {
+    type: candidate.type,
+    sub: candidate.sub,
+    event_time: typeof candidate.event_time === "number" ? candidate.event_time : undefined,
+  };
+}
+
+async function findUserIdForAppleSub(sub: string): Promise<string | null> {
+  const [link] = await db
+    .select({ userId: oauthAccounts.userId })
+    .from(oauthAccounts)
+    .where(and(eq(oauthAccounts.provider, "apple"), eq(oauthAccounts.providerAccountId, sub)))
+    .limit(1);
+  return link?.userId ?? null;
+}
+
+/** Apply one Apple notification event. Every branch is idempotent: a repeat
+ *  delivery finds the already-processed state and reports a `noop_*` action
+ *  without erroring, so Apple retries and duplicate posts converge. */
+export async function handleAppleNotificationEvent(
+  event: AppleNotificationEvent,
+): Promise<AppleNotificationResult> {
+  const userId = await findUserIdForAppleSub(event.sub);
+
+  switch (event.type) {
+    // Apple's reference documents `account-deleted`; issue #338 and several
+    // integrations in the wild use `account-delete`. Accept both spellings.
+    case "account-delete":
+    case "account-deleted": {
+      // Same transactional path as in-app deletion (#158): cascades user data and
+      // writes account_deletion_log. The oauth_accounts link cascades away, so a
+      // repeat delivery resolves no user and lands in noop_user_not_found.
+      if (!userId) return { actionTaken: "noop_user_not_found", userId: null };
+      const deleted = await deleteUserAccount(userId);
+      return { actionTaken: deleted ? "account_deleted" : "noop_already_deleted", userId };
+    }
+
+    case "consent-revoked": {
+      // Drop the Apple link so the next sign-in requires fresh consent. Active
+      // sp_token JWTs are stateless and age out at the 7-day expiry; a token
+      // blocklist is explicitly out of scope (#338).
+      if (!userId) return { actionTaken: "noop_user_not_found", userId: null };
+      const removed = await db
+        .delete(oauthAccounts)
+        .where(and(eq(oauthAccounts.provider, "apple"), eq(oauthAccounts.providerAccountId, event.sub)))
+        .returning({ id: oauthAccounts.id });
+      return {
+        actionTaken: removed.length > 0 ? "apple_link_removed" : "noop_link_already_removed",
+        userId,
+      };
+    }
+
+    case "email-disabled":
+    case "email-enabled": {
+      if (!userId) return { actionTaken: "noop_user_not_found", userId: null };
+      const deliverable = event.type === "email-enabled";
+      await db
+        .update(users)
+        .set({ emailDeliverable: deliverable, updatedAt: new Date() })
+        .where(eq(users.id, userId));
+      return {
+        actionTaken: deliverable ? "email_marked_deliverable" : "email_marked_undeliverable",
+        userId,
+      };
+    }
+
+    default:
+      return { actionTaken: "ignored_unknown_event_type", userId };
+  }
+}
+
+/** Append one row to the apple_notification_log audit table. */
+export async function logAppleNotification(params: {
+  eventType: string;
+  subject: string;
+  eventTime: number | undefined;
+  jti: string | undefined;
+  userId: string | null;
+  actionTaken: string;
+}): Promise<void> {
+  await db.insert(appleNotificationLog).values({
+    eventType: params.eventType,
+    subject: params.subject,
+    eventTime: params.eventTime !== undefined ? new Date(params.eventTime) : null,
+    jti: params.jti ?? null,
+    userId: params.userId,
+    actionTaken: params.actionTaken,
+  });
+}

--- a/src/lib/apple-notifications.ts
+++ b/src/lib/apple-notifications.ts
@@ -1,7 +1,13 @@
-import { and, eq } from "drizzle-orm";
+import { and, desc, eq, isNotNull } from "drizzle-orm";
 import { db } from "@/db";
 import { appleNotificationLog, oauthAccounts, users } from "@/db/schema";
 import { deleteUserAccount } from "@/lib/accountDeletion";
+
+/** Column widths from schema.ts — externally sourced strings are truncated to
+ *  fit so a pathological value can never turn an audit insert into a 500. */
+const EVENT_TYPE_MAX = 50;
+const SUBJECT_MAX = 255;
+const JTI_MAX = 255;
 
 /** One event from the JWT `events` claim of an Apple server-to-server notification. */
 export type AppleNotificationEvent = {
@@ -49,7 +55,20 @@ async function findUserIdForAppleSub(sub: string): Promise<string | null> {
     .from(oauthAccounts)
     .where(and(eq(oauthAccounts.provider, "apple"), eq(oauthAccounts.providerAccountId, sub)))
     .limit(1);
-  return link?.userId ?? null;
+  if (link) return link.userId;
+
+  // consent-revoked deletes the oauth link while the user remains, and Apple
+  // commonly sends consent-revoked before account-delete. Fall back to the most
+  // recent audit row that resolved this subject so later events still find the
+  // user; handlers verify current state (returning()/deleteUserAccount) so a
+  // stale row degrades to a noop_* action, never a wrong mutation.
+  const [prior] = await db
+    .select({ userId: appleNotificationLog.userId })
+    .from(appleNotificationLog)
+    .where(and(eq(appleNotificationLog.subject, sub), isNotNull(appleNotificationLog.userId)))
+    .orderBy(desc(appleNotificationLog.receivedAt))
+    .limit(1);
+  return prior?.userId ?? null;
 }
 
 /** Apply one Apple notification event. Every branch is idempotent: a repeat
@@ -92,10 +111,13 @@ export async function handleAppleNotificationEvent(
     case "email-enabled": {
       if (!userId) return { actionTaken: "noop_user_not_found", userId: null };
       const deliverable = event.type === "email-enabled";
-      await db
+      const updated = await db
         .update(users)
         .set({ emailDeliverable: deliverable, updatedAt: new Date() })
-        .where(eq(users.id, userId));
+        .where(eq(users.id, userId))
+        .returning({ id: users.id });
+      // A fallback-resolved user may have been deleted since — 0 rows is a noop.
+      if (updated.length === 0) return { actionTaken: "noop_user_not_found", userId };
       return {
         actionTaken: deliverable ? "email_marked_deliverable" : "email_marked_undeliverable",
         userId,
@@ -107,21 +129,35 @@ export async function handleAppleNotificationEvent(
   }
 }
 
-/** Append one row to the apple_notification_log audit table. */
-export async function logAppleNotification(params: {
+/** Append the audit row for a verified notification BEFORE it is handled, with
+ *  `action_taken = "received"`. Two-phase logging means a crash mid-handling can
+ *  never lose the receipt — the row is finalized with the real action afterwards. */
+export async function recordAppleNotificationReceipt(params: {
   eventType: string;
   subject: string;
   eventTime: number | undefined;
   jti: string | undefined;
-  userId: string | null;
-  actionTaken: string;
-}): Promise<void> {
-  await db.insert(appleNotificationLog).values({
-    eventType: params.eventType,
-    subject: params.subject,
-    eventTime: params.eventTime !== undefined ? new Date(params.eventTime) : null,
-    jti: params.jti ?? null,
-    userId: params.userId,
-    actionTaken: params.actionTaken,
-  });
+}): Promise<string> {
+  const [row] = await db
+    .insert(appleNotificationLog)
+    .values({
+      eventType: params.eventType.slice(0, EVENT_TYPE_MAX),
+      subject: params.subject.slice(0, SUBJECT_MAX),
+      eventTime: params.eventTime !== undefined ? new Date(params.eventTime) : null,
+      jti: params.jti !== undefined ? params.jti.slice(0, JTI_MAX) : null,
+      actionTaken: "received",
+    })
+    .returning({ id: appleNotificationLog.id });
+  return row.id;
+}
+
+/** Finalize the receipt row with the handler outcome (or `processing_failed`). */
+export async function finalizeAppleNotificationLog(
+  logId: string,
+  result: AppleNotificationResult,
+): Promise<void> {
+  await db
+    .update(appleNotificationLog)
+    .set({ actionTaken: result.actionTaken.slice(0, 64), userId: result.userId })
+    .where(eq(appleNotificationLog.id, logId));
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,6 +9,9 @@ const publicExactPaths = [
   "/api/auth/login",
   "/api/auth/logout",
   "/api/auth/apple-native",
+  // #338: Apple posts server-to-server notifications with no sp_token; the
+  // route authenticates the Apple-signed JWT itself (JWKS + iss + aud).
+  "/api/auth/apple/notifications",
   "/api/auth/google/callback",
   "/api/auth/oauth-complete",
   // Auth.js v5 catch-all routes (#136) — bare endpoints. The catch-all


### PR DESCRIPTION
## **User description**
Closes #338

## What changed

`POST /api/auth/apple/notifications` — Sign in with Apple server-to-server notifications. Apple posts `{"payload": "<JWS>"}` here when a user deletes their Apple ID, revokes consent, or toggles Hide My Email forwarding.

- **`src/lib/apple-auth.ts`** — shared Apple JWKS verification (`jose.createRemoteJWKSet`): signature, `iss https://appleid.apple.com`, `aud` ∈ {App ID bundle id (`AUTH_APPLE_IOS_AUDIENCE`, default `com.brettonauerbach.stillpoint`), web Services ID (`AUTH_APPLE_ID`)}. Test seam for a local JWKS.
- **`src/lib/apple-notifications.ts`** — event handlers, all idempotent:
  - `account-delete` / `account-deleted` → `deleteUserAccount()` — same transactional path as in-app deletion (#158); writes both `account_deletion_log` and the new Apple notification log. (Apple's reference documents `account-deleted`; the issue says `account-delete` — both accepted.)
  - `consent-revoked` → deletes the `oauth_accounts` apple link so re-auth requires fresh consent. Active sessions are stateless 7-day `sp_token` JWTs; token blocklist explicitly out of scope per the plan.
  - `email-disabled` / `email-enabled` → `users.email_deliverable` flag (new column, default true).
- **Schema/migrations** — `apple_notification_log` audit table (no user FK so rows survive deletion, like `account_deletion_log`) + `users.email_deliverable`; two NEW idempotent `*_incremental.sql` files, no historical edits.
- **Middleware** — endpoint added to the public list; the verified Apple JWT is the authentication.
- **Docs** — `docs/mobile-oauth-integration.md`: verification, event table, idempotency, audit log, console setup, e2e steps.

## Why

Apple requires apps to honor account-state changes made outside the app (App Review + privacy). Without this, Apple-side deletions/revocations leave dangling Still Point accounts.

## Notes for review

- Apple does **not** document retry/status-code semantics for these notifications (verified against the SIWA reference). Processing failures return 500 + `console.error` (Vercel logs) for manual follow-up; redelivery is safe because handlers are idempotent.
- `apple-native/route.ts` keeps its inline JWKS verify — deliberately not refactored onto `apple-auth.ts` here to keep this diff focused on a shipped, tested auth path; trivial follow-up if wanted.
- Audit log intentionally appends one row per delivery (including duplicates/unknown types) — AC asks for *every received* notification.

## Test plan

- [x] `POST /api/auth/apple/notifications` verifies Apple-signed JWT against Apple JWKS; bad signature/iss/aud rejected (unit-tested: `src/lib/apple-auth.test.ts`, incl. tampered-body case)
- [x] `account-delete`(`d`) deletes the user via the same code path as in-app deletion (#158)
- [x] `consent-revoked` invalidates the user's active sessions (apple link removed; stateless JWTs age out ≤7d — no blocklist by design)
- [x] `email-disabled` / `email-enabled` update `users.email_deliverable`
- [x] Idempotent — same notification posted twice produces the same end state (unit-tested)
- [x] Audit log records every received notification (event type, timestamp, JWT subject, action taken)
- [x] Unit suite green for new files — `npm run test:unit` (NOT in CI; run locally: 36/36 pass)
- [x] Documented in `docs/mobile-oauth-integration.md`
- [ ] 👤 OPERATOR: Apple Developer console — set Server-to-Server Notification Endpoint `https://still-point.me/api/auth/apple/notifications` on App ID `com.brettonauerbach.stillpoint` (steps in docs)
- [ ] 👤 OPERATOR: e2e — Apple-side account deletion reflected in Still Point within ~30s (requires console config above + physical device)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Handle Apple account, consent, and email relay notifications**

### What Changed
- Added a public Apple notification endpoint that accepts Apple-signed server-to-server messages and rejects unsigned, malformed, or unverified requests.
- When Apple reports account deletion, consent revocation, or Hide My Email changes, the app now deletes the account, removes the Apple sign-in link, or updates email deliverability status.
- Every verified notification is saved in an audit log, including repeat deliveries and unknown event types, so Apple-driven changes can be traced later.
- Added setup and verification guidance for configuring the Apple notification endpoint and checking the expected results.

### Impact
`✅ Apple account deletions take effect outside the app`
`✅ Fewer missed consent changes after Apple sign-in`
`✅ Clearer handling of private relay email bounces`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

