### PR TITLE
feat(history): web journey parity with iOS #379 — collapse long gaps, show quick sits

### DIFF
--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -16,6 +16,7 @@ import { BuddySessionRoom, type BuddyPersonalRecordPayload } from "@/components/
 import { useIsMobile } from "@/lib/useIsMobile";
 import { api, ApiError } from "@/lib/api";
 import type { SessionType } from "@/lib/constants";
+import { todayLocalIsoDate } from "@/lib/sessionCalendar";
 
 type View =
   | "home"
@@ -38,14 +39,6 @@ type CompletionData = {
   thoughtCount: number;
   thoughts: Array<{ timeInSession: number; text: string }>;
 };
-
-function getLocalIsoDate(): string {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  const day = String(now.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-}
 
 function calendarSyncMessageFromResult(sync: CalendarSyncResult[] | undefined): string | null {
   const item = sync?.[0];
@@ -239,7 +232,7 @@ export default function StillPoint() {
           clearPercent: data.clearPercent,
           thoughtCount: data.thoughtCount,
           mindStateLog: data.mindStateLog,
-          sessionDate: getLocalIsoDate(),
+          sessionDate: todayLocalIsoDate(),
         }),
       });
 
@@ -311,7 +304,7 @@ export default function StillPoint() {
           clearPercent: data.clearPercent,
           thoughtCount: data.thoughtCount,
           mindStateLog: data.mindStateLog,
-          sessionDate: getLocalIsoDate(),
+          sessionDate: todayLocalIsoDate(),
         }),
       });
 

--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -13,6 +13,7 @@ import { loadSoundPrefs, saveSoundPrefs, unlockAudioContext, type SoundPrefs } f
 import { computeClearPercentFromLog } from "@/lib/mindStateSession";
 import { useMindStateHold } from "@/lib/useMindStateHold";
 import { useKeepScreenAwakePref, useWakeLock } from "@/lib/useWakeLock";
+import { todayLocalIsoDate } from "@/lib/sessionCalendar";
 
 /** Payload for the shared `/app` completion screen after a buddy sit (#119). */
 export type BuddyPersonalRecordPayload = {
@@ -32,14 +33,6 @@ type BuddySessionRoomProps = {
   /** When set, a finished shared timer saves a personal session row then opens the normal completion flow. */
   onPersonalRecordComplete?: (data: BuddyPersonalRecordPayload) => void;
 };
-
-function getLocalIsoDate(): string {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  const day = String(now.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-}
 
 type BuddyMindState = "clear" | "thinking" | "hyperfocus";
 type FinalizeAttemptResult = "started" | "already-saving" | "not-ready";
@@ -451,7 +444,7 @@ export function BuddySessionRoom({
         thoughtCount: thoughtsSnapshot.length,
         mindStateLog: mindStateLogRef.current,
         actualTime: durationSeconds,
-        sessionDate: getLocalIsoDate(),
+        sessionDate: todayLocalIsoDate(),
         thoughts: thoughtsSnapshot,
       });
       try {

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -71,6 +71,9 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
   });
   const [expandedEntryId, setExpandedEntryId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  // UTC calendar day for the trailing gap-to-today, refreshed on day rollover so the
+  // journey stays correct if the view is left open past midnight (PR #426 review).
+  const [todayDate, setTodayDate] = useState<string>(() => todayIsoDateUtc());
   const isMobile = useIsMobile();
   const sessionLabelColWidth = isMobile ? "88px" : "100px";
 
@@ -92,6 +95,16 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
     }).catch(() => setLoading(false));
   }, []);
 
+  // Re-evaluate "today" once a minute; only re-renders when the UTC day actually
+  // changes, keeping the trailing gap fresh across midnight without a refetch.
+  useEffect(() => {
+    const id = setInterval(() => {
+      const d = todayIsoDateUtc();
+      setTodayDate(prev => (prev === d ? prev : d));
+    }, 60_000);
+    return () => clearInterval(id);
+  }, []);
+
   const journeyRows = useMemo(() => {
     // Include all session types (quick + standard) — quick sits are rendered with
     // visual distinction rather than filtered out (#381). Pass today so the gap
@@ -103,9 +116,9 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
         sortKey: sessionSortKey(s),
         data: s,
       })),
-      todayIsoDateUtc(),
+      todayDate,
     );
