### PR TITLE
ci: pin GitHub Actions to commit SHAs + persist-credentials + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # Keep the SHA-pinned GitHub Actions in .github/workflows/ current. Dependabot
+  # opens weekly PRs that bump each pinned commit SHA (and its trailing # vX.Y.Z
+  # comment) to the latest release, so pinning for supply-chain safety does not
+  # mean the actions silently rot. Scoped to github-actions only by design.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/cr-plan-on-issue.yml
+++ b/.github/workflows/cr-plan-on-issue.yml
@@ -13,7 +13,7 @@ jobs:
     if: "!endsWith(github.event.issue.user.login, '[bot]')"
     steps:
       - name: Comment @coderabbitai plan
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             await github.rest.issues.createComment({

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -22,10 +22,12 @@ jobs:
         lane: [smoke, critical]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -81,7 +83,7 @@ jobs:
 
       - name: Upload iOS E2E artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: e2e-ios-${{ matrix.lane }}-artifacts
           path: artifacts/e2e/ios/**
@@ -90,7 +92,7 @@ jobs:
 
       - name: Upload simulator diagnostic reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: e2e-ios-${{ matrix.lane }}-diagreports
           path: ~/Library/Logs/DiagnosticReports/**
@@ -108,7 +110,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install XcodeGen
         env:

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -26,10 +26,12 @@ jobs:
           - mobile-webkit-iphone
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -45,7 +47,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report-${{ matrix.project }}
           path: playwright-report/
@@ -53,7 +55,7 @@ jobs:
 
       - name: Upload Playwright test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-results-${{ matrix.project }}
           path: test-results/

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -14,10 +14,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -43,10 +45,12 @@ jobs:
       SEED_CONFIRM: still-point-nonprod
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -62,7 +66,7 @@ jobs:
 
       - name: Upload web smoke artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: web-e2e-smoke-artifacts
           path: |
@@ -85,10 +89,12 @@ jobs:
       SEED_CONFIRM: still-point-nonprod
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -114,7 +120,7 @@ jobs:
 
       - name: Upload web critical artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: web-e2e-critical-artifacts
           path: |
@@ -140,7 +146,9 @@ jobs:
       JWT_SECRET: ${{ secrets.E2E_AUTH_DB_JWT_SECRET }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Check auth DB secrets
         id: authdb
@@ -157,7 +165,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.authdb.outputs.configured == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -176,7 +184,7 @@ jobs:
 
       - name: Upload auth DB integration artifacts
         if: always() && steps.authdb.outputs.configured == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: web-e2e-auth-db-artifacts
           path: |

--- a/.github/workflows/ios-app-store-release.yml
+++ b/.github/workflows/ios-app-store-release.yml
@@ -22,10 +22,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -62,7 +64,7 @@ jobs:
 
       - name: Upload simulator diagnostic reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ios-app-store-release-preflight-diagreports
           path: ~/Library/Logs/DiagnosticReports/**
@@ -71,7 +73,7 @@ jobs:
 
       - name: Upload xcresult bundle
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ios-app-store-release-preflight-xcresult
           path: artifacts/e2e/ios/**
@@ -85,10 +87,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
 
@@ -142,7 +146,7 @@ jobs:
 
       - name: Upload App Store submission dry-run evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ios-app-store-dry-run-release
           path: artifacts/ios-app-store-dry-run/**
@@ -178,7 +182,7 @@ jobs:
         run: xcodegen generate
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: "3.3"
           bundler-cache: true

--- a/.github/workflows/ios-screenshots.yml
+++ b/.github/workflows/ios-screenshots.yml
@@ -18,15 +18,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: "3.3"
           bundler-cache: false
@@ -102,7 +104,7 @@ jobs:
         run: bundle exec fastlane screenshots
 
       - name: Upload candidates bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ios-screenshot-candidates
           path: ios/screenshots/candidates/**

--- a/.github/workflows/ios-shared-tests.yml
+++ b/.github/workflows/ios-shared-tests.yml
@@ -14,7 +14,9 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       # StillPointShared is a pure SwiftPM package, so `swift test` builds and runs
       # the suite without xcodegen/xcodebuild (the same path agents use locally,

--- a/.github/workflows/ios-testflight-auto.yml
+++ b/.github/workflows/ios-testflight-auto.yml
@@ -48,7 +48,7 @@ jobs:
       tag: ${{ steps.bump.outputs.tag }}
     steps:
       - name: Checkout merge commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.merge_commit_sha }}

--- a/.github/workflows/ios-testflight-build.yml
+++ b/.github/workflows/ios-testflight-build.yml
@@ -47,12 +47,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -92,7 +93,7 @@ jobs:
 
       - name: Upload simulator diagnostic reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ios-testflight-preflight-diagreports
           path: ~/Library/Logs/DiagnosticReports/**
@@ -101,7 +102,7 @@ jobs:
 
       - name: Upload xcresult bundle
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ios-testflight-preflight-xcresult
           path: artifacts/e2e/ios/**
@@ -115,9 +116,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
 
       - name: Verify Xcode and iOS SDK versions
         shell: bash

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,10 +13,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           cache: npm
@@ -38,10 +40,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -13,10 +13,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Summary

Hardens CI supply-chain posture across all of `.github/workflows/` (issue #437):

1. **Pinned every external action to a full 40-char commit SHA** with a trailing `# vX.Y.Z` readability comment, so a tag being re-pointed (e.g. a compromised `v4`) can no longer silently change what runs.
2. **Added `persist-credentials: false`** to every read-only `actions/checkout` step, so the `GITHUB_TOKEN` is not persisted into the runner's git config where no later step needs it.
3. **Added `.github/dependabot.yml`** with a weekly `github-actions` update so the pinned SHAs are kept current (scoped to github-actions only).

The diff is surgical: only `uses:` refs changed (tag → SHA + comment), `persist-credentials: false` added where appropriate, plus the new `dependabot.yml`. No job names, step names, `run:` logic, env, or secrets were touched. In particular the `Info.plist in sync with project.yml` job in `e2e-ios.yml` is unchanged (per #439).

## Resolved SHA pins (action → SHA → version)

Each SHA is the latest release matching the major version already in use, resolved via `git ls-remote --tags`:

| Action | Was | Pinned SHA | Version |
|---|---|---|---|
| `actions/checkout` | `@v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
| `actions/checkout` | `@v5` | `93cb6efe18208431cddfb8368fd83d5badbf9bfd` | v5.0.1 |
| `actions/setup-node` | `@v4` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 |
| `actions/setup-node` | `@v5` | `a0853c24544627f65ddf259abe73b1d18a591444` | v5.0.0 |
| `actions/upload-artifact` | `@v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4.6.2 |
| `actions/github-script` | `@v7` | `f28e40c7f34bde8b3046d885e986cb6290c5673b` | v7.1.0 |
| `ruby/setup-ruby` | `@v1` | `9eb537ca036ebaed86729dcb9309076e4c5c3b74` | v1.314.0 |

**Not pinned (intentional):** the two local reusable-workflow calls `uses: ./.github/workflows/ios-testflight-build.yml` (in `ios-testflight.yml` and `ios-testflight-auto.yml`) — these reference in-repo files, not external actions, so a SHA pin does not apply.

## `persist-credentials` audit

17 `actions/checkout` steps total. **16 are read-only and received `persist-credentials: false`**; **1 was intentionally left WITH credentials.**

**Left WITH credentials (needs git write):**
- `ios-testflight-auto.yml` → `tag` job ("Checkout merge commit"). This job's later step runs `git commit`, `git tag`, and `git push --atomic origin HEAD:main`, so it needs the persisted token. It has `permissions: contents: write` on the job.

**Got `persist-credentials: false` (read-only):**
- `e2e-ios.yml` — `ios-e2e` checkout, and `infoplist-sync` checkout (its later `git diff --exit-code` is read-only).
- `e2e-web.yml` — all 4 checkouts (`e2e-policy`, `web-e2e-smoke`, `web-e2e-critical`, `web-e2e-auth-db`).
- `e2e-mobile.yml` — `e2e-mobile` checkout.
- `web-build.yml` — `build` checkout.
- `unit-tests.yml` — `unit-tests` and `typecheck` checkouts.
- `ios-shared-tests.yml` — `swift-test` checkout.
- `ios-screenshots.yml` — `regenerate-candidates` checkout.
- `ios-app-store-release.yml` — `pre-flight-tests` and `fastlane-release` checkouts. These use App Store Connect API keys + manual signing (no `git push`); the validation steps only `grep`/`git diff`. Workflow-level `permissions: contents: read`.
- `ios-testflight-build.yml` — both reusable-workflow checkouts. App Store Connect upload via `xcodebuild`, no `git push`. Workflow-level `permissions: contents: read`.

## Validation

- All 13 workflow files + `dependabot.yml` parse cleanly (`yaml.safe_load`).
- Every pinned ref verified as exactly 40 hex chars.
- Diff reviewed line-by-line: every removed line is a `uses: …@vN` tag ref; every added line is a pinned `uses:`, a `with:`, or `persist-credentials: false`. No names/logic changed.
- `actionlint` was not available in the environment, so YAML-level validation was used instead.

## Follow-up / notes

- No unresolved SHAs — outbound network to GitHub was available and every action was resolved.
- `neon-preview-reset.yml` and `ios-testflight.yml` use no external actions, so they are unchanged.

Closes #437

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToQFbqWWgb5QkxfVWEvtzW)_