### PR TITLE
fix(ios): restore required Info.plist keys dropped by XcodeGen regeneration

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -96,3 +96,46 @@ jobs:
           path: ~/Library/Logs/DiagnosticReports/**
           if-no-files-found: ignore
           retention-days: 14
+
+  # Guards against project.yml <-> Info.plist drift. CI regenerates Info.plist via
+  # `xcodegen generate` before every build, so any key that lives only in the committed
+  # Info.plist (and not in project.yml's info.properties) is silently dropped from
+  # shipped builds. This job fails the PR if regeneration would change the committed
+  # Info.plist, forcing project.yml to stay the single source of truth. See issue #432.
+  infoplist-sync:
+    name: Info.plist in sync with project.yml
+    runs-on: macos-26
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install XcodeGen
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          for attempt in 1 2 3; do
+            if brew install xcodegen; then
+              exit 0
+            fi
+            if [[ "$attempt" -lt 3 ]]; then
+              sleep $((attempt * 10))
+            fi
+          done
+          echo "Failed to install xcodegen after 3 attempts."
+          exit 1
+
+      - name: Generate Xcode project
+        working-directory: ios
+        run: xcodegen generate
+
+      - name: Verify committed Info.plist matches XcodeGen output
+        run: |
+          if ! git diff --exit-code -- ios/StillPointApp/Info.plist; then
+            echo "::error::ios/StillPointApp/Info.plist is out of sync with ios/project.yml."
+            echo "CI regenerates Info.plist via 'xcodegen generate' before every build, so any key that"
+            echo "exists only in the committed Info.plist (not in project.yml info.properties) is DROPPED"
+            echo "from shipped builds. Fix: add the key(s) to ios/project.yml -> targets.StillPoint.info.properties,"
+            echo "then run 'cd ios && xcodegen generate' and commit the regenerated ios/StillPointApp/Info.plist."
+            exit 1
+          fi

--- a/ios/StillPointApp/Info.plist
+++ b/ios/StillPointApp/Info.plist
@@ -18,8 +18,6 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
-	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -31,12 +29,12 @@
 			</array>
 		</dict>
 	</array>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSCameraUsageDescription</key>
 	<string>Still Point needs camera access for partner video sessions.</string>
-	<key>NSFamilyControlsUsageDescription</key>
-	<string>Still Point uses Screen Time permission to block your selected apps until you complete a meditation session.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Still Point needs microphone access for partner video sessions.</string>
 	<key>UIAppFonts</key>

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -32,6 +32,25 @@ targets:
           - Fonts/JetBrainsMono-Variable.ttf
         CFBundleIconName: AppIcon
         ITSAppUsesNonExemptEncryption: false
+        # Custom URL scheme (stillpoint://) for deep links: daily-reminder push taps,
+        # buddy invites (stillpoint://buddy/...), and session links. See AppViewModel /
+        # RootView.onOpenURL / PushNotificationCoordinator.
+        CFBundleURLTypes:
+          - CFBundleURLName: com.brettonauerbach.stillpoint
+            CFBundleURLSchemes:
+              - stillpoint
+        # Privacy purpose strings — REQUIRED by iOS for the buddy video web view
+        # (BuddyVideoWebView: WKWebView -> Daily.co getUserMedia). A missing key is a
+        # hard crash the moment camera/mic is requested, not a graceful denial.
+        NSCameraUsageDescription: Still Point needs camera access for partner video sessions.
+        NSMicrophoneUsageDescription: Still Point needs microphone access for partner video sessions.
+        # NSFamilyControlsUsageDescription is intentionally NOT declared: it is not a
+        # recognized iOS key. FamilyControls / Screen Time authorization is gated by the
+        # com.apple.developer.family-controls entitlement (StillPointApp/StillPoint.entitlements),
+        # and the authorization dialog text cannot be customized via Info.plist. See #432.
+        # Keep audio alive when the app is backgrounded mid-session.
+        UIBackgroundModes:
+          - audio
         UILaunchScreen: {}
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -48,6 +48,7 @@ targets:
         # recognized iOS key. FamilyControls / Screen Time authorization is gated by the
         # com.apple.developer.family-controls entitlement (StillPointApp/StillPoint.entitlements),
         # and the authorization dialog text cannot be customized via Info.plist. See #432.
+
         # Keep audio alive when the app is backgrounded mid-session.
         UIBackgroundModes:
           - audio


### PR DESCRIPTION
## **User description**
Fixes #432

## Problem

CI runs `xcodegen generate` before **every** iOS build (`e2e-ios.yml` and the reusable `ios-testflight-build.yml`). XcodeGen **regenerates** `ios/StillPointApp/Info.plist` from `project.yml`'s `info.properties` — it does not merge with the on-disk file. Four keys lived **only** in the committed `Info.plist` and never in `project.yml`, so they were **silently dropped from every shipped build** (incl. Build 11 / v1.0.3):

| Key | Effect of being missing |
|---|---|
| `CFBundleURLTypes` (`stillpoint://`) | `stillpoint://` deep links don't route — breaks daily-reminder push taps (`PushNotificationCoordinator` → `stillpoint://home`), buddy invites (`stillpoint://buddy/...`), session links (`AppViewModel.handleIncomingURL` via `RootView.onOpenURL`) |
| `NSCameraUsageDescription` | **Hard crash** when `BuddyVideoWebView`'s `WKWebView` (Daily.co) requests camera via `getUserMedia` |
| `NSMicrophoneUsageDescription` | **Hard crash** on mic access (same path) |
| `UIBackgroundModes` `[audio]` | Background-audio capability not declared (`AudioEngine` uses `AVAudioSession(.playback)`) |

## Changes

- **`ios/project.yml`** — add the 4 keys above to `targets.StillPoint.info.properties` so regeneration produces a complete `Info.plist`.
- **Drop `NSFamilyControlsUsageDescription`** (not added to `project.yml`; removed from the committed plist). Verified it's a **no-op**: it is not a recognized iOS key. FamilyControls / Screen Time is gated by the `com.apple.developer.family-controls` entitlement (`StillPoint.entitlements`, present) and the auth dialog text can't be customized via Info.plist. `AppBlockingManager`'s `AuthorizationCenter.requestAuthorization(for: .individual)` doesn't consult it. A note documenting this is in `project.yml`.
- **`ios/StillPointApp/Info.plist`** — reordered to match XcodeGen's alphabetical output (`CFBundleURLTypes` had been hand-inserted out of order, after `CFBundleVersion`). Net diff is the `CFBundleURLTypes` move + the `NSFamilyControlsUsageDescription` removal; nothing else changes.
- **`.github/workflows/e2e-ios.yml`** — new `infoplist-sync` job runs `xcodegen generate` and fails the PR if the committed `Info.plist` drifts from XcodeGen's output. Recurrence guard for this whole class of bug.

## Verification

- ✅ Keys absent from `project.yml` confirmed via `git log -S … -- ios/project.yml` (never present).
- ✅ Not injected via `INFOPLIST_KEY_*` build settings either (grep of committed `project.pbxproj` is empty) — the plist file is the only source.
- ✅ XcodeGen sorts keys alphabetically: with the 5 hand-added keys removed, the committed plist is already perfectly alphabetical, and regenerating the *current* `project.yml` produces exactly **21 line deletions and no other changes** — i.e. the rest of the file is byte-exact XcodeGen output. The reconstructed plist here = that output + the 4 restored keys in alphabetical position.
- ✅ `project.yml` and the workflow parse as valid YAML; restored values match the committed strings exactly.
- ⚠️ **Could not run `xcodegen generate` in the sandbox** (Linux; XcodeGen is macOS-only) and **could not inspect a real TestFlight `.ipa`** (no App Store Connect access). The new `infoplist-sync` CI job verifies the zero-diff invariant authoritatively on `macos-26`. To confirm locally: `cd ios && xcodegen generate && git diff --exit-code ios/StillPointApp/Info.plist`.
- ℹ️ No `ios/StillPointShared` changes, so `swift test` there is N/A; iOS app-target compile is exercised by the existing E2E lanes.

## Highest-priority follow-up

A buddy **video** session on a shipped build should be re-tested on-device after a build carrying this fix — that's the camera/mic crash path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToQFbqWWgb5QkxfVWEvtzW)_


___

## **CodeAnt-AI Description**
**Restore iPhone permissions, deep links, and background audio in shipped builds**

### What Changed
- Added the app’s custom `stillpoint://` link handling back into the generated iPhone settings, so daily reminders, buddy invites, and session links open correctly.
- Restored the camera and microphone permission prompts needed for partner video sessions, preventing app crashes when those devices are requested.
- Re-enabled background audio so sessions can continue when the app is sent to the background.
- Removed the unused Screen Time permission text from the committed settings file.
- Added a CI check that fails if the committed iPhone settings drift from the generated output, so missing keys are caught before release.

### Impact
`✅ Working deep links from reminders and invites`
`✅ Fewer camera and microphone crashes during video sessions`
`✅ Audio that keeps playing in the background`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added camera and microphone permissions for partner video sessions
  * Introduced deep-link URL scheme support for app navigation
  * Enabled background audio capability to maintain audio during backgrounded sessions

* **Chores**
  * Added CI verification to ensure iOS configuration consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->