-  }, [sessions]);
+  }, [sessions, todayDate]);
 
   const history: HistoryEntry[] = useMemo(
     () =>

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -5,7 +5,7 @@ import { durationForDay } from "@/lib/constants";
 import type { Session, Thought } from "@/lib/api";
 import { useIsMobile } from "@/lib/useIsMobile";
 import { buildHistoryJourneyRows } from "@/lib/historyJourney";
-import { todayIsoDateUtc } from "@/lib/buddyCalendarRange";
+import { todayLocalIsoDate } from "@/lib/sessionCalendar";
 
 type HistoryEntry = {
   sessionId?: string;
@@ -73,7 +73,7 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
   const [loading, setLoading] = useState(true);
   // UTC calendar day for the trailing gap-to-today, refreshed on day rollover so the
   // journey stays correct if the view is left open past midnight (PR #426 review).
-  const [todayDate, setTodayDate] = useState<string>(() => todayIsoDateUtc());
+  const [todayDate, setTodayDate] = useState<string>(() => todayLocalIsoDate());
   const isMobile = useIsMobile();
   const sessionLabelColWidth = isMobile ? "88px" : "100px";
 
@@ -99,7 +99,7 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
   // changes, keeping the trailing gap fresh across midnight without a refetch.
   useEffect(() => {
     const id = setInterval(() => {
-      const d = todayIsoDateUtc();
+      const d = todayLocalIsoDate();
       setTodayDate(prev => (prev === d ? prev : d));
     }, 60_000);
     return () => clearInterval(id);

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -5,6 +5,7 @@ import { durationForDay } from "@/lib/constants";
 import type { Session, Thought } from "@/lib/api";
 import { useIsMobile } from "@/lib/useIsMobile";
 import { buildHistoryJourneyRows } from "@/lib/historyJourney";
+import { todayIsoDateUtc } from "@/lib/buddyCalendarRange";
 
 type HistoryEntry = {
   sessionId?: string;
@@ -18,7 +19,12 @@ type HistoryEntry = {
   thoughtCount: number;
   sessionType?: Session["sessionType"];
   missed?: boolean;
-  /** 1-based index among standard sessions on the same calendar day */
+  /** Collapsed run of 3+ consecutive missed days (single "N days missed" row). */
+  collapsed?: boolean;
+  collapsedDayCount?: number;
+  /** Inclusive end of the collapsed range (`date` holds the start). */
+  collapsedEndDate?: string;
+  /** 1-based index among same-type sessions on the same calendar day */
   sessionIndexInDay?: number;
 };
 
@@ -36,6 +42,12 @@ function formatFullDateLabel(isoDate: string): string {
 function formatShortDateLabel(isoDate: string): string {
   const d = new Date(isoDate + "T12:00:00");
   return d.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
+}
+
+/** Month + day only (e.g. "Jun 10") — used for the collapsed-gap date range. */
+function formatCompactDateLabel(isoDate: string): string {
+  const d = new Date(isoDate + "T12:00:00");
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
 
 function sessionSortKey(s: Session): string {
@@ -81,13 +93,17 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
   }, []);
 
   const journeyRows = useMemo(() => {
-    const standard = sessions.filter(s => s.sessionType !== "quick");
+    // Include all session types (quick + standard) — quick sits are rendered with
+    // visual distinction rather than filtered out (#381). Pass today so the gap
+    // between the last session and now is also collapsed.
     return buildHistoryJourneyRows(
-      standard.map(s => ({
+      sessions.map(s => ({
         sessionDate: s.sessionDate,
+        sessionType: s.sessionType,
         sortKey: sessionSortKey(s),
         data: s,
       })),
+      todayIsoDateUtc(),
     );
   }, [sessions]);
 
@@ -105,6 +121,22 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
             clearPercent: 0,
             thoughtCount: 0,
             missed: true,
+          };
+        }
+        if (row.kind === "collapsedGap") {
+          return {
+            day: null,
+            duration: 0,
+            bonusSeconds: 0,
+            actualTime: 0,
+            completed: false,
+            date: row.startDate,
+            clearPercent: 0,
+            thoughtCount: 0,
+            missed: true,
+            collapsed: true,
+            collapsedDayCount: row.dayCount,
+            collapsedEndDate: row.endDate,
           };
         }
         const s = row.data;
@@ -209,6 +241,45 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
               ? true
               : !prev || prev.missed || prev.date !== entry.date;
 
+            if (entry.collapsed) {
+              const rangeLabel = `${formatCompactDateLabel(entry.date)} – ${formatCompactDateLabel(entry.collapsedEndDate ?? entry.date)}`;
+              return (
+                <div key={`collapsed-${idx}`} style={{
+                  display: "flex", alignItems: "center", gap: isMobile ? "8px" : "12px",
+                  padding: "2px 0", opacity: 0.35,
+                }}>
+                  <div style={{
+                    fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                    fontSize: isMobile ? "10px" : "11px", color: "var(--fg-4)",
+                    width: isMobile ? undefined : "160px", minWidth: isMobile ? "72px" : undefined,
+                    textAlign: "right", whiteSpace: "nowrap",
+                  }}>
+                    {rangeLabel}
+                  </div>
+                  <div style={{
+                    fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                    fontSize: "11px", color: "var(--fg-3)",
+                    width: sessionLabelColWidth, textAlign: "right",
+                  }}>
+                    &mdash;
+                  </div>
+                  <div style={{
+                    flex: 1, height: "24px", borderRadius: "3px",
+                    border: "1px dashed var(--border-1)",
+                    display: "flex", alignItems: "center", paddingLeft: "10px",
+                  }}>
+                    <span style={{
+                      fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                      fontSize: "11px", color: "var(--fg-4)", fontStyle: "italic",
+                    }}>
+                      {entry.collapsedDayCount} days missed
+                    </span>
+                  </div>
+                  <div style={{ width: isMobile ? "80px" : "120px" }} />
+                </div>
+              );
+            }
+
             if (entry.missed) {
               const dateLabel = formatFullDateLabel(entry.date);
               return (
@@ -259,8 +330,9 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
 
             const dateLabelFull = formatFullDateLabel(entry.date);
             const dateLabelShort = formatShortDateLabel(entry.date);
+            const isQuick = entry.sessionType === "quick";
             const sessionOrdinal = entry.sessionIndexInDay ?? 1;
-            const sessionLabel = `Session ${sessionOrdinal}`;
+            const sessionLabel = isQuick ? "Quick" : `Session ${sessionOrdinal}`;
 
             const entryId = entry.sessionId ? `sess-${entry.sessionId}` : `day-${entry.day}-${idx}`;
             const isExpanded = expandedEntryId === entryId;
@@ -322,7 +394,7 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
                   )}
                   <div style={{
                     fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-                    fontSize: "11px", color: "var(--fg-3)",
+                    fontSize: "11px", color: isQuick ? "var(--fg-4)" : "var(--fg-3)",
                     width: sessionLabelColWidth, textAlign: "right",
                   }}>
                     {sessionLabel}
@@ -335,6 +407,7 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
                       height: "100%",
                       width: `${(entry.actualTime / maxDuration) * 100}%`,
                       borderRadius: "3px", overflow: "hidden", display: "flex",
+                      opacity: isQuick ? 0.55 : 1,
                     }}>
                       <div style={{
                         width: `${entry.clearPercent}%`, height: "100%",

--- a/src/lib/historyJourney.test.ts
+++ b/src/lib/historyJourney.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
-import { buildHistoryJourneyRows, sortSessionsForHistory } from "./historyJourney";
+import {
+  buildHistoryJourneyRows,
+  sortSessionsForHistory,
+  COLLAPSE_GAP_THRESHOLD_DAYS,
+} from "./historyJourney";
 
 describe("buildHistoryJourneyRows", () => {
   test("labels sequential sessions on the same calendar day", () => {
@@ -8,28 +12,25 @@ describe("buildHistoryJourneyRows", () => {
       { sessionDate: "2026-04-28", sortKey: "b", data: { id: "2" } },
       { sessionDate: "2026-04-28", sortKey: "c", data: { id: "3" } },
     ]);
-    expect(rows.filter(r => r.kind === "session").map(r => r.sessionIndexInDay)).toEqual([1, 2, 3]);
+    expect(rows.map(r => (r.kind === "session" ? r.sessionIndexInDay : null))).toEqual([1, 2, 3]);
   });
 
-  test("inserts missed rows for calendar gaps", () => {
+  test("inserts per-day missed rows for short calendar gaps", () => {
     const rows = buildHistoryJourneyRows([
       { sessionDate: "2026-04-26", sortKey: "a", data: { id: "1" } },
       { sessionDate: "2026-04-28", sortKey: "b", data: { id: "2" } },
     ]);
-    expect(rows.map(r => (r.kind === "missed" ? `missed:${r.date}` : `session:${r.date}:${r.sessionIndexInDay}`))).toEqual([
+    expect(
+      rows.map(r => {
+        if (r.kind === "missed") return `missed:${r.date}`;
+        if (r.kind === "collapsedGap") return `gap:${r.startDate}:${r.dayCount}`;
+        return `session:${r.date}:${r.sessionIndexInDay}`;
+      }),
+    ).toEqual([
       "session:2026-04-26:1",
       "missed:2026-04-27",
       "session:2026-04-28:1",
     ]);
-  });
-
-  test("caps missed rows for very large calendar gaps", () => {
-    const rows = buildHistoryJourneyRows([
-      { sessionDate: "2020-01-01", sortKey: "a", data: { id: "1" } },
-      { sessionDate: "2030-01-01", sortKey: "b", data: { id: "2" } },
-    ]);
-    const missed = rows.filter(r => r.kind === "missed");
-    expect(missed.length).toBe(366);
   });
 
   test("sorts by sessionDate then sortKey", () => {
@@ -39,5 +40,123 @@ describe("buildHistoryJourneyRows", () => {
       { sessionDate: "2026-04-27", sortKey: "z", data: 0 },
     ]);
     expect(sorted.map(s => s.data)).toEqual([0, 1, 2]);
+  });
+
+  // MARK: quick sits in the journey (#381 / iOS #379)
+
+  test("quick-only sessions produce session rows", () => {
+    const rows = buildHistoryJourneyRows([
+      { sessionDate: "2026-06-10", sessionType: "quick", sortKey: "q1", data: { id: "q1" } },
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ kind: "session", sessionIndexInDay: 1, data: { id: "q1" } });
+  });
+
+  test("quick and standard mix uses per-type day indices", () => {
+    const rows = buildHistoryJourneyRows([
+      { sessionDate: "2026-06-10", sessionType: "standard", sortKey: "2026-06-10T08:00:00.000Z", data: { id: "s1" } },
+      { sessionDate: "2026-06-10", sessionType: "quick", sortKey: "2026-06-10T09:00:00.000Z", data: { id: "q1" } },
+      { sessionDate: "2026-06-10", sessionType: "standard", sortKey: "2026-06-10T10:00:00.000Z", data: { id: "s2" } },
+    ]);
+    expect(rows).toHaveLength(3);
+    // Chronological interleaving preserved...
+    expect(rows.map(r => (r.kind === "session" ? (r.data as { id: string }).id : null))).toEqual(["s1", "q1", "s2"]);
+    // ...while standard numbering ignores the quick sit in between.
+    expect(rows.map(r => (r.kind === "session" ? r.sessionIndexInDay : null))).toEqual([1, 1, 2]);
+  });
+
+  // MARK: gap collapsing (#381 / iOS #379)
+
+  test("two missed days stay as per-day missed rows", () => {
+    const rows = buildHistoryJourneyRows([
+      { sessionDate: "2026-06-01", sortKey: "a", data: { id: "a" } },
+      { sessionDate: "2026-06-04", sortKey: "b", data: { id: "b" } },
+    ]);
+    expect(rows).toHaveLength(4);
+    expect(rows[1]).toEqual({ kind: "missed", date: "2026-06-02" });
+    expect(rows[2]).toEqual({ kind: "missed", date: "2026-06-03" });
+  });
+
+  test("three missed days collapse to a single range (threshold boundary)", () => {
+    const rows = buildHistoryJourneyRows([
+      { sessionDate: "2026-06-01", sortKey: "a", data: { id: "a" } },
+      { sessionDate: "2026-06-05", sortKey: "b", data: { id: "b" } },
+    ]);
+    expect(rows).toHaveLength(3);
+    expect(rows[1]).toEqual({ kind: "collapsedGap", startDate: "2026-06-02", endDate: "2026-06-04", dayCount: 3 });
+    expect(COLLAPSE_GAP_THRESHOLD_DAYS).toBe(3);
+  });
+
+  test("a 30-day gap collapses to one range and keeps the prior session reachable", () => {
+    const rows = buildHistoryJourneyRows([
+      { sessionDate: "2026-04-01", sortKey: "a", data: { id: "a" } },
+      { sessionDate: "2026-05-01", sortKey: "b", data: { id: "b" } },
+    ]);
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toMatchObject({ kind: "session", data: { id: "a" } });
+    expect(rows[1]).toEqual({ kind: "collapsedGap", startDate: "2026-04-02", endDate: "2026-04-30", dayCount: 29 });
+    expect(rows[2]).toMatchObject({ kind: "session", data: { id: "b" } });
+  });
+
+  test("a gap spanning standard then quick sessions still collapses", () => {
+    const rows = buildHistoryJourneyRows([
+      { sessionDate: "2026-04-01", sessionType: "standard", sortKey: "a", data: { id: "s1" } },
+      { sessionDate: "2026-05-06", sessionType: "quick", sortKey: "b", data: { id: "q1" } },
+    ]);
+    expect(rows).toHaveLength(3);
+    expect(rows[1]).toEqual({ kind: "collapsedGap", startDate: "2026-04-02", endDate: "2026-05-05", dayCount: 34 });
+    expect(rows[2]).toMatchObject({ kind: "session", data: { id: "q1" } });
+  });
+
+  // MARK: gap adjacent to today (#381 / iOS #379)
+
+  test("a long gap between the last session and today collapses", () => {
+    const rows = buildHistoryJourneyRows(
+      [{ sessionDate: "2026-05-01", sortKey: "a", data: { id: "a" } }],
+      "2026-06-11",
+    );
+    expect(rows).toHaveLength(2);
+    // today itself is never emitted as missed.
+    expect(rows[1]).toEqual({ kind: "collapsedGap", startDate: "2026-05-02", endDate: "2026-06-10", dayCount: 40 });
+  });
+
+  test("a short trailing gap emits per-day missed rows", () => {
+    const rows = buildHistoryJourneyRows(
+      [{ sessionDate: "2026-06-09", sortKey: "a", data: { id: "a" } }],
+      "2026-06-11",
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows[1]).toEqual({ kind: "missed", date: "2026-06-10" });
+  });
+
+  test("no trailing gap when the last session is today", () => {
+    const rows = buildHistoryJourneyRows(
+      [{ sessionDate: "2026-06-11", sortKey: "a", data: { id: "a" } }],
+      "2026-06-11",
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ kind: "session" });
+  });
+
+  test("no trailing gap when the last session was yesterday", () => {
+    const rows = buildHistoryJourneyRows(
+      [{ sessionDate: "2026-06-10", sortKey: "a", data: { id: "a" } }],
+      "2026-06-11",
+    );
+    expect(rows).toHaveLength(1);
+  });
+
+  test("empty sessions produce no rows", () => {
+    expect(buildHistoryJourneyRows([], "2026-06-11")).toEqual([]);
+  });
+
+  test("very large calendar gaps collapse to one range (no per-day cap)", () => {
+    const rows = buildHistoryJourneyRows([
+      { sessionDate: "2020-01-01", sortKey: "a", data: { id: "1" } },
+      { sessionDate: "2030-01-01", sortKey: "b", data: { id: "2" } },
+    ]);
+    expect(rows).toHaveLength(3);
+    expect(rows.filter(r => r.kind === "missed")).toHaveLength(0);
+    expect(rows[1]).toMatchObject({ kind: "collapsedGap", startDate: "2020-01-02", endDate: "2029-12-31" });
   });
 });

--- a/src/lib/historyJourney.ts
+++ b/src/lib/historyJourney.ts
@@ -1,10 +1,15 @@
 import { addDaysToIsoDate, daysBetweenIsoDatesInclusive } from "./sessionCalendar";
 
-/** Max consecutive missed-day rows between two sessions (then remaining gap is collapsed). */
-const MAX_MISSED_GAP_ROWS = 366;
+/**
+ * Gaps of this many consecutive missed days or more collapse into a single
+ * `collapsedGap` row; shorter gaps keep per-day `missed` rows (#379/#381).
+ * Mirrors iOS `HistoryJourney.collapseGapThresholdDays`.
+ */
+export const COLLAPSE_GAP_THRESHOLD_DAYS = 3;
 
 export type HistoryJourneySession<T> = {
   sessionDate: string;
+  /** "standard" | "quick" (defaults to standard when absent) — drives per-type day numbering. */
   sessionType?: string;
   /** Lexicographic tiebreaker for multiple sessions on one calendar day */
   sortKey: string;
@@ -13,10 +18,12 @@ export type HistoryJourneySession<T> = {
 
 export type HistoryJourneyRow<T> =
   | { kind: "missed"; date: string }
+  | { kind: "collapsedGap"; startDate: string; endDate: string; dayCount: number }
   | { kind: "session"; date: string; sessionIndexInDay: number; data: T };
 
 /**
- * Standard sessions only (quick filtered upstream). Sort by calendar date then stable order.
+ * Sort by calendar date then stable tiebreaker. Includes all session types
+ * (quick + standard) — quick sits are no longer filtered upstream (#381).
  */
 export function sortSessionsForHistory<T>(sessions: HistoryJourneySession<T>[]): HistoryJourneySession<T>[] {
   return [...sessions].sort((a, b) => {
@@ -25,26 +32,60 @@ export function sortSessionsForHistory<T>(sessions: HistoryJourneySession<T>[]):
   });
 }
 
-export function buildHistoryJourneyRows<T>(sessions: HistoryJourneySession<T>[]): HistoryJourneyRow<T>[] {
+/**
+ * Emits rows for the missed days strictly between `fromIso` and `toIso`: per-day
+ * `missed` rows for short gaps, a single `collapsedGap` at/above the collapse
+ * threshold. Mirrors iOS `HistoryJourney.appendGapRows`.
+ */
+function appendGapRows<T>(fromIso: string, toIso: string, rows: HistoryJourneyRow<T>[]): void {
+  const daysBetween = daysBetweenIsoDatesInclusive(fromIso, toIso);
+  const missedCount = Math.max(0, daysBetween - 1);
+  if (missedCount <= 0) return;
+  if (missedCount >= COLLAPSE_GAP_THRESHOLD_DAYS) {
+    rows.push({
+      kind: "collapsedGap",
+      startDate: addDaysToIsoDate(fromIso, 1),
+      endDate: addDaysToIsoDate(fromIso, missedCount),
+      dayCount: missedCount,
+    });
+  } else {
+    for (let gap = 1; gap <= missedCount; gap++) {
+      rows.push({ kind: "missed", date: addDaysToIsoDate(fromIso, gap) });
+    }
+  }
+}
+
+/**
+ * Builds journey rows from all sessions (standard and quick), sorted by
+ * `sessionDate` then `sortKey`.
+ *
+ * `sessionIndexInDay` counts per session type within a calendar day, so standard
+ * numbering is unaffected by interleaved quick sits. Pass `todayDate` (caller's
+ * UTC calendar day, same convention used to stamp `sessionDate`) to also emit
+ * gap rows between the last session and today; today itself is never missed (#381).
+ */
+export function buildHistoryJourneyRows<T>(
+  sessions: HistoryJourneySession<T>[],
+  todayDate?: string,
+): HistoryJourneyRow<T>[] {
   const sorted = sortSessionsForHistory(sessions);
   const rows: HistoryJourneyRow<T>[] = [];
-  const perDayIndex = new Map<string, number>();
+  const perDayTypeIndex = new Map<string, number>();
 
   for (let i = 0; i < sorted.length; i++) {
     const cur = sorted[i]!;
     if (i > 0) {
-      const prev = sorted[i - 1]!;
-      const daysBetween = daysBetweenIsoDatesInclusive(prev.sessionDate, cur.sessionDate);
-      const missedCount = Math.max(0, daysBetween - 1);
-      const toEmit = Math.min(missedCount, MAX_MISSED_GAP_ROWS);
-      for (let gap = 1; gap <= toEmit; gap++) {
-        const missedDate = addDaysToIsoDate(prev.sessionDate, gap);
-        rows.push({ kind: "missed", date: missedDate });
-      }
+      appendGapRows(sorted[i - 1]!.sessionDate, cur.sessionDate, rows);
     }
-    const n = (perDayIndex.get(cur.sessionDate) ?? 0) + 1;
-    perDayIndex.set(cur.sessionDate, n);
+    const key = `${cur.sessionDate}|${cur.sessionType ?? "standard"}`;
+    const n = (perDayTypeIndex.get(key) ?? 0) + 1;
+    perDayTypeIndex.set(key, n);
     rows.push({ kind: "session", date: cur.sessionDate, sessionIndexInDay: n, data: cur.data });
+  }
+
+  const last = sorted[sorted.length - 1];
+  if (todayDate && last) {
+    appendGapRows(last.sessionDate, todayDate, rows);
   }
   return rows;
 }

--- a/src/lib/sessionCalendar.test.ts
+++ b/src/lib/sessionCalendar.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { todayLocalIsoDate, isValidSessionCalendarDate } from "./sessionCalendar";
+
+describe("todayLocalIsoDate", () => {
+  afterEach(() => vi.useRealTimers());
+
+  test("formats the local calendar day as zero-padded YYYY-MM-DD", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 5, 10, 30, 0)); // local Jan 5, 2026
+    expect(todayLocalIsoDate()).toBe("2026-01-05");
+  });
+
+  test("reports the local calendar day late in the evening (no UTC rollover)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 11, 31, 23, 59, 0)); // local Dec 31, 2026
+    expect(todayLocalIsoDate()).toBe("2026-12-31");
+    expect(isValidSessionCalendarDate(todayLocalIsoDate())).toBe(true);
+  });
+});

--- a/src/lib/sessionCalendar.ts
+++ b/src/lib/sessionCalendar.ts
@@ -31,3 +31,17 @@ export function daysBetweenIsoDatesInclusive(fromIso: string, toIso: string): nu
   const toMs = Date.UTC(ty, tm - 1, td);
   return Math.round((toMs - fromMs) / (1000 * 60 * 60 * 24));
 }
+
+/**
+ * Today's calendar day as `YYYY-MM-DD` in the client's LOCAL timezone — the same
+ * convention used to stamp `session_date` on the write path (solo + buddy session
+ * saves). History/journey gap math must use this rather than a UTC day so the
+ * trailing gap to "today" lines up with locally-dated sessions for non-UTC users.
+ */
+export function todayLocalIsoDate(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}


### PR DESCRIPTION
## **User description**
## What & why

Web side of the iOS #379 fix (history Journey parity, #381). The web journey had the pre-#379 behavior: quick sits were filtered out, long gaps rendered one \`missed\` row per day (capped at 366), and no gap was shown between the last session and today.

This is a manual port of \`HistoryJourney.swift\`:

- **Quick sits appear** in the journey, rendered as muted "Quick" rows (reduced-opacity bar) instead of being filtered out.
- **Long gaps collapse**: 3+ consecutive missed days become a single "N days missed" row (\`COLLAPSE_GAP_THRESHOLD_DAYS = 3\`, matching iOS \`collapseGapThresholdDays\`). 1–2 day gaps stay as per-day \`missed\` rows.
- **Trailing gap to today** is now emitted (optional \`todayDate\` param), collapsed by the same rule. Today itself is never marked missed.
- Per-day session numbering is now **per session type**, so interleaved quick sits don't disturb "Session N" numbering.

Stats (\`calculateSessionStats\`) still exclude quick sits — unchanged, locked in #379. Web and iOS are separate codebases; this is a manual port, not shared code.

## Test plan

- [x] Quick sits appear in the web history journey with visual distinction (muted "Quick" row)
- [x] Gaps of 3+ consecutive missed days collapse into a single "N days missed" row (threshold = 3, matches iOS)
- [x] Trailing gap between the last session and today renders, collapsed by the same rule
- [x] Unit tests mirror \`HistoryJourneyTests\` scenarios (quick+standard mix, 30-day gap, gap adjacent to today)
- [x] \`npx tsc --noEmit\` clean (verified locally)
- [x] \`npm run test:unit\` green (verified locally: 219/219, incl. 15 journey tests)

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Show quick sessions in the history journey and collapse long gaps into a single missed-range row

### What Changed
- Quick sessions now appear in the journey instead of being hidden, with a muted label and bar so they stand apart from standard sessions
- Standard session numbering stays in order even when quick sessions are mixed in on the same day
- Gaps of 3 or more missed days now collapse into one range row, while shorter gaps still show day by day
- The journey now also shows the gap between the latest session and today, without marking today as missed

### Impact
`✅ Visible quick-session history`
`✅ Shorter history timelines`
`✅ Clearer long-gap display`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

