### PR TITLE
feat(ios): daily app-block re-lock via DeviceActivity (#423)

### DIFF
--- a/ios/AppBlockingShared/AppBlockingShared.swift
+++ b/ios/AppBlockingShared/AppBlockingShared.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Storage + scheduling shared between the main app and the `StillPointMonitor`
+/// DeviceActivity extension (#423).
+///
+/// The extension runs in its own sandboxed process, so the saved
+/// `FamilyActivitySelection` is shared through an App Group's `UserDefaults`.
+/// The Family Controls / DeviceActivity APIs are guarded behind
+/// `#if !targetEnvironment(simulator)` to match the rest of the app: the
+/// simulator (PR e2e) build never links those frameworks, so it launches
+/// without the device-only entitlements.
+enum AppBlockingShared {
+    /// App Group shared by the app + monitor extension. Must be enabled on both
+    /// App IDs and present in both provisioning profiles (device only).
+    static let appGroupID = "group.com.brettonauerbach.stillpoint"
+
+    /// Key for the encoded `FamilyActivitySelection` in the shared suite.
+    /// Matches the historical app-only key so a migration can copy it forward.
+    static let selectionKey = "appBlocking.selection.v1"
+
+    /// Identifier for the repeating daily monitoring interval.
+    static let activityName = "dailyLock"
+
+    /// Shared defaults suite the app writes the selection to and the extension reads.
+    static var sharedDefaults: UserDefaults? { UserDefaults(suiteName: appGroupID) }
+}
+
+#if !targetEnvironment(simulator)
+import FamilyControls
+import ManagedSettings
+import DeviceActivity
+
+extension AppBlockingShared {
+    static var deviceActivityName: DeviceActivityName { DeviceActivityName(activityName) }
+
+    /// Repeating daily schedule whose interval starts at local midnight. The
+    /// monitor extension's `intervalDidStart` fires at the start of each day,
+    /// which is when the gated apps re-lock — even if the app is suspended.
+    static func dailySchedule() -> DeviceActivitySchedule {
+        DeviceActivitySchedule(
+            intervalStart: DateComponents(hour: 0, minute: 0),
+            intervalEnd: DateComponents(hour: 23, minute: 59, second: 59),
+            repeats: true
+        )
+    }
+
+    /// Decode the stored selection, distinguishing a load *failure* from a genuine
+    /// "no selection": returns `nil` when the App Group is unavailable or stored
+    /// data exists but cannot be decoded (corruption); returns an empty selection
+    /// only when no data has ever been saved. Callers that mutate shields must
+    /// treat `nil` as "do not relax shielding" (fail closed).
+    static func decodeStoredSelection() -> FamilyActivitySelection? {
+        guard let defaults = sharedDefaults else { return nil }
+        guard let data = defaults.data(forKey: selectionKey) else {
+            return FamilyActivitySelection()
+        }
+        return try? JSONDecoder().decode(FamilyActivitySelection.self, from: data)
+    }
+
+    /// Convenience for the app's in-memory selection at launch: an empty selection
+    /// on any failure. The unattended monitor path uses `decodeStoredSelection()`
+    /// instead, so a read/decode failure there never clears existing shields.
+    static func loadSelection() -> FamilyActivitySelection {
+        decodeStoredSelection() ?? FamilyActivitySelection()
+    }
+
+    /// Persist the selection to the shared suite so the extension can read it.
+    @discardableResult
+    static func saveSelection(_ selection: FamilyActivitySelection) -> Bool {
+        guard let data = try? JSONEncoder().encode(selection) else { return false }
+        guard let defaults = sharedDefaults else { return false }
+        defaults.set(data, forKey: selectionKey)
+        return true
+    }
+
+    /// Re-apply the shield for the saved selection. Called by the extension at
+    /// interval start (new local day → re-lock). Deliberately minimal to respect
+    /// the DeviceActivity extension's tight memory budget.
+    ///
+    /// Fail closed: the monitor only ever *adds* shields for a confidently decoded,
+    /// non-empty selection. If the App Group is unavailable, the stored data is
+    /// missing/corrupt, or the selection is empty, it leaves the current shield
+    /// state untouched rather than clearing it — a transient read/decode failure
+    /// must never silently unlock the user's apps at midnight. Clearing shields is
+    /// exclusively the app's job (on a qualifying unlock), never the monitor's.
+    static func applySavedShield(to store: ManagedSettingsStore) {
+        guard let selection = decodeStoredSelection() else { return }
+        let isEmpty = selection.applicationTokens.isEmpty
+            && selection.categoryTokens.isEmpty
+            && selection.webDomainTokens.isEmpty
+        guard !isEmpty else { return }
+        store.shield.applications = selection.applicationTokens.isEmpty
+            ? nil
+            : selection.applicationTokens
+        store.shield.applicationCategories = selection.categoryTokens.isEmpty
+            ? nil
+            : .specific(selection.categoryTokens)
+        store.shield.webDomains = selection.webDomainTokens.isEmpty
+            ? nil
+            : selection.webDomainTokens
+    }
+}
+#endif

--- a/ios/StillPoint.xcodeproj/project.pbxproj
+++ b/ios/StillPoint.xcodeproj/project.pbxproj
@@ -7,100 +7,152 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		13177552A26E700472836E9A /* NotificationPreferencesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E16CD986E277DA88A2EB6F1 /* NotificationPreferencesViewModel.swift */; };
 		15177B86F124B5A10AB03456 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C683A9F0586D58020E60DD87 /* RootView.swift */; };
 		1649BE1D765A6851D5802BBA /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D356465C1B0F69C57FE47A80 /* SettingsView.swift */; };
-		17A359000000000000000002 /* NotificationsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A359000000000000000001 /* NotificationsSettingsView.swift */; };
-		16697A0A2D8E95D300EEA791 /* BuddyVideoWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0F8BA13F32BC68EEA0198C /* BuddyVideoWebView.swift */; };
-		17A248000000000000000008 /* AppleSignInController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A248000000000000000007 /* AppleSignInController.swift */; };
-		17A248000000000000000001 /* AppBlockingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A248000000000000000002 /* AppBlockingManager.swift */; };
-		17A248000000000000000003 /* AppBlockingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A248000000000000000004 /* AppBlockingSettingsView.swift */; };
-		17A248000000000000000012 /* PushNotificationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A248000000000000000013 /* PushNotificationCoordinator.swift */; };
-		17A248000000000000000014 /* DeviceTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A248000000000000000015 /* DeviceTokenStore.swift */; };
-		17A248000000000000000016 /* SessionIdleTimerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A248000000000000000017 /* SessionIdleTimerController.swift */; };
+		1AD1C504911C0820878EFAA4 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14BEE5E52F5249E22EA4DB08 /* SnapshotHelper.swift */; };
 		1BE60070F826B7B31DFAB315 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FA6DAE71EE23FAF8EE0F12 /* HomeView.swift */; };
-		25295F15540B9986B15EB839 /* BuddySessionContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6D8D4FA0580148DEAB74CC3 /* BuddySessionContainerView.swift */; };
 		2E31C1B6A86E612EF7171348 /* ThoughtJournalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44912B427658554F984CCC3A /* ThoughtJournalView.swift */; };
+		39045EBEEF3AF94277B45E02 /* SessionStateBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF304356E66657666901E4F /* SessionStateBadge.swift */; };
 		3E8960D90E815E3462FF241B /* ThoughtJournalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42927B68B0A976D71FE0637F /* ThoughtJournalViewModel.swift */; };
-		17A345000000000000000002 /* NotificationPreferencesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A345000000000000000001 /* NotificationPreferencesViewModel.swift */; };
-		3F95AB4ED8A3AB01D8D2B042 /* BuddySessionHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4D291539A7556C58555EC6 /* BuddySessionHubView.swift */; };
-		42BF1908A778629F7C747264 /* BuddySessionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAF68030111C6FA73098D17 /* BuddySessionViewModel.swift */; };
 		3F1BEE1BEA197162093263CB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9311B0CBDED4DF207E799ACC /* Assets.xcassets */; };
 		432648A182B69A2E98314B0C /* BoardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D22599DCB705628A5CB6F51 /* BoardViewModel.swift */; };
+		47381BA7F1BB53B93A40989B /* BuddyActiveSessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007BDD6AAA013A4DAE0AD04B /* BuddyActiveSessionView.swift */; };
 		4BC69FCAE79FAF2487A6E152 /* JetBrainsMono-Variable.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 797A65A5FC78734F7733B1BD /* JetBrainsMono-Variable.ttf */; };
 		4D652980F04840078B8FC938 /* SessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F95E6E47148AEF494393FDB /* SessionView.swift */; };
