### PR TITLE
feat(web): reflect active tab in URL via /app/[[...tab]] catch-all route

### DIFF
--- a/e2e/routing/tab-routing.spec.ts
+++ b/e2e/routing/tab-routing.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "../fixtures/auth.fixture";
+import { tap } from "../utils/mobile-helpers";
 
 // Verifies issue #292: the client-side router reflects the active tab in the
 // URL, deep-linking/refresh/back-forward land on the correct tab, transient
@@ -91,5 +92,47 @@ test.describe("tab routing reflects in URL (#292)", () => {
 
     await page.goto("/app/board?buddy=invite-token-abc");
     await expect(page).toHaveURL(/\/app\/buddy$/);
+  });
+
+  test("buddy invite token survives email/password sign-in", async ({ page, mockApiState }) => {
+    await page.route("**/api/buddy/sessions/join", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ sessionId: "buddy-session-1", calendarSync: [] }),
+      }),
+    );
+
+    // Land on a standard buddy invite URL while logged out, then sign up.
+    await page.goto("/app?buddy=invite-token-abc");
+    await tap(page.getByRole("button", { name: "sign up" }));
+    await page.getByPlaceholder("email").fill(mockApiState.credentials.email);
+    await page.getByPlaceholder("username").fill(mockApiState.credentials.username);
+    await page.getByPlaceholder("password").fill(mockApiState.credentials.password);
+    await tap(page.getByRole("button", { name: "Begin the journey" }));
+
+    // Sign-in must not drop the token before the buddy join effect runs.
+    await expect(page).toHaveURL(/\/app\/buddy$/);
+  });
+
+  test("browser back clears a session overlay instead of desyncing from the URL", async ({ page, ensureLoggedIn }) => {
+    await ensureLoggedIn();
+
+    // Build history: history tab, then progress tab.
+    await page.goto("/app/history");
+    await expect(page).toHaveURL(/\/app\/history$/);
+    await page.goto("/app/progress");
+    await expect(page.getByRole("button", { name: "Begin" })).toBeVisible();
+
+    // Start a session (overlay) on the Progress tab.
+    await page.getByRole("button", { name: "Begin" }).click();
+    await expect(page.getByRole("button", { name: "pause" })).toBeVisible();
+
+    // Going back must land on History with its content, not a session view
+    // stuck on the wrong URL.
+    await page.goBack();
+    await expect(page).toHaveURL(/\/app\/history$/);
+    await expect(page.getByRole("button", { name: "pause" })).toHaveCount(0);
+    await expect(page.getByRole("heading", { name: "Progress" })).toBeVisible();
   });
 });

