### PR TITLE
chore: remove unused @types/bcryptjs dep, dead exports, dead iOS API (sweep 2/4)

### DIFF
--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -240,14 +240,6 @@ public actor APIClient {
         return response.session
     }
 
-    public func getSession(dayNumber: Int) async throws -> (session: SessionDTO, thoughts: [ThoughtDTO]) {
-        if let uiTestResult = try uiTestGetSession(dayNumber: dayNumber) {
-            return uiTestResult
-        }
-        let response: SessionDetailResponse = try await get("/api/sessions/\(dayNumber)")
-        return (response.session, response.thoughts)
-    }
-
     public func getSessionBySessionId(_ sessionId: String) async throws -> (session: SessionDTO, thoughts: [ThoughtDTO]) {
         if let uiTestResult = try uiTestGetSession(sessionId: sessionId) {
             return uiTestResult
@@ -665,22 +657,6 @@ public actor APIClient {
         try ensureUITestAuthenticated(store: store)
 
         guard let session = store.sessions.first(where: { $0.id == sessionId }) else {
-            throw APIError(status: 404, message: "Session not found")
-        }
-
-        let thoughts = store.thoughts.filter { $0.sessionId == session.id }
-            .sorted { $0.timeInSession < $1.timeInSession }
-        return (session, thoughts)
-    }
-
-    private func uiTestGetSession(dayNumber: Int) throws -> (session: SessionDTO, thoughts: [ThoughtDTO])? {
-        guard uiTestConfig != nil else { return nil }
-        guard let store = uiTestStore else {
-            throw APIError(status: 0, message: "UI test store is unavailable")
-        }
-        try ensureUITestAuthenticated(store: store)
-
-        guard let session = store.sessions.last(where: { $0.dayNumber == dayNumber }) else {
             throw APIError(status: 404, message: "Session not found")
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
-        "@types/bcryptjs": "^2.4.6",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -2328,13 +2327,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@types/bcryptjs": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
-      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
-    "@types/bcryptjs": "^2.4.6",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/lib/apple-auth.ts
+++ b/src/lib/apple-auth.ts
@@ -2,7 +2,7 @@ import { createRemoteJWKSet, jwtVerify, type JWTPayload, type JWTVerifyGetKey } 
 
 /** Issuer for every Sign in with Apple JWT (identity tokens and server-to-server notifications). */
 export const APPLE_ISSUER = "https://appleid.apple.com";
-export const APPLE_JWKS_URL = `${APPLE_ISSUER}/auth/keys`;
+const APPLE_JWKS_URL = `${APPLE_ISSUER}/auth/keys`;
 
 let remoteJwks: JWTVerifyGetKey | null = null;
 

--- a/src/lib/apple-client-secret.ts
+++ b/src/lib/apple-client-secret.ts
@@ -30,7 +30,7 @@ function normalizePem(raw: string): string {
 }
 
 /** Mint the ES256 client secret JWT Apple expects for the web/Services ID flow. */
-export async function mintAppleClientSecret(): Promise<string> {
+async function mintAppleClientSecret(): Promise<string> {
   const { teamId, clientId, keyId, rawKey } = requireAppleSigningEnv();
   const pem = normalizePem(rawKey);
   const key = await importPKCS8(pem, "ES256");

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -27,7 +27,7 @@ export async function createToken(payload: { userId: string; email: string }): P
     .sign(getSecret());
 }
 
-export async function verifyToken(token: string): Promise<{ userId: string; email: string } | null> {
+async function verifyToken(token: string): Promise<{ userId: string; email: string } | null> {
   try {
     const { payload } = await jwtVerify(token, getSecret());
     return payload as { userId: string; email: string };

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -4,7 +4,7 @@ export const BASE_DURATION = 60;
 export const QUICK_DURATION = 60;
 export const INCREMENT = 10;
 export const BLOCK_DURATION = 10;
-export const SESSION_TYPES = ["standard", "quick"] as const;
+const SESSION_TYPES = ["standard", "quick"] as const;
 export type SessionType = (typeof SESSION_TYPES)[number];
 
 export type SessionStatsInput = {

--- a/src/lib/google.ts
+++ b/src/lib/google.ts
@@ -34,7 +34,7 @@ export class GoogleCalendarUnavailableError extends Error {
   }
 }
 
-export class GoogleCalendarApiError extends Error {
+class GoogleCalendarApiError extends Error {
   readonly status: number;
   readonly body: unknown;
 
@@ -66,7 +66,7 @@ export type CalendarSyncResult =
 
 export const GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE = "Could not sync Google Calendar";
 
-export type GoogleCalendarStatus = {
+type GoogleCalendarStatus = {
   connected: boolean;
   email: string | null;
 };
@@ -302,7 +302,7 @@ export async function exchangeGoogleCodeForTokens(
     });
 }
 
-export async function getGoogleOAuthToken(userId: string) {
+async function getGoogleOAuthToken(userId: string) {
   const [token] = await db
     .select()
     .from(googleOAuthTokens)

--- a/src/lib/historyJourney.ts
+++ b/src/lib/historyJourney.ts
@@ -1,7 +1,7 @@
 import { addDaysToIsoDate, daysBetweenIsoDatesInclusive } from "./sessionCalendar";
 
 /** Max consecutive missed-day rows between two sessions (then remaining gap is collapsed). */
-export const MAX_MISSED_GAP_ROWS = 366;
+const MAX_MISSED_GAP_ROWS = 366;
 
 export type HistoryJourneySession<T> = {
   sessionDate: string;

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -12,9 +12,9 @@ import { sendWebPushToUser } from "@/lib/web-push";
 const invalidTokenReasons = new Set(["BadDeviceToken", "DeviceTokenNotForTopic", "Unregistered"]);
 const PUSH_SEND_CONCURRENCY = 3;
 
-export const MISS_A_DAY_DEEP_LINK = "stillpoint://session/quick";
-export const FRIEND_REQUEST_DEEP_LINK = "stillpoint://home";
-export const FRIEND_REQUEST_WEB_URL = "/app?view=friends";
+const MISS_A_DAY_DEEP_LINK = "stillpoint://session/quick";
+const FRIEND_REQUEST_DEEP_LINK = "stillpoint://home";
+const FRIEND_REQUEST_WEB_URL = "/app?view=friends";
 
 function toApnsEnvironment(value: string): ApnsEnvironment {
   return value === "production" ? "production" : "development";

--- a/src/lib/notifications/daily-reminder.ts
+++ b/src/lib/notifications/daily-reminder.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte, inArray } from "drizzle-orm";
+import { and, eq, gte } from "drizzle-orm";
 import { db } from "@/db";
 import { notificationDispatches, sessions } from "@/db/schema";
 import type { ApnsPayload } from "@/lib/apns";
@@ -124,27 +124,4 @@ export async function hasMissADayDispatchForDate(
     .limit(1);
 
   return !!row;
-}
-
-async function loadCompletedSessionDates(
-  userIds: string[],
-  sessionDates: string[],
-): Promise<Set<string>> {
-  if (userIds.length === 0 || sessionDates.length === 0) return new Set();
-
-  const rows = await db
-    .select({
-      userId: sessions.userId,
-      sessionDate: sessions.sessionDate,
-    })
-    .from(sessions)
-    .where(
-      and(
-        eq(sessions.completed, true),
-        inArray(sessions.userId, userIds),
-        inArray(sessions.sessionDate, sessionDates),
-      ),
-    );
-
-  return new Set(rows.map((row) => `${row.userId}:${row.sessionDate}`));
 }

--- a/src/lib/notifications/daily-reminder.ts
+++ b/src/lib/notifications/daily-reminder.ts
@@ -5,9 +5,9 @@ import type { ApnsPayload } from "@/lib/apns";
 import { calculateSessionStats, type SessionStatsInput } from "@/lib/constants";
 import { addDaysToIsoDate } from "@/lib/sessionCalendar";
 
-export const DAILY_REMINDER_NOTIFICATION_TYPE = "daily_reminder";
+const DAILY_REMINDER_NOTIFICATION_TYPE = "daily_reminder";
 export const MISS_A_DAY_NOTIFICATION_TYPE = "miss_a_day";
-export const DAILY_REMINDER_DEEP_LINK = "stillpoint://home";
+const DAILY_REMINDER_DEEP_LINK = "stillpoint://home";
 
 const STREAK_LOOKBACK_DAYS = 90;
 
@@ -126,7 +126,7 @@ export async function hasMissADayDispatchForDate(
   return !!row;
 }
 
-export async function loadCompletedSessionDates(
+async function loadCompletedSessionDates(
   userIds: string[],
   sessionDates: string[],
 ): Promise<Set<string>> {

--- a/src/lib/oauth-user-resolution.ts
+++ b/src/lib/oauth-user-resolution.ts
@@ -44,7 +44,7 @@ async function generateUniqueUsername(seed: string): Promise<string> {
 
 /** Insert a (provider, providerAccountId) -> userId link, returning the
  *  userId that ends up owning the link. */
-export async function linkProviderToUser(
+async function linkProviderToUser(
   provider: string,
   providerAccountId: string,
   userId: string,

--- a/src/lib/passwordReset.ts
+++ b/src/lib/passwordReset.ts
@@ -2,10 +2,7 @@ import "server-only";
 
 import { createHash, randomBytes } from "crypto";
 import { SignJWT, jwtVerify } from "jose";
-import { and, eq, gt, isNull } from "drizzle-orm";
 import type { NextRequest } from "next/server";
-import { passwordResetTokens } from "@/db/schema";
-import type { PoolDb } from "@/db/pool";
 
 const TOKEN_BYTES = 32;
 export const PASSWORD_RESET_TTL_MINUTES = 60;
@@ -74,32 +71,6 @@ export async function getPasswordResetPayload(token: string) {
   } catch {
     return null;
   }
-}
-
-export async function consumePasswordResetToken(tx: PoolDb, token: string) {
-  const payload = await getPasswordResetPayload(token);
-  if (!payload) {
-    return { ok: false as const };
-  }
-
-  const [resetToken] = await tx
-    .update(passwordResetTokens)
-    .set({ usedAt: new Date() })
-    .where(
-      and(
-        eq(passwordResetTokens.userId, payload.userId),
-        eq(passwordResetTokens.tokenHash, payload.tokenHash),
-        isNull(passwordResetTokens.usedAt),
-        gt(passwordResetTokens.expiresAt, new Date()),
-      ),
-    )
-    .returning({ userId: passwordResetTokens.userId });
-
-  if (!resetToken) {
-    return { ok: false as const };
-  }
-
-  return { ok: true as const, userId: resetToken.userId };
 }
 
 type ResetAttempt = {

--- a/src/lib/thoughtSaving.ts
+++ b/src/lib/thoughtSaving.ts
@@ -1,4 +1,4 @@
-export type ThoughtInput = {
+type ThoughtInput = {
   timeInSession: number;
   text: string;
 };

--- a/src/lib/web-push-client.ts
+++ b/src/lib/web-push-client.ts
@@ -34,7 +34,7 @@ export function needsPwaInstallForWebPush(): boolean {
   return nav.standalone !== true;
 }
 
-export function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
+function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
   const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
   const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
   const raw = window.atob(base64);
@@ -45,7 +45,7 @@ export function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuf
   return output;
 }
 
-export async function registerServiceWorker(): Promise<ServiceWorkerRegistration> {
+async function registerServiceWorker(): Promise<ServiceWorkerRegistration> {
   return navigator.serviceWorker.register("/sw.js", { scope: "/" });
 }
 

--- a/src/lib/web-push.ts
+++ b/src/lib/web-push.ts
@@ -78,7 +78,7 @@ export function getWebPushPublicKey(): string | null {
   return key.length > 0 ? key : null;
 }
 
-export function getWebPushVapidSubject(): string | null {
+function getWebPushVapidSubject(): string | null {
   const subject = (process.env.WEB_PUSH_VAPID_SUBJECT ?? "").trim();
   return subject.length > 0 ? subject : null;
 }


### PR DESCRIPTION
## **User description**
Closes #402 (child 2/4 of campaign #400)

## What changed
Sweep 2/4 — unused dependency + dead exports + dead iOS API. 100 lines net removed.

**Dependencies (1 removed):**
- Removed `@types/bcryptjs` devDependency — `bcryptjs@3.0.3` ships its own types (`umd/index.d.ts`), so the `@types` shim is redundant. Lockfile synced; runtime `bcryptjs` retained.
- **Kept `jotai`** despite zero direct imports — it is a required **peer dependency of `@daily-co/daily-react`** (`jotai: "^2"`). Neither knip nor depcheck flag it; removing it would break the buddy-session video stack. (This is why "prove with clean `npm ci`" matters.)
- Kept `server-only` (side-effect imports) and `@daily-co/daily-js` (peer dep).

**Dead exports (web):** knip surfaced 26 "unused exports" but none were fully dead — all are used internally or by their own test. Remediation:
- Stripped the dead `export` keyword from 18 internally-used symbols across `apple-auth`, `apple-client-secret`, `auth`, `constants`, `google`, `historyJourney`, `notifications`, `notifications/daily-reminder`, `oauth-user-resolution`, `web-push`, `web-push-client`, `thoughtSaving` (now module-private; tsc-verified no external consumer).
- Deleted `consumePasswordResetToken` from `passwordReset.ts` (zero callers anywhere — fully dead) plus its now-orphaned drizzle imports (`and`/`eq`/`gt`/`isNull`, `passwordResetTokens`, `PoolDb`).
- **Deferred** the `buddyCalendar`/`buddyCalendarRange`/`buddySession`/`buddySessionDuration` re-export cluster (tangled barrels + `buddyCalendar.test.ts` imports — risk > value). Kept test-only (`notificationTime.*`) and framework-risky (`signIn`/`signOut` NextAuth destructure, `sendEmail`).

**iOS:** deleted the unused `APIClient.getSession(dayNumber:)` overload (live paths are `getSessions()`/`getSessionBySessionId(_:)`) and its now-dead `uiTestGetSession(dayNumber:)` helper. Kept `isEndNote`, `setBaseURL(_:)` (possible tooling/UI-test use), `shouldAdvanceDay` (test-only) — conservative, app compile is CI-only.

## Benefit
Removes a redundant dependency and dead code surface; tightens module API boundaries without behavior change.

## Test plan
- [x] `npx tsc --noEmit` — no NEW errors vs main (identical 5-error #396 baseline)
- [x] `npm run test:unit` — 168/168 passed (manual; not in CI)
- [x] Production build (`npm run build`) succeeds
- [x] `swift test` in `ios/StillPointShared` — 52/52 passed
- [x] Fresh clean-room `npm ci` from synced lockfile succeeds; runtime `bcryptjs` resolves, `@types/bcryptjs` gone
- [x] Every removed/unexported symbol grep-verified (incl. peer-dep + test + dynamic checks)
- [x] Local CodeRabbit review: clean (0 findings)
- [x] iOS app-target compile green in CI (local xcodebuild cannot parse the project)
- [x] Playwright e2e green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal module organization and API surface by consolidating public exports across authentication, notification, and utility modules.
  * Updated session retrieval mechanism to use session identifiers.
  * Streamlined password reset with in-memory rate limiting for enhanced security.

* **Chores**
  * Updated development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Remove unused app code and a dead iOS session lookup path**

### What Changed
- Removed an unused TypeScript types package that the project no longer needs
- Hid several helpers and constants that were only used inside their own files, and deleted a dead password reset consume step plus its unused database logic
- Removed the iOS session lookup by day number and its test-only helper, leaving the session-by-ID path as the supported way to load session details

### Impact
`✅ Smaller install footprint`
`✅ Fewer dead code paths`
`✅ Less maintenance around session lookup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
