### PR TITLE
ci: run swift test for StillPointShared on PRs

### DIFF
--- a/.github/workflows/ios-shared-tests.yml
+++ b/.github/workflows/ios-shared-tests.yml
@@ -1,0 +1,27 @@
+name: iOS Shared Unit Tests
+
+on:
+  pull_request:
+    paths:
+      - "ios/StillPointShared/**"
+      - ".github/workflows/ios-shared-tests.yml"
+  workflow_dispatch:
+
+jobs:
+  swift-test:
+    name: StillPointShared swift test
+    runs-on: macos-26
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # StillPointShared is a pure SwiftPM package, so `swift test` builds and runs
+      # the suite without xcodegen/xcodebuild (the same path agents use locally,
+      # where the app's Xcode project can't be parsed). The ~50 tests are
+      # sub-second; wall-clock is dominated by macOS runner spin-up + the package
+      # build. Path-filtered to the package (and this workflow) so web-only PRs
+      # don't burn macOS minutes.
+      - name: Run StillPointShared unit tests
+        working-directory: ios/StillPointShared
+        run: swift test


### PR DESCRIPTION
## **User description**
## What
Add a dedicated `iOS Shared Unit Tests` workflow that runs `swift test` for the `ios/StillPointShared` SwiftPM package on PRs.

New file `.github/workflows/ios-shared-tests.yml`: `macos-26`, `actions/checkout@v4`, a single `swift test` step in `ios/StillPointShared`. Triggered on `pull_request` path-filtered to `ios/StillPointShared/**` + the workflow file, plus `workflow_dispatch`.

## Why
`ios/StillPointShared` has a real XCTest suite (52 tests) but nothing in CI runs it — the iOS e2e jobs only compile the package. A logic regression in shared code (streaks, journey rows, calendar math) could pass green CI. This wires the unit suite into CI. Part of #80; sibling of #405/#422.

`swift test` also works where the app's Xcode project can't be parsed locally, giving CI parity with the local validation path agents already use.

## Benefit
A logic regression in StillPointShared fails a check on PRs that touch the package.

## Wall-clock cost
The suite is sub-second (52 tests in ~0.01s locally). CI wall-clock is dominated by macOS runner spin-up + the SwiftPM build (a few minutes cold). Path filtering keeps web-only PRs off macOS runners.

## Test Plan
- [x] A CI check runs `swift test` for `ios/StillPointShared` on PRs that touch the package (ran on this PR: pass 41s)
- [x] A failing unit test turns the check red (verified on CI via scratch PR #428: `StillPointShared swift test` failed 33s; then closed/deleted)
- [x] Wall-clock cost documented (above): 41s observed in CI, runner spin-up + SwiftPM build dominate

Closes #397


___

## **CodeAnt-AI Description**
Run StillPointShared unit tests in CI on pull requests

### What Changed
- Added a PR workflow that runs the `StillPointShared` Swift package test suite on changes to the package
- The test job also runs when the workflow file itself changes
- The workflow can be started manually when needed

### Impact
`✅ Catch shared code regressions before merge`
`✅ Fewer broken PRs from unchecked unit tests`
`✅ Faster confidence for changes to StillPointShared`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
