### PR TITLE
chore(ios): prune 17 dead symbols from app target (sweep 1/4)

### DIFF
--- a/ios/StillPointApp/PushNotificationCoordinator.swift
+++ b/ios/StillPointApp/PushNotificationCoordinator.swift
@@ -42,27 +42,6 @@ final class PushNotificationCoordinator: NSObject, UIApplicationDelegate, UNUser
         }
     }
 
-    func requestAuthorizationAndRegisterAsync() async {
-        guard ProcessInfo.processInfo.environment["SP_UI_TEST_MODE"] != "1" else { return }
-
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, error in
-                if let error {
-                    print("Push notification authorization failed: \(error.localizedDescription)")
-                    continuation.resume()
-                    return
-                }
-
-                if granted {
-                    DispatchQueue.main.async {
-                        UIApplication.shared.registerForRemoteNotifications()
-                    }
-                }
-                continuation.resume()
-            }
-        }
-    }
-
     /// Re-uploads the device token when the user already granted permission (e.g. after login).
     func registerIfAlreadyAuthorized() {
         guard ProcessInfo.processInfo.environment["SP_UI_TEST_MODE"] != "1" else { return }
@@ -112,11 +91,6 @@ final class PushNotificationCoordinator: NSObject, UIApplicationDelegate, UNUser
         didReceive response: UNNotificationResponse
     ) async {
         queueOrDeliverDeepLink(from: response.notification.request.content.userInfo)
-    }
-
-    func getAuthorizationStatus() async -> UNAuthorizationStatus {
-        let settings = await UNUserNotificationCenter.current().notificationSettings()
-        return settings.authorizationStatus
     }
 
     private func queueOrDeliverDeepLink(from userInfo: [AnyHashable: Any]) {

--- a/ios/StillPointApp/Theme/DesignTokens.swift
+++ b/ios/StillPointApp/Theme/DesignTokens.swift
@@ -25,12 +25,7 @@ public enum SPColor {
     // Green / Clear Mind
     static let green = Color(red: 74/255, green: 222/255, blue: 128/255)
     static let greenEnd = Color(red: 34/255, green: 197/255, blue: 94/255)
-    static let greenStrong = green.opacity(0.7)
     static let greenText = green.opacity(0.6)
-    static let greenDim = green.opacity(0.5)
-    static let greenBg = green.opacity(0.4)
-    static let greenGlow = green.opacity(0.3)
-    static let greenMuted = green.opacity(0.25)
     static let greenBorder = green.opacity(0.2)
     static let greenBorderSubtle = green.opacity(0.15)
     static let greenBgSubtle = green.opacity(0.08)
@@ -42,8 +37,6 @@ public enum SPColor {
     static let amberText = amber.opacity(0.6)
     static let amberDim = amber.opacity(0.5)
     static let amberBorder = amber.opacity(0.4)
-    static let amberHint = amber.opacity(0.3)
-    static let amberMuted = amber.opacity(0.25)
     static let amberBorderSubtle = amber.opacity(0.2)
     static let amberBg = amber.opacity(0.15)
     static let amberBgFaint = amber.opacity(0.06)
@@ -51,12 +44,10 @@ public enum SPColor {
     // Red / Danger
     static let danger = Color.red.opacity(0.7)
     static let dangerMuted = Color.red.opacity(0.5)
-    static let dangerBorder = Color.red.opacity(0.2)
     static let dangerBorderSubtle = Color.red.opacity(0.15)
 
     // Overlay
     static let overlayText = Color.black.opacity(0.5)
-    static let overlayBg = Color.black.opacity(0.3)
 }
 
 // MARK: - Spacing (matching globals.css scale)
@@ -119,9 +110,6 @@ public enum SPFont {
     static let timerDisplay = mono(80, weight: .ultraLight)
     static let statValue = mono(28, weight: .light)
     static let statLabel = mono(11, weight: .regular)
-    static let navLabel = mono(11, weight: .medium)
-    static let bodyText = serif(17, weight: .light)
-    static let caption = mono(14, weight: .regular)
 }
 
 // MARK: - View Extensions
@@ -130,11 +118,6 @@ extension View {
     /// Apply the Still Point dark background
     func stillPointBackground() -> some View {
         self.background(SPColor.bg.ignoresSafeArea().allowsHitTesting(false))
-    }
-
-    /// Fade-in animation matching web app's fadeIn keyframe
-    func fadeIn() -> some View {
-        self.transition(.opacity.combined(with: .move(edge: .bottom)))
     }
 }
 

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -9,7 +9,6 @@ struct SessionView: View {
     let appVM: AppViewModel
     @State private var vm: SessionViewModel
     @State private var showSaveError = false
-    @Environment(\.verticalSizeClass) private var verticalSizeClass
 
     init(appVM: AppViewModel, sessionType: SessionType = .standard) {
         self.appVM = appVM
@@ -212,10 +211,6 @@ struct SessionView: View {
 
     private var bottomOverlayReserve: CGFloat {
         Self.bottomOverlayReserveWithControls
-    }
-
-    private var controlsShouldBeVisible: Bool {
-        vm.controlsVisible || !vm.isActive || verticalSizeClass == .compact
     }
 
     private var thoughtCaptureBottomPadding: CGFloat {


### PR DESCRIPTION
Closes #401 (child 1/4 of campaign #400)

## What changed
Conservative dead-code prune, iOS app target only — 48 lines of pure deletions, 17 provably-unreferenced symbols:
- **SessionView.swift**: the #401 seed `controlsShouldBeVisible` (dead since #275) + its now-orphaned `verticalSizeClass` environment property
- **DesignTokens.swift**: 13 unused tokens — `SPColor` greenStrong/greenDim/greenBg/greenGlow/greenMuted/amberHint/amberMuted/dangerBorder/overlayBg, `SPFont` navLabel/bodyText/caption, and `View.fadeIn()`
- **PushNotificationCoordinator.swift**: `requestAuthorizationAndRegisterAsync()` and `getAuthorizationStatus()` (never called; sync counterparts are the live paths)

## Why
Phase 1 of the #400 dead-code sweep. Every symbol was grep-verified to exactly one occurrence (its declaration) across all 70 Swift files, with no Info.plist / pbxproj / asset-catalog / CI-script / string-literal references.

Web side: zero deletions this phase — all 3 knip unused-file candidates were false positives (`e2e/global-setup.ts` env-gated in playwright.config.ts, `public/sw.js` dynamically registered, `scripts/ios-screenshot-index.mjs` used by Fastfile). Documented in #401; unused-exports/deps lists deferred to #402.

## Benefit
Less misleading surface for readers/agents, smaller review noise; sets the verified baseline for sweep phases 2-4.

## Test plan
- [x] `npx tsc --noEmit` — no NEW errors vs main (identical 5-error #396 baseline)
- [x] `npm run test:unit` — 168/168 passed (manual; not in CI)
- [x] Production build (`npm run build`) succeeds
- [x] `swift test` in `ios/StillPointShared` — 52/52 passed
- [x] Every removed symbol grep-confirmed zero remaining references (incl. dynamic/string-literal)
- [x] Local CodeRabbit review: clean (0 findings)
- [x] iOS app-target compile green in CI (ios-e2e-smoke + ios-e2e-critical built and ran the app)
- [x] Playwright e2e green in CI (web-e2e smoke/critical/auth-db + e2e-mobile x3 all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
