### PR TITLE
feat(web): Duolingo-style L1–L5 lesson pathway in HomeView

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -104,6 +104,18 @@ a {
   50% { transform: scale(1.02); opacity: 1; }
 }
 
+/* Current pathway node — gentle amber glow (#336) */
+@keyframes pathwayPulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 var(--accent-amber-muted);
+    border-color: var(--accent-amber-border);
+  }
+  50% {
+    box-shadow: 0 0 0 6px transparent;
+    border-color: var(--accent-amber);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     animation-duration: 0.01ms !important;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -105,7 +105,7 @@ a {
 }
 
 /* Current pathway node — gentle amber glow (#336) */
-@keyframes pathwayPulse {
+@keyframes pathway-pulse {
   0%, 100% {
     box-shadow: 0 0 0 0 var(--accent-amber-muted);
     border-color: var(--accent-amber-border);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -116,6 +116,13 @@ a {
   }
 }
 
+/* Keyboard-accessible pathway scroll region — visible focus ring (#336) */
+section[aria-label="Lesson pathway"]:focus-visible {
+  outline: 2px solid var(--accent-amber);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     animation-duration: 0.01ms !important;

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { BLOCK_DURATION, QUICK_DURATION, durationForDay } from "@/lib/constants";
+import { Pathway } from "@/components/Pathway";
 
 type HomeViewProps = {
   currentDay: number;
@@ -60,6 +61,9 @@ export function HomeView({ currentDay, onBegin, onQuickBegin, onBuddy }: HomeVie
           day &middot; {todayDuration}s &middot; {totalBlocks} blocks
         </div>
       </div>
+
+      {/* Block B2: Lesson pathway (#336) */}
+      <Pathway currentDay={currentDay} />
 
       {/* Block C: CTA */}
       <button

--- a/src/components/Pathway.tsx
+++ b/src/components/Pathway.tsx
@@ -16,9 +16,13 @@ function levelLabelColor(state: NodeState): string {
 
 function Node({ node }: { node: PathwayNode }) {
   const base = {
-    width: "30px",
-    height: "30px",
-    flex: "0 0 auto",
+    // Shrink-to-fit so ten nodes never overflow narrow phone widths (#336 review):
+    // grow 0 / shrink 1 / basis 30px, with aspect-ratio keeping the node circular
+    // as it shrinks. minWidth:0 lets the flex item shrink below its content box.
+    flex: "0 1 30px",
+    maxWidth: "30px",
+    minWidth: 0,
+    aspectRatio: "1 / 1",
     borderRadius: "50%",
     display: "flex",
     alignItems: "center",
@@ -59,7 +63,7 @@ function Node({ node }: { node: PathwayNode }) {
           background: "var(--accent-amber-bg)",
           color: "var(--accent-amber)",
           fontWeight: 600,
-          animation: "pathwayPulse 2.4s ease-in-out infinite",
+          animation: "pathway-pulse 2.4s ease-in-out infinite",
         }}
       >
         {node.day}
@@ -151,8 +155,11 @@ export function Pathway({ currentDay }: PathwayProps) {
                       flex: 1,
                       height: "1px",
                       minWidth: "4px",
+                      // Green when the *preceding* node is finished, so the
+                      // traversed path reaches all the way into the current
+                      // (amber) node rather than stopping one step short (#336 review).
                       background:
-                        node.state === "completed"
+                        level.nodes[i - 1]?.state === "completed"
                           ? "var(--accent-green-border)"
                           : "var(--border-1)",
                     }}

--- a/src/components/Pathway.tsx
+++ b/src/components/Pathway.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { buildPathway, type NodeState, type PathwayNode } from "@/lib/pathway";
+
+type PathwayProps = {
+  currentDay: number;
+};
+
+const mono = "var(--font-jetbrains), 'JetBrains Mono', monospace";
+
+function levelLabelColor(state: NodeState): string {
+  if (state === "completed") return "var(--accent-green-text)";
+  if (state === "current") return "var(--accent-amber-text)";
+  return "var(--fg-3)";
+}
+
+function Node({ node }: { node: PathwayNode }) {
+  const base = {
+    width: "30px",
+    height: "30px",
+    flex: "0 0 auto",
+    borderRadius: "50%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    fontFamily: mono,
+    fontSize: "11px",
+    lineHeight: 1,
+    boxSizing: "border-box" as const,
+  };
+
+  if (node.state === "completed") {
+    return (
+      <div
+        title={`Day ${node.day} · completed`}
+        aria-label={`Day ${node.day}, completed`}
+        style={{
+          ...base,
+          border: "1px solid var(--accent-green-border)",
+          background: "var(--accent-green-bg-subtle)",
+          color: "var(--accent-green)",
+          fontSize: "13px",
+        }}
+      >
+        &#10003;
+      </div>
+    );
+  }
+
+  if (node.state === "current") {
+    return (
+      <div
+        title={`Day ${node.day} · current lesson`}
+        aria-label={`Day ${node.day}, current lesson`}
+        aria-current="step"
+        style={{
+          ...base,
+          border: "2px solid var(--accent-amber)",
+          background: "var(--accent-amber-bg)",
+          color: "var(--accent-amber)",
+          fontWeight: 600,
+          animation: "pathwayPulse 2.4s ease-in-out infinite",
+        }}
+      >
+        {node.day}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      title={`Day ${node.day} · locked`}
+      aria-label={`Day ${node.day}, locked`}
+      style={{
+        ...base,
+        border: "1px solid var(--border-1)",
+        background: "var(--surface-1)",
+        color: "var(--fg-4)",
+      }}
+    >
+      {node.day}
+    </div>
+  );
+}
+
+export function Pathway({ currentDay }: PathwayProps) {
+  const levels = buildPathway(currentDay);
+
+  return (
+    <section
+      aria-label="Lesson pathway"
+      style={{
+        width: "100%",
+        maxWidth: "min(420px, calc(100vw - 40px))",
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--s4)",
+      }}
+    >
+      <div
+        style={{
+          fontFamily: mono,
+          fontSize: "12px",
+          color: "var(--fg-3)",
+          letterSpacing: "0.15em",
+          textTransform: "uppercase",
+          textAlign: "center",
+        }}
+      >
+        Pathway
+      </div>
+
+      {levels.map((level) => (
+        <div
+          key={level.level}
+          style={{ display: "flex", flexDirection: "column", gap: "var(--s2)" }}
+        >
+          {/* Level header */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "baseline",
+              justifyContent: "space-between",
+              fontFamily: mono,
+              fontSize: "11px",
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              color: levelLabelColor(level.state),
+              opacity: level.state === "locked" ? 0.7 : 1,
+            }}
+          >
+            <span>
+              L{level.level} &middot; {level.name}
+            </span>
+            <span style={{ color: "var(--fg-3)" }}>
+              {level.completedCount}/{level.nodes.length}
+            </span>
+          </div>
+
+          {/* Node track */}
+          <div style={{ display: "flex", alignItems: "center", width: "100%" }}>
+            {level.nodes.map((node, i) => (
+              <div
+                key={node.day}
+                style={{ display: "contents" }}
+              >
+                {i > 0 && (
+                  <div
+                    aria-hidden="true"
+                    style={{
+                      flex: 1,
+                      height: "1px",
+                      minWidth: "4px",
+                      background:
+                        node.state === "completed"
+                          ? "var(--accent-green-border)"
+                          : "var(--border-1)",
+                    }}
+                  />
+                )}
+                <Node node={node} />
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/src/components/Pathway.tsx
+++ b/src/components/Pathway.tsx
@@ -108,9 +108,6 @@ export function Pathway({ currentDay }: PathwayProps) {
         display: "flex",
         flexDirection: "column",
         gap: "var(--s4)",
-        // focus-visible outline supplied via :focus-visible in globals.css;
-        // suppress the default browser outline here to avoid double ring.
-        outline: "none",
       }}
     >
       <div

--- a/src/components/Pathway.tsx
+++ b/src/components/Pathway.tsx
@@ -96,6 +96,11 @@ export function Pathway({ currentDay }: PathwayProps) {
       style={{
         width: "100%",
         maxWidth: "min(420px, calc(100vw - 40px))",
+        // Cap height so the section scrolls internally rather than pushing
+        // the Begin CTA into the fixed bottom nav on narrow/short viewports
+        // (e.g. iPhone SE 375×667). clamp: 160px floor, 30vh mid, 240px ceiling.
+        maxHeight: "clamp(160px, 30vh, 240px)",
+        overflowY: "auto",
         display: "flex",
         flexDirection: "column",
         gap: "var(--s4)",

--- a/src/components/Pathway.tsx
+++ b/src/components/Pathway.tsx
@@ -93,6 +93,10 @@ export function Pathway({ currentDay }: PathwayProps) {
   return (
     <section
       aria-label="Lesson pathway"
+      // tabIndex={0} makes this overflow region keyboard-accessible: once
+      // focused, arrow keys / Page Down scroll the content so keyboard-only
+      // users can reach lower levels that are hidden below the height cap.
+      tabIndex={0}
       style={{
         width: "100%",
         maxWidth: "min(420px, calc(100vw - 40px))",
@@ -104,6 +108,9 @@ export function Pathway({ currentDay }: PathwayProps) {
         display: "flex",
         flexDirection: "column",
         gap: "var(--s4)",
+        // focus-visible outline supplied via :focus-visible in globals.css;
+        // suppress the default browser outline here to avoid double ring.
+        outline: "none",
       }}
     >
       <div

--- a/src/lib/pathway.test.ts
+++ b/src/lib/pathway.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "vitest";
+import {
+  DAYS_PER_LEVEL,
+  LEVEL_NAMES,
+  PATHWAY_MAX_DAY,
+  TOTAL_LEVELS,
+  buildPathway,
+  nodeStateForDay,
+} from "./pathway";
+
+describe("nodeStateForDay", () => {
+  test("days before currentDay are completed", () => {
+    expect(nodeStateForDay(1, 5)).toBe("completed");
+    expect(nodeStateForDay(4, 5)).toBe("completed");
+  });
+
+  test("the currentDay node is current", () => {
+    expect(nodeStateForDay(5, 5)).toBe("current");
+  });
+
+  test("days after currentDay are locked", () => {
+    expect(nodeStateForDay(6, 5)).toBe("locked");
+    expect(nodeStateForDay(50, 5)).toBe("locked");
+  });
+});
+
+describe("buildPathway", () => {
+  test("produces five named levels with ten nodes each", () => {
+    const levels = buildPathway(1);
+    expect(levels).toHaveLength(TOTAL_LEVELS);
+    expect(levels.map((l) => l.name)).toEqual([...LEVEL_NAMES]);
+    for (const level of levels) {
+      expect(level.nodes).toHaveLength(DAYS_PER_LEVEL);
+    }
+  });
+
+  test("node days are contiguous from 1..50", () => {
+    const days = buildPathway(1).flatMap((l) => l.nodes.map((n) => n.day));
+    expect(days).toEqual(Array.from({ length: PATHWAY_MAX_DAY }, (_, i) => i + 1));
+  });
+
+  test("day 1: first node current, rest locked", () => {
+    const [first] = buildPathway(1);
+    expect(first!.nodes[0]!.state).toBe("current");
+    expect(first!.nodes.slice(1).every((n) => n.state === "locked")).toBe(true);
+    expect(first!.completedCount).toBe(0);
+    expect(first!.state).toBe("current");
+  });
+
+  test("mid-level currentDay marks completed/current/locked correctly", () => {
+    // currentDay 13 → L1 fully complete, L2 has 2 completed + day 13 current
+    const levels = buildPathway(13);
+    const l1 = levels[0]!;
+    const l2 = levels[1]!;
+    expect(l1.state).toBe("completed");
+    expect(l1.completedCount).toBe(DAYS_PER_LEVEL);
+    expect(l1.nodes.every((n) => n.state === "completed")).toBe(true);
+
+    expect(l2.state).toBe("current");
+    expect(l2.completedCount).toBe(2);
+    expect(l2.nodes[0]!.state).toBe("completed"); // day 11
+    expect(l2.nodes[1]!.state).toBe("completed"); // day 12
+    expect(l2.nodes[2]!.state).toBe("current"); // day 13
+    expect(l2.nodes[3]!.state).toBe("locked"); // day 14
+  });
+
+  test("exactly one node is current within the pathway range", () => {
+    const currents = buildPathway(27)
+      .flatMap((l) => l.nodes)
+      .filter((n) => n.state === "current");
+    expect(currents).toHaveLength(1);
+    expect(currents[0]!.day).toBe(27);
+  });
+
+  test("currentDay beyond the program completes every node", () => {
+    const levels = buildPathway(PATHWAY_MAX_DAY + 5);
+    const allNodes = levels.flatMap((l) => l.nodes);
+    expect(allNodes.every((n) => n.state === "completed")).toBe(true);
+    expect(levels.every((l) => l.state === "completed")).toBe(true);
+  });
+
+  test("currentDay exactly at the last day keeps it current", () => {
+    const last = buildPathway(PATHWAY_MAX_DAY)[TOTAL_LEVELS - 1]!;
+    expect(last.nodes[DAYS_PER_LEVEL - 1]!.state).toBe("current");
+    expect(last.state).toBe("current");
+  });
+
+  test("clamps non-finite or sub-1 input to day 1", () => {
+    for (const input of [0, -5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const levels = buildPathway(input as number);
+      if (input === Number.POSITIVE_INFINITY) {
+        // Infinity is non-finite → clamped to 1
+        expect(levels[0]!.nodes[0]!.state).toBe("current");
+      } else {
+        expect(levels[0]!.nodes[0]!.state).toBe("current");
+      }
+    }
+  });
+});

--- a/src/lib/pathway.ts
+++ b/src/lib/pathway.ts
@@ -1,0 +1,104 @@
+/**
+ * Duolingo-style pathway derivation (#336, web v1).
+ *
+ * Levels and node states are derived purely from the user's `currentDay`; there
+ * is no backend or migration. `currentDay` is the day the user is *on* (not yet
+ * completed) — completing a standard sit advances it by one (see
+ * `handleSessionComplete` in `src/app/app/page.tsx`). That gives the v1 unlock
+ * rule: finishing a lesson unlocks the next.
+ */
+
+/** Days that make up a single level. Five levels cover days 1–50. */
+export const DAYS_PER_LEVEL = 10;
+
+/** Ordered L1–L5 level names. */
+export const LEVEL_NAMES = [
+  "Stillness",
+  "Awareness",
+  "Focus",
+  "Intention",
+  "Kindness",
+] as const;
+
+export const TOTAL_LEVELS = LEVEL_NAMES.length;
+
+/** Highest day represented in the pathway (L5, day 10). */
+export const PATHWAY_MAX_DAY = TOTAL_LEVELS * DAYS_PER_LEVEL;
+
+export type NodeState = "completed" | "current" | "locked";
+
+export type PathwayNode = {
+  /** 1-based day number this node represents. */
+  day: number;
+  /** Position within the level (1..DAYS_PER_LEVEL). */
+  dayInLevel: number;
+  state: NodeState;
+};
+
+export type PathwayLevel = {
+  /** 1-based level index (1..TOTAL_LEVELS). */
+  level: number;
+  name: string;
+  nodes: PathwayNode[];
+  /** Count of completed nodes within this level. */
+  completedCount: number;
+  /**
+   * Level rollup state: `completed` when every node is done, `current` when the
+   * user's current day falls in this level, otherwise `locked`.
+   */
+  state: NodeState;
+};
+
+/**
+ * Resolve a single day's node state relative to `currentDay`.
+ * - day < currentDay  → completed
+ * - day === currentDay → current
+ * - day > currentDay  → locked
+ */
+export function nodeStateForDay(day: number, currentDay: number): NodeState {
+  if (day < currentDay) return "completed";
+  if (day === currentDay) return "current";
+  return "locked";
+}
+
+/**
+ * Build the full L1–L5 pathway for a given `currentDay`. Non-finite or sub-1
+ * inputs are clamped to day 1 so the first node is always the current one.
+ */
+export function buildPathway(currentDay: number): PathwayLevel[] {
+  const day = Number.isFinite(currentDay) ? Math.max(1, Math.floor(currentDay)) : 1;
+
+  const levels: PathwayLevel[] = [];
+  for (let level = 1; level <= TOTAL_LEVELS; level++) {
+    const nodes: PathwayNode[] = [];
+    let completedCount = 0;
+
+    for (let dayInLevel = 1; dayInLevel <= DAYS_PER_LEVEL; dayInLevel++) {
+      const nodeDay = (level - 1) * DAYS_PER_LEVEL + dayInLevel;
+      const state = nodeStateForDay(nodeDay, day);
+      if (state === "completed") completedCount += 1;
+      nodes.push({ day: nodeDay, dayInLevel, state });
+    }
+
+    const levelStartDay = (level - 1) * DAYS_PER_LEVEL + 1;
+    const levelEndDay = level * DAYS_PER_LEVEL;
+    let state: NodeState;
+    if (day > levelEndDay) {
+      state = "completed";
+    } else if (day >= levelStartDay) {
+      state = "current";
+    } else {
+      state = "locked";
+    }
+
+    levels.push({
+      level,
+      name: LEVEL_NAMES[level - 1]!,
+      nodes,
+      completedCount,
+      state,
+    });
+  }
+
+  return levels;
+}


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #336

## What

Adds a Duolingo-style lesson pathway to the web `HomeView`, embedded between the day display and the action buttons. Lesson nodes are grouped into five levels (L1 Stillness, L2 Awareness, L3 Focus, L4 Intention, L5 Kindness), each with 10 day-nodes.

Node states (derived purely from `currentDay`, no backend change):
- **completed** (green check) — `day < currentDay`
- **current** (amber, animated glow) — `day === currentDay`
- **locked** (dimmed, visible) — `day > currentDay`

v1 unlock rule: completing a standard sit advances `currentDay`, which unlocks the next node.

## Walkthrough

[pathway_unlock_progression_demo.mp4](https://cursor.com/agents/bc-728cadb0-9f1a-4725-8bf2-570273330b2e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpathway_unlock_progression_demo.mp4)

Unlock progression: the amber current node advances and passed nodes turn green; `set 55` shows the fully-completed pathway.

[Pathway at day 13](https://cursor.com/agents/bc-728cadb0-9f1a-4725-8bf2-570273330b2e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpathway_day13.webp)
[Pathway at day 1](https://cursor.com/agents/bc-728cadb0-9f1a-4725-8bf2-570273330b2e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpathway_day1.webp)
[Pathway fully completed](https://cursor.com/agents/bc-728cadb0-9f1a-4725-8bf2-570273330b2e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpathway_day55_complete.webp)

## Review feedback addressed

- **Connector into current node** (Bugbot): the path line now greens based on the *preceding* node's completed state, so it reaches into the amber current node instead of stopping one step short.<br />[Green connector into current node](https://cursor.com/agents/bc-728cadb0-9f1a-4725-8bf2-570273330b2e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpathway_fix_connector_green.webp)
- **Narrow-viewport overflow** (Bugbot): nodes are now shrink-to-fit (`flex: 0 1 30px` + `aspect-ratio: 1`), so all 10 nodes fit without clipping on small phones.<br />[All nodes fit at 360px width](https://cursor.com/agents/bc-728cadb0-9f1a-4725-8bf2-570273330b2e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpathway_fix_narrow_360px.webp)
- **Keyframe naming** (CodeRabbit): renamed `pathwayPulse` → `pathway-pulse` for stylelint kebab-case.
- **Auto-scroll to current node** (CodeRabbit): intentionally not implemented — it is outside the locked CR plan / issue ACs, and a window-level `scrollIntoView` on this inline section would jump the page past the brand/day header every time Home opens. Can be revisited as a follow-up if desired.

## Files
- `src/lib/pathway.ts` — pure level/node derivation (`buildPathway`, `nodeStateForDay`).
- `src/lib/pathway.test.ts` — unit tests for derivation + edge cases.
- `src/components/Pathway.tsx` — pathway UI (CSS vars, inline styles, JetBrains Mono).
- `src/components/HomeView.tsx` — embeds `<Pathway />` between day display and CTAs.
- `src/app/globals.css` — `pathway-pulse` keyframe for the current node (respects `prefers-reduced-motion`).

Web-only; no migration, no API change. iOS parity is a separate follow-up.

## Test plan
- ✅ `npm run test:unit` (232 passed, incl. new `pathway.test.ts`)
- ✅ `npm run typecheck`
- ✅ Manual: verified completed/current/locked rendering, unlock progression, the green connector fix, and narrow-viewport (360px) fit (artifacts above).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-728cadb0-9f1a-4725-8bf2-570273330b2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-728cadb0-9f1a-4725-8bf2-570273330b2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Lesson pathway” section to the home screen with level/day progress.
  * Steps now reflect completed/current/locked states, including a pulsing highlight for the current step.
* **Bug Fixes**
  * Improved pathway progress handling for edge cases, including invalid, non-finite, or out-of-range day values (with correct current-step behavior at the max day).
* **Tests**
  * Added automated coverage for pathway state transitions, level grouping, and boundary conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Add a Duolingo-style lesson pathway to the Home screen

### What Changed
- Home now shows a five-level lesson pathway between the day display and the main action button, with each day marked as completed, current, or locked
- Passed days show a green check, the current day is highlighted with an amber glow, and future days stay visible but dimmed
- The pathway now stays within its own scroll area on small screens so the main button does not get pushed into the bottom nav
- The pathway can be focused and scrolled with the keyboard, and the active focus state is visible
- The connector line now reaches into the current lesson instead of stopping one step short

### Impact
`✅ Clearer lesson progress`
`✅ Fewer mobile layout overlaps`
`✅ Keyboard-accessible lesson navigation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
