### PR TITLE
ci: run npm run test:unit on every PR and push to main

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,28 @@
+name: Unit Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm run test:unit


### PR DESCRIPTION
Closes #398

## What changed

- New workflow `.github/workflows/unit-tests.yml`: runs `npm ci && npm run test:unit` on every `pull_request` and on `push` to `main`, on `ubuntu-latest` with a 10-minute timeout.
- Triggers mirror `web-build.yml`; the job installs Node 22 with npm cache and needs no env vars or secrets — the suite is fully mocked.
- Actions are pinned at `actions/checkout@v5` / `actions/setup-node@v5` rather than the `@v4` used elsewhere in the repo: runner logs during verification warned that v4 actions run on Node 20, which GitHub force-migrates to Node 24 on **June 16, 2026**, so a brand-new workflow shouldn't ship on deprecated pins. The other ten workflows are unchanged (out of scope; worth a follow-up).
- Standalone workflow rather than a job in `web-build.yml`, per the plan on #398: keeps the fast test signal separate from the slower build-verification check.

## Why

`test:unit` was not run by any CI job, so failures sat unnoticed on `main` — most recently #385 (scheduler test red for 3 days after #360). The suite is green and cheap (28 files / 168 tests, ~7s test time), so this is pure signal.

## Test plan

- [x] `npm run test:unit` green locally on this branch from a clean dependency install (28 files / 168 tests)
- [x] Workflow YAML parses (`yaml.safe_load`)
- [x] Green on a clean CI checkout: the `Unit Tests / unit-tests` check ran on this PR and passed — [run #1](https://github.com/auerbachb/still-point/actions/runs/27428862253) (initial `@v4`) and [run #3](https://github.com/auerbachb/still-point/actions/runs/27429034510) (final head `04681a1`, `@v5`), each ~27s end to end
- [x] Fails the check on test failure: temporary commit `489a1af` with an intentional failing test turned the check red ([run #2](https://github.com/auerbachb/still-point/actions/runs/27428931540): `1 failed | 168 passed`, exit code 1), then was force-pushed away — final branch state is a single clean commit
- [x] After merge: tick the "CI integration (run tests on every PR)" web checkbox in #80 referencing #398, and confirm the `push`-to-`main` run is green

Once this has a short track record, consider adding `unit-tests` to the required status checks on `main` (noted in #398, not done in this PR).

https://claude.ai/code/session_01HHxn8iTYtRhiZwf8kaxceW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration testing infrastructure by adding automated unit test execution on code changes to ensure code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->