-		4FF6F665DB343AF63E7E1718 /* BuddyWaitingRoomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D903EE2C350B6705F6917952 /* BuddyWaitingRoomView.swift */; };
 		50CD873CA594B5A6FCDBB251 /* HistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F75039BBEED880C73680860 /* HistoryViewModel.swift */; };
+		5147B5721B90EB7D83D843FF /* DeviceTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD56539A4822B6F632F6CEC0 /* DeviceTokenStore.swift */; };
 		55CB825BEE151D314A4DD2FA /* AppViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 218693B76FDAF56B6E0321DE /* AppViewModel.swift */; };
 		5CD3F9D38AB8369BA65DD128 /* Newsreader-Italic-Variable.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4F0CE80470C4C3CE0D9B4C00 /* Newsreader-Italic-Variable.ttf */; };
+		5E1134CA9CA16D2589A0FDDE /* BuddySessionHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D00E2E996D254A5D3D96DF9 /* BuddySessionHubView.swift */; };
 		5EA3E8C9B84298DE1F37251F /* AuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00D7B1EDF2C56A1B6EB4C28 /* AuthView.swift */; };
+		6760DF427777049973A0D182 /* AppleSignInController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8807A08DBDE8A121951350FD /* AppleSignInController.swift */; };
+		6B6572152FB23B94F990D66B /* AppBlockingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F0B6135A30B315B9962460 /* AppBlockingManager.swift */; };
+		6E8830D16FED5FBB78B6DF34 /* XCUIElement+TapAndType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E69E315D37F87410DBE4B8C /* XCUIElement+TapAndType.swift */; };
 		74AE784447C3D50E1E6980E9 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7766937C968433C205A250C /* HistoryView.swift */; };
-		760C4A2F57E6B207F729ABEA /* BuddyActiveSessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09E9BBE4830753E3B8FCC1C0 /* BuddyActiveSessionView.swift */; };
+		750987110FAE532744F6571E /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 45BC84AB51307C865EF7257A /* README.md */; };
 		80005A5883007151E3A9C5C3 /* MindStateBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB771FA099C779B2F3A86AB /* MindStateBarView.swift */; };
 		8260BE3D7302FE11A35677B2 /* StillPointShared in Frameworks */ = {isa = PBXBuildFile; productRef = FE1475755D9C9BA63C80748F /* StillPointShared */; };
+		840761F5A9A217D4441A7FB5 /* BuddyWaitingRoomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D0005AAA572020F3028B9F /* BuddyWaitingRoomView.swift */; };
 		8A9734076E9FB3D5477913A0 /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6CBD1A192FD74748A6D36BF /* AuthViewModel.swift */; };
 		977B64DE4C6FCAE7ADDD898B /* Newsreader-Variable.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 59BC4CFFEEC93BECAACE1111 /* Newsreader-Variable.ttf */; };
 		9ECB83ED063EDAA82E88004B /* CompletionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D13B1D65F99CF21AA713D32 /* CompletionView.swift */; };
+		9F4E4B6270115FC333B22575 /* BuddySessionContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B273C4819BA7697AD256ABDA /* BuddySessionContainerView.swift */; };
+		A1636CD509D32399A02C45B3 /* AppBlockingShared.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFD4FE5B2BFD74718DC3CE1 /* AppBlockingShared.swift */; };
+		A21FE7A1E00EA88626526059 /* BuddyCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69FDE084FF9D5E20CF6725A2 /* BuddyCalendarView.swift */; };
+		A564D3891222DA735A7F96B7 /* StillPointAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0D9EC50BFCE181AA8F6E7E /* StillPointAppUITests.swift */; };
+		AC092ECADA2EA4C161CAF5E7 /* AppBlockingShared.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFD4FE5B2BFD74718DC3CE1 /* AppBlockingShared.swift */; };
 		AC4DAD06FA75C7C480DDFF27 /* SessionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE2D028ACC5D7FEFD82703D /* SessionViewModel.swift */; };
 		B106890588723F191CC4AEAA /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7B5A3374B6B8AC64C22F537 /* MainTabView.swift */; };
+		B2C69D176260DEF6EE91C9BA /* BuddyVideoWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A926CF90DAFC03754D7434B3 /* BuddyVideoWebView.swift */; };
 		B41D20D3939E0F51F7471F44 /* ThoughtCaptureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A71F34D9A1ED328C5438F7 /* ThoughtCaptureView.swift */; };
+		B6A3805810E44935E75EEC11 /* AppBlockingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B72DC4A41DAD78C377853469 /* AppBlockingSettingsView.swift */; };
+		C0FD436A962D0DC179B37D73 /* NotificationsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A34376705757DF9CD77D013A /* NotificationsSettingsView.swift */; };
 		C57D92D33ED679E23F5E2E49 /* DesignTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB4B1423B22DD22F5B6E069 /* DesignTokens.swift */; };
+		D3744C3003DA233DC0B74C99 /* BuddyFilterChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DAA0ED0064C69AE18FAD991 /* BuddyFilterChips.swift */; };
+		D44FB0782DD33A5900AF8D60 /* BuddyCalendarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE015F8D72AE054E6990FB3 /* BuddyCalendarViewModel.swift */; };
+		D4BA6F49AEC3DDCE40AFE5D1 /* BuddySessionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FF5BFB92C98C791296977A /* BuddySessionViewModel.swift */; };
+		DB29DB67C1C843229183E662 /* StillPointMonitor.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 58A0BC69E330440BE836DDC4 /* StillPointMonitor.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		DB99CD9DA2E6BB2A49B63025 /* PublicBoardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BD7D2C82C908604A0C3D914 /* PublicBoardView.swift */; };
 		E1FBFCD4730D9BC4E924C938 /* StillPointApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CEC6DBFFB1C10CFDDA8424 /* StillPointApp.swift */; };
+		E636EACFC27E6022A80898FC /* SnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2EB81E2A5E7CD9E4586F3BE /* SnapshotTests.swift */; };
+		E72B904E4F87A91D52EBF826 /* SessionIdleTimerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F3B170D19689EEF2E14436A /* SessionIdleTimerController.swift */; };
+		EA20FAB8B6D3C8B249AFAF82 /* PushNotificationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4870AA6067BE7239DF3130 /* PushNotificationCoordinator.swift */; };
+		EE8F0D07AFA655F960F274F8 /* StillPointMonitorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C905A2D3D5DA83146A9CC9 /* StillPointMonitorExtension.swift */; };
 		F370AA8F6AA102355FC599C9 /* BlockGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EAF998E3470CBB4056699F /* BlockGridView.swift */; };
