### PR TITLE
ci(ios-e2e): scope cold-start guard + raise bound to 8000ms

### DIFF
--- a/docs/testing/e2e-policy.md
+++ b/docs/testing/e2e-policy.md
@@ -190,6 +190,16 @@ Fail thresholds are optional:
 
 Default behavior: report-only, store JSON artifacts.
 
+### iOS cold-start auth-check bound
+
+`StillPointAppUITests` carries an in-test guard (`coldStartMaxMs`) on the
+app-reported cold-start auth-check latency (`coldStartAuthCheckMs`), distinct
+from the `app_boot_seconds` metric above and from XCTest launch overhead.
+
+- **Bound:** 8000ms. Raised from 5000ms in [#334](https://github.com/auerbachb/still-point/issues/334) because the auth-check intermittently exceeded 5000ms on contended macos-26 / iOS-26 simulators, producing infra-shaped flakes rather than real regressions.
+- **Scope:** the assertion runs only on cold-start paths that boot to the auth screen (`seedAuthenticated: false`). Authenticated boots (`seedAuthenticated: true`) and seeded relaunches pass `assertColdStart: false`, since the auth-check there is incidental to what the test asserts (home/settings/session behavior).
+- **Rationale:** keeping the guard on the unauthenticated cold-start path preserves a meaningful latency check where it is the focus, while removing it from authenticated boots eliminates the intermittent failures flagged in #334 (Option 3: skip where cold-start is not the focus).
+
 ## 11) PR merge gating policy
 
 For pull requests, required lanes:

--- a/ios/StillPointAppUITests/README.md
+++ b/ios/StillPointAppUITests/README.md
@@ -22,7 +22,7 @@ This directory contains native iOS UI smoke tests for Issue #193 ("journeys beyo
 - Token expiry re-auth path (`testTokenExpiryRoutesToReauthMessage`)
 - Failed sessions API displays visible error (no silent hang) (`testSessionsFailureShowsVisibleRetryMessage`)
 
-Cold-start acceptance guard used by tests: **auth check must complete within 5,000 ms** (captured via root accessibility value `coldStartAuthCheckMs=<n>`).
+Cold-start acceptance guard used by tests: **auth check must complete within 8,000 ms** (captured via root accessibility value `coldStartAuthCheckMs=<n>`). Raised from 5,000 ms in [#334](https://github.com/auerbachb/still-point/issues/334) to absorb macos-26/iOS-26 simulator contention. The guard is asserted only on `seedAuthenticated: false` cold-start paths (boot to auth); authenticated boots and seeded relaunches pass `assertColdStart: false`.
 
 ## Environment knobs used by tests
 

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -5,7 +5,13 @@ final class StillPointAppUITests: XCTestCase {
     // macos-26/iOS 26 CI. `coldStartMaxMs` is separate: it is the app-reported
     // auth-check latency in `coldStartAuthCheckMs`, not XCTest launch overhead.
     private let launchTimeout: TimeInterval = 45
-    private let coldStartMaxMs = 5_000
+    // Bound bumped 5000 -> 8000ms (issue #334): the app-reported cold-start
+    // auth-check intermittently exceeded 5000ms on contended macos-26 iOS-26
+    // simulators, producing infra-shaped flakes rather than real regressions.
+    // 8000ms keeps a meaningful guard while absorbing simulator contention. The
+    // assertion is also scoped to `seedAuthenticated: false` cold-start paths
+    // only (see `waitForRoot`/`assertColdStart`); authenticated boots skip it.
+    private let coldStartMaxMs = 8_000
 
     override func setUpWithError() throws {
         continueAfterFailure = false
@@ -163,7 +169,7 @@ final class StillPointAppUITests: XCTestCase {
         let app = makeApp(seedAuthenticated: true, resetStore: true)
         app.launch()
 
-        waitForRoot("home", in: app, failureMessage: "Home screen did not appear")
+        waitForRoot("home", in: app, failureMessage: "Home screen did not appear", assertColdStart: false)
         openTab(identifier: "tab.progress", in: app, waitingFor: app.staticTexts["history.title"])
 
         openTab(identifier: "tab.settings", in: app, waitingFor: app.staticTexts["settings.title"])
@@ -175,7 +181,7 @@ final class StillPointAppUITests: XCTestCase {
         let app = makeApp(seedAuthenticated: true, resetStore: true)
         app.launch()
 
-        waitForRoot("home", in: app, failureMessage: "Home screen did not appear")
+        waitForRoot("home", in: app, failureMessage: "Home screen did not appear", assertColdStart: false)
         openTab(identifier: "tab.settings", in: app, waitingFor: app.staticTexts["settings.title"])
 
         let editButton = app.buttons["settings.usernameEditButton"]
@@ -203,7 +209,7 @@ final class StillPointAppUITests: XCTestCase {
         let app = makeApp(seedAuthenticated: true, resetStore: true)
         app.launch()
 
-        waitForRoot("home", in: app, failureMessage: "Home screen did not appear")
+        waitForRoot("home", in: app, failureMessage: "Home screen did not appear", assertColdStart: false)
         openTab(identifier: "tab.settings", in: app, waitingFor: app.staticTexts["settings.title"])
 
         let editButton = app.buttons["settings.usernameEditButton"]
@@ -234,7 +240,7 @@ final class StillPointAppUITests: XCTestCase {
         let app = makeApp(seedAuthenticated: true, resetStore: true, forceUsernameConflict: true)
         app.launch()
 
-        waitForRoot("home", in: app, failureMessage: "Home screen did not appear")
+        waitForRoot("home", in: app, failureMessage: "Home screen did not appear", assertColdStart: false)
         openTab(identifier: "tab.settings", in: app, waitingFor: app.staticTexts["settings.title"])
 
         let editButton = app.buttons["settings.usernameEditButton"]
@@ -322,7 +328,7 @@ final class StillPointAppUITests: XCTestCase {
         let app = makeApp(seedAuthenticated: true, resetStore: true, sessionSeconds: 60, timerMultiplier: 1.0)
         app.launch()
 
-        waitForRoot("home", in: app, failureMessage: "Home screen did not appear")
+        waitForRoot("home", in: app, failureMessage: "Home screen did not appear", assertColdStart: false)
         let beginButton = app.buttons["home.beginButton"]
         XCTAssertTrue(beginButton.waitForExistence(timeout: 5))
         tap(beginButton, thenWaitForRoot: "session", in: app)
@@ -349,7 +355,7 @@ final class StillPointAppUITests: XCTestCase {
         let app = makeApp(seedAuthenticated: true, resetStore: true)
         app.launch()
 
-        waitForRoot("home", in: app, failureMessage: "Home screen did not appear")
+        waitForRoot("home", in: app, failureMessage: "Home screen did not appear", assertColdStart: false)
         let beginButton = app.buttons["home.beginButton"]
         XCTAssertTrue(beginButton.waitForExistence(timeout: 5))
         XCTAssertTrue(beginButton.isHittable, "Home primary action should be visible above safe-area/home indicator")
@@ -361,7 +367,7 @@ final class StillPointAppUITests: XCTestCase {
         let app = makeApp(seedAuthenticated: true, resetStore: true, sessionSeconds: 600, timerMultiplier: 0.05)
         app.launch()
 
-        waitForRoot("home", in: app, failureMessage: "Home screen did not appear")
+        waitForRoot("home", in: app, failureMessage: "Home screen did not appear", assertColdStart: false)
         let beginButton = app.buttons["home.beginButton"]
         XCTAssertTrue(beginButton.waitForExistence(timeout: 5))
         XCTAssertEqual(beginButton.label, "Start session")
@@ -381,7 +387,7 @@ final class StillPointAppUITests: XCTestCase {
         let app = makeApp(seedAuthenticated: true, resetStore: false, forceSessionsFailure: true, forceProgressTab: true)
         app.launch()
 
-        waitForRoot("home", in: app, failureMessage: "Home screen did not appear")
+        waitForRoot("home", in: app, failureMessage: "Home screen did not appear", assertColdStart: false)
         let errorLabel = app.staticTexts["history.errorMessage"]
 
         XCTAssertTrue(errorLabel.waitForExistence(timeout: 8))


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #334

## What

The app-reported cold-start auth-check (`coldStartAuthCheckMs`) intermittently exceeded the `5000ms` bound on contended macos-26 / iOS-26 simulators, surfacing as `XCTAssertLessThanOrEqual ... Cold start auth check exceeded documented bound` failures. These are infra-shaped flakes (simulator contention), not real regressions. **Test-only change — no app code touched, does not feed the build.**

Implements the locked plan (Option 3 — skip where cold-start is not the focus) plus a bound bump:

- **Raise `coldStartMaxMs` 5000 → 8000ms** with an explanatory comment, in `ios/StillPointAppUITests/StillPointAppUITests.swift`.
- **Scope the cold-start assertion to `seedAuthenticated: false` cold-start paths only** (boot to the auth screen). All `seedAuthenticated: true` tests now pass `assertColdStart: false`, following the existing `assertColdStart: false` convention already used in 5 places.
- **Document** the bound + scope in `docs/testing/e2e-policy.md` (§10) and `ios/StillPointAppUITests/README.md`.

After the change, the cold-start guard remains enabled only on the two unauthenticated cold-start tests (`testLaunchLoginCompleteSessionAndHistoryPersistence`, `testKeyboardOverlapKeepsSubmitReachable`); every other `waitForRoot` call passes `assertColdStart: false`.

## Acceptance criteria

- [x] Option 3 (skip where not the focus) + bound 5000→8000ms
- [x] `coldStartMaxMs` updated with an explanatory comment
- [x] Cold-start assertion kept only on `seedAuthenticated: false` tests; others pass `assertColdStart: false`
- [x] Previously-flaking test green across ≥3 reruns (links below)

## Test plan

Local `xcodebuild` cannot parse the project (no macOS/Xcode toolchain on the agent host), so verification is the iOS E2E lane in CI (`ios-e2e-smoke` + `ios-e2e-critical`). The PR #328 classifier in `scripts/e2e/run-ios-tests.sh` auto-retries infra-shaped failures.

Three consecutive green iOS E2E runs (both lanes green each time — the previously-flaking cold-start assertion no longer trips):

1. [Run #1 — 28181947460](https://github.com/auerbachb/still-point/actions/runs/28181947460) (smoke 9m48s, critical 9m50s)
2. [Run #2 — 28182976062](https://github.com/auerbachb/still-point/actions/runs/28182976062) (smoke 6m27s, critical 9m11s)
3. [Run #3 — 28183684809](https://github.com/auerbachb/still-point/actions/runs/28183684809) (smoke 11m48s, critical 9m42s)

Reruns #2 and #3 were triggered via empty commits because the agent's `gh` CLI is read-only (no `gh run rerun`); these can be squashed on merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70c5f34e-d74f-4981-a800-dad77a6f051f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70c5f34e-d74f-4981-a800-dad77a6f051f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
Keep the cold-start check only where it matters and raise its limit to reduce iOS E2E flakes

### What Changed
- Increased the cold-start auth-check limit from 5,000 ms to 8,000 ms so contended macOS/iOS simulators do not fail tests for slow startup checks
- Kept the cold-start assertion only on tests that actually boot to the auth screen; seeded authenticated flows now skip that check
- Updated the iOS E2E testing docs to explain the new limit and where the guard still applies

### Impact
`✅ Fewer false iOS E2E failures`
`✅ Stable authenticated smoke tests`
`✅ Clearer cold-start testing rules`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
