### PR TITLE
docs: use www host for Apple S2S notification endpoint

### DIFF
--- a/docs/mobile-oauth-integration.md
+++ b/docs/mobile-oauth-integration.md
@@ -88,7 +88,7 @@ Requests that fail JWT verification return **401** and are not processed — the
 ### Operator setup (one-time, Apple Developer console)
 
 1. [developer.apple.com](https://developer.apple.com/account) → **Certificates, Identifiers & Profiles → Identifiers** → App ID `com.brettonauerbach.stillpoint`.
-2. **Sign in with Apple → Edit** → set **Server-to-Server Notification Endpoint** to `https://still-point.me/api/auth/apple/notifications` → Save.
+2. **Sign in with Apple → Edit** → set **Server-to-Server Notification Endpoint** to `https://www.still-point.me/api/auth/apple/notifications` → Save. Use the `www.` host: the apex `still-point.me` 307-redirects to `www`, and Apple's notification sender expects a direct 2xx and does not reliably follow redirects.
 
 Notifications for the whole App ID group (including the web Services ID flow) are delivered to this endpoint.
 


### PR DESCRIPTION
Closes #407

## What changed

`docs/mobile-oauth-integration.md` operator step now points the Apple Developer console **Server-to-Server Notification Endpoint** at `https://www.still-point.me/api/auth/apple/notifications` (was the apex `https://still-point.me/...`), with a one-line note on why.

## Why

The apex `still-point.me` 307-redirects to the canonical `www.still-point.me`. Apple's S2S notification sender expects a direct 2xx and does not reliably follow redirects, so the apex URL risked dropped deliveries. Verified 2026-06-15: `www` host returns 401 directly; apex returns 307→www. The live Apple console was already corrected to `www`; this stops the doc from reintroducing the apex URL for the next operator.

Line 48 (native client targets apex `https://still-point.me`) is intentionally left unchanged — the iOS app's URLSession follows redirects automatically, so the apex default is fine for sign-in; only Apple's webhook sender is redirect-averse.

## Test plan

- [x] Operator-setup step uses the `www.still-point.me` notification endpoint URL
- [x] No remaining non-www `still-point.me/api/auth/apple/notifications` occurrences in the repo (`grep` clean)
- [x] Docs-only change — no code, schema, or test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Corrected Apple Server-to-Server Notification Endpoint configuration to use the proper host URL, preventing potential redirect-related delivery failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->