### PR TITLE
fix(notifications): close cron window off-by-one + harden miss_a_day dispatch (#440)

### DIFF
--- a/src/lib/notification-scheduler.test.ts
+++ b/src/lib/notification-scheduler.test.ts
@@ -112,6 +112,45 @@ describe("notification scheduler", () => {
     expect(second.sent).toBe(0);
   });
 
+  test("sends a due reminder at the cron window boundary minute (#440 off-by-one)", async () => {
+    const { dispatchDueNotifications } = await import("./notification-scheduler");
+    // reminder 09:00, run at 09:05 => delta === CRON_WINDOW_MINUTES (the boundary that
+    // was previously dropped by the exclusive `<` comparison).
+    const result = await dispatchDueNotifications(new Date("2026-05-29T09:05:00.000Z"));
+
+    expect(result.sent).toBe(1);
+    expect(sendDailyReminderNotification).toHaveBeenCalledTimes(1);
+  });
+
+  test("idempotency still prevents double-sends across overlapping boundary runs (#440)", async () => {
+    const { dispatchDueNotifications } = await import("./notification-scheduler");
+
+    // First run at delta 0 claims and sends.
+    const first = await dispatchDueNotifications(new Date("2026-05-29T09:00:00.000Z"));
+    // Adjacent run that now also matches the same reminder at the boundary minute. The
+    // claim row already exists, so onConflictDoNothing returns no row -> no second send.
+    insertReturning.mockResolvedValueOnce([]);
+    const second = await dispatchDueNotifications(new Date("2026-05-29T09:05:00.000Z"));
+
+    expect(first.sent).toBe(1);
+    expect(second.sent).toBe(0);
+    expect(sendDailyReminderNotification).toHaveBeenCalledTimes(1);
+  });
+
+  test("miss-a-day send exception releases the claim instead of blocking the user (#440)", async () => {
+    preferenceRows = [{ ...basePrefs, missADayEnabled: true, dailyReminderEnabled: false }];
+    userCompletedSessionOnDate.mockResolvedValue(false);
+    sendMissADayNotification.mockRejectedValueOnce(new Error("APNs exploded"));
+
+    const { dispatchDueNotifications } = await import("./notification-scheduler");
+    const result = await dispatchDueNotifications(new Date("2026-05-29T09:02:00.000Z"));
+
+    // The run completes without throwing and nothing was marked sent...
+    expect(result.missADaySent).toBe(0);
+    // ...but the claim is rolled back so a later run can retry.
+    expect(dbDelete).toHaveBeenCalled();
+  });
+
   test("dispatchDueNotifications sends miss-a-day when yesterday was missed", async () => {
     preferenceRows = [{ ...basePrefs, missADayEnabled: true, dailyReminderEnabled: false }];
     userCompletedSessionOnDate.mockResolvedValue(false);

--- a/src/lib/notification-scheduler.test.ts
+++ b/src/lib/notification-scheduler.test.ts
@@ -137,6 +137,28 @@ describe("notification scheduler", () => {
     expect(sendDailyReminderNotification).toHaveBeenCalledTimes(1);
   });
 
+  test("midnight-boundary: 23:55 reminder does not double-send across the date change (#440)", async () => {
+    // Reproduce the CodeAnt finding: a reminder at 23:55 is covered both by the 23:55
+    // run (delta=0, windowKey="2026-05-29") and by the 00:00 run (delta=5, still <=
+    // CRON_WINDOW_MINUTES). Before the dayOffset fix the 00:00 run used windowKey
+    // "2026-05-30", bypassing the existing claimNotificationDispatch deduplication and
+    // triggering a second send minutes after the first.
+    preferenceRows = [{ ...basePrefs, dailyReminderTime: "23:55" }];
+    const { dispatchDueNotifications } = await import("./notification-scheduler");
+
+    // 23:55 run — delta=0, intendedDateKey="2026-05-29", claims + sends.
+    const first = await dispatchDueNotifications(new Date("2026-05-29T23:55:00.000Z"));
+
+    // 00:00 next-day run — delta=5, intendedDateKey must still be "2026-05-29" (the
+    // reminder's intended date). The claim row already exists, so no second send.
+    insertReturning.mockResolvedValueOnce([]);
+    const second = await dispatchDueNotifications(new Date("2026-05-30T00:00:00.000Z"));
+
+    expect(first.sent).toBe(1);
+    expect(second.sent).toBe(0);
+    expect(sendDailyReminderNotification).toHaveBeenCalledTimes(1);
+  });
+
   test("miss-a-day send exception releases the claim instead of blocking the user (#440)", async () => {
     preferenceRows = [{ ...basePrefs, missADayEnabled: true, dailyReminderEnabled: false }];
     userCompletedSessionOnDate.mockResolvedValue(false);

--- a/src/lib/notification-scheduler.test.ts
+++ b/src/lib/notification-scheduler.test.ts
@@ -219,4 +219,20 @@ describe("notification scheduler", () => {
     expect(sendDailyReminderNotification).not.toHaveBeenCalled();
     expect(sendMissADayNotification).not.toHaveBeenCalled();
   });
+  test("weekly 23:55 reminder sends on cross-midnight 00:00 run (#440 frequency gate)", async () => {
+    // 2026-05-25 is a Monday (dayIndex 1). A weekly reminder at 23:55 is covered by
+    // both the 23:55 run (delta=0) and the next-day 00:00 run (delta=5). Before this fix
+    // frequencyAllowsSend used local (Tuesday's dayIndex=2) instead of intendedDateKey
+    // (Monday), causing the midnight catch-up run to skip the send entirely.
+    preferenceRows = [{ ...basePrefs, dailyReminderTime: "23:55", dailyReminderFrequency: "weekly" }];
+    const { dispatchDueNotifications } = await import("./notification-scheduler");
+
+    // Simulate only the midnight catch-up run (23:55 run missed / no claim yet).
+    const result = await dispatchDueNotifications(new Date("2026-05-26T00:00:00.000Z")); // Tuesday 00:00 UTC
+
+    expect(result.sent).toBe(1);
+    expect(sendDailyReminderNotification).toHaveBeenCalledTimes(1);
+  });
+
+
 });

--- a/src/lib/notification-scheduler.ts
+++ b/src/lib/notification-scheduler.ts
@@ -85,7 +85,12 @@ function parseReminderMinutes(time: string): number {
 function isWithinCronWindow(localMinutes: number, reminderMinutes: number): boolean {
   const dayMinutes = 24 * 60;
   const delta = (localMinutes - reminderMinutes + dayMinutes) % dayMinutes;
-  return delta < CRON_WINDOW_MINUTES;
+  // Inclusive upper bound: the cron runs every CRON_WINDOW_MINUTES, but Vercel cron
+  // invocations can drift by up to a minute. With an exclusive bound a reminder whose
+  // only covering run landed exactly CRON_WINDOW_MINUTES late (delta === window) was
+  // dropped, leaving enabled users with no notification for days. The 1-minute overlap
+  // this creates between adjacent runs is de-duplicated by claimNotificationDispatch.
+  return delta <= CRON_WINDOW_MINUTES;
 }
 
 function isInQuietHours(
@@ -147,6 +152,18 @@ export async function claimNotificationDispatch(params: {
   return inserted.length > 0;
 }
 
+async function releaseMissADayClaim(userId: string, windowKey: string): Promise<void> {
+  await db
+    .delete(notificationDispatches)
+    .where(
+      and(
+        eq(notificationDispatches.userId, userId),
+        eq(notificationDispatches.notificationType, "miss_a_day"),
+        eq(notificationDispatches.windowKey, windowKey),
+      ),
+    );
+}
+
 function addCalendarDays(dateKey: string, deltaDays: number): string {
   const [y, m, d] = dateKey.split("-").map(Number);
   const utc = new Date(Date.UTC(y, m - 1, d + deltaDays));
@@ -204,21 +221,21 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
           });
 
           if (claimed) {
-            const { delivered } = await sendMissADayNotification({ recipientUserId: prefs.userId });
-            if (delivered) {
-              missADaySent += 1;
-              sent += 1;
-              continue;
+            try {
+              const { delivered } = await sendMissADayNotification({ recipientUserId: prefs.userId });
+              if (delivered) {
+                missADaySent += 1;
+                sent += 1;
+                continue;
+              }
+              await releaseMissADayClaim(prefs.userId, local.dateKey);
+            } catch (sendError) {
+              // Without this catch, a thrown send would leave the claim row in place,
+              // permanently blocking both miss_a_day and (via hasMissADayDispatchForDate)
+              // the daily reminder for this user/date. Release the claim so the next run retries.
+              console.error(`Failed to send miss-a-day to user ${prefs.userId}:`, sendError);
+              await releaseMissADayClaim(prefs.userId, local.dateKey);
             }
-            await db
-              .delete(notificationDispatches)
-              .where(
-                and(
-                  eq(notificationDispatches.userId, prefs.userId),
-                  eq(notificationDispatches.notificationType, "miss_a_day"),
-                  eq(notificationDispatches.windowKey, local.dateKey),
-                ),
-              );
           }
         }
       }

--- a/src/lib/notification-scheduler.ts
+++ b/src/lib/notification-scheduler.ts
@@ -82,15 +82,39 @@ function parseReminderMinutes(time: string): number {
   return h * 60 + m;
 }
 
-function isWithinCronWindow(localMinutes: number, reminderMinutes: number): boolean {
+/**
+ * Returns whether the current cron run covers a due reminder, and the calendar-day
+ * offset of the reminder's *intended* date relative to the run's local date.
+ *
+ * dayOffset is 0 when the reminder was due today, -1 when the run crossed midnight
+ * and is catching a reminder that was due yesterday (e.g. a 23:55 reminder covered
+ * by the 00:00 run). Callers must use `addCalendarDays(local.dateKey, dayOffset)` as
+ * the dispatch windowKey so that the existing claimNotificationDispatch idempotency
+ * anchors each send to the reminder's *intended* date rather than the run's date.
+ *
+ * Without the dayOffset correction a 23:55 reminder could be sent twice in five minutes:
+ * - 23:55 run: delta=0, windowKey="2026-05-29" → claims and sends ✓
+ * - 00:00 run: delta=5 (still within window), windowKey="2026-05-30" → new key, sends again ✗
+ */
+function isWithinCronWindow(
+  localMinutes: number,
+  reminderMinutes: number,
+): { within: boolean; dayOffset: 0 | -1 } {
   const dayMinutes = 24 * 60;
   const delta = (localMinutes - reminderMinutes + dayMinutes) % dayMinutes;
   // Inclusive upper bound: the cron runs every CRON_WINDOW_MINUTES, but Vercel cron
   // invocations can drift by up to a minute. With an exclusive bound a reminder whose
   // only covering run landed exactly CRON_WINDOW_MINUTES late (delta === window) was
   // dropped, leaving enabled users with no notification for days. The 1-minute overlap
-  // this creates between adjacent runs is de-duplicated by claimNotificationDispatch.
-  return delta <= CRON_WINDOW_MINUTES;
+  // between adjacent runs is de-duplicated by claimNotificationDispatch — but only when
+  // both runs use the same windowKey (see dayOffset below).
+  if (delta > CRON_WINDOW_MINUTES) {
+    return { within: false, dayOffset: 0 };
+  }
+  // When localMinutes < reminderMinutes the modular arithmetic wrapped: the run is just
+  // past midnight and the reminder was due on the *previous* calendar day.
+  const dayOffset: 0 | -1 = delta > 0 && localMinutes < reminderMinutes ? -1 : 0;
+  return { within: true, dayOffset };
 }
 
 function isInQuietHours(
@@ -127,11 +151,17 @@ function frequencyAllowsSend(
   return local.dayIndex === 1;
 }
 
-function windowKeyForFrequency(frequency: DailyReminderFrequency, local: LocalParts): string {
+function windowKeyForFrequency(
+  frequency: DailyReminderFrequency,
+  local: LocalParts,
+  intendedDateKey: string,
+): string {
   if (frequency === "weekly") {
-    return local.weekKey;
+    // For weekly cadence use the ISO week of the intended date, not the run date.
+    const { isoYear, week } = isoWeekPartsFromDateKey(intendedDateKey);
+    return `${isoYear}-W${week}`;
   }
-  return local.dateKey;
+  return intendedDateKey;
 }
 
 export async function claimNotificationDispatch(params: {
@@ -198,10 +228,17 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
       const local = getLocalParts(now, prefs.tz);
       const reminderMinutes = parseReminderMinutes(prefs.dailyReminderTime);
 
-      if (!isWithinCronWindow(local.minutesSinceMidnight, reminderMinutes)) {
+      const { within, dayOffset } = isWithinCronWindow(local.minutesSinceMidnight, reminderMinutes);
+      if (!within) {
         skipped += 1;
         continue;
       }
+
+      // intendedDateKey is the calendar date the reminder was *due* — today for normal runs,
+      // yesterday when the cron just crossed midnight catching a late-evening reminder.
+      // Using it as the dispatch windowKey anchors deduplication to the reminder's intended
+      // date rather than the run's date, preventing duplicate sends at midnight boundaries.
+      const intendedDateKey = addCalendarDays(local.dateKey, dayOffset);
 
       if (isInQuietHours(local.minutesSinceMidnight, prefs.quietHoursStart, prefs.quietHoursEnd)) {
         skipped += 1;
@@ -209,15 +246,15 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
       }
 
       if (prefs.missADayEnabled) {
-        const yesterday = addCalendarDays(local.dateKey, -1);
-        const meditatedToday = await userCompletedSessionOnDate(prefs.userId, local.dateKey);
+        const yesterday = addCalendarDays(intendedDateKey, -1);
+        const meditatedToday = await userCompletedSessionOnDate(prefs.userId, intendedDateKey);
         const completedYesterday = await userCompletedSessionOnDate(prefs.userId, yesterday);
 
         if (!meditatedToday && !completedYesterday) {
           const claimed = await claimNotificationDispatch({
             userId: prefs.userId,
             notificationType: "miss_a_day",
-            windowKey: local.dateKey,
+            windowKey: intendedDateKey,
           });
 
           if (claimed) {
@@ -228,13 +265,13 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
                 sent += 1;
                 continue;
               }
-              await releaseMissADayClaim(prefs.userId, local.dateKey);
+              await releaseMissADayClaim(prefs.userId, intendedDateKey);
             } catch (sendError) {
               // Without this catch, a thrown send would leave the claim row in place,
               // permanently blocking both miss_a_day and (via hasMissADayDispatchForDate)
               // the daily reminder for this user/date. Release the claim so the next run retries.
               console.error(`Failed to send miss-a-day to user ${prefs.userId}:`, sendError);
-              await releaseMissADayClaim(prefs.userId, local.dateKey);
+              await releaseMissADayClaim(prefs.userId, intendedDateKey);
             }
           }
         }
@@ -251,17 +288,17 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
         continue;
       }
 
-      if (await userCompletedSessionOnDate(prefs.userId, local.dateKey)) {
+      if (await userCompletedSessionOnDate(prefs.userId, intendedDateKey)) {
         skipped += 1;
         continue;
       }
 
-      if (await hasMissADayDispatchForDate(prefs.userId, local.dateKey)) {
+      if (await hasMissADayDispatchForDate(prefs.userId, intendedDateKey)) {
         skipped += 1;
         continue;
       }
 
-      const windowKey = windowKeyForFrequency(frequency, local);
+      const windowKey = windowKeyForFrequency(frequency, local, intendedDateKey);
       const claimed = await claimNotificationDispatch({
         userId: prefs.userId,
         notificationType: "daily_reminder",
@@ -274,7 +311,7 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
       }
 
       try {
-        const streak = await loadUserStreak(prefs.userId, local.dateKey);
+        const streak = await loadUserStreak(prefs.userId, intendedDateKey);
         const { delivered } = await sendDailyReminderNotification({ recipientUserId: prefs.userId, streak });
         if (delivered) {
           sent += 1;

--- a/src/lib/notification-scheduler.ts
+++ b/src/lib/notification-scheduler.ts
@@ -138,17 +138,25 @@ function isInQuietHours(
 
 function frequencyAllowsSend(
   frequency: DailyReminderFrequency,
-  local: LocalParts,
+  intendedDateKey: string,
 ): boolean {
   if (frequency === "daily") {
     return true;
   }
   if (frequency === "every_other") {
-    const anchor = new Date(`${local.dateKey}T00:00:00.000Z`).getTime();
+    // Use the reminder's intended date, not the run's local date. A cross-midnight run
+    // (e.g. 00:00 covering a 23:55 reminder) must evaluate parity on the intended day
+    // or the send is incorrectly skipped.
+    const anchor = new Date(`${intendedDateKey}T00:00:00.000Z`).getTime();
     const days = Math.floor(anchor / 86_400_000);
     return days % 2 === 0;
   }
-  return local.dayIndex === 1;
+  // weekly: reminder is due on Monday (dayIndex 1). Derive the day-of-week from the
+  // intended date so a cross-midnight run doesn't apply Tuesday's index to a Monday
+  // reminder.
+  const [y, m, d] = intendedDateKey.split("-").map(Number);
+  const intendedDayIndex = new Date(Date.UTC(y, m - 1, d)).getUTCDay();
+  return intendedDayIndex === 1;
 }
 
 function windowKeyForFrequency(
@@ -270,7 +278,7 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
               // Without this catch, a thrown send would leave the claim row in place,
               // permanently blocking both miss_a_day and (via hasMissADayDispatchForDate)
               // the daily reminder for this user/date. Release the claim so the next run retries.
-              console.error(`Failed to send miss-a-day to user ${prefs.userId}:`, sendError);
+              console.error("Failed to send miss-a-day notification:", sendError);
               await releaseMissADayClaim(prefs.userId, intendedDateKey);
             }
           }
@@ -283,7 +291,7 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
       }
 
       const frequency = prefs.dailyReminderFrequency as DailyReminderFrequency;
-      if (!frequencyAllowsSend(frequency, local)) {
+      if (!frequencyAllowsSend(frequency, intendedDateKey)) {
         skipped += 1;
         continue;
       }

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -181,6 +181,29 @@ describe("sendFriendRequestNotification", () => {
     expect(sendApnsNotification).toHaveBeenCalledTimes(1);
   });
 
+  test("logs rejected channel promises and failed deliveries (#440)", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    sendWebPushToUser.mockRejectedValue(new Error("web push blew up"));
+    // No device tokens -> APNs reports not delivered, web push promise rejects.
+    const { sendDailyReminderNotification } = await import("./notifications");
+
+    const result = await sendDailyReminderNotification({ recipientUserId: "recipient-id" });
+
+    expect(result.delivered).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "daily_reminder channel promise rejected",
+      expect.objectContaining({ reason: expect.any(Error) }),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      "daily_reminder not delivered on any channel",
+      expect.objectContaining({ outcomes: expect.any(Array) }),
+    );
+
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
   test("miss-a-day is delivered when only Web Push succeeds", async () => {
     sendWebPushToUser.mockResolvedValue({ delivered: true });
     const { sendMissADayNotification } = await import("./notifications");

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -70,16 +70,29 @@ export async function sendPushNotificationToUser(params: {
 }
 
 async function fanOutChannels(
+  channel: string,
   tasks: Array<() => Promise<{ delivered: boolean } | void>>,
 ): Promise<boolean> {
   const results = await Promise.allSettled(tasks.map((task) => task()));
-  return results.some((result) => {
-    if (result.status !== "fulfilled") {
+  const delivered = results.some((result) => {
+    if (result.status === "rejected") {
+      // Surface rejected channel promises so silent send failures are debuggable.
+      console.error(`${channel} channel promise rejected`, { reason: result.reason });
       return false;
     }
     const value = result.value;
     return typeof value === "object" && value !== null && "delivered" in value && value.delivered === true;
   });
+
+  if (!delivered) {
+    console.warn(`${channel} not delivered on any channel`, {
+      outcomes: results.map((result) =>
+        result.status === "fulfilled" ? "fulfilled" : "rejected",
+      ),
+    });
+  }
+
+  return delivered;
 }
 
 export async function sendDailyReminderNotification(params: {
@@ -87,7 +100,7 @@ export async function sendDailyReminderNotification(params: {
   streak?: number;
 }): Promise<{ delivered: boolean }> {
   const streak = params.streak ?? 0;
-  const delivered = await fanOutChannels([
+  const delivered = await fanOutChannels("daily_reminder", [
     () => sendPushNotificationToUser({
       recipientUserId: params.recipientUserId,
       payload: buildDailyReminderPayload(streak),
@@ -106,7 +119,7 @@ export async function sendMissADayNotification(params: {
   const title = "Still Point";
   const body = "Missed yesterday — try a quick 1-min sit to get back.";
 
-  const delivered = await fanOutChannels([
+  const delivered = await fanOutChannels("miss_a_day", [
     () => sendPushNotificationToUser({
       recipientUserId: params.recipientUserId,
       payload: {
@@ -141,7 +154,7 @@ export async function sendFriendRequestNotification(params: {
   const title = "New friend request";
   const body = `${params.senderUsername} wants to connect on Still Point.`;
 
-  await fanOutChannels([
+  await fanOutChannels("friend_request", [
     () => sendPushNotificationToUser({
       recipientUserId: params.recipientUserId,
       payload: {

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -74,12 +74,17 @@ async function fanOutChannels(
   tasks: Array<() => Promise<{ delivered: boolean } | void>>,
 ): Promise<boolean> {
   const results = await Promise.allSettled(tasks.map((task) => task()));
-  const delivered = results.some((result) => {
+  // Log every rejection independently before computing delivery status.
+  // Using a side effect inside some() would skip later rejections after an earlier
+  // result short-circuits the iteration with a truthy return.
+  for (const result of results) {
     if (result.status === "rejected") {
       // Surface rejected channel promises so silent send failures are debuggable.
       console.error(`${channel} channel promise rejected`, { reason: result.reason });
-      return false;
     }
+  }
+  const delivered = results.some((result) => {
+    if (result.status !== "fulfilled") return false;
     const value = result.value;
     return typeof value === "object" && value !== null && "delivered" in value && value.delivered === true;
   });


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #440

## Root cause
Enabled users could go days with no notifications because of an off-by-one in the cron dispatch window. The cron is scheduled `*/5 * * * *` and `dispatchDueNotifications` only fired a reminder when `delta = (localMinutes - reminderMinutes) mod 1440` was strictly `< CRON_WINDOW_MINUTES` (5). Vercel cron invocations can drift by up to a minute, so a reminder whose only covering run landed exactly `CRON_WINDOW_MINUTES` late (`delta === 5`) fell into a gap between adjacent runs and was silently dropped. Depending on a user's reminder time vs. cron drift, that gap recurred every day.

Two secondary hazards compounded the silence:
- The `miss_a_day` path claimed a dispatch row, then called `sendMissADayNotification` **without** a try/catch. A thrown send left the claim row in place, which permanently blocked `miss_a_day` *and* (via `hasMissADayDispatchForDate`) the daily reminder for that user/date.
- `fanOutChannels` swallowed rejected channel promises and failed deliveries, so these failures were undebuggable.

## Changes
- `src/lib/notification-scheduler.ts`: cron window comparison `<` → `<=`. The resulting 1-minute overlap between adjacent runs is de-duplicated by the existing `claimNotificationDispatch` (`onConflictDoNothing` on `windowKey`), so no double-sends.
- `src/lib/notification-scheduler.ts`: wrap the `miss_a_day` send in try/catch and release the dispatch claim (new `releaseMissADayClaim` helper) on both non-delivery and exception, so a failure can be retried instead of permanently blocking the user.
- `src/lib/notifications.ts`: `fanOutChannels` now takes a channel label and logs rejected channel promises (`console.error`) and failed deliveries (`console.warn`).

No env-gated behavior was added (per the `VERCEL_ENV` gotcha). Ships to production via the Vercel cron on merge; no TestFlight build needed.

## Test plan
- [x] **Off-by-one fixed / boundary minute sends**: new unit test dispatches at `09:05` for a `09:00` reminder (`delta === CRON_WINDOW_MINUTES`). Verified it **fails** under the old `<` (sent 0) and **passes** under `<=` (sent 1).
- [x] **Idempotency after window change**: new unit test runs two overlapping boundary runs (`09:00` then `09:05`) for the same day; only one send occurs because the second claim conflicts.
- [x] **miss_a_day exception can't block the user**: new unit test makes `sendMissADayNotification` throw; the run completes without throwing and the claim is rolled back (`db.delete` called) so a later run retries.
- [x] **Rejected promise + failed delivery logging**: new unit test makes a channel promise reject and asserts `console.error` (rejected promise) and `console.warn` (not delivered on any channel) are emitted.
- [x] `npm run test:unit` — 225 passed.
- [x] `npm run typecheck` — clean.

`npm run test:unit` is not in CI, so it was run locally for this subsystem (#385/#390 conventions).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7287efdd-dc0a-46f5-9c6d-3ee58cf5c99a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7287efdd-dc0a-46f5-9c6d-3ee58cf5c99a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reminder scheduling around midnight and cron-boundary runs so notifications no longer double-send or miss the intended day.
  * Improved retry handling for missed notifications so a failed send can be attempted again later instead of getting stuck.
  * Added clearer delivery logging and warnings when notifications fail to send on all channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Prevent missed or duplicate notifications around cron boundary times

### What Changed
- Daily reminders now include the exact cron-boundary minute, so reminders due at the edge of the 5-minute window are no longer skipped.
- Cross-midnight runs now count a reminder against the day it was actually due, preventing a late-night reminder from sending twice when the next cron run lands after midnight.
- Weekly and every-other-day reminders now use the intended reminder date for delivery checks, so midnight catch-up runs no longer skip valid notifications.
- Miss-a-day notifications now release their claim if sending fails, allowing the next run to retry instead of leaving the user blocked.
- Rejected channel sends and total delivery failures are now logged, making failed notifications visible instead of silent.

### Impact
`✅ Fewer missed daily reminders`
`✅ No duplicate late-night reminder sends`
`✅ Reliable miss-a-day retries after send failures`
`✅ Clearer notification failure logs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