-		17A346000000000000000001 /* BuddyCalendarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A346000000000000000011 /* BuddyCalendarViewModel.swift */; };
-		17A346000000000000000002 /* BuddyCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A346000000000000000012 /* BuddyCalendarView.swift */; };
-		17A346000000000000000003 /* SessionStateBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A346000000000000000013 /* SessionStateBadge.swift */; };
-		17A346000000000000000004 /* BuddyFilterChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A346000000000000000014 /* BuddyFilterChips.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		540585E1D78B21D6A3B5B30D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 17E69AC4DBE973C4774D38B6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1EC3D1ED76F9038154716BEC;
+			remoteInfo = StillPoint;
+		};
+		7D96BF3D0EE2B0569179B9CB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 17E69AC4DBE973C4774D38B6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EC97B0CE4FB530B3C2368458;
+			remoteInfo = StillPointMonitor;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		F78D861A536366A248BE993E /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				DB29DB67C1C843229183E662 /* StillPointMonitor.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		007BDD6AAA013A4DAE0AD04B /* BuddyActiveSessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyActiveSessionView.swift; sourceTree = "<group>"; };
 		0BD7D2C82C908604A0C3D914 /* PublicBoardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicBoardView.swift; sourceTree = "<group>"; };
 		0D22599DCB705628A5CB6F51 /* BoardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardViewModel.swift; sourceTree = "<group>"; };
+		0DAA0ED0064C69AE18FAD991 /* BuddyFilterChips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyFilterChips.swift; sourceTree = "<group>"; };
+		0EE015F8D72AE054E6990FB3 /* BuddyCalendarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyCalendarViewModel.swift; sourceTree = "<group>"; };
+		107CCEB76752E572D0D142EF /* StillPoint.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StillPoint.entitlements; sourceTree = "<group>"; };
+		14BEE5E52F5249E22EA4DB08 /* SnapshotHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
 		14CEC6DBFFB1C10CFDDA8424 /* StillPointApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StillPointApp.swift; sourceTree = "<group>"; };
-		17A248000000000000000002 /* AppBlockingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBlockingManager.swift; sourceTree = "<group>"; };
-		17A248000000000000000004 /* AppBlockingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBlockingSettingsView.swift; sourceTree = "<group>"; };
-		17A248000000000000000013 /* PushNotificationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationCoordinator.swift; sourceTree = "<group>"; };
-		17A248000000000000000015 /* DeviceTokenStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceTokenStore.swift; sourceTree = "<group>"; };
-		17A248000000000000000017 /* SessionIdleTimerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIdleTimerController.swift; sourceTree = "<group>"; };
-		17A248000000000000000005 /* StillPoint.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StillPoint.entitlements; sourceTree = "<group>"; };
-		17A248000000000000000007 /* AppleSignInController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInController.swift; sourceTree = "<group>"; };
+		1F3B170D19689EEF2E14436A /* SessionIdleTimerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIdleTimerController.swift; sourceTree = "<group>"; };
 		1F75039BBEED880C73680860 /* HistoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryViewModel.swift; sourceTree = "<group>"; };
-		17A345000000000000000001 /* NotificationPreferencesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPreferencesViewModel.swift; sourceTree = "<group>"; };
 		218693B76FDAF56B6E0321DE /* AppViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppViewModel.swift; sourceTree = "<group>"; };
 		23FA6DAE71EE23FAF8EE0F12 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		2F95E6E47148AEF494393FDB /* SessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionView.swift; sourceTree = "<group>"; };
+		2FF304356E66657666901E4F /* SessionStateBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStateBadge.swift; sourceTree = "<group>"; };
+		3D00E2E996D254A5D3D96DF9 /* BuddySessionHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddySessionHubView.swift; sourceTree = "<group>"; };
+		3E69E315D37F87410DBE4B8C /* XCUIElement+TapAndType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElement+TapAndType.swift"; sourceTree = "<group>"; };
 		42927B68B0A976D71FE0637F /* ThoughtJournalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThoughtJournalViewModel.swift; sourceTree = "<group>"; };
+		4448B4F081A909461B669A8B /* StillPointApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StillPointApp.entitlements; sourceTree = "<group>"; };
 		44912B427658554F984CCC3A /* ThoughtJournalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThoughtJournalView.swift; sourceTree = "<group>"; };
+		45BC84AB51307C865EF7257A /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		48FF5BFB92C98C791296977A /* BuddySessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddySessionViewModel.swift; sourceTree = "<group>"; };
 		4F0CE80470C4C3CE0D9B4C00 /* Newsreader-Italic-Variable.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Newsreader-Italic-Variable.ttf"; sourceTree = "<group>"; };
+		503A6D41F27BA9646DA35192 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		58A0BC69E330440BE836DDC4 /* StillPointMonitor.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = StillPointMonitor.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		59BC4CFFEEC93BECAACE1111 /* Newsreader-Variable.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Newsreader-Variable.ttf"; sourceTree = "<group>"; };
+		69FDE084FF9D5E20CF6725A2 /* BuddyCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyCalendarView.swift; sourceTree = "<group>"; };
+		6E16CD986E277DA88A2EB6F1 /* NotificationPreferencesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPreferencesViewModel.swift; sourceTree = "<group>"; };
 		71A71F34D9A1ED328C5438F7 /* ThoughtCaptureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThoughtCaptureView.swift; sourceTree = "<group>"; };
 		797A65A5FC78734F7733B1BD /* JetBrainsMono-Variable.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMono-Variable.ttf"; sourceTree = "<group>"; };
 		7CB771FA099C779B2F3A86AB /* MindStateBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MindStateBarView.swift; sourceTree = "<group>"; };
 		7D13B1D65F99CF21AA713D32 /* CompletionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionView.swift; sourceTree = "<group>"; };
-		7E4D291539A7556C58555EC6 /* BuddySessionHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddySessionHubView.swift; sourceTree = "<group>"; };
+		7D4870AA6067BE7239DF3130 /* PushNotificationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationCoordinator.swift; sourceTree = "<group>"; };
 		85EAF998E3470CBB4056699F /* BlockGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockGridView.swift; sourceTree = "<group>"; };
+		8807A08DBDE8A121951350FD /* AppleSignInController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInController.swift; sourceTree = "<group>"; };
+		92F0B6135A30B315B9962460 /* AppBlockingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBlockingManager.swift; sourceTree = "<group>"; };
 		9311B0CBDED4DF207E799ACC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		9A0F8BA13F32BC68EEA0198C /* BuddyVideoWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyVideoWebView.swift; sourceTree = "<group>"; };
 		A00D7B1EDF2C56A1B6EB4C28 /* AuthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthView.swift; sourceTree = "<group>"; };
+		A34376705757DF9CD77D013A /* NotificationsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsSettingsView.swift; sourceTree = "<group>"; };
 		A67F64CE400EF98ED2925FF9 /* StillPointShared */ = {isa = PBXFileReference; lastKnownFileType = folder; name = StillPointShared; path = StillPointShared; sourceTree = SOURCE_ROOT; };
+		A926CF90DAFC03754D7434B3 /* BuddyVideoWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyVideoWebView.swift; sourceTree = "<group>"; };
 		AB8762D63FDB945A01DEA97F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		AC0D9EC50BFCE181AA8F6E7E /* StillPointAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StillPointAppUITests.swift; sourceTree = "<group>"; };
+		AD56539A4822B6F632F6CEC0 /* DeviceTokenStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceTokenStore.swift; sourceTree = "<group>"; };
+		B273C4819BA7697AD256ABDA /* BuddySessionContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddySessionContainerView.swift; sourceTree = "<group>"; };
+		B3C905A2D3D5DA83146A9CC9 /* StillPointMonitorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StillPointMonitorExtension.swift; sourceTree = "<group>"; };
 		B6CBD1A192FD74748A6D36BF /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
+		B72DC4A41DAD78C377853469 /* AppBlockingSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBlockingSettingsView.swift; sourceTree = "<group>"; };
+		C20B7B5A94F2DE23B28B579A /* StillPointMonitor.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StillPointMonitor.entitlements; sourceTree = "<group>"; };
+		C2EB81E2A5E7CD9E4586F3BE /* SnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotTests.swift; sourceTree = "<group>"; };
 		C683A9F0586D58020E60DD87 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		C7766937C968433C205A250C /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryView.swift; sourceTree = "<group>"; };
 		CDB4B1423B22DD22F5B6E069 /* DesignTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignTokens.swift; sourceTree = "<group>"; };
 		D15A7FF17302B1E2FD147920 /* StillPoint.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = StillPoint.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D356465C1B0F69C57FE47A80 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
-		17A359000000000000000001 /* NotificationsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsSettingsView.swift; sourceTree = "<group>"; };
-		D6D8D4FA0580148DEAB74CC3 /* BuddySessionContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddySessionContainerView.swift; sourceTree = "<group>"; };
 		D7B5A3374B6B8AC64C22F537 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
-		D903EE2C350B6705F6917952 /* BuddyWaitingRoomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyWaitingRoomView.swift; sourceTree = "<group>"; };
-		DAAF68030111C6FA73098D17 /* BuddySessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddySessionViewModel.swift; sourceTree = "<group>"; };
+		DDFD4FE5B2BFD74718DC3CE1 /* AppBlockingShared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBlockingShared.swift; sourceTree = "<group>"; };
+		E1C10719A1709CEE1EAEBE17 /* StillPointAppUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = StillPointAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4D0005AAA572020F3028B9F /* BuddyWaitingRoomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyWaitingRoomView.swift; sourceTree = "<group>"; };
 		FDE2D028ACC5D7FEFD82703D /* SessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionViewModel.swift; sourceTree = "<group>"; };
-		09E9BBE4830753E3B8FCC1C0 /* BuddyActiveSessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyActiveSessionView.swift; sourceTree = "<group>"; };
-		17A346000000000000000011 /* BuddyCalendarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyCalendarViewModel.swift; sourceTree = "<group>"; };
-		17A346000000000000000012 /* BuddyCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyCalendarView.swift; sourceTree = "<group>"; };
-		17A346000000000000000013 /* SessionStateBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStateBadge.swift; sourceTree = "<group>"; };
-		17A346000000000000000014 /* BuddyFilterChips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyFilterChips.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -115,22 +167,33 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		00907B112AF3AFED14FA0192 /* StillPointAppUITests */ = {
+			isa = PBXGroup;
+			children = (
+				45BC84AB51307C865EF7257A /* README.md */,
+				AC0D9EC50BFCE181AA8F6E7E /* StillPointAppUITests.swift */,
+				54D40F602F07E94E9BD6CF37 /* Helpers */,
+				F0FD78DD2EB1220358FB4672 /* Snapshots */,
+			);
+			path = StillPointAppUITests;
+			sourceTree = "<group>";
+		};
 		0125A97693D46BCCED4DC74E /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				B72DC4A41DAD78C377853469 /* AppBlockingSettingsView.swift */,
 				A00D7B1EDF2C56A1B6EB4C28 /* AuthView.swift */,