--- a/e2e/routing/tab-routing.spec.ts
+++ b/e2e/routing/tab-routing.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from "../fixtures/auth.fixture";
+
+// Verifies issue #292: the client-side router reflects the active tab in the
+// URL, deep-linking/refresh/back-forward land on the correct tab, transient
+// flows (active session) keep the tab URL intact, and the buddy invite
+// query-param flow still works from any tab URL.
+
+test.describe("tab routing reflects in URL (#292)", () => {
+  test("/app resolves to the Progress tab", async ({ page, ensureLoggedIn }) => {
+    await ensureLoggedIn();
+    await page.goto("/app");
+    await expect(page.getByRole("button", { name: "Begin" })).toBeVisible();
+  });
+
+  test("nav buttons push per-tab routes", async ({ page, ensureLoggedIn }) => {
+    await ensureLoggedIn();
+    await page.goto("/app");
+
+    await page.getByRole("button", { name: "history" }).click();
+    await expect(page).toHaveURL(/\/app\/history$/);
+
+    await page.getByRole("button", { name: "board" }).click();
+    await expect(page).toHaveURL(/\/app\/board$/);
+
+    await page.getByRole("button", { name: "settings" }).click();
+    await expect(page).toHaveURL(/\/app\/settings$/);
+  });
+
+  test("deep-linking renders the matching tab", async ({ page, ensureLoggedIn }) => {
+    await ensureLoggedIn();
+    await page.goto("/app/settings");
+    // Settings exposes a logout control unique to that tab.
+    await expect(page.getByRole("button", { name: /log out/i })).toBeVisible();
+  });
+
+  test("back/forward + refresh land on the correct tab", async ({ page, ensureLoggedIn }) => {
+    await ensureLoggedIn();
+    await page.goto("/app");
+
+    await page.getByRole("button", { name: "history" }).click();
+    await expect(page).toHaveURL(/\/app\/history$/);
+    await page.getByRole("button", { name: "settings" }).click();
+    await expect(page).toHaveURL(/\/app\/settings$/);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/app\/history$/);
+
+    await page.goForward();
+    await expect(page).toHaveURL(/\/app\/settings$/);
+
+    await page.reload();
+    await expect(page).toHaveURL(/\/app\/settings$/);
+    await expect(page.getByRole("button", { name: /log out/i })).toBeVisible();
+  });
+
+  test("unknown slug falls back to Progress", async ({ page, ensureLoggedIn }) => {
+    await ensureLoggedIn();
+    await page.goto("/app/not-a-real-tab");
+    await expect(page).toHaveURL(/\/app\/progress$/);
+    await expect(page.getByRole("button", { name: "Begin" })).toBeVisible();
+  });
+
+  test("active session overlay keeps the tab URL intact", async ({ page, ensureLoggedIn }) => {
+    await ensureLoggedIn();
+    await page.goto("/app/progress");
+
+    await page.getByRole("button", { name: "Begin" }).click();
+    // Session controls render and the URL stays on the Progress tab.
+    await expect(page.getByRole("button", { name: "pause" })).toBeVisible();
+    await expect(page).toHaveURL(/\/app\/progress$/);
+  });
+
+  test("legacy ?view=settings deep link redirects to /app/settings", async ({ page, ensureLoggedIn }) => {
+    await ensureLoggedIn();
+    await page.goto("/app?view=settings");
+    await expect(page).toHaveURL(/\/app\/settings$/);
+    await expect(page.getByRole("button", { name: /log out/i })).toBeVisible();
+  });
+
+  test("buddy invite query-param flow opens the buddy tab from any tab URL", async ({ page, ensureLoggedIn }) => {
+    await ensureLoggedIn();
+
+    // Mock the join endpoint (registered after the fixture, so it wins).
+    await page.route("**/api/buddy/sessions/join", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ sessionId: "buddy-session-1", calendarSync: [] }),
+      }),
+    );
+
+    await page.goto("/app/board?buddy=invite-token-abc");
+    await expect(page).toHaveURL(/\/app\/buddy$/);
+  });
+});

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import { useParams, useRouter } from "next/navigation";
 import type { CalendarSyncResult, User } from "@/lib/api";
 import { AuthScreen } from "@/components/AuthScreen";
 import { HomeView } from "@/components/HomeView";
@@ -18,16 +19,35 @@ import { api, ApiError } from "@/lib/api";
 import type { SessionType } from "@/lib/constants";
 import { todayLocalIsoDate } from "@/lib/sessionCalendar";
 
-type View =
-  | "home"
-  | "session"
-  | "buddy"
-  | "complete"
+// URL-driven tabs. The first path segment of /app/[[...tab]] selects the tab;
+// `/app` (no segment) resolves to the Progress tab.
+type Tab =
+  | "progress"
   | "history"
   | "journal"
   | "board"
   | "friends"
