### PR TITLE
fix(tests): resolve tsc --noEmit errors in signup route and email unit tests

### DIFF
--- a/src/app/api/auth/signup/route.test.ts
+++ b/src/app/api/auth/signup/route.test.ts
@@ -2,7 +2,7 @@ import type { NextRequest } from "next/server";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const selectLimit = vi.fn();
-const selectWhere = vi.fn(() => ({ limit: selectLimit }));
+const selectWhere = vi.fn((_predicate: unknown) => ({ limit: selectLimit }));
 const selectFrom = vi.fn(() => ({ where: selectWhere }));
 const dbSelect = vi.fn(() => ({ from: selectFrom }));
 

--- a/src/lib/email.test.ts
+++ b/src/lib/email.test.ts
@@ -5,42 +5,40 @@ vi.mock("server-only", () => ({}));
 import { passwordResetAppBaseUrl } from "./email";
 
 describe("passwordResetAppBaseUrl", () => {
-  const env = { ...process.env };
-
   beforeEach(() => {
-    delete process.env.NEXT_PUBLIC_APP_URL;
-    delete process.env.VERCEL_ENV;
-    delete process.env.VERCEL_URL;
-    process.env.NODE_ENV = "test";
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", undefined);
+    vi.stubEnv("VERCEL_ENV", undefined);
+    vi.stubEnv("VERCEL_URL", undefined);
+    vi.stubEnv("NODE_ENV", "test");
   });
 
   afterEach(() => {
-    process.env = { ...env };
+    vi.unstubAllEnvs();
   });
 
   it("uses explicit NEXT_PUBLIC_APP_URL when set", () => {
-    process.env.NEXT_PUBLIC_APP_URL = "https://custom.example";
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://custom.example");
     expect(passwordResetAppBaseUrl()).toBe("https://custom.example");
   });
 
   it("uses still-point.me on Vercel production when unset", () => {
-    process.env.VERCEL_ENV = "production";
+    vi.stubEnv("VERCEL_ENV", "production");
     expect(passwordResetAppBaseUrl()).toBe("https://still-point.me");
   });
 
   it("uses VERCEL_URL on preview when unset", () => {
-    process.env.VERCEL_ENV = "preview";
-    process.env.VERCEL_URL = "my-app-git-branch.vercel.app";
+    vi.stubEnv("VERCEL_ENV", "preview");
+    vi.stubEnv("VERCEL_URL", "my-app-git-branch.vercel.app");
     expect(passwordResetAppBaseUrl()).toBe("https://my-app-git-branch.vercel.app");
   });
 
   it("uses localhost in non-production without Vercel", () => {
-    process.env.NODE_ENV = "development";
+    vi.stubEnv("NODE_ENV", "development");
     expect(passwordResetAppBaseUrl()).toBe("http://127.0.0.1:3000");
   });
 
   it("uses still-point.me in production without Vercel", () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     expect(passwordResetAppBaseUrl()).toBe("https://still-point.me");
   });
 });


### PR DESCRIPTION
## Summary

Fixes the 5 pre-existing `npx tsc --noEmit` errors in test files (vitest tolerated them; tsc did not; CI's `next build` doesn't typecheck test files, so nothing caught them). Test code only — no production source changes, no `@ts-ignore` / `@ts-expect-error` / lint suppressions.

- **`src/app/api/auth/signup/route.test.ts`** — the `selectWhere` mock was declared with no parameters, so vitest typed `mock.calls[1]` as the empty tuple `[]`: indexing `[0]` was TS2493, and asserting the resulting `undefined` to `{ kind?: string }` was TS2352. The mock now declares the single predicate parameter the route actually passes to `.where(...)` (route.ts:33, :41), so `mock.calls[1][0]` types as `unknown` and the existing assertion on line 107 is a legal narrowing — fixed at the root rather than via an `as unknown as` cast chain (which would still leave TS2493).
- **`src/lib/email.test.ts`** — direct `process.env.NODE_ENV = ...` assignments (lines 14/38/43) were TS2540 because Next's types declare `ProcessEnv.NODE_ENV` read-only. All env setup in the file now uses the standard vitest pattern: `vi.stubEnv(...)` in `beforeEach`/tests (with `undefined` to unset, supported on the repo's vitest 4.1.5) and a single `vi.unstubAllEnvs()` in `afterEach`. The manual `const env = { ...process.env }` snapshot + whole-object restore is removed, so all env mutation goes through one tracked, auto-restored mechanism. `passwordResetAppBaseUrl` reads these vars via `?.trim()` truthiness / strict equality, so unset-vs-empty semantics are behaviorally identical.

Implements the plan merged into the issue body.

Closes #396

## Test plan

- [x] Baseline reproduced on main first: exactly the 5 errors from the issue; `npm run test:unit` 127/127 green
- [x] `npx tsc --noEmit` → exit 0, zero errors
- [x] `npm run test:unit` → 25 files / 127 tests passed (same totals as baseline)
- [x] Targeted run: `npx vitest run src/lib/email.test.ts src/app/api/auth/signup/route.test.ts` → 11/11 (signup 6/6, email 5/5)
- [x] Diff grep confirms no `@ts-ignore` / `@ts-expect-error` / `eslint-disable` introduced; diff touches only the two test files

https://claude.ai/code/session_01CRwvvxAixPv3z395h6gwkC

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRwvvxAixPv3z395h6gwkC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for authentication and email functionality testing by updating mock signatures and environment variable handling methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->