-				9AEB18D5D4C55CB98F814D43 /* BuddySession */,
-				17A346000000000000000010 /* BuddyCalendar */,
 				7D13B1D65F99CF21AA713D32 /* CompletionView.swift */,
 				C7766937C968433C205A250C /* HistoryView.swift */,
 				23FA6DAE71EE23FAF8EE0F12 /* HomeView.swift */,
-				17A248000000000000000004 /* AppBlockingSettingsView.swift */,
+				A34376705757DF9CD77D013A /* NotificationsSettingsView.swift */,
 				0BD7D2C82C908604A0C3D914 /* PublicBoardView.swift */,
 				C683A9F0586D58020E60DD87 /* RootView.swift */,
 				2F95E6E47148AEF494393FDB /* SessionView.swift */,
 				D356465C1B0F69C57FE47A80 /* SettingsView.swift */,
-				17A359000000000000000001 /* NotificationsSettingsView.swift */,
 				44912B427658554F984CCC3A /* ThoughtJournalView.swift */,
+				3CF33E14AFF118C76854F60A /* BuddyCalendar */,
+				8BFB3AFE8B8A4AFB50ADB37B /* BuddySession */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -154,19 +217,38 @@
 			path = Fonts;
 			sourceTree = "<group>";
 		};
+		379B38AC4868912EF44556DF /* AppBlockingShared */ = {
+			isa = PBXGroup;
+			children = (
+				DDFD4FE5B2BFD74718DC3CE1 /* AppBlockingShared.swift */,
+			);
+			path = AppBlockingShared;
+			sourceTree = "<group>";
+		};
+		3CF33E14AFF118C76854F60A /* BuddyCalendar */ = {
+			isa = PBXGroup;
+			children = (
+				69FDE084FF9D5E20CF6725A2 /* BuddyCalendarView.swift */,
+				0DAA0ED0064C69AE18FAD991 /* BuddyFilterChips.swift */,
+				2FF304356E66657666901E4F /* SessionStateBadge.swift */,
+			);
+			path = BuddyCalendar;
+			sourceTree = "<group>";
+		};
 		489EB05EBE530B8F6E4F1C7F /* StillPointApp */ = {
 			isa = PBXGroup;
 			children = (
+				AD56539A4822B6F632F6CEC0 /* DeviceTokenStore.swift */,
 				AB8762D63FDB945A01DEA97F /* Info.plist */,
-				17A248000000000000000005 /* StillPoint.entitlements */,
+				7D4870AA6067BE7239DF3130 /* PushNotificationCoordinator.swift */,
+				107CCEB76752E572D0D142EF /* StillPoint.entitlements */,
+				4448B4F081A909461B669A8B /* StillPointApp.entitlements */,
 				14CEC6DBFFB1C10CFDDA8424 /* StillPointApp.swift */,
-				17A248000000000000000015 /* DeviceTokenStore.swift */,
-				17A248000000000000000013 /* PushNotificationCoordinator.swift */,
 				4DB1C67E76477BADB30F0F77 /* Components */,
-				17A248000000000000000006 /* Managers */,
-				17A248000000000000000009 /* Services */,
+				6F81A1DEB3C67EC2415E179A /* Managers */,
 				551003AC2B5AD8A7B3C3D426 /* Navigation */,
 				09EA4336C05552F95AE85178 /* Resources */,
+				9A1FCA572FDAB69F4F6E75EB /* Services */,
 				AC788F412B1414C8C2BDB3CB /* Theme */,
 				B5DCE12E19F7C00786209F0E /* ViewModels */,
 				0125A97693D46BCCED4DC74E /* Views */,
@@ -184,6 +266,14 @@
 			path = Components;
 			sourceTree = "<group>";
 		};
+		54D40F602F07E94E9BD6CF37 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				3E69E315D37F87410DBE4B8C /* XCUIElement+TapAndType.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
 		551003AC2B5AD8A7B3C3D426 /* Navigation */ = {
 			isa = PBXGroup;
 			children = (
@@ -192,52 +282,35 @@
 			path = Navigation;
 			sourceTree = "<group>";
 		};
-		17A248000000000000000006 /* Managers */ = {
+		6F81A1DEB3C67EC2415E179A /* Managers */ = {
 			isa = PBXGroup;
 			children = (
-				17A248000000000000000002 /* AppBlockingManager.swift */,
-				17A248000000000000000017 /* SessionIdleTimerController.swift */,
+				92F0B6135A30B315B9962460 /* AppBlockingManager.swift */,
+				1F3B170D19689EEF2E14436A /* SessionIdleTimerController.swift */,
 			);
 			path = Managers;
-			sourceTree = "<group>";
-		};
-		17A248000000000000000009 /* Services */ = {
-			isa = PBXGroup;
-			children = (
-				17A248000000000000000007 /* AppleSignInController.swift */,
-			);
-			path = Services;
-			sourceTree = "<group>";
-		};
-		9AEB18D5D4C55CB98F814D43 /* BuddySession */ = {
-			isa = PBXGroup;
-			children = (
-				7E4D291539A7556C58555EC6 /* BuddySessionHubView.swift */,
-				D903EE2C350B6705F6917952 /* BuddyWaitingRoomView.swift */,
-				09E9BBE4830753E3B8FCC1C0 /* BuddyActiveSessionView.swift */,
-				D6D8D4FA0580148DEAB74CC3 /* BuddySessionContainerView.swift */,
-				9A0F8BA13F32BC68EEA0198C /* BuddyVideoWebView.swift */,
-			);
-			path = BuddySession;
-			sourceTree = "<group>";
-		};
-		17A346000000000000000010 /* BuddyCalendar */ = {
-			isa = PBXGroup;
-			children = (
-				17A346000000000000000012 /* BuddyCalendarView.swift */,
-				17A346000000000000000014 /* BuddyFilterChips.swift */,
-				17A346000000000000000013 /* SessionStateBadge.swift */,
-			);
-			path = BuddyCalendar;
 			sourceTree = "<group>";
 		};
 		70234ED5699E0294984184EC = {
 			isa = PBXGroup;
 			children = (
+				379B38AC4868912EF44556DF /* AppBlockingShared */,
 				72C36256C4A12941449D9B2F /* Packages */,
 				489EB05EBE530B8F6E4F1C7F /* StillPointApp */,
+				00907B112AF3AFED14FA0192 /* StillPointAppUITests */,
+				71B26AFC0A48AD3E9373C0DA /* StillPointMonitor */,
 				D6729D98E36CD4883502F855 /* Products */,
 			);
+			sourceTree = "<group>";
+		};
+		71B26AFC0A48AD3E9373C0DA /* StillPointMonitor */ = {
+			isa = PBXGroup;
+			children = (
+				503A6D41F27BA9646DA35192 /* Info.plist */,
+				C20B7B5A94F2DE23B28B579A /* StillPointMonitor.entitlements */,
+				B3C905A2D3D5DA83146A9CC9 /* StillPointMonitorExtension.swift */,
+			);
+			path = StillPointMonitor;
 			sourceTree = "<group>";
 		};
 		72C36256C4A12941449D9B2F /* Packages */ = {
@@ -246,6 +319,26 @@
 				A67F64CE400EF98ED2925FF9 /* StillPointShared */,
 			);
 			name = Packages;
+			sourceTree = "<group>";
+		};
+		8BFB3AFE8B8A4AFB50ADB37B /* BuddySession */ = {
+			isa = PBXGroup;
+			children = (
+				007BDD6AAA013A4DAE0AD04B /* BuddyActiveSessionView.swift */,
+				B273C4819BA7697AD256ABDA /* BuddySessionContainerView.swift */,
+				3D00E2E996D254A5D3D96DF9 /* BuddySessionHubView.swift */,
+				A926CF90DAFC03754D7434B3 /* BuddyVideoWebView.swift */,
+				F4D0005AAA572020F3028B9F /* BuddyWaitingRoomView.swift */,
+			);
+			path = BuddySession;
+			sourceTree = "<group>";
+		};
+		9A1FCA572FDAB69F4F6E75EB /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				8807A08DBDE8A121951350FD /* AppleSignInController.swift */,
+			);
+			path = Services;
 			sourceTree = "<group>";
 		};
 		AC788F412B1414C8C2BDB3CB /* Theme */ = {
@@ -261,13 +354,13 @@
 			children = (
 				218693B76FDAF56B6E0321DE /* AppViewModel.swift */,
 				B6CBD1A192FD74748A6D36BF /* AuthViewModel.swift */,
-				DAAF68030111C6FA73098D17 /* BuddySessionViewModel.swift */,
 				0D22599DCB705628A5CB6F51 /* BoardViewModel.swift */,
+				0EE015F8D72AE054E6990FB3 /* BuddyCalendarViewModel.swift */,
+				48FF5BFB92C98C791296977A /* BuddySessionViewModel.swift */,
 				1F75039BBEED880C73680860 /* HistoryViewModel.swift */,
-				17A346000000000000000011 /* BuddyCalendarViewModel.swift */,
+				6E16CD986E277DA88A2EB6F1 /* NotificationPreferencesViewModel.swift */,
 				FDE2D028ACC5D7FEFD82703D /* SessionViewModel.swift */,
 				42927B68B0A976D71FE0637F /* ThoughtJournalViewModel.swift */,
-				17A345000000000000000001 /* NotificationPreferencesViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -276,8 +369,19 @@
 			isa = PBXGroup;
 			children = (
 				D15A7FF17302B1E2FD147920 /* StillPoint.app */,
+				E1C10719A1709CEE1EAEBE17 /* StillPointAppUITests.xctest */,
+				58A0BC69E330440BE836DDC4 /* StillPointMonitor.appex */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		F0FD78DD2EB1220358FB4672 /* Snapshots */ = {
+			isa = PBXGroup;
+			children = (
+				14BEE5E52F5249E22EA4DB08 /* SnapshotHelper.swift */,
+				C2EB81E2A5E7CD9E4586F3BE /* SnapshotTests.swift */,
+			);
+			path = Snapshots;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -290,10 +394,12 @@
 				788E99323C1F4CDCA2A903FC /* Sources */,
 				0B31A9FD8CF7CD832FD44715 /* Resources */,
 				60417DAC61CFEF1804125570 /* Frameworks */,
+				F78D861A536366A248BE993E /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				14A922200F707D6C907444EF /* PBXTargetDependency */,
 			);
 			name = StillPoint;
 			packageProductDependencies = (
@@ -302,6 +408,42 @@
 			productName = StillPoint;
 			productReference = D15A7FF17302B1E2FD147920 /* StillPoint.app */;
 			productType = "com.apple.product-type.application";
+		};
+		C9202FF3B9BAEE265E1F8CFA /* StillPointAppUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DF601809504D3DDE725AD63F /* Build configuration list for PBXNativeTarget "StillPointAppUITests" */;
+			buildPhases = (
+				5CE9F26962BE7AC20278243F /* Sources */,
+				3FEBF3FCE3B4B802D71336AF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8F3F65CA0C6B88D39F210112 /* PBXTargetDependency */,
+			);
+			name = StillPointAppUITests;
+			packageProductDependencies = (
+			);
+			productName = StillPointAppUITests;
+			productReference = E1C10719A1709CEE1EAEBE17 /* StillPointAppUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		EC97B0CE4FB530B3C2368458 /* StillPointMonitor */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0A153FA2CF4C9856BDAB8FA0 /* Build configuration list for PBXNativeTarget "StillPointMonitor" */;
+			buildPhases = (
+				E5417D311AE5DE6660B91CC0 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = StillPointMonitor;
+			packageProductDependencies = (
+			);
+			productName = StillPointMonitor;
+			productReference = 58A0BC69E330440BE836DDC4 /* StillPointMonitor.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
@@ -313,6 +455,13 @@
 				LastUpgradeCheck = 2600;
 				TargetAttributes = {
 					1EC3D1ED76F9038154716BEC = {
+						DevelopmentTeam = T5UU4BP6AV;
+						ProvisioningStyle = Automatic;
+					};
+					C9202FF3B9BAEE265E1F8CFA = {
+						TestTargetID = 1EC3D1ED76F9038154716BEC;
+					};
+					EC97B0CE4FB530B3C2368458 = {
 						DevelopmentTeam = T5UU4BP6AV;
 						ProvisioningStyle = Automatic;
 					};
@@ -336,6 +485,8 @@
 			projectRoot = "";
 			targets = (
 				1EC3D1ED76F9038154716BEC /* StillPoint */,
+				C9202FF3B9BAEE265E1F8CFA /* StillPointAppUITests */,
+				EC97B0CE4FB530B3C2368458 /* StillPointMonitor */,
 			);
 		};
 /* End PBXProject section */
@@ -352,56 +503,98 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3FEBF3FCE3B4B802D71336AF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				750987110FAE532744F6571E /* README.md in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		5CE9F26962BE7AC20278243F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1AD1C504911C0820878EFAA4 /* SnapshotHelper.swift in Sources */,
+				E636EACFC27E6022A80898FC /* SnapshotTests.swift in Sources */,
+				A564D3891222DA735A7F96B7 /* StillPointAppUITests.swift in Sources */,
+				6E8830D16FED5FBB78B6DF34 /* XCUIElement+TapAndType.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		788E99323C1F4CDCA2A903FC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6B6572152FB23B94F990D66B /* AppBlockingManager.swift in Sources */,
+				B6A3805810E44935E75EEC11 /* AppBlockingSettingsView.swift in Sources */,
+				A1636CD509D32399A02C45B3 /* AppBlockingShared.swift in Sources */,
 				55CB825BEE151D314A4DD2FA /* AppViewModel.swift in Sources */,
-				17A248000000000000000008 /* AppleSignInController.swift in Sources */,
-				17A248000000000000000001 /* AppBlockingManager.swift in Sources */,
-				17A248000000000000000003 /* AppBlockingSettingsView.swift in Sources */,
-				17A248000000000000000012 /* PushNotificationCoordinator.swift in Sources */,
-				17A248000000000000000014 /* DeviceTokenStore.swift in Sources */,
-				17A248000000000000000016 /* SessionIdleTimerController.swift in Sources */,
+				6760DF427777049973A0D182 /* AppleSignInController.swift in Sources */,
 				5EA3E8C9B84298DE1F37251F /* AuthView.swift in Sources */,
 				8A9734076E9FB3D5477913A0 /* AuthViewModel.swift in Sources */,
 				F370AA8F6AA102355FC599C9 /* BlockGridView.swift in Sources */,
-				760C4A2F57E6B207F729ABEA /* BuddyActiveSessionView.swift in Sources */,
-				25295F15540B9986B15EB839 /* BuddySessionContainerView.swift in Sources */,
-				3F95AB4ED8A3AB01D8D2B042 /* BuddySessionHubView.swift in Sources */,
-				17A346000000000000000001 /* BuddyCalendarViewModel.swift in Sources */,
-				17A346000000000000000002 /* BuddyCalendarView.swift in Sources */,
-				17A346000000000000000003 /* SessionStateBadge.swift in Sources */,
-				17A346000000000000000004 /* BuddyFilterChips.swift in Sources */,
-				42BF1908A778629F7C747264 /* BuddySessionViewModel.swift in Sources */,
-				16697A0A2D8E95D300EEA791 /* BuddyVideoWebView.swift in Sources */,
-				4FF6F665DB343AF63E7E1718 /* BuddyWaitingRoomView.swift in Sources */,
 				432648A182B69A2E98314B0C /* BoardViewModel.swift in Sources */,
+				47381BA7F1BB53B93A40989B /* BuddyActiveSessionView.swift in Sources */,
+				A21FE7A1E00EA88626526059 /* BuddyCalendarView.swift in Sources */,
+				D44FB0782DD33A5900AF8D60 /* BuddyCalendarViewModel.swift in Sources */,
+				D3744C3003DA233DC0B74C99 /* BuddyFilterChips.swift in Sources */,
+				9F4E4B6270115FC333B22575 /* BuddySessionContainerView.swift in Sources */,
+				5E1134CA9CA16D2589A0FDDE /* BuddySessionHubView.swift in Sources */,
+				D4BA6F49AEC3DDCE40AFE5D1 /* BuddySessionViewModel.swift in Sources */,
+				B2C69D176260DEF6EE91C9BA /* BuddyVideoWebView.swift in Sources */,
+				840761F5A9A217D4441A7FB5 /* BuddyWaitingRoomView.swift in Sources */,
 				9ECB83ED063EDAA82E88004B /* CompletionView.swift in Sources */,
 				C57D92D33ED679E23F5E2E49 /* DesignTokens.swift in Sources */,
+				5147B5721B90EB7D83D843FF /* DeviceTokenStore.swift in Sources */,
 				74AE784447C3D50E1E6980E9 /* HistoryView.swift in Sources */,
 				50CD873CA594B5A6FCDBB251 /* HistoryViewModel.swift in Sources */,
 				1BE60070F826B7B31DFAB315 /* HomeView.swift in Sources */,
 				B106890588723F191CC4AEAA /* MainTabView.swift in Sources */,
 				80005A5883007151E3A9C5C3 /* MindStateBarView.swift in Sources */,
+				13177552A26E700472836E9A /* NotificationPreferencesViewModel.swift in Sources */,
+				C0FD436A962D0DC179B37D73 /* NotificationsSettingsView.swift in Sources */,
 				DB99CD9DA2E6BB2A49B63025 /* PublicBoardView.swift in Sources */,
+				EA20FAB8B6D3C8B249AFAF82 /* PushNotificationCoordinator.swift in Sources */,
 				15177B86F124B5A10AB03456 /* RootView.swift in Sources */,
+				E72B904E4F87A91D52EBF826 /* SessionIdleTimerController.swift in Sources */,
+				39045EBEEF3AF94277B45E02 /* SessionStateBadge.swift in Sources */,
 				4D652980F04840078B8FC938 /* SessionView.swift in Sources */,
 				AC4DAD06FA75C7C480DDFF27 /* SessionViewModel.swift in Sources */,
 				1649BE1D765A6851D5802BBA /* SettingsView.swift in Sources */,
-				17A359000000000000000002 /* NotificationsSettingsView.swift in Sources */,
 				E1FBFCD4730D9BC4E924C938 /* StillPointApp.swift in Sources */,
 				B41D20D3939E0F51F7471F44 /* ThoughtCaptureView.swift in Sources */,
 				2E31C1B6A86E612EF7171348 /* ThoughtJournalView.swift in Sources */,
 				3E8960D90E815E3462FF241B /* ThoughtJournalViewModel.swift in Sources */,
-				17A345000000000000000002 /* NotificationPreferencesViewModel.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E5417D311AE5DE6660B91CC0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AC092ECADA2EA4C161CAF5E7 /* AppBlockingShared.swift in Sources */,
+				EE8F0D07AFA655F960F274F8 /* StillPointMonitorExtension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		14A922200F707D6C907444EF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EC97B0CE4FB530B3C2368458 /* StillPointMonitor */;
+			targetProxy = 7D96BF3D0EE2B0569179B9CB /* PBXContainerItemProxy */;
+		};
+		8F3F65CA0C6B88D39F210112 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1EC3D1ED76F9038154716BEC /* StillPoint */;
+			targetProxy = 540585E1D78B21D6A3B5B30D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		11E27EB55EEE0D1829FD2125 /* Release */ = {
@@ -409,21 +602,40 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = StillPointApp/StillPointApp.entitlements;
+				"CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]" = StillPointApp/StillPoint.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*] = StillPointApp/StillPoint.entitlements;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = T5UU4BP6AV;
 				INFOPLIST_FILE = StillPointApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.brettonauerbach.stillpoint;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
 				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		328D322BE7FCBDB8F927A164 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.brettonauerbach.stillpoint.uitests;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.9;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = StillPoint;
 			};
 			name = Release;
 		};
