### PR TITLE
DO NOT MERGE: RED-gate CI verification (#422 typecheck + #397 swift test)

### DIFF
--- a/ios/StillPointShared/Tests/StillPointSharedTests/RedGateDemoTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/RedGateDemoTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+// RED-gate verification for #397 — DO NOT MERGE. A deliberately failing test so
+// `swift test` exits non-zero and turns the StillPointShared swift test check red.
+final class RedGateDemoTests: XCTestCase {
+    func testRedGateDeliberateFailure() {
+        XCTFail("RED-gate verification: proves a failing unit test turns the check red.")
+    }
+}

--- a/src/lib/redGateDemo.test.ts
+++ b/src/lib/redGateDemo.test.ts
@@ -1,0 +1,9 @@
+import { test } from "vitest";
+
+// RED-gate verification for #422 — DO NOT MERGE. A string is not assignable to
+// number, so `tsc --noEmit` must fail the `typecheck` check on this scratch PR.
+const _redGateBadType: number = "not a number";
+
+test("red-gate demo", () => {
+  void _redGateBadType;
+});


### PR DESCRIPTION
Throwaway PR to prove both new gates go red on real CI. Adds one bad-typed `*.test.ts` (must fail `typecheck`) and one failing swift test (must fail `StillPointShared swift test`). Will be closed and the branch deleted once both checks report red. Verifies the RED half of the Test Plans on #424/#425.