### PR TITLE
chore(ios): bump build number to 12 for TestFlight verification build

### DIFF
--- a/ios/project.yml
+++ b/ios/project.yml
@@ -69,7 +69,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint
         MARKETING_VERSION: "1.0.3"
-        CURRENT_PROJECT_VERSION: 11
+        CURRENT_PROJECT_VERSION: 12
         DEVELOPMENT_TEAM: T5UU4BP6AV
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]: StillPointApp/StillPoint.entitlements


### PR DESCRIPTION
## What
Bump `CURRENT_PROJECT_VERSION` `11` → `12` in `ios/project.yml` (marketing version stays `1.0.3`).

## Why
Build **11** of 1.0.3 is already in App Store Connect (Jun 11). In this repo `CURRENT_PROJECT_VERSION` is the `CFBundleVersion` source of truth (the tag name is just a label — see `.github/workflows/ios-testflight-auto.yml`), and it was still `11` on main. Cutting a TestFlight archive today would therefore upload as a duplicate `CFBundleVersion` and be rejected. Bumping to `12` lets the manual escape-hatch tag `ios-v1.0.3-build12` (→ `ios-testflight.yml`) produce a unique, uploadable build — needed to verify the app **and** the new `StillPointMonitor` extension sign correctly now that #436/#442 wired the signing pipeline.

## How
- One line in `ios/project.yml`: `CURRENT_PROJECT_VERSION: 12`. The `$(CURRENT_PROJECT_VERSION)` substitution in `info.properties` propagates it to `CFBundleVersion` at archive time.
- **No** `release:ios` label on this PR: after merge I'll push the `ios-v1.0.3-build12` tag manually (manual TestFlight path), so the auto-workflow doesn't also fire and double-bump.

## Test plan
- [x] `ios/project.yml` has `CURRENT_PROJECT_VERSION: 12`, `MARKETING_VERSION: "1.0.3"`
- [x] `xcodegen generate` produces a valid project and does not strip `Info.plist` keys (the "Info.plist in sync" CI check passes)
- [x] PR CI green (iOS e2e simulator build unaffected by a version-only change; web checks unaffected)
- [ ] (Post-merge, device) the `ios-v1.0.3-build12` tag triggers `ios-testflight.yml`; the archive signs the app **and** the embedded `StillPointMonitor` extension and uploads build 12 to App Store Connect / TestFlight

Closes #443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version number to 12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