@@ -432,19 +644,58 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = StillPointApp/StillPointApp.entitlements;
+				"CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]" = StillPointApp/StillPoint.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*] = StillPointApp/StillPoint.entitlements;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = T5UU4BP6AV;
 				INFOPLIST_FILE = StillPointApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.brettonauerbach.stillpoint;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.9;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		87297D64E18D4BDBB2D81F1C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.brettonauerbach.stillpoint.uitests;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.9;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = StillPoint;
+			};
+			name = Debug;
+		};
+		A826A78862E645F34283BFE2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]" = StillPointMonitor/StillPointMonitor.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = T5UU4BP6AV;
+				INFOPLIST_FILE = StillPointMonitor/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.brettonauerbach.stillpoint.monitor;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.9;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -569,9 +820,38 @@
 			};
 			name = Release;
 		};
+		F67C139DC441092F7DBC53D2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]" = StillPointMonitor/StillPointMonitor.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = T5UU4BP6AV;
+				INFOPLIST_FILE = StillPointMonitor/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.brettonauerbach.stillpoint.monitor;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.9;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		0A153FA2CF4C9856BDAB8FA0 /* Build configuration list for PBXNativeTarget "StillPointMonitor" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A826A78862E645F34283BFE2 /* Debug */,
+				F67C139DC441092F7DBC53D2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		A869842DC3454C47D11359A9 /* Build configuration list for PBXProject "StillPoint" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -586,6 +866,15 @@
 			buildConfigurations = (
 				79085E6777D72FCC1A887CA8 /* Debug */,
 				11E27EB55EEE0D1829FD2125 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		DF601809504D3DDE725AD63F /* Build configuration list for PBXNativeTarget "StillPointAppUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				87297D64E18D4BDBB2D81F1C /* Debug */,
