### PR TITLE
perf(db): buddy index hygiene — add participants(user_id), drop redundant calendar(session) index (#383, #384)

### DIFF
--- a/drizzle/buddy_session_calendar_events_drop_session_index_incremental.sql
+++ b/drizzle/buddy_session_calendar_events_drop_session_index_incremental.sql
@@ -1,0 +1,7 @@
+-- #384: drop redundant idx_buddy_session_calendar_events_session (buddy_session_id).
+-- It is an exact leading prefix of the unique (buddy_session_id, user_id) index
+-- (buddy_session_calendar_events_session_user), so that btree already serves any
+-- standalone buddy_session_id predicate. KEEP idx_buddy_session_calendar_events_user.
+-- Precedent: friendships_drop_user1_index_incremental.sql.
+-- Idempotent; safe to re-apply. Applied via npm run db:migrate on deploy.
+DROP INDEX IF EXISTS "idx_buddy_session_calendar_events_session";

--- a/drizzle/buddy_session_participants_user_index_incremental.sql
+++ b/drizzle/buddy_session_participants_user_index_incremental.sql
@@ -1,0 +1,8 @@
+-- #383: idx_buddy_session_participants_user (user_id).
+-- Backs `WHERE user_id = ?` calendar lookups (src/lib/buddyCalendar.ts) and the
+-- ON DELETE CASCADE fan-out from users on account deletion. The unique
+-- (buddy_session_id, user_id) index can't serve a standalone user_id predicate
+-- because user_id is not its leading column.
+-- Idempotent; safe to re-apply. Applied via npm run db:migrate on deploy.
+CREATE INDEX IF NOT EXISTS "idx_buddy_session_participants_user"
+  ON "buddy_session_participants" ("user_id");

--- a/drizzle/zz_buddy_session_calendar_events_drop_session_index_incremental.sql
+++ b/drizzle/zz_buddy_session_calendar_events_drop_session_index_incremental.sql
@@ -1,0 +1,8 @@
+-- #384 follow-up: re-drop idx_buddy_session_calendar_events_session after
+-- partner_scheduling_google_calendar_incremental.sql, which recreates it with
+-- CREATE INDEX IF NOT EXISTS. On existing databases this file is a no-op (the
+-- index was already dropped by buddy_session_calendar_events_drop_session_index_incremental.sql).
+-- On greenfield/backfill runs the lexicographic sort causes the first drop to run
+-- before the partner-scheduling migration recreates the index; this late-sorting
+-- file ensures the net result is the same: index absent. Idempotent; safe to re-apply.
+DROP INDEX IF EXISTS "idx_buddy_session_calendar_events_session";

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -279,11 +279,13 @@ export const buddySessionCalendarEvents = pgTable("buddy_session_calendar_events
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 }, (table) => ({
+  /** #384: also serves standalone `buddy_session_id` predicates as a left-prefix,
+   *  which is why the separate `idx_buddy_session_calendar_events_session` was
+   *  dropped as redundant. */
   sessionUserUnique: uniqueIndex("buddy_session_calendar_events_session_user").on(
     table.buddySessionId,
     table.userId,
   ),
-  sessionIdx: index("idx_buddy_session_calendar_events_session").on(table.buddySessionId),
   userIdx: index("idx_buddy_session_calendar_events_user").on(table.userId),
   statusCheck: check(
     "buddy_session_calendar_events_status_allowed",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -244,6 +244,11 @@ export const buddySessionParticipants = pgTable("buddy_session_participants", {
   oneHostPerSessionIdx: uniqueIndex("buddy_session_participants_one_host_per_session")
     .on(table.buddySessionId)
     .where(sql`${table.isHost}`),
+  /** #383: backs `WHERE user_id = ?` calendar lookups and the on-delete-cascade
+   *  fan-out from `users` on account deletion. The unique
+   *  `(buddy_session_id, user_id)` index can't serve a standalone `user_id`
+   *  predicate (wrong leading column). */
+  userIdx: index("idx_buddy_session_participants_user").on(table.userId),
 }));
 
 /** Google Calendar OAuth connection per app user (#204). Tokens are encrypted server-side. */


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Buddy-table index hygiene from the #143/#391 audit. Bundled into one PR because both edits touch the same buddy-table region of `src/db/schema.ts`; splitting would guarantee a conflict.

- **#383** — add `idx_buddy_session_participants_user` on `buddy_session_participants(user_id)`. Backs standalone `WHERE user_id = ?` calendar lookups (`src/lib/buddyCalendar.ts`) and the `ON DELETE CASCADE` fan-out from `users` on account deletion. The unique `(buddy_session_id, user_id)` index cannot serve a `user_id`-only predicate (wrong leading column).
- **#384** — drop redundant `idx_buddy_session_calendar_events_session` on `buddy_session_calendar_events(buddy_session_id)`. It is an exact leading prefix of the unique `(buddy_session_id, user_id)` index, so that btree already serves any standalone `buddy_session_id` predicate. **Keeps** `idx_buddy_session_calendar_events_user`. Precedent: `friendships_drop_user1_index_incremental.sql`.

## Changes

- `src/db/schema.ts`: add participants `userIdx`; remove calendar `sessionIdx`.
- New idempotent incremental migrations (auto-applied on deploy via `npm run db:migrate`):
  - `drizzle/buddy_session_participants_user_index_incremental.sql` — `CREATE INDEX IF NOT EXISTS`.
  - `drizzle/buddy_session_calendar_events_drop_session_index_incremental.sql` — `DROP INDEX IF EXISTS`.

Both are NEW incremental files (no edits to already-applied migrations), avoiding checksum drift (#368/#370). No `_journal.json` change — the journal only tracks the numbered drizzle-kit snapshot.

## Test plan

Verification uses the `pg_indexes` catalog (NOT `EXPLAIN`, since Neon small tables always seq-scan), run against in-process Postgres (PGlite):

1. **Migration DDL** — reproduced the pre-PR production index set, applied both new `*.sql` files **twice** (idempotency), then queried `pg_indexes`:
   - `idx_buddy_session_participants_user` EXISTS (#383)
   - `idx_buddy_session_calendar_events_session` DROPPED (#384)
   - `idx_buddy_session_calendar_events_user` + both unique indexes KEPT
   - identical after pass 2 → idempotent
2. **No schema drift** — pushed `src/db/schema.ts` into a fresh DB and confirmed the same `pg_indexes` result, so schema and migrations agree.
3. `npx tsc --noEmit` clean; existing buddy integration test (`record-personal-session/route.integration.test.ts`) passes (it pushes `schema.ts`).

## Dependencies / merge gate

Migration journal: land after/before other migration PRs, not simultaneously (avoids concurrent ledger churn).

Closes #383, Closes #384
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a289baf0-c52b-4529-9f04-eb3be272ba75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a289baf0-c52b-4529-9f04-eb3be272ba75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Improve buddy calendar lookups and keep the calendar-events index removal effective**

### What Changed
- Added an index for `buddy_session_participants.user_id` so user-based buddy calendar lookups and account-deletion cleanup run against a matching index.
- Removed the separate `buddy_session_calendar_events.buddy_session_id` index because the existing session-and-user index already covers those lookups.
- Added a follow-up drop so the removed calendar-events index stays absent on all deploy paths, including greenfield and backfill runs.

### Impact
`✅ Faster buddy calendar lookups`
`✅ Faster account deletion cleanup`
`✅ Smaller index footprint on calendar events`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
