### PR TITLE
ci: add tsc --noEmit typecheck gate for test files

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,3 +26,28 @@ jobs:
 
       - name: Run unit tests
         run: npm run test:unit
+
+  # Full-project type gate. `next build` only typechecks app code, so test-only
+  # type errors (bad mock signatures, NODE_ENV assignment, etc.) used to land on
+  # main undetected (#396). `tsc --noEmit` honors tsconfig's `include`
+  # (**/*.ts, **/*.tsx), so *.test.ts files are typechecked too. Runs in parallel
+  # with unit-tests as its own required-able check.
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck (tsc --noEmit, includes test files)
+        run: npm run typecheck

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "db:migrate": "tsx scripts/apply-migrations.ts",
     "db:reconcile": "tsx scripts/reconcile-migration-checksum.ts",
     "test:unit": "vitest run src",
+    "typecheck": "tsc --noEmit",
     "start": "next start",
     "db:seed": "tsx scripts/seed.ts",
     "test:e2e": "playwright test",


### PR DESCRIPTION
## What
Add a `typecheck` CI job that runs `tsc --noEmit` over the whole project, including `*.test.ts(x)` files.

- `package.json`: new `typecheck` script (`tsc --noEmit`).
- `.github/workflows/unit-tests.yml`: new parallel `typecheck` job (ubuntu, Node 22, cached `npm ci`), documented inline.

`tsconfig.json` already includes `**/*.ts`/`**/*.tsx`, so test files are covered with no config change.

## Why
`next build` only typechecks app code and vitest tolerates type errors at runtime, so test-only type errors silently landed on `main` (#396 fixed 5 such errors). This is the systemic gate that prevents recurrence — the sibling of #405 (`test:unit` in CI).

## Benefit
Future test-file type errors (bad mock signatures, `NODE_ENV` assignment, bad tuple indexing) fail a dedicated check instead of reaching `main`.

## Notes
- `main` is tsc-clean today (#396/#399). Verified locally on this branch's base: `npm run typecheck` exits 0.
- Runtime: `tsc` over this project is ~2s locally; `npm ci` is cached via `actions/setup-node`. `--incremental` buildinfo caching is a future option if it ever slows down.
- Making `typecheck` a required status check is a branch-protection change — left for a separate, user-confirmed step.

## Test Plan
- [x] CI runs `tsc --noEmit` over the whole project (test files included) on every PR and push to `main`
- [x] A deliberately-introduced `*.test.ts` type error turns the `typecheck` check red (verified on CI via scratch PR #428: `typecheck` failed 31s; then closed/deleted)
- [x] `main` is green on the new check at merge time (typecheck green on PR head = main + this change; re-confirmed at merge)
- [x] Step is reasonably fast / cached; documented in the workflow (typecheck 28s; `npm ci` cached via setup-node)

Closes #422