+				328D322BE7FCBDB8F927A164 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/ios/StillPointApp/Managers/AppBlockingManager.swift
+++ b/ios/StillPointApp/Managers/AppBlockingManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import StillPointShared
 
 #if targetEnvironment(simulator)
 
@@ -13,7 +14,6 @@ final class AppBlockingManager {
     private let defaults: UserDefaults
     private let unlockedForDateKey = "appBlocking.unlockedForDate.v1"
     private let uiTestSelectionEnabled: Bool
-    private var midnightTimer: Timer?
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
@@ -28,8 +28,7 @@ final class AppBlockingManager {
 
     /// Unlocked when a qualifying session was completed earlier *today* (local calendar day).
     var isUnlocked: Bool {
-        guard let unlockedForDate else { return false }
-        return Calendar.current.isDateInToday(unlockedForDate)
+        !AppBlockGate.isUnlockExpired(unlockedFor: unlockedForDate)
     }
 
     var statusText: String {
@@ -60,22 +59,19 @@ final class AppBlockingManager {
         unlockedForDate = Date()
         didUnlockFromLastCompletedSession = true
         defaults.set(unlockedForDate, forKey: unlockedForDateKey)
-        scheduleMidnightResetTimer()
     }
 
     func lockNow() {
         didUnlockFromLastCompletedSession = false
         unlockedForDate = nil
         defaults.removeObject(forKey: unlockedForDateKey)
-        scheduleMidnightResetTimer()
     }
 
     func refreshShielding() {
         // Daily reset: an unlock only counts for the calendar day it was earned.
-        // When the app foregrounds (or the midnight timer fires) on a new day, the
-        // stale date is cleared and the apps re-lock.
-        if let unlockedForDate, !Calendar.current.isDateInToday(unlockedForDate) {
-            self.unlockedForDate = nil
+        // When the app foregrounds on a new day, the stale date is cleared.
+        if unlockedForDate != nil, AppBlockGate.isUnlockExpired(unlockedFor: unlockedForDate) {
+            unlockedForDate = nil
             didUnlockFromLastCompletedSession = false
             defaults.removeObject(forKey: unlockedForDateKey)
         }
@@ -85,30 +81,6 @@ final class AppBlockingManager {
             didUnlockFromLastCompletedSession = false
             defaults.removeObject(forKey: unlockedForDateKey)
         }
-        scheduleMidnightResetTimer()
-    }
-
-    /// Schedule a one-shot timer for the next local midnight so apps re-lock even
-    /// if the app stays foregrounded across the day boundary. Only needed while unlocked.
-    private func scheduleMidnightResetTimer() {
-        midnightTimer?.invalidate()
-        midnightTimer = nil
-        guard isUnlocked, let nextMidnight = Self.nextLocalMidnight() else { return }
-        let interval = nextMidnight.timeIntervalSinceNow
-        guard interval > 0 else { return }
-        midnightTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: false) { [weak self] _ in
-            Task { @MainActor in
-                self?.refreshShielding()
-            }
-        }
-    }
-
-    private static func nextLocalMidnight() -> Date? {
-        Calendar.current.nextDate(
-            after: Date(),
-            matching: DateComponents(hour: 0, minute: 0, second: 0),
-            matchingPolicy: .nextTime
-        )
     }
 }
 
@@ -116,6 +88,7 @@ final class AppBlockingManager {
 
 import FamilyControls
 import ManagedSettings
+import DeviceActivity
 
 @Observable
 @MainActor
@@ -129,10 +102,13 @@ final class AppBlockingManager {
 
     private let defaults: UserDefaults
     private let store: ManagedSettingsStore?
-    private let selectionKey = "appBlocking.selection.v1"
     private let unlockedForDateKey = "appBlocking.unlockedForDate.v1"
     private let uiTestMode: Bool
     private let uiTestSelectionEnabled: Bool
+    private let deviceActivityCenter = DeviceActivityCenter()
+    /// Foreground-only backup: fires at the next local midnight while the app is
+    /// open so the in-app state re-locks even if the system schedule is delayed.
+    /// DeviceActivity remains the primary mechanism (it runs while suspended).
     private var midnightTimer: Timer?
 
     init(defaults: UserDefaults = .standard) {
@@ -140,7 +116,12 @@ final class AppBlockingManager {
         let uiTestMode = environment["SP_UI_TEST_MODE"] == "1"
         let uiTestSelectionEnabled = environment["SP_UI_TEST_APP_BLOCKING_SELECTED"] == "1"
         self.defaults = defaults
-        self.selection = Self.loadSelection(defaults: defaults, key: selectionKey)
+        if !uiTestMode {
+            // Older builds stored the selection in standard defaults; copy it into
+            // the App Group suite so the monitor extension can read it.
+            Self.migrateLegacySelectionIfNeeded(from: defaults)
+        }
+        self.selection = AppBlockingShared.loadSelection()
         self.unlockedForDate = defaults.object(forKey: unlockedForDateKey) as? Date
         self.authorizationStatus = uiTestMode ? .notDetermined : AuthorizationCenter.shared.authorizationStatus
         self.uiTestMode = uiTestMode
@@ -168,8 +149,7 @@ final class AppBlockingManager {
 
     /// Unlocked when a qualifying session was completed earlier *today* (local calendar day).
     var isUnlocked: Bool {
-        guard let unlockedForDate else { return false }
-        return Calendar.current.isDateInToday(unlockedForDate)
+        !AppBlockGate.isUnlockExpired(unlockedFor: unlockedForDate)
     }
 
     var statusText: String {
@@ -220,7 +200,9 @@ final class AppBlockingManager {
         defaults.set(unlockedForDate, forKey: unlockedForDateKey)
         lastErrorMessage = nil
         clearShielding()
-        scheduleMidnightResetTimer()
+        // Keep the daily schedule (and foreground backup) armed so the apps re-lock
+        // at the next local midnight even if the app is suspended/terminated overnight.
+        updateDailyResetScheduling()
     }
 
     func lockNow() {
@@ -236,10 +218,11 @@ final class AppBlockingManager {
         }
 
         // Daily reset: an unlock only counts for the calendar day it was earned.
-        // When the app foregrounds (or the midnight timer fires) on a new day, the
-        // stale date is cleared and the apps re-lock.
-        if let unlockedForDate, !Calendar.current.isDateInToday(unlockedForDate) {
-            self.unlockedForDate = nil
+        // When the app foregrounds on a new day, the stale date is cleared and the
+        // apps re-lock. (The DeviceActivity monitor handles re-locking while the app
+        // is suspended; this foreground pass is the belt-and-suspenders backup.)
+        if unlockedForDate != nil, AppBlockGate.isUnlockExpired(unlockedFor: unlockedForDate) {
+            unlockedForDate = nil
             didUnlockFromLastCompletedSession = false
             defaults.removeObject(forKey: unlockedForDateKey)
         }
@@ -248,24 +231,27 @@ final class AppBlockingManager {
             unlockedForDate = nil
             didUnlockFromLastCompletedSession = false
             defaults.removeObject(forKey: unlockedForDateKey)
-            scheduleMidnightResetTimer()
+            updateDailyResetScheduling()
             clearShielding()
             return
         }
 
         guard !isUnlocked else {
-            scheduleMidnightResetTimer()
+            updateDailyResetScheduling()
             clearShielding()
             return
         }
 
         guard isAuthorizationApproved else {
+            // Authorization was lost/never granted: tear down the schedule + backup
+            // timer so a stale DeviceActivity registration can't re-shield later.
+            updateDailyResetScheduling()
             clearShielding()
             return
         }
 
         applyShielding()
-        scheduleMidnightResetTimer()
+        updateDailyResetScheduling()
     }
 
     private var realSelectedItemCount: Int {
@@ -301,12 +287,46 @@ final class AppBlockingManager {
         store?.clearAllSettings()
     }
 
-    /// Schedule a one-shot timer for the next local midnight so apps re-lock even
-    /// if the app stays foregrounded across the day boundary. Only needed while unlocked.
-    private func scheduleMidnightResetTimer() {
+    /// Arm or tear down the daily re-lock machinery based on whether there is an
+    /// authorized selection to guard.
+    ///
+    /// - Primary: a repeating `DeviceActivitySchedule`. The monitor extension's
+    ///   `intervalDidStart` re-applies the shield at local midnight even when the
+    ///   app is suspended/terminated — the case the old in-process `Timer` could
+    ///   not handle.
+    /// - Backup: a foreground-only one-shot `Timer` to the next local midnight, so
+    ///   if the app stays open across the day boundary (no `scenePhase` change to
+    ///   trigger `refreshShielding`) the in-app state still re-locks promptly even
+    ///   if the system schedule is delayed.
+    ///
+    /// When there is no authorized selection both are torn down, so a stale schedule
+    /// can never re-shield after the user removes apps or revokes authorization.
+    private func updateDailyResetScheduling() {
+        guard !uiTestMode else { return }
+        guard hasSelection, isAuthorizationApproved else {
+            deviceActivityCenter.stopMonitoring([AppBlockingShared.deviceActivityName])
+            midnightTimer?.invalidate()
+            midnightTimer = nil
+            return
+        }
+        do {
+            try deviceActivityCenter.startMonitoring(
+                AppBlockingShared.deviceActivityName,
+                during: AppBlockingShared.dailySchedule()
+            )
+        } catch {
+            // Re-registering an already-active schedule is benign. Any other
+            // failure just means the system schedule isn't armed this run; the
+            // foreground backup timer + foreground refresh remain, so the
+            // daily-lock guarantee degrades gracefully rather than breaking.
+        }
+        scheduleForegroundMidnightBackup()
+    }
+
+    private func scheduleForegroundMidnightBackup() {
         midnightTimer?.invalidate()
         midnightTimer = nil
-        guard isUnlocked, let nextMidnight = Self.nextLocalMidnight() else { return }
+        guard let nextMidnight = Self.nextLocalMidnight() else { return }
         let interval = nextMidnight.timeIntervalSinceNow
         guard interval > 0 else { return }
         midnightTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: false) { [weak self] _ in
@@ -326,21 +346,22 @@ final class AppBlockingManager {
 
     private func saveSelection() {
         guard !uiTestMode else { return }
-        do {
-            let encoded = try JSONEncoder().encode(selection)
-            defaults.set(encoded, forKey: selectionKey)
+        if AppBlockingShared.saveSelection(selection) {
             lastErrorMessage = nil
-        } catch {
+        } else {
             lastErrorMessage = "Could not save selected apps."
         }
     }
 
-    private static func loadSelection(defaults: UserDefaults, key: String) -> FamilyActivitySelection {
-        guard let data = defaults.data(forKey: key),
-              let decoded = try? JSONDecoder().decode(FamilyActivitySelection.self, from: data) else {
-            return FamilyActivitySelection()
-        }
-        return decoded
+    /// One-time migration of the encoded selection from standard `UserDefaults`
+    /// (older builds) into the App Group suite. No-op once the shared suite holds
+    /// a value, or if there is nothing to migrate.
+    private static func migrateLegacySelectionIfNeeded(from defaults: UserDefaults) {
+        guard let shared = AppBlockingShared.sharedDefaults else { return }
+        let key = AppBlockingShared.selectionKey
+        guard shared.data(forKey: key) == nil,
+              let legacy = defaults.data(forKey: key) else { return }
+        shared.set(legacy, forKey: key)
     }
 }
 

--- a/ios/StillPointMonitor/Info.plist
+++ b/ios/StillPointMonitor/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Still Point Monitor</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.deviceactivity.monitor-extension</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).StillPointMonitorExtension</string>
+	</dict>
+</dict>
+</plist>

--- a/ios/StillPointMonitor/StillPointMonitor.entitlements
+++ b/ios/StillPointMonitor/StillPointMonitor.entitlements
@@ -2,17 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.applesignin</key>
-	<array>
-		<string>Default</string>
-	</array>
 	<key>com.apple.developer.family-controls</key>
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.brettonauerbach.stillpoint</string>
 	</array>
-	<key>aps-environment</key>
-	<string>development</string>
 </dict>
 </plist>

--- a/ios/StillPointMonitor/StillPointMonitorExtension.swift
+++ b/ios/StillPointMonitor/StillPointMonitorExtension.swift
@@ -1,0 +1,28 @@
+#if !targetEnvironment(simulator)
+import DeviceActivity
+import ManagedSettings
+
+/// Re-locks the gated apps at the start of each local day (#423).
+///
+/// Registered by the app through `DeviceActivityCenter`. The system launches
+/// this extension at the schedule's interval start (local midnight) even when
+/// Still Point itself is suspended or terminated — which is exactly the case the
+/// old in-process `Timer` could not handle.
+final class StillPointMonitorExtension: DeviceActivityMonitor {
+    private let store = ManagedSettingsStore()
+
+    override func intervalDidStart(for activity: DeviceActivityName) {
+        super.intervalDidStart(for: activity)
+        // A new calendar day has begun, so the prior day's unlock has expired:
+        // re-apply the shield from the saved selection.
+        AppBlockingShared.applySavedShield(to: store)
+    }
+}
+#else
+import Foundation
+
+/// Simulator stub. The monitor extension is never invoked in simulator (PR e2e)
+/// builds; this keeps the target compiling without linking Family Controls, so
+/// the simulator build needs no provisioning profile.
+final class StillPointMonitorExtension: NSObject {}
+#endif

--- a/ios/StillPointShared/Sources/StillPointShared/AppBlockGate.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AppBlockGate.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Pure daily-reset rule for the app-lock gate (#348 / #423).
+///
+/// An unlock earned on a given local day expires once the calendar advances to a
+/// later day. Kept in the shared package (Foundation only — no DeviceActivity /
+/// Family Controls imports) so the day-boundary contract is unit-testable on every
+/// platform, and reused by both the simulator and device `AppBlockingManager`
+/// branches so the two cannot drift.
+public enum AppBlockGate {
+    /// `true` when the gated apps should be (re-)locked: either there is no
+    /// stored unlock, or the stored unlock is not from the same local day as `now`.
+    ///
+    /// - Parameters:
+    ///   - date: the date a qualifying session was completed, or `nil`.
+    ///   - now: the reference "now" (injectable for tests).
+    ///   - calendar: the calendar defining the local day boundary (injectable for tests).
+    public static func isUnlockExpired(
+        unlockedFor date: Date?,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> Bool {
+        guard let date else { return true }
+        return !calendar.isDate(date, inSameDayAs: now)
+    }
+}

--- a/ios/StillPointShared/Tests/StillPointSharedTests/AppBlockGateTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/AppBlockGateTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import StillPointShared
+
+final class AppBlockGateTests: XCTestCase {
+    // Pin the comparison calendar to the same zone the test dates are built in,
+    // so `isDate(_:inSameDayAs:)` does not flip day boundaries when CI runs in UTC.
+    private let calendar: Calendar = {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "America/New_York")!
+        return cal
+    }()
+
+    private func date(_ y: Int, _ mo: Int, _ d: Int, _ h: Int = 12, _ mi: Int = 0) -> Date {
+        var c = DateComponents()
+        c.year = y; c.month = mo; c.day = d; c.hour = h; c.minute = mi
+        c.timeZone = TimeZone(identifier: "America/New_York")
+        return Calendar(identifier: .gregorian).date(from: c)!
+    }
+
+    func testNilUnlockIsExpired() {
+        XCTAssertTrue(AppBlockGate.isUnlockExpired(unlockedFor: nil, now: date(2026, 6, 15)))
+    }
+
+    func testSameDayUnlockIsNotExpired() {
+        let morning = date(2026, 6, 15, 6, 30)
+        let evening = date(2026, 6, 15, 23, 0)
+        XCTAssertFalse(AppBlockGate.isUnlockExpired(unlockedFor: morning, now: evening, calendar: calendar))
+    }
+
+    func testYesterdayUnlockIsExpired() {
+        let yesterday = date(2026, 6, 14, 23, 30)
+        let today = date(2026, 6, 15, 0, 5)
+        XCTAssertTrue(AppBlockGate.isUnlockExpired(unlockedFor: yesterday, now: today, calendar: calendar))
+    }
+
+    func testFutureDayUnlockIsExpired() {
+        // A clock that moved backward should also re-lock (not "today").
+        let tomorrow = date(2026, 6, 16, 1, 0)
+        let today = date(2026, 6, 15, 12, 0)
+        XCTAssertTrue(AppBlockGate.isUnlockExpired(unlockedFor: tomorrow, now: today, calendar: calendar))
+    }
+
+    func testJustAfterMidnightExpiresPreviousDayUnlock() {
+        // Core #423 boundary: unlock at 11:59pm, "now" one minute later (new day).
+        let lastMinute = date(2026, 6, 15, 23, 59)
+        let justAfterMidnight = date(2026, 6, 16, 0, 0)
+        XCTAssertTrue(AppBlockGate.isUnlockExpired(unlockedFor: lastMinute, now: justAfterMidnight, calendar: calendar))
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -16,11 +16,13 @@ targets:
     platform: iOS
     sources:
       - StillPointApp
+      - AppBlockingShared
     resources:
       - path: StillPointApp/Resources
         buildPhase: resources
     dependencies:
       - package: StillPointShared
+      - target: StillPointMonitor
     info:
       path: StillPointApp/Info.plist
       properties:
@@ -55,6 +57,28 @@ targets:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
         CODE_SIGN_ENTITLEMENTS: StillPointApp/StillPointApp.entitlements
+
+  StillPointMonitor:
+    type: app-extension
+    platform: iOS
+    sources:
+      - StillPointMonitor
+      - AppBlockingShared
+    info:
+      path: StillPointMonitor/Info.plist
+      properties:
+        CFBundleDisplayName: Still Point Monitor
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.deviceactivity.monitor-extension
+          NSExtensionPrincipalClass: $(PRODUCT_MODULE_NAME).StillPointMonitorExtension
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint.monitor
+        DEVELOPMENT_TEAM: T5UU4BP6AV
+        CODE_SIGN_STYLE: Automatic
+        CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]: StillPointMonitor/StillPointMonitor.entitlements
+        SWIFT_VERSION: "5.9"
+        SKIP_INSTALL: YES
 
   StillPointAppUITests:
     type: bundle.ui-testing


### PR DESCRIPTION
## **User description**
## What
Replaces the in-process midnight `Timer` with a system-driven repeating `DeviceActivitySchedule` plus a new `DeviceActivityMonitor` app-extension (`StillPointMonitor`) that re-applies the app-block shield at local midnight — even when Still Point is suspended or terminated.

## Why
`ManagedSettings` shields persist until we change them. After a completed sit cleared the shield, the only re-lock was an in-process `Timer`, which cannot fire while the app is suspended overnight. So gated apps stayed unlocked until the next manual launch instead of re-locking the next day. (Root cause + repro in #423.)

## How
- New `StillPointMonitor` DeviceActivity extension; `intervalDidStart` (local midnight, repeating) re-applies the shield from the saved selection. Kept minimal for the extension memory budget.
- App Group `group.com.brettonauerbach.stillpoint` shares the `FamilyActivitySelection` with the extension (one-time migration from standard `UserDefaults`).
- `AppBlockingManager` registers the daily schedule via `DeviceActivityCenter`, **drops the in-process `Timer`**, and keeps foreground `refreshShielding()` as a belt-and-suspenders backup.
- Pure `AppBlockGate.isUnlockExpired` day-boundary predicate extracted to `StillPointShared` (unit-tested; both manager branches use it so they cannot drift).
- All Family Controls / DeviceActivity code is guarded `#if !targetEnvironment(simulator)`, so the simulator app's framework linkage is unchanged — PR e2e CI needs no provisioning.

## Signing — needs @auerbachb (Apple Developer portal)
The new extension needs its own App ID + App Store distribution profile + the App Group enabled on both App IDs. The account-level Family Controls **Distribution** entitlement is already approved (#371), so there is **no new Apple review** — just portal setup + one CI secret. Exact step-by-step is in the #423 Implementation Plan.

> Until that lands, the **TestFlight device archive** fails signing for the new target. **PR-level simulator CI is unaffected** and stays green.

Closes #423

## Test plan
- [x] `swift test` in `ios/StillPointShared` passes, including new `AppBlockGateTests` (day-boundary expiry)
- [x] PR CI: iOS e2e `smoke` + `critical` lanes green (extension compiles for simulator; app linkage unchanged)
- [x] Regression: Still Point-only lock/unlock path unaffected; `uiTestMode` (no store) still no-ops
- [ ] (Device, after signing) Complete a sit → force-quit Still Point → cross local midnight without reopening → selected apps are blocked again
- [ ] (Device, after signing) Complete today's sit → apps unlock for the rest of the day
- [ ] (Device, after signing) Foreground refresh still re-locks on a new day as the backup path


___

## **CodeAnt-AI Description**
**Daily app blocking now re-locks at midnight, even if the app is closed**

### What Changed
- Gated apps now re-lock at the start of the next local day, even if Still Point is suspended or terminated overnight
- If the app stays open across midnight, the lock state still updates at the day boundary
- When selected apps are removed or authorization is no longer available, the app clears the blocking state instead of leaving a stale lock schedule in place
- The app keeps the same unlock rules across the main app and the daily re-lock check

### Impact
`✅ Fewer apps left unlocked overnight`
`✅ Reliable next-day re-locking`
`✅ Fewer stale app-block states`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>



> **Deferred (post-merge / device):** The three device items above require the Apple Developer portal signing/provisioning work for the StillPointMonitor extension (see issue body) and on-device TestFlight testing. Verified after merge, not in PR CI. Merged per maintainer authorization with CI-verifiable AC green.