### PR TITLE
fix(ios): sign StillPointMonitor extension at export + sync its version for TestFlight

### DIFF
--- a/.github/workflows/ios-testflight-auto.yml
+++ b/.github/workflows/ios-testflight-auto.yml
@@ -86,14 +86,19 @@ jobs:
 
           # Bump CURRENT_PROJECT_VERSION for every target that defines it — the app
           # and the StillPointMonitor extension (#446) — so their build numbers stay
-          # in lockstep. sed already substitutes on every matching line; the trailing
-          # g is belt-and-suspenders for multiple matches on a single line.
-          sed -i.bak -E "s/^([[:space:]]+CURRENT_PROJECT_VERSION:[[:space:]]*)[0-9]+.*/\1${NEW}/g" "$PROJECT"
+          # in lockstep. sed runs per line, so each target entry is rewritten; the
+          # optional quotes keep it working even if a value is ever written as "13".
+          sed -i.bak -E "s/^([[:space:]]+CURRENT_PROJECT_VERSION:[[:space:]]*)\"?[0-9]+\"?.*/\1${NEW}/" "$PROJECT"
           rm -f "${PROJECT}.bak"
 
-          APPLIED="$(grep -E '^[[:space:]]+CURRENT_PROJECT_VERSION:' "$PROJECT" | head -1 | sed -E 's/.*CURRENT_PROJECT_VERSION:[[:space:]]*"?([0-9]+)"?.*/\1/' | xargs)"
-          if [[ "$APPLIED" != "$NEW" ]]; then
-            echo "::error::Failed to update CURRENT_PROJECT_VERSION to ${NEW} (got '${APPLIED}')."
+          # Verify EVERY entry reached ${NEW}, not just the first match. A partial
+          # update would silently break app/extension version lockstep and get
+          # rejected at upload, so fail loudly here instead.
+          if grep -E '^[[:space:]]+CURRENT_PROJECT_VERSION:' "$PROJECT" \
+             | sed -E 's/.*CURRENT_PROJECT_VERSION:[[:space:]]*"?([0-9]+)"?.*/\1/' \
+             | grep -qv "^${NEW}$"; then
+            echo "::error::Not all CURRENT_PROJECT_VERSION entries were updated to ${NEW}."
+            grep -nE '^[[:space:]]+CURRENT_PROJECT_VERSION:' "$PROJECT" >&2
             exit 1
           fi
 

--- a/.github/workflows/ios-testflight-auto.yml
+++ b/.github/workflows/ios-testflight-auto.yml
@@ -84,9 +84,11 @@ jobs:
             exit 1
           fi
 
-          # Increment CURRENT_PROJECT_VERSION in place (only the StillPoint target
-          # defines this key, so a single substitution is unambiguous).
-          sed -i.bak -E "s/^([[:space:]]+CURRENT_PROJECT_VERSION:[[:space:]]*)[0-9]+.*/\1${NEW}/" "$PROJECT"
+          # Bump CURRENT_PROJECT_VERSION for every target that defines it — the app
+          # and the StillPointMonitor extension (#446) — so their build numbers stay
+          # in lockstep. sed already substitutes on every matching line; the trailing
+          # g is belt-and-suspenders for multiple matches on a single line.
+          sed -i.bak -E "s/^([[:space:]]+CURRENT_PROJECT_VERSION:[[:space:]]*)[0-9]+.*/\1${NEW}/g" "$PROJECT"
           rm -f "${PROJECT}.bak"
 
           APPLIED="$(grep -E '^[[:space:]]+CURRENT_PROJECT_VERSION:' "$PROJECT" | head -1 | sed -E 's/.*CURRENT_PROJECT_VERSION:[[:space:]]*"?([0-9]+)"?.*/\1/' | xargs)"

--- a/ios/ExportOptions.plist
+++ b/ios/ExportOptions.plist
@@ -14,6 +14,8 @@
 	<dict>
 		<key>com.brettonauerbach.stillpoint</key>
 		<string>StillPoint App Store</string>
+		<key>com.brettonauerbach.stillpoint.monitor</key>
+		<string>StillPoint Monitor App Store</string>
 	</dict>
 	<key>uploadSymbols</key>
 	<true/>

--- a/ios/ExportOptionsFastlane.plist
+++ b/ios/ExportOptionsFastlane.plist
@@ -14,6 +14,8 @@
 	<dict>
 		<key>com.brettonauerbach.stillpoint</key>
 		<string>StillPoint App Store</string>
+		<key>com.brettonauerbach.stillpoint.monitor</key>
+		<string>StillPoint Monitor App Store</string>
 	</dict>
 	<key>uploadSymbols</key>
 	<true/>

--- a/ios/StillPoint.xcodeproj/project.pbxproj
+++ b/ios/StillPoint.xcodeproj/project.pbxproj
@@ -616,7 +616,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Automatic;
 				"CODE_SIGN_STYLE[sdk=iphoneos*]" = Manual;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_TEAM = T5UU4BP6AV;
 				INFOPLIST_FILE = StillPointApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -661,7 +661,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Automatic;
 				"CODE_SIGN_STYLE[sdk=iphoneos*]" = Manual;
-				CURRENT_PROJECT_VERSION = 11;
+				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_TEAM = T5UU4BP6AV;
 				INFOPLIST_FILE = StillPointApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -702,6 +702,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Automatic;
 				"CODE_SIGN_STYLE[sdk=iphoneos*]" = Manual;
+				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_TEAM = T5UU4BP6AV;
 				INFOPLIST_FILE = StillPointMonitor/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -709,6 +710,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.brettonauerbach.stillpoint.monitor;
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "StillPoint Monitor App Store";
 				SDKROOT = iphoneos;