-  | "settings";
+  | "settings"
+  | "buddy";
+
+// Tabs that appear in the persistent nav, in display order. `buddy` is reached
+// from the Progress screen rather than the nav, so it is intentionally omitted.
+const NAV_TABS: Tab[] = ["progress", "history", "journal", "board", "friends", "settings"];
+
+const ALL_TABS: Tab[] = [...NAV_TABS, "buddy"];
+
+const DEFAULT_TAB: Tab = "progress";
+
+function isTab(value: string | undefined): value is Tab {
+  return value !== undefined && (ALL_TABS as string[]).includes(value);
+}
+
+function pathForTab(tab: Tab): string {
+  return `/app/${tab}`;
+}
+
+// Transient flows that overlay the active tab without changing the URL.
+type Overlay = "session" | "complete";
 
 type CompletionData = {
   sessionId: string | null;
@@ -49,8 +69,13 @@ function calendarSyncMessageFromResult(sync: CalendarSyncResult[] | undefined): 
 }
 
 export default function StillPoint() {
+  const router = useRouter();
+  const params = useParams<{ tab?: string[] }>();
+  const rawTab = Array.isArray(params.tab) ? params.tab[0] : undefined;
+  const tab: Tab = isTab(rawTab) ? rawTab : DEFAULT_TAB;
+
   const [user, setUser] = useState<User | null>(null);
-  const [view, setView] = useState<View>("home");
+  const [overlay, setOverlay] = useState<Overlay | null>(null);
   const [authChecked, setAuthChecked] = useState(false);
   const [authError, setAuthError] = useState<string | null>(null);
   const [authRetryKey, setAuthRetryKey] = useState(0);
@@ -109,20 +134,24 @@ export default function StillPoint() {
     };
   }, [authRetryKey]);
 
+  // Redirect legacy `?view=` deep links and unknown tab slugs to their routes.
   useEffect(() => {
     if (!user || !authChecked) return;
     const params = new URLSearchParams(window.location.search);
     const viewParam = params.get("view");
     if (viewParam === "settings") {
-      setView("settings");
-      window.history.replaceState({}, "", "/app");
+      router.replace(pathForTab("settings"));
       return;
     }
     if (viewParam === "friends") {
-      setView("friends");
-      window.history.replaceState({}, "", "/app");
+      router.replace(pathForTab("friends"));
+      return;
     }
-  }, [user, authChecked]);
+    // Unknown slug (e.g. /app/garbage) falls back to Progress.
+    if (rawTab !== undefined && !isTab(rawTab)) {
+      router.replace(pathForTab(DEFAULT_TAB));
+    }
+  }, [user, authChecked, rawTab, router]);
 
   useEffect(() => {
     if (!user || !authChecked || buddyInviteInFlight.current) return;
@@ -140,15 +169,16 @@ export default function StillPoint() {
         setBuddyInviteError(null);
         setBuddyCalendarMessage(calendarSyncMessageFromResult(calendarSync));
         setBuddySessionId(sessionId);
-        setView("buddy");
-        window.history.replaceState({}, "", "/app");
+        setOverlay(null);
+        router.replace(pathForTab("buddy"));
       } catch (e) {
         if (!cancelled) {
           buddyInviteInFlight.current = false;
           setBuddyInviteError(
             e instanceof ApiError ? e.message : "Could not open that buddy invite.",
           );
-          window.history.replaceState({}, "", "/app");
+          // Strip the consumed invite token from whatever tab URL we are on.
+          router.replace(rawTab && isTab(rawTab) ? pathForTab(rawTab) : pathForTab(DEFAULT_TAB));
         }
       }
     })();
@@ -156,32 +186,43 @@ export default function StillPoint() {
     return () => {
       cancelled = true;
     };
-  }, [user, authChecked]);
+  }, [user, authChecked, rawTab, router]);
+
+  const goToTab = useCallback(
+    (next: Tab) => {
+      setOverlay(null);
+      router.push(pathForTab(next));
+    },
+    [router],
+  );
 
   const handleLogin = (userData: User) => {
     setUser(userData);
-    setView("home");
+    setOverlay(null);
+    router.replace(pathForTab(DEFAULT_TAB));
   };
 
   const handleLogout = () => {
     buddyInviteInFlight.current = false;
     setBuddySessionId(null);
     setBuddyCalendarMessage(null);
+    setOverlay(null);
     setUser(null);
-    setView("home");
+    router.replace(pathForTab(DEFAULT_TAB));
   };
 
   const handleBegin = (sessionType: SessionType = "standard") => {
     setActiveSessionType(sessionType);
-    setView("session");
+    setOverlay("session");
   };
 
   const handleBuddyExit = useCallback(() => {
     setBuddySessionId(null);
     setBuddyCalendarMessage(null);
     setBuddyInviteError(null);
-    setView("home");
-  }, []);
+    setOverlay(null);
+    router.push(pathForTab(DEFAULT_TAB));
+  }, [router]);
 
   const handleBuddyPersonalRecordComplete = useCallback((data: BuddyPersonalRecordPayload) => {
     setBuddySessionId(null);
@@ -196,7 +237,7 @@ export default function StillPoint() {
       thoughtCount: data.thoughtCount,
       thoughts: data.thoughts,
     });
-    setView("complete");
+    setOverlay("complete");
     void api
       .me()
       .then(({ user: u }) => setUser(u))
@@ -274,7 +315,7 @@ export default function StillPoint() {
       thoughtCount: data.thoughtCount,
       thoughts: data.thoughts,
     });
