### PR TITLE
feat(ios): tap-to-breathe breath-counting mode (#374)

### DIFF
--- a/drizzle/sessions_breath_count_incremental.sql
+++ b/drizzle/sessions_breath_count_incremental.sql
@@ -1,0 +1,16 @@
+-- #374: tap-to-breathe breath-counting sessions.
+-- Allow the 'breath' session type and add the nullable breath_count column.
+-- Idempotent + safe to re-run on hand-migrated databases (matches the runner
+-- contract in scripts/apply-migrations.ts). Do NOT edit after it is applied
+-- (the schema_migrations checksum ledger will reject a changed body).
+
+ALTER TABLE "sessions"
+ADD COLUMN IF NOT EXISTS "breath_count" integer;
+
+-- Relax the session-type CHECK to include 'breath'. DROP+ADD is idempotent and
+-- order-independent vs. sessions_session_type_incremental.sql, whose own ADD is
+-- guarded by IF NOT EXISTS and therefore cannot downgrade this 3-value form.
+ALTER TABLE "sessions" DROP CONSTRAINT IF EXISTS "sessions_session_type_allowed";
+ALTER TABLE "sessions"
+ADD CONSTRAINT "sessions_session_type_allowed"
+CHECK ("session_type" in ('standard', 'quick', 'breath'));

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -21,6 +21,7 @@ enum AppView: Equatable {
         duration: Int,
         bonusSeconds: Int
     )
+    case breathCounting
     case history
     case journal
     case board
@@ -31,6 +32,7 @@ enum AppView: Equatable {
         case (.auth, .auth), (.home, .home),
              (.buddyHub, .buddyHub),
              (.buddyCalendar, .buddyCalendar),
+             (.breathCounting, .breathCounting),
              (.history, .history), (.journal, .journal), (.board, .board),
              (.settings, .settings):
             return true
@@ -70,6 +72,8 @@ final class AppViewModel {
     var authStatusMessage: String?
     var lastColdStartAuthCheckMs: Int?
     var buddyInviteError: String?
+    /// Guards `completeBreathSession` against re-entrant End taps creating duplicate rows.
+    private var isSavingBreathSession = false
     private var appBlockingManagerStorage: AppBlockingManager?
     var appBlockingManager: AppBlockingManager {
         if let appBlockingManagerStorage {
@@ -105,6 +109,7 @@ final class AppViewModel {
         if case .session = currentView { return true }
         if case .buddySession = currentView { return true }
         if case .completion = currentView { return true }
+        if case .breathCounting = currentView { return true }
         return false
     }
 
@@ -165,6 +170,7 @@ final class AppViewModel {
         case .buddyCalendarWithBuddy: return "buddyCalendarWithBuddy"
         case .buddySession: return "buddySession"
         case .completion: return "completion"
+        case .breathCounting: return "breathCounting"
         case .history: return "history"
         case .journal: return "journal"
         case .board: return "board"
@@ -212,6 +218,56 @@ final class AppViewModel {
 
     func beginSession(type: SessionType = .standard) {
         currentView = .session(type: type)
+    }
+
+    func beginBreathCounting() {
+        currentView = .breathCounting
+    }
+
+    /// Save a completed breath session and return to home.
+    ///
+    /// Mirrors SessionViewModel.saveSession / AppViewModel.completeSession field construction exactly.
+    /// On API failure the error is logged and the user returns home anyway — we never trap them on the breath screen.
+    func completeBreathSession(elapsedSeconds: Int, breathCount: Int) async {
+        // Skip empty sessions (entered then ended with no taps) — nothing to log.
+        guard elapsedSeconds > 0 || breathCount > 0 else {
+            currentView = .home
+            return
+        }
+        // Re-entrancy guard: a second End tap during the await must not create a
+        // duplicate row. Cleared explicitly after the await rather than via defer,
+        // which would not fire at the @MainActor suspension point.
+        guard !isSavingBreathSession else { return }
+        isSavingBreathSession = true
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.calendar = Calendar(identifier: .gregorian)
+
+        let request = CreateSessionRequest(
+            dayNumber: currentDay,
+            sessionType: .breath,
+            duration: max(elapsedSeconds, 1),
+            bonusSeconds: 0,
+            completed: true,
+            actualTime: elapsedSeconds,
+            clearPercent: 0,
+            thoughtCount: 0,
+            mindStateLog: [],
+            sessionDate: dateFormatter.string(from: Date()),
+            breathCount: breathCount
+        )
+
+        do {
+            _ = try await APIClient.shared.createSession(request)
+        } catch {
+            // Non-fatal: session save failure is logged but does not block navigation home.
+            print("Failed to save breath session: \(error)")
+        }
+
+        isSavingBreathSession = false
+        currentView = .home
     }
 
     func beginBuddySession() {

--- a/ios/StillPointApp/ViewModels/BreathCountingViewModel.swift
+++ b/ios/StillPointApp/ViewModels/BreathCountingViewModel.swift
@@ -1,0 +1,79 @@
+import Foundation
+import SwiftUI
+import UIKit
+import StillPointShared
+
+// Mirrors the wall-clock pattern from SessionViewModel (see SessionViewModel.swift ~lines 42, 121, 289):
+// `startDate` is set once on first tap; elapsed is recomputed from Date() each tick so
+// backgrounding doesn't corrupt the counter.
+
+@Observable
+@MainActor
+final class BreathCountingViewModel {
+    // MARK: - Published state
+
+    private(set) var tapCount: Int = 0
+    private(set) var startedAt: Date?
+    private(set) var elapsedSeconds: Int = 0
+
+    // MARK: - Computed from BreathCounting helpers
+
+    var breathCount: Int {
+        BreathCounting.breathCount(forTaps: tapCount)
+    }
+
+    var phase: BreathPhase {
+        BreathCounting.phase(forTaps: tapCount)
+    }
+
+    var elapsedDisplay: String {
+        BreathCounting.elapsedDisplay(elapsedSeconds)
+    }
+
+    // MARK: - Private
+
+    private var timer: Timer?
+
+    // MARK: - Actions
+
+    /// Record a tap (inhale or exhale). Starts the wall-clock timer on the first tap.
+    func recordTap() {
+        tapCount += 1
+
+        if startedAt == nil {
+            startedAt = Date()
+            startTimer()
+        }
+
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    }
+
+    /// End the session. Stops the timer and returns final values for the caller to persist.
+    func end() -> (elapsed: Int, breaths: Int) {
+        // Recompute elapsed from the wall clock so ending between 1-second ticks
+        // (or right after the first tap) doesn't under-report the persisted duration.
+        let finalElapsed = startedAt.map { BreathCounting.elapsedSeconds(since: $0) } ?? elapsedSeconds
+        stop()
+        return (elapsed: finalElapsed, breaths: breathCount)
+    }
+
+    /// Invalidate the timer. Idempotent; called on End and from the view's
+    /// `onDisappear`. (A `deinit` can't touch this `@MainActor`-isolated state
+    /// under strict concurrency, and the timer's `[weak self]` closure means it
+    /// never retains the view model, so lifecycle-driven cleanup is sufficient.)
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    // MARK: - Private
+
+    private func startTimer() {
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self, let start = self.startedAt else { return }
+                self.elapsedSeconds = BreathCounting.elapsedSeconds(since: start)
+            }
+        }
+    }
+}

--- a/ios/StillPointApp/Views/BreathCountingView.swift
+++ b/ios/StillPointApp/Views/BreathCountingView.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+import StillPointShared
+
+// Mirrors SessionView.swift for idle-timer wiring (~lines 109-154) and
+// AppViewModel / BreathCountingViewModel integration patterns.
+
+struct BreathCountingView: View {
+    let appVM: AppViewModel
+    @State private var vm = BreathCountingViewModel()
+
+    var body: some View {
+        ZStack {
+            // Full-screen tap target — a tap anywhere (eyes-closed) registers a breath.
+            SPColor.bg
+                .ignoresSafeArea()
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    vm.recordTap()
+                }
+
+            // Centered status. Non-interactive so taps on the labels (especially the
+            // large timer) fall through to the tap target above rather than being
+            // swallowed — otherwise center taps would never count.
+            VStack(spacing: SPSpacing.s5) {
+                Text(vm.elapsedDisplay)
+                    .font(SPFont.timerDisplay)
+                    .foregroundStyle(Color(SPColor.fg))
+                    .monospacedDigit()
+                    .contentTransition(.numericText())
+                    .accessibilityIdentifier("breath.elapsedLabel")
+                    .accessibilityLabel("Elapsed time \(vm.elapsedDisplay)")
+
+                // Phase indicator: shows the next expected action.
+                Text(vm.startedAt == nil ? "tap to begin" : (vm.phase == .inhale ? "in" : "out"))
+                    .font(SPFont.mono(28, weight: .ultraLight))
+                    .foregroundStyle(
+                        vm.startedAt == nil
+                            ? Color(SPColor.fg4)
+                            : vm.phase == .inhale
+                                ? SPColor.greenText
+                                : Color(SPColor.fg3)
+                    )
+                    .tracking(4)
+                    .animation(.easeInOut(duration: 0.2), value: vm.phase == .inhale)
+                    .accessibilityIdentifier("breath.phaseLabel")
+
+                if vm.breathCount > 0 {
+                    Text("\(vm.breathCount) breath\(vm.breathCount == 1 ? "" : "s")")
+                        .font(SPFont.mono(16, weight: .light))
+                        .foregroundStyle(SPColor.greenText)
+                        .tracking(2)
+                        .accessibilityIdentifier("breath.countLabel")
+                } else {
+                    Text("tap each inhale and exhale")
+                        .font(SPFont.mono(13, weight: .light))
+                        .foregroundStyle(Color(SPColor.fg4))
+                        .tracking(1)
+                }
+            }
+            .padding(.horizontal, SPSpacing.s4)
+            .allowsHitTesting(false)
+
+            // End control — explicit, interactive, pinned to the bottom.
+            VStack {
+                Spacer()
+                Button {
+                    let result = vm.end()
+                    Task {
+                        await appVM.completeBreathSession(
+                            elapsedSeconds: result.elapsed,
+                            breathCount: result.breaths
+                        )
+                    }
+                } label: {
+                    Text("End")
+                        .font(SPFont.mono(13, weight: .medium))
+                        .foregroundStyle(Color(SPColor.fg3))
+                        .padding(.horizontal, SPSpacing.s4)
+                        .padding(.vertical, SPSpacing.s2)
+                        .background(SPColor.surface1)
+                        .clipShape(Capsule())
+                        .overlay(Capsule().stroke(SPColor.border1))
+                }
+                .accessibilityIdentifier("breath.endButton")
+                .accessibilityLabel("End breath counting session")
+                .padding(.bottom, SPSpacing.s5)
+            }
+        }
+        .onAppear {
+            // No session until the first tap; reflect actual running state.
+            SessionIdleTimerController.syncLocalSession(appVM: appVM, isRunning: vm.startedAt != nil)
+        }
+        .onDisappear {
+            vm.stop()
+            SessionIdleTimerController.syncLocalSession(appVM: appVM, isRunning: false)
+        }
+        .onChange(of: vm.startedAt) { _, _ in
+            // The session starts on the first tap — keep the screen awake from then on.
+            SessionIdleTimerController.syncLocalSession(appVM: appVM, isRunning: vm.startedAt != nil)
+        }
+        .onChange(of: appVM.keepScreenAwakeDuringSession) { _, _ in
+            // Re-sync when the preference toggles while on screen.
+            SessionIdleTimerController.syncLocalSession(appVM: appVM, isRunning: vm.startedAt != nil)
+        }
+    }
+}

--- a/ios/StillPointApp/Views/HistoryView.swift
+++ b/ios/StillPointApp/Views/HistoryView.swift
@@ -150,10 +150,10 @@ struct HistoryView: View {
                         .frame(width: 56, alignment: .trailing)
                         .lineLimit(1)
 
-                    // Session label within the day (quick sits visually distinct)
-                    Text(session.sessionType == .quick ? "Quick \(sessionIndexInDay)" : "Session \(sessionIndexInDay)")
+                    // Session label within the day (quick / breath sits visually distinct)
+                    Text(sessionLabel(session: session, index: sessionIndexInDay))
                         .font(SPFont.mono(11, weight: .medium))
-                        .foregroundStyle(session.sessionType == .quick ? SPColor.amberText : SPColor.fg3)
+                        .foregroundStyle(sessionLabelColor(session: session))
                         .frame(width: 72, alignment: .trailing)
 
                     // Proportional bar
@@ -232,6 +232,36 @@ struct HistoryView: View {
                 .padding(.leading, 44)
                 .padding(.vertical, 4)
             }
+        }
+    }
+
+    // MARK: - Session Label Helpers
+
+    private func sessionLabel(session: SessionDTO, index: Int) -> String {
+        switch session.sessionType {
+        case .quick:
+            return "Quick \(index)"
+        case .breath:
+            // Optionally surface breath count when available
+            if let count = session.breathCount, count > 0 {
+                return "Breath \(count)b"
+            }
+            return "Breath \(index)"
+        case .standard:
+            return "Session \(index)"
+        }
+    }
+
+    private func sessionLabelColor(session: SessionDTO) -> Color {
+        switch session.sessionType {
+        case .quick:
+            return SPColor.amberText
+        case .breath:
+            // Muted green, matching the breath-count accent in BreathCountingView and
+            // distinct from quick (amber) and standard (fg3).
+            return SPColor.greenText
+        case .standard:
+            return Color(SPColor.fg3)
         }
     }
 

--- a/ios/StillPointApp/Views/HomeView.swift
+++ b/ios/StillPointApp/Views/HomeView.swift
@@ -82,6 +82,24 @@ struct HomeView: View {
 
                     Button {
                         withAnimation {
+                            appVM.beginBreathCounting()
+                        }
+                    } label: {
+                        Text("Breath counting")
+                            .font(SPFont.mono(11, weight: .medium))
+                            .tracking(1.4)
+                            .foregroundStyle(Color(SPColor.fg3))
+                            .padding(.horizontal, 24)
+                            .padding(.vertical, SPSpacing.s2)
+                            .background(SPColor.surface1)
+                            .clipShape(Capsule())
+                            .overlay(Capsule().stroke(SPColor.border1))
+                    }
+                    .accessibilityIdentifier("home.breathCountingButton")
+                    .accessibilityLabel("Start breath counting")
+
+                    Button {
+                        withAnimation {
                             appVM.beginBuddySession()
                         }
                     } label: {

--- a/ios/StillPointApp/Views/RootView.swift
+++ b/ios/StillPointApp/Views/RootView.swift
@@ -57,6 +57,10 @@ struct RootView: View {
                 )
                 .transition(.opacity)
 
+            case .breathCounting:
+                BreathCountingView(appVM: appVM)
+                    .transition(.opacity)
+
             default:
                 MainTabView(appVM: appVM)
                     .transition(.opacity)
@@ -175,6 +179,8 @@ struct RootView: View {
             return "buddySession"
         case .completion:
             return "completion"
+        case .breathCounting:
+            return "breathCounting"
         case .history:
             return "history"
         case .journal:

--- a/ios/StillPointShared/Sources/StillPointShared/BreathCountingLogic.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/BreathCountingLogic.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+// MARK: - Breath Phase
+
+/// Which side of a breath the user is on.
+///
+/// Phase semantics: taps alternate inhale / exhale.
+///   - tap 1 → registers the first inhale  → tapCount becomes 1 (odd) → phase becomes .exhale (waiting for exhale)
+///   - tap 2 → registers first exhale      → tapCount becomes 2 (even) → phase becomes .inhale (one full breath done)
+///   - tap 3 → registers second inhale     → tapCount becomes 3 (odd) → phase becomes .exhale
+///   …
+/// So `phase(forTaps:)` returns the *next expected* action:
+///   even tapCount (incl. 0) → .inhale  (next tap should be an inhale)
+///   odd  tapCount            → .exhale  (just inhaled, now exhale)
+public enum BreathPhase {
+    case inhale
+    case exhale
+}
+
+// MARK: - BreathCounting
+
+public enum BreathCounting {
+
+    /// Number of complete breaths (1 breath = 1 inhale + 1 exhale = 2 taps).
+    public static func breathCount(forTaps taps: Int) -> Int {
+        taps / 2
+    }
+
+    /// The *next expected* breath phase given how many taps have been recorded.
+    ///
+    /// - Even tapCount (0, 2, 4, …): inhale is next.
+    /// - Odd tapCount (1, 3, 5, …): exhale is next.
+    public static func phase(forTaps taps: Int) -> BreathPhase {
+        taps % 2 == 0 ? .inhale : .exhale
+    }
+
+    /// Elapsed whole seconds since `start`, clamped to a minimum of 0.
+    ///
+    /// Uses wall-clock difference so it survives backgrounding without drift.
+    public static func elapsedSeconds(since start: Date, now: Date = Date()) -> Int {
+        max(0, Int(now.timeIntervalSince(start)))
+    }
+
+    /// Format a second count as "M:SS" or "MM:SS".
+    ///
+    /// Examples:
+    ///   0   → "0:00"
+    ///   65  → "1:05"
+    ///   600 → "10:00"
+    public static func elapsedDisplay(_ seconds: Int) -> String {
+        let s = max(0, seconds)
+        let minutes = s / 60
+        let secs = s % 60
+        return "\(minutes):\(String(format: "%02d", secs))"
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/Constants.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/Constants.swift
@@ -3,6 +3,8 @@ import Foundation
 public enum SessionType: String, Codable, Sendable {
     case standard
     case quick
+    /// Open-ended breath-counting sit. Does not advance the day counter.
+    case breath
 }
 
 public enum StillPoint {
@@ -30,7 +32,15 @@ public enum StillPoint {
     }
 
     public static func duration(for sessionType: SessionType, day: Int) -> Int {
-        sessionType == .quick ? quickDuration : duration(forDay: day)
+        switch sessionType {
+        case .quick:
+            return quickDuration
+        case .breath:
+            // Breath sessions are open-ended; 0 is a sentinel (value unused during session).
+            return 0
+        case .standard:
+            return duration(forDay: day)
+        }
     }
 
     public static func shouldAdvanceDay(sessionType: SessionType, completed: Bool) -> Bool {

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -34,6 +34,8 @@ public struct SessionDTO: Codable, Sendable {
     /// ISO-8601 from API when present; used for same-day ordering (matches web `sessionSortKey`).
     public let createdAt: String?
     public let buddySessionId: String?
+    /// Number of full breaths counted during a breath session (nil for non-breath sessions).
+    public let breathCount: Int?
 
     public init(
         id: String,
@@ -48,7 +50,8 @@ public struct SessionDTO: Codable, Sendable {
         mindStateLog: [MindStateEntry]?,
         sessionDate: String,
         createdAt: String? = nil,
-        buddySessionId: String?
+        buddySessionId: String?,
+        breathCount: Int? = nil
     ) {
         self.id = id
         self.dayNumber = dayNumber
@@ -63,6 +66,7 @@ public struct SessionDTO: Codable, Sendable {
         self.sessionDate = sessionDate
         self.createdAt = createdAt
         self.buddySessionId = buddySessionId
+        self.breathCount = breathCount
     }
 }
 
@@ -125,6 +129,8 @@ public struct CreateSessionRequest: Codable, Sendable {
     public let thoughtCount: Int
     public let mindStateLog: [MindStateEntry]
     public let sessionDate: String
+    /// Number of full breaths counted. Only sent for `.breath` sessions; nil otherwise.
+    public let breathCount: Int?
 
     public init(
         dayNumber: Int,
@@ -136,7 +142,8 @@ public struct CreateSessionRequest: Codable, Sendable {
         clearPercent: Int,
         thoughtCount: Int,
         mindStateLog: [MindStateEntry],
-        sessionDate: String
+        sessionDate: String,
+        breathCount: Int? = nil
     ) {
         self.dayNumber = dayNumber
         self.sessionType = sessionType
@@ -148,6 +155,7 @@ public struct CreateSessionRequest: Codable, Sendable {
         self.thoughtCount = thoughtCount
         self.mindStateLog = mindStateLog
         self.sessionDate = sessionDate
+        self.breathCount = breathCount
     }
 }
 

--- a/ios/StillPointShared/Tests/StillPointSharedTests/BreathCountingLogicTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/BreathCountingLogicTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+@testable import StillPointShared
+
+final class BreathCountingLogicTests: XCTestCase {
+
+    // MARK: - breathCount(forTaps:)
+
+    func testBreathCountZeroTaps() {
+        XCTAssertEqual(BreathCounting.breathCount(forTaps: 0), 0)
+    }
+
+    func testBreathCountOneTap() {
+        // 1 tap = inhale registered, no complete breath yet
+        XCTAssertEqual(BreathCounting.breathCount(forTaps: 1), 0)
+    }
+
+    func testBreathCountTwoTaps() {
+        // 2 taps = 1 full breath (inhale + exhale)
+        XCTAssertEqual(BreathCounting.breathCount(forTaps: 2), 1)
+    }
+
+    func testBreathCountFiveTaps() {
+        // 5 taps = 2 full breaths (4 taps) + 1 pending inhale
+        XCTAssertEqual(BreathCounting.breathCount(forTaps: 5), 2)
+    }
+
+    func testBreathCountEvenTaps() {
+        XCTAssertEqual(BreathCounting.breathCount(forTaps: 10), 5)
+    }
+
+    // MARK: - phase(forTaps:)
+
+    func testPhaseAtZeroTapsIsInhale() {
+        // No taps yet → next action is inhale
+        XCTAssertEqual(BreathCounting.phase(forTaps: 0), .inhale)
+    }
+
+    func testPhaseAfterOneTapIsExhale() {
+        // 1 tap recorded (inhale done) → next is exhale
+        XCTAssertEqual(BreathCounting.phase(forTaps: 1), .exhale)
+    }
+
+    func testPhaseAfterTwoTapsIsInhale() {
+        // 2 taps (full breath done) → next is inhale
+        XCTAssertEqual(BreathCounting.phase(forTaps: 2), .inhale)
+    }
+
+    func testPhaseAlternatesCorrectly() {
+        // Even = inhale, odd = exhale
+        for taps in 0...10 {
+            let expected: BreathPhase = taps % 2 == 0 ? .inhale : .exhale
+            XCTAssertEqual(
+                BreathCounting.phase(forTaps: taps), expected,
+                "phase(forTaps: \(taps)) should be \(expected)"
+            )
+        }
+    }
+
+    // MARK: - elapsedSeconds(since:now:)
+
+    func testElapsedSecondsZero() {
+        let now = Date()
+        XCTAssertEqual(BreathCounting.elapsedSeconds(since: now, now: now), 0)
+    }
+
+    func testElapsedSecondsPositive() {
+        let start = Date()
+        let later = start.addingTimeInterval(65)
+        XCTAssertEqual(BreathCounting.elapsedSeconds(since: start, now: later), 65)
+    }
+
+    func testElapsedSecondsClampedToZeroForNegativeDiff() {
+        // now is before start — should clamp to 0, not return negative
+        let start = Date()
+        let before = start.addingTimeInterval(-5)
+        XCTAssertEqual(BreathCounting.elapsedSeconds(since: start, now: before), 0)
+    }
+
+    func testElapsedSecondsAcrossOneMinute() {
+        let start = Date()
+        let later = start.addingTimeInterval(90)
+        XCTAssertEqual(BreathCounting.elapsedSeconds(since: start, now: later), 90)
+    }
+
+    func testElapsedSecondsTruncatesNotRounds() {
+        // 59.9 seconds → 59, not 60
+        let start = Date()
+        let later = start.addingTimeInterval(59.9)
+        XCTAssertEqual(BreathCounting.elapsedSeconds(since: start, now: later), 59)
+    }
+
+    // MARK: - elapsedDisplay(_:)
+
+    func testElapsedDisplayZero() {
+        XCTAssertEqual(BreathCounting.elapsedDisplay(0), "0:00")
+    }
+
+    func testElapsedDisplayOneMinuteFiveSeconds() {
+        XCTAssertEqual(BreathCounting.elapsedDisplay(65), "1:05")
+    }
+
+    func testElapsedDisplayTenMinutes() {
+        XCTAssertEqual(BreathCounting.elapsedDisplay(600), "10:00")
+    }
+
+    func testElapsedDisplayNineSeconds() {
+        XCTAssertEqual(BreathCounting.elapsedDisplay(9), "0:09")
+    }
+
+    func testElapsedDisplayOneHour() {
+        XCTAssertEqual(BreathCounting.elapsedDisplay(3600), "60:00")
+    }
+
+    func testElapsedDisplayClampedNegative() {
+        // Negative input is treated as 0
+        XCTAssertEqual(BreathCounting.elapsedDisplay(-5), "0:00")
+    }
+}

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -42,6 +42,15 @@ export async function POST(request: NextRequest) {
     const { dayNumber, duration, actualTime, clearPercent, thoughtCount, mindStateLog, sessionDate } = body;
     const completed = parseCompleted(body.completed);
     const sessionType = parseOptionalSessionType(body.sessionType);
+    // #374: taps-per-breath count. Only persisted for breath sessions (so a stray
+    // breathCount on a standard/quick payload can't violate the data contract), and
+    // clamped to the Postgres integer range so an out-of-range value can't turn into
+    // a 500 at insert time.
+    const breathCountRaw = body.breathCount;
+    const breathCount =
+      sessionType === "breath" && typeof breathCountRaw === "number" && Number.isFinite(breathCountRaw)
+        ? Math.min(2_147_483_647, Math.max(0, Math.floor(breathCountRaw)))
+        : null;
     const bonusSecondsRaw = body.bonusSeconds;
     const bonusSeconds =
       typeof bonusSecondsRaw === "number" && Number.isFinite(bonusSecondsRaw)
@@ -68,6 +77,7 @@ export async function POST(request: NextRequest) {
       actualTime: actualTime ?? duration,
       clearPercent,
       thoughtCount: thoughtCount ?? 0,
+      breathCount,
       mindStateLog: mindStateLog ?? [],
       sessionDate,
     }).returning();

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -344,8 +344,9 @@ export function HistoryView({ currentDay, username }: HistoryViewProps) {
             const dateLabelFull = formatFullDateLabel(entry.date);
             const dateLabelShort = formatShortDateLabel(entry.date);
             const isQuick = entry.sessionType === "quick";
+            const isBreath = entry.sessionType === "breath";
             const sessionOrdinal = entry.sessionIndexInDay ?? 1;
-            const sessionLabel = isQuick ? "Quick" : `Session ${sessionOrdinal}`;
+            const sessionLabel = isQuick ? "Quick" : isBreath ? "Breath" : `Session ${sessionOrdinal}`;
 
             const entryId = entry.sessionId ? `sess-${entry.sessionId}` : `day-${entry.day}-${idx}`;
             const isExpanded = expandedEntryId === entryId;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -294,6 +294,8 @@ export const sessions = pgTable("sessions", {
   actualTime: integer("actual_time"),
   clearPercent: integer("clear_percent").notNull(),
   thoughtCount: integer("thought_count").default(0).notNull(),
+  /** #374: taps-per-breath count for breath-counting sessions; null for other types. */
+  breathCount: integer("breath_count"),
   mindStateLog: jsonb("mind_state_log").$type<Array<{ time: number; state: string }>>(),
   sessionDate: date("session_date").notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
@@ -302,7 +304,7 @@ export const sessions = pgTable("sessions", {
   buddyIdx: index("idx_sessions_buddy_session").on(table.buddySessionId),
   sessionTypeCheck: check(
     "sessions_session_type_allowed",
-    sql`${table.sessionType} in ('standard', 'quick')`,
+    sql`${table.sessionType} in ('standard', 'quick', 'breath')`,
   ),
   /** At most one personal session row per user per shared buddy sit. */
   userBuddyUnique: uniqueIndex("sessions_user_buddy_session_unique").on(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -35,7 +35,7 @@ export type Session = {
   duration: number;
   /** Seconds added via +1/+5 extensions beyond planned duration (#90). */
   bonusSeconds?: number;
-  sessionType: "standard" | "quick";
+  sessionType: "standard" | "quick" | "breath";
   completed: boolean;
   actualTime: number | null;
   clearPercent: number;
@@ -183,7 +183,7 @@ export const api = {
     dayNumber: number;
     duration: number;
     bonusSeconds?: number;
-    sessionType?: "standard" | "quick";
+    sessionType?: "standard" | "quick" | "breath";
     completed: boolean;
     actualTime: number;
     clearPercent: number;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -4,7 +4,7 @@ export const BASE_DURATION = 60;
 export const QUICK_DURATION = 60;
 export const INCREMENT = 10;
 export const BLOCK_DURATION = 10;
-const SESSION_TYPES = ["standard", "quick"] as const;
+const SESSION_TYPES = ["standard", "quick", "breath"] as const;
 export type SessionType = (typeof SESSION_TYPES)[number];
 
 export type SessionStatsInput = {


### PR DESCRIPTION
## **User description**
## What
Adds a **breath-counting** practice mode on iOS: a full-screen tap target (eyes-closed friendly) with a count-up timer, a light haptic per tap, an in/out phase indicator, and a running breath count. Sessions persist and appear in history. `breath` is a first-class session type end-to-end (iOS + backend + Postgres), excluded from streak/day progression.

## Why
A second practice modality for anchoring attention by physically marking each breath, with a record of how long the practice was sustained. (Issue #374.)

## How
**iOS**
- New full-screen `BreathCountingView` + `BreathCountingViewModel` — wall-clock elapsed that survives backgrounding (mirrors `SessionViewModel`'s `startDate` pattern), light haptic per tap, idle timer kept awake, explicit End control.
- Pure `BreathCounting` logic (taps → breaths/phase, elapsed seconds, MM:SS) in `StillPointShared`, with 20 unit tests.
- `AppView.breathCounting` state + Home entry point + History label ("Breath").
- On End: persists via the existing `createSession` API with `sessionType: .breath`, `breathCount`, and elapsed seconds.

**Backend / shared (full integration)**
- `SessionType` gains `breath` (Swift enum + web TS `SESSION_TYPES`).
- Postgres: nullable `breath_count` column + the `session_type` CHECK relaxed to allow `'breath'`, via a new idempotent incremental migration (`drizzle/sessions_breath_count_incremental.sql`). DROP+ADD constraint is order-independent vs. the existing session-type incremental (whose ADD is `IF NOT EXISTS`, so it cannot downgrade the 3-value form).
- `POST /api/sessions` persists `breathCount`. `shouldAdvanceDay('breath')` is false and `calculateSessionStats` excludes non-standard, so breath sessions record + show in history but do not affect streak/day progression.
- Web tolerates the new type (history labels it "Breath"; the per-type ordinal already prevents numbering offset). The web breath **input** UI remains its own sibling issue.

Closes #374

## Test plan
- [x] `swift test` in `ios/StillPointShared` passes incl. new `BreathCountingLogicTests` (20 cases) — ✅ locally (77 total)
- [x] PR CI green: iOS e2e (smoke + critical), web typecheck/lint/build, unit tests
- [x] Migration applies cleanly on the Vercel preview DB (idempotent; CHECK allows breath; `breath_count` added)
- [ ] (Device/manual) Full-screen taps register with haptic; count-up starts on first tap; breath count + in/out phase update per tap
- [ ] (Device/manual) Background mid-session and return — elapsed + count uncorrupted
- [ ] (Device/manual) End logs the session; it appears in History as a breath entry; streak/day unaffected
- [ ] Screen stays awake during an active breath session


___

## **CodeAnt-AI Description**
**Add breath-counting sessions and show them in history**

### What Changed
- Added a new breath-counting mode that starts from the Home screen, uses full-screen tapping for inhale/exhale counting, shows elapsed time, current breath count, and the next phase, and ends with an explicit button
- Breath sessions are saved with their breath count and appear in history as “Breath,” with matching labels and colors in the app
- Breath sessions no longer behave like standard sessions in day progression, and the app now recognizes the new session type everywhere it is sent or displayed
- Breath counts are rejected for non-breath sessions and are clamped before saving so invalid values do not fail session creation

### Impact
`✅ New breath-counting practice mode`
`✅ Clearer session history labels`
`✅ Fewer failed session saves`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added breath-counting sessions to both iOS and web apps, including tap-driven phase guidance and an elapsed timer during the session.
  * Breath sessions now persist an optional breath count, and results appear in session history with breath-specific labels.

* **Bug Fixes**
  * Session saving is safer and avoids duplicate submissions; when finishing a breath session, you return to Home even if saving fails.
  * Breath count values are validated and only stored for breath sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


> **Deferred (post-merge / device):** The full-screen-tap/haptic, backgrounding, history-entry, and screen-awake items require on-device manual testing. Verified after merge, not in PR CI. Merged per maintainer authorization with CI-verifiable AC green.