@@ -844,6 +846,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Automatic;
 				"CODE_SIGN_STYLE[sdk=iphoneos*]" = Manual;
+				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_TEAM = T5UU4BP6AV;
 				INFOPLIST_FILE = StillPointMonitor/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -851,6 +854,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.brettonauerbach.stillpoint.monitor;
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "StillPoint Monitor App Store";
 				SDKROOT = iphoneos;

--- a/ios/StillPointMonitor/Info.plist
+++ b/ios/StillPointMonitor/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -69,7 +69,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint
         MARKETING_VERSION: "1.0.3"
-        CURRENT_PROJECT_VERSION: 12
+        CURRENT_PROJECT_VERSION: 13
         DEVELOPMENT_TEAM: T5UU4BP6AV
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]: StillPointApp/StillPoint.entitlements
@@ -94,12 +94,16 @@ targets:
       path: StillPointMonitor/Info.plist
       properties:
         CFBundleDisplayName: Still Point Monitor
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         NSExtension:
           NSExtensionPointIdentifier: com.apple.deviceactivity.monitor-extension
           NSExtensionPrincipalClass: $(PRODUCT_MODULE_NAME).StillPointMonitorExtension
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint.monitor
+        MARKETING_VERSION: "1.0.3"
+        CURRENT_PROJECT_VERSION: 13
         DEVELOPMENT_TEAM: T5UU4BP6AV
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]: StillPointMonitor/StillPointMonitor.entitlements


### PR DESCRIPTION
## **User description**
## What
Fixes the two reasons TestFlight build 12 (run [27924411295](https://github.com/auerbachb/still-point/actions/runs/27924411295)) failed at the export/upload stage, and bumps to **build 13**.

## Why
Build 12 **archived fine** (app + `StillPointMonitor` extension both signed via the per-target profiles from #442) but `** EXPORT FAILED **` (exit 70):
```
error: exportArchive "StillPointMonitor.appex" requires a provisioning profile with the App Groups and Family Controls features.
```
Two separate gaps, neither covered by #442 (which fixed *archive* signing only):
1. **`ExportOptions.plist` never mapped the extension.** Archive signing is driven by `project.yml`; **export** signing is driven by `ExportOptions.plist`'s `provisioningProfiles` dict, which mapped only the main app (untouched since #52, before the extension existed). So `-exportArchive` had no profile for `com.brettonauerbach.stillpoint.monitor`.
2. **Extension version mismatch.** `StillPointMonitor/Info.plist` hardcoded `1.0 (1)` vs the app's `1.0.3 (12)`; Xcode warned and App Store would reject it.

Build 12 was never uploaded (export failed first), so no App Store Connect slot was consumed.

## How
- **`ios/ExportOptions.plist`** + **`ios/ExportOptionsFastlane.plist`** (the latter used by `fastlane/Fastfile`) — add `com.brettonauerbach.stillpoint.monitor` → `StillPoint Monitor App Store` to `provisioningProfiles`. Fixed both so the fastlane/App Store path doesn't hit the same wall.
- **`ios/project.yml`** — the `StillPointMonitor` `info.properties` now sets `CFBundleShortVersionString`/`CFBundleVersion` from `$(MARKETING_VERSION)`/`$(CURRENT_PROJECT_VERSION)` (so `xcodegen generate` stops resetting it to `1`), and the target gets `MARKETING_VERSION: "1.0.3"` + `CURRENT_PROJECT_VERSION`. Both `StillPoint` and `StillPointMonitor` are at **build 13** (the auto-bump `sed` rewrites every `CURRENT_PROJECT_VERSION:` line, so they stay in lockstep).
- **`ios/StillPointMonitor/Info.plist`** + **`ios/StillPoint.xcodeproj/project.pbxproj`** — regenerated via `xcodegen generate`. The app `Info.plist` is byte-identical (sync check passes); the pbxproj also re-syncs the main app's `CURRENT_PROJECT_VERSION`, which #444 had left stale at `11`.

## Test plan
- [x] `ExportOptions.plist` + `ExportOptionsFastlane.plist` `provisioningProfiles` map both `com.brettonauerbach.stillpoint` and `com.brettonauerbach.stillpoint.monitor`
- [x] `ios/project.yml`: both targets at `CURRENT_PROJECT_VERSION: 13`, `MARKETING_VERSION: "1.0.3"`; extension `info.properties` carries the `$(…)` version keys
- [x] `Info.plist in sync with project.yml` check passes (app Info.plist unchanged); PR CI green (simulator e2e unaffected)
- [x] (Post-merge, device) `ios-v1.0.3-build13` archives, **exports**, and uploads to TestFlight — embedded `StillPointMonitor` signed, **no** extension version-mismatch warning

Closes #446


___

## **CodeAnt-AI Description**
**Fix TestFlight export for the Still Point Monitor extension and keep its version in sync with the app**

### What Changed
- TestFlight exports now include signing for the Still Point Monitor extension, so the build can upload successfully instead of failing during export
- The extension now uses the same version and build number as the main app, avoiding version mismatch warnings and App Store rejection risk
- The app and extension were bumped to build 13

### Impact
`✅ Fewer TestFlight export failures`
`✅ Clearer App Store version matching`
`✅ Smoother upload for app and extension builds`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Kept iOS app and companion extension versioning consistent by wiring Info.plist values to the project’s marketing/build version variables.
  * Expanded App Store signing/export configuration to include an additional provisioning profile mapping for the companion extension.
  * Updated the automated TestFlight build-number bump to reliably increment all matching version entries in the iOS project metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