-    setView("complete");
+    setOverlay("complete");
   }, [user]);
 
   const handleSessionAbandon = useCallback(async (data: {
@@ -327,10 +368,11 @@ export default function StillPoint() {
       console.error("Failed to save abandoned session:", error);
     }
 
-    setView("home");
+    setOverlay(null);
   }, []);
 
-  const navItems: View[] = ["home", "history", "journal", "board", "friends", "settings"];
+  const inBuddyRoom = tab === "buddy" && !!buddySessionId;
+  const isImmersive = overlay === "session" || inBuddyRoom;
 
   // Loading state
   if (!authChecked) {
@@ -410,10 +452,7 @@ export default function StillPoint() {
     <div style={{
       minHeight: "100%",
       display: "grid",
-      gridTemplateRows:
-        view === "session" || (view === "buddy" && buddySessionId)
-          ? "1fr"
-          : "auto 1fr auto",
+      gridTemplateRows: isImmersive ? "1fr" : "auto 1fr auto",
       alignItems: "center",
       fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
       padding: isMobile
@@ -421,7 +460,7 @@ export default function StillPoint() {
         : "var(--s4) var(--s4)",
     }}>
       {/* Nav */}
-      {view !== "session" && !(view === "buddy" && buddySessionId) && (
+      {!isImmersive && (
         <div style={isMobile ? {
           position: "fixed", bottom: 0, left: 0, right: 0,
           display: "flex", justifyContent: "space-around",
@@ -434,14 +473,14 @@ export default function StillPoint() {
           display: "flex", gap: "var(--s3)",
           zIndex: 100,
         }}>
-          {navItems.map(v => (
+          {NAV_TABS.map(t => (
             <button
               type="button"
-              key={v}
-              onClick={() => setView(v)}
+              key={t}
+              onClick={() => goToTab(t)}
               style={{
                 background: "none", border: "none",
-                color: view === v ? "var(--fg)" : "var(--fg-2)",
+                color: !overlay && tab === t ? "var(--fg)" : "var(--fg-2)",
                 fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
                 fontSize: isMobile ? "13px" : "11px",
                 letterSpacing: "0.1em",
@@ -456,8 +495,8 @@ export default function StillPoint() {
                 position: "relative",
               }}
             >
-              {v}
-              {view === v && isMobile && (
+              {t}
+              {!overlay && tab === t && isMobile && (
                 <span style={{
                   position: "absolute", bottom: "4px", left: "50%", transform: "translateX(-50%)",
                   width: "16px", height: "2px", borderRadius: "1px",
@@ -470,7 +509,7 @@ export default function StillPoint() {
       )}
 
       {/* Welcome header */}
-      {view !== "session" && !(view === "buddy" && buddySessionId) && (
+      {!isImmersive && (
         <div style={{
           fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
           fontSize: "12px", color: "var(--fg-3)",
@@ -484,7 +523,7 @@ export default function StillPoint() {
         </div>
       )}
 
-      {buddyInviteError && view !== "session" && (
+      {buddyInviteError && overlay !== "session" && (
         <div
           role="alert"
           style={{
@@ -526,42 +565,8 @@ export default function StillPoint() {
         </div>
       )}
 
-      {/* Views */}
-      {view === "home" && (
-        <HomeView
-          currentDay={user.currentDay}
-          onBegin={() => handleBegin("standard")}
-          onQuickBegin={() => handleBegin("quick")}
-          onBuddy={() => {
-            setBuddySessionId(null);
-            setBuddyCalendarMessage(null);
-            setBuddyInviteError(null);
-            setView("buddy");
-          }}
-        />
-      )}
-
-      {view === "buddy" && !buddySessionId && (
-        <BuddySessionHub
-          onEnterSession={(id, calendarSync) => {
-            setBuddyCalendarMessage(calendarSyncMessageFromResult(calendarSync ?? undefined));
-            setBuddySessionId(id);
-          }}
-          onBack={handleBuddyExit}
-        />
-      )}
-
-      {view === "buddy" && buddySessionId && (
-        <BuddySessionRoom
-          sessionId={buddySessionId}
-          currentUserId={user.id}
-          calendarMessage={buddyCalendarMessage}
-          onExit={handleBuddyExit}
-          onPersonalRecordComplete={handleBuddyPersonalRecordComplete}
-        />
-      )}
-
-      {view === "session" && (
+      {/* Transient overlays take precedence over the active tab. */}
+      {overlay === "session" && (
         <SessionView
           currentDay={user.currentDay}
           sessionType={activeSessionType}
@@ -570,7 +575,7 @@ export default function StillPoint() {
         />
       )}
 
-      {view === "complete" && completionData && (
+      {overlay === "complete" && completionData && (
         <CompletionScreen
           dayNumber={completionData.dayNumber}
           sessionType={completionData.sessionType}
@@ -580,7 +585,8 @@ export default function StillPoint() {
           thoughtCount={completionData.thoughtCount}
           thoughts={completionData.thoughts}
           onReturn={() => {
-            setView("home");
+            setOverlay(null);
+            router.push(pathForTab(DEFAULT_TAB));
             void api
               .me()
               .then(({ user: u }) => setUser(u))
@@ -603,21 +609,56 @@ export default function StillPoint() {
         />
       )}
 
-      {view === "history" && (
+      {/* Tab content (rendered when no transient overlay is active). */}
+      {!overlay && tab === "progress" && (
+        <HomeView
+          currentDay={user.currentDay}
+          onBegin={() => handleBegin("standard")}
+          onQuickBegin={() => handleBegin("quick")}
+          onBuddy={() => {
+            setBuddySessionId(null);
+            setBuddyCalendarMessage(null);
+            setBuddyInviteError(null);
+            goToTab("buddy");
+          }}
+        />
+      )}
+
+      {!overlay && tab === "buddy" && !buddySessionId && (
+        <BuddySessionHub
+          onEnterSession={(id, calendarSync) => {
+            setBuddyCalendarMessage(calendarSyncMessageFromResult(calendarSync ?? undefined));
+            setBuddySessionId(id);
+          }}
+          onBack={handleBuddyExit}
+        />
+      )}
+
+      {!overlay && tab === "buddy" && buddySessionId && (
+        <BuddySessionRoom
+          sessionId={buddySessionId}
+          currentUserId={user.id}
+          calendarMessage={buddyCalendarMessage}
+          onExit={handleBuddyExit}
+          onPersonalRecordComplete={handleBuddyPersonalRecordComplete}
+        />
+      )}
+
+      {!overlay && tab === "history" && (
         <HistoryView currentDay={user.currentDay} username={user.username} />
       )}
 
-      {view === "journal" && (
+      {!overlay && tab === "journal" && (
         <ThoughtJournal username={user.username} />
       )}
 
-      {view === "board" && (
+      {!overlay && tab === "board" && (
         <PublicBoard currentUsername={user.username} />
       )}
 
-      {view === "friends" && <FriendsView />}
+      {!overlay && tab === "friends" && <FriendsView />}
 
-      {view === "settings" && (
+      {!overlay && tab === "settings" && (
         <SettingsView
           user={user}
           onTogglePublic={(isPublic) =>

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -38,6 +38,19 @@ const ALL_TABS: Tab[] = [...NAV_TABS, "buddy"];
 
 const DEFAULT_TAB: Tab = "progress";
 
+// Visible nav labels are decoupled from the route slug: the Progress tab keeps
+// its existing "home" label (shorter, so the 6-item mobile nav row stays
+// readable) while living at /app/progress.
+const TAB_LABELS: Record<Tab, string> = {
+  progress: "home",
+  history: "history",
+  journal: "journal",
+  board: "board",
+  friends: "friends",
+  settings: "settings",
+  buddy: "buddy",
+};
+
 function isTab(value: string | undefined): value is Tab {
   return value !== undefined && (ALL_TABS as string[]).includes(value);
 }
@@ -495,7 +508,7 @@ export default function StillPoint() {
                 position: "relative",
               }}
             >
-              {t}
+              {TAB_LABELS[t]}
               {!overlay && tab === t && isMobile && (
                 <span style={{
                   position: "absolute", bottom: "4px", left: "50%", transform: "translateX(-50%)",

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -183,6 +183,7 @@ export default function StillPoint() {
         setBuddyCalendarMessage(calendarSyncMessageFromResult(calendarSync));
         setBuddySessionId(sessionId);
         setOverlay(null);
+        buddyInviteInFlight.current = false;
         router.replace(pathForTab("buddy"));
       } catch (e) {
         if (!cancelled) {
@@ -198,6 +199,7 @@ export default function StillPoint() {
 
     return () => {
       cancelled = true;
+      buddyInviteInFlight.current = false;
     };
   }, [user, authChecked, rawTab, router]);
 

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -201,6 +201,19 @@ export default function StillPoint() {
     };
   }, [user, authChecked, rawTab, router]);
 
+  // Keep transient state in sync with the URL. Browser back/forward (and any
+  // other navigation) changes the active tab via useParams without touching
+  // React state, so clear the session/completion overlay and drop any stale
+  // buddy room when we land on a different tab. This runs only when `tab`
+  // actually changes, so it never interferes with starting a session/overlay
+  // on the current tab.
+  useEffect(() => {
+    setOverlay(null);
+    if (tab !== "buddy") {
+      setBuddySessionId(null);
+    }
+  }, [tab]);
+
   const goToTab = useCallback(
     (next: Tab) => {
       setOverlay(null);
@@ -210,9 +223,11 @@ export default function StillPoint() {
   );
 
   const handleLogin = (userData: User) => {
+    // Intentionally do not navigate: keep the current URL so deep-link state
+    // (e.g. /app?buddy=<token> or a deep-linked tab) survives sign-in and the
+    // buddy-invite / ?view= effects below can still consume it.
     setUser(userData);
     setOverlay(null);
-    router.replace(pathForTab(DEFAULT_TAB));
   };
 
   const handleLogout = () => {
@@ -221,7 +236,6 @@ export default function StillPoint() {
     setBuddyCalendarMessage(null);
     setOverlay(null);
     setUser(null);
-    router.replace(pathForTab(DEFAULT_TAB));
   };
 
   const handleBegin = (sessionType: SessionType = "standard") => {

--- a/src/app/app/settings/notifications/page.tsx
+++ b/src/app/app/settings/notifications/page.tsx
@@ -29,7 +29,7 @@ export default function NotificationSettingsPage() {
             }}
           >
             <Link
-              href="/app?view=settings"
+              href="/app/settings"
               style={{
                 fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
                 fontSize: "11px",


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #292.

The web client previously kept the active tab in SPA `useState` only, so refresh/back/forward and deep-linking always landed on Progress and the URL never changed. This moves the single-page app shell into a Next.js **optional catch-all** route `src/app/app/[[...tab]]/page.tsx` so each tab has its own URL, while keeping the existing single-page architecture and AJAX data fetching intact.

### Routing model
- `/app` → Progress
- `/app/progress`, `/app/history`, `/app/journal`, `/app/board`, `/app/friends`, `/app/settings`, `/app/buddy` → respective tabs
- Unknown slugs (e.g. `/app/garbage`) redirect to Progress

### State split (per CR plan)
- **URL-driven tabs** (6 nav tabs + buddy): the first path segment drives the active tab via `useParams`; nav buttons call `router.push()`.
- **Internal overlay state** (active session, completion): kept in component state via `setOverlay()` so transient flows never write to or corrupt the tab URL. Overlays are also cleared whenever the active tab changes, so browser back/forward can't leave an overlay rendered on a mismatched URL.

### Buddy invite + legacy deep links
- The `?buddy=<token>` invite flow still works regardless of which tab URL it lands on, and survives email/password sign-in (sign-in no longer rewrites the URL). It joins the session, opens the buddy room, and strips the token via `router.replace`.
- Legacy `?view=settings` / `?view=friends` deep links redirect to `/app/settings` / `/app/friends`.
- Notifications back link updated from `/app?view=settings` to `/app/settings`.

### Nav label note
The Progress route slug (`/app/progress`) is intentionally decoupled from its visible nav label, which stays `home`, to avoid any change to the already-tight 6-item mobile nav row versus `main`.

### Compatibility
- The optional catch-all coexists with the existing static sibling routes (`/app/settings/notifications`, `/app/buddies/calendar`, `/app/buddies/[id]/calendar`) — confirmed by a clean `next build`.
- No DB migration. Web-only.

## Review fixes (Cursor Bugbot + CI)
- **Buddy token dropped on sign-in** (Bugbot, medium): `handleLogin`/`handleLogout` no longer `router.replace('/app/progress')`. The redirect both dropped the URL query (so `/app?buddy=…` lost its token before the join effect ran) and raced with `page.goto('/app')` in the e2e suite, which was the root cause of the failing `e2e-mobile` checks (`navigation interrupted`). Sign-in now preserves the current URL.
- **Overlay/URL desync on back/forward** (Bugbot, medium): transient overlay + stale buddy-room state are now cleared when the active tab changes.

## Test plan
- `npm run typecheck`, `npm run build`, `npm run test:unit` (221) — pass
- `e2e/routing/tab-routing.spec.ts` (chromium + webkit) covers `/app`→Progress, per-tab `router.push`, deep-linking, back/forward + refresh, unknown-slug fallback, active-session URL stability, legacy `?view=` redirect, buddy invite from a non-default tab, **buddy token surviving sign-in**, and **back clearing a session overlay**.
- `e2e/auth`, `e2e/session`, `e2e/layout` pass on `mobile-chromium-narrow`, `mobile-chromium-wide`, and `mobile-webkit-iphone`; CI `e2e-mobile` is green.

## Walkthrough
[tab_routing_walkthrough.webm](https://cursor.com/agents/bc-eeb6769e-4142-4396-aa2b-2bd372f382de/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftab_routing_walkthrough.webm)

Deep-linking straight to `/app/settings` renders the Settings tab:

[Deep-linked /app/settings tab](https://cursor.com/agents/bc-eeb6769e-4142-4396-aa2b-2bd372f382de/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdeeplink_settings_tab.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eeb6769e-4142-4396-aa2b-2bd372f382de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eeb6769e-4142-4396-aa2b-2bd372f382de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
Put app tabs in the URL and keep deep links working

### What Changed
- The app now opens each main tab from its own URL, so refresh, back/forward, and shared links land on the same tab the user was on
- Old links like `?view=settings` and `?view=friends` now redirect to the matching tab URL, and the notifications settings link now points to `/app/settings`
- Temporary screens like a running session or completion screen stay tied to the current tab instead of replacing it in the URL
- Buddy invite links still open the buddy flow from any tab, and sign-in no longer drops the invite token before it is used
- Added end-to-end coverage for tab links, browser navigation, legacy redirects, invite handling, and session overlays

### Impact
`✅ Reliable refresh on the same tab`
`✅ Fewer broken old links`
`✅ Buddy invites survive sign-in`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
