### PR TITLE
fix(buddy): make a partner's tick audible on their own device (autoplay unlock)

### DIFF
--- a/src/components/BuddySessionRoom.tsx
+++ b/src/components/BuddySessionRoom.tsx
@@ -1398,7 +1398,8 @@ export function BuddySessionRoom({
                       textAlign: "center",
                     }}
                   >
-                    The timer is shared. Tick, chime, and end sounds are local to this device.
+                    The timer is shared. Tick, chime, and end sounds play only on this device — if
+                    your buddy turns them on too, they stay naturally aligned by the shared timer.
                   </p>
                   {audioBlocked && (
                     <p

--- a/src/lib/audio.test.ts
+++ b/src/lib/audio.test.ts
@@ -185,9 +185,13 @@ describe("unlockAudioContext — autoplay policy", () => {
         throw new Error("createBufferSource not implemented");
       }
     };
-    const { unlockAudioContext } = await loadAudio({ ctor: throwingCtor });
+    const { unlockAudioContext, playTick } = await loadAudio({ ctor: throwingCtor });
 
     policy = "lenient";
+    // Create the suspended context outside a gesture so unlock takes the
+    // prime + resume() path where createBufferSource throws.
+    expect(playTick()).toBe(false);
+
     gesture.active = true;
     const result = await unlockAudioContext();
     gesture.active = false;

--- a/src/lib/audio.test.ts
+++ b/src/lib/audio.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Faithful-enough model of the Web Audio autoplay policy.
+ *
+ * - "lenient" (desktop Chrome): `resume()` invoked during a user gesture flips
+ *   the context to "running" on its own.
+ * - "strict" (iOS Safari / WebKit): `resume()` resolves but the context only
+ *   becomes "running" once a sound-producing node has actually been *started*
+ *   from within a user gesture. This is the case that left a buddy's tick
+ *   silent even after #233 added a `resume()`-only unlock (issue #131).
+ */
+type Policy = "lenient" | "strict";
+
+const gesture = { active: false };
+let policy: Policy = "strict";
+
+class MockAudioParam {
+  value = 0;
+  setValueAtTime() {}
+  exponentialRampToValueAtTime() {}
+}
+
+class MockNode {
+  connect() {}
+}
+
+class MockOscillator extends MockNode {
+  type = "sine";
+  frequency = new MockAudioParam();
+  constructor(private readonly ctx: MockAudioContext) {
+    super();
+  }
+  start() {
+    this.ctx.noteStarted();
+  }
+  stop() {}
+}
+
+class MockGain extends MockNode {
+  gain = new MockAudioParam();
+}
+
+class MockBufferSource extends MockNode {
+  buffer: unknown = null;
+  constructor(private readonly ctx: MockAudioContext) {
+    super();
+  }
+  start() {
+    this.ctx.noteStarted();
+  }
+  stop() {}
+}
+
+class MockAudioContext {
+  state: "suspended" | "running" | "closed";
+  currentTime = 0;
+  destination = new MockNode();
+  /** True once a node has been started while a user gesture was active. */
+  primedDuringGesture = false;
+
+  constructor() {
+    // A context created outside a gesture (e.g. by a silent chime attempt while
+    // the buddy timer is already running) starts suspended.
+    this.state = gesture.active ? "running" : "suspended";
+    if (gesture.active) this.primedDuringGesture = true;
+  }
+
+  noteStarted() {
+    if (gesture.active) this.primedDuringGesture = true;
+  }
+
+  createOscillator() {
+    return new MockOscillator(this);
+  }
+  createGain() {
+    return new MockGain();
+  }
+  createBufferSource() {
+    return new MockBufferSource(this);
+  }
+  createBuffer() {
+    return {};
+  }
+
+  async resume() {
+    if (policy === "lenient") {
+      if (gesture.active || this.primedDuringGesture) this.state = "running";
+    } else {
+      // strict: resume() alone is not enough — a node must have been started
+      // from within a gesture.
+      if (this.primedDuringGesture) this.state = "running";
+    }
+  }
+
+  async suspend() {
+    this.state = "suspended";
+  }
+}
+
+type AudioModule = typeof import("./audio");
+
+async function loadAudio(opts?: {
+  withAudioContext?: boolean;
+  ctor?: typeof MockAudioContext;
+}): Promise<AudioModule> {
+  const withAudioContext = opts?.withAudioContext ?? true;
+  const ctor = opts?.ctor ?? MockAudioContext;
+  vi.resetModules();
+  (globalThis as { window?: unknown }).window = withAudioContext
+    ? { AudioContext: ctor as unknown as typeof AudioContext }
+    : {};
+  return import("./audio");
+}
+
+beforeEach(() => {
+  gesture.active = false;
+  policy = "strict";
+});
+
+afterEach(() => {
+  delete (globalThis as { window?: unknown }).window;
+});
+
+describe("unlockAudioContext — autoplay policy", () => {
+  it("returns 'unavailable' when Web Audio is not supported", async () => {
+    const { unlockAudioContext } = await loadAudio({ withAudioContext: false });
+    await expect(unlockAudioContext()).resolves.toBe("unavailable");
+  });
+
+  it("desktop Chrome (lenient): toggle gesture unlocks and tick plays", async () => {
+    policy = "lenient";
+    const { unlockAudioContext, playTick } = await loadAudio();
+
+    // Before any gesture the suspended context cannot produce sound.
+    expect(playTick()).toBe(false);
+
+    gesture.active = true;
+    const result = await unlockAudioContext();
+    gesture.active = false;
+
+    expect(result).toBe("unlocked");
+    expect(playTick()).toBe(true);
+  });
+
+  it("regression: on a strict (iOS/WebKit) context, resume() alone stays silent", async () => {
+    // This reproduces the #131 silent path: #233 only called resume().
+    const ctx = new MockAudioContext(); // suspended (created outside a gesture)
+    gesture.active = true;
+    await ctx.resume(); // resume-only, no primed node
+    gesture.active = false;
+
+    expect(ctx.state).toBe("suspended"); // still blocked → buddy hears nothing
+  });
+
+  it("fix: strict (iOS/WebKit) context unlocks because the gesture primes a node", async () => {
+    const { unlockAudioContext, playTick, playChime, playCompletion } = await loadAudio();
+
+    // Simulate a silent chime attempt that lazily created the suspended context
+    // before the buddy ever interacted with the sound controls.
+    expect(playTick()).toBe(false);
+
+    // Buddy toggles tick ON → unlock runs inside the user gesture.
+    gesture.active = true;
+    const result = await unlockAudioContext();
+    gesture.active = false;
+
+    expect(result).toBe("unlocked");
+    // All synthesized sounds now reach the (running) context.
+    expect(playTick()).toBe(true);
+    expect(playChime(2)).toBe(true);
+    expect(playCompletion()).toBe(true);
+  });
+
+  it("reports 'blocked' when the gesture cannot unlock the context", async () => {
+    const { unlockAudioContext } = await loadAudio();
+    // No gesture active → strict policy keeps it suspended even after priming.
+    const result = await unlockAudioContext();
+    expect(result).toBe("blocked");
+  });
+
+  it("priming is best-effort: unlock still resolves if node creation throws", async () => {
+    const throwingCtor = class extends MockAudioContext {
+      createBufferSource(): MockBufferSource {
+        throw new Error("createBufferSource not implemented");
+      }
+    };
+    const { unlockAudioContext } = await loadAudio({ ctor: throwingCtor });
+
+    policy = "lenient";
+    gesture.active = true;
+    const result = await unlockAudioContext();
+    gesture.active = false;
+
+    expect(result).toBe("unlocked");
+  });
+});

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -29,14 +29,36 @@ function readAudioContextState(ctx: AudioContext): AudioContextState {
   return ctx.state;
 }
 
+/**
+ * Starts an inaudible 1-sample buffer on the context. On iOS Safari and other
+ * strict-autoplay browsers, calling `resume()` alone resolves but leaves the
+ * context unable to produce sound — a node must actually be started from inside
+ * the user gesture for playback to unlock. This must run synchronously within
+ * the gesture (before any `await`) to count as gesture-initiated.
+ */
+function primeAudioContext(ctx: AudioContext): void {
+  try {
+    const source = ctx.createBufferSource();
+    source.buffer = ctx.createBuffer(1, 1, 22050);
+    source.connect(ctx.destination);
+    source.start(0);
+  } catch {
+    // Best-effort: priming failures shouldn't block the resume() path.
+  }
+}
+
 export async function unlockAudioContext(): Promise<AudioUnlockResult> {
   const ctx = getAudioContext();
   if (!ctx) return "unavailable";
-  if (ctx.state === "running") return "unlocked";
-  try {
-    await ctx.resume();
-  } catch {
-    return "blocked";
+  // Prime within the user gesture first — this is what actually unlocks audio
+  // for a buddy whose context never received a sound-producing gesture.
+  primeAudioContext(ctx);
+  if (ctx.state !== "running") {
+    try {
+      await ctx.resume();
+    } catch {
+      return "blocked";
+    }
   }
   return readAudioContextState(ctx) === "running" ? "unlocked" : "blocked";
 }

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -50,10 +50,11 @@ function primeAudioContext(ctx: AudioContext): void {
 export async function unlockAudioContext(): Promise<AudioUnlockResult> {
   const ctx = getAudioContext();
   if (!ctx) return "unavailable";
-  // Prime within the user gesture first — this is what actually unlocks audio
-  // for a buddy whose context never received a sound-producing gesture.
-  primeAudioContext(ctx);
   if (ctx.state !== "running") {
+    // Prime within the user gesture before resuming — starting a node is what
+    // actually unlocks audio for a buddy whose context never received a
+    // sound-producing gesture. Skipped once the context is already running.
+    primeAudioContext(ctx);
     try {
       await ctx.resume();
     } catch {


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Closes #131

Buddy sessions keep sounds **local per device** (the locked decision — no Daily/WebSocket audio sync). The remaining defect was the *silent path*: a partner who never produced sound has a **suspended** `AudioContext`, and PR #233 unlocked it with `resume()` only. On iOS Safari / strict-autoplay browsers `resume()` resolves but the context stays silent until a sound node is actually **started from within a user gesture** — so the partner toggled tick ON, saw no error, and heard nothing.

### Changes
- `src/lib/audio.ts` — `unlockAudioContext()` now starts an inaudible 1-sample buffer (`primeAudioContext`) **synchronously inside the toggle gesture** before `resume()`. Priming is what truly unlocks playback on strict browsers; it's best-effort and wrapped in try/catch so it never blocks the `resume()` fallback.
- `src/components/BuddySessionRoom.tsx` — caption now states sounds play only on this device and stay **naturally aligned by the shared timer** when both buddies enable them (acceptance-criterion copy).
- `src/lib/audio.test.ts` — new unit tests modeling **lenient (Chrome)** and **strict (iOS/WebKit)** autoplay policies.

The existing blocked-audio banner ("Browser audio is paused — Enable local audio") already surfaces visible feedback instead of silence; this PR makes the primary toggle path actually unlock so that banner is rarely needed.

### Acceptance criteria
- [x] Decision: local-only, clarified in UI copy
- [x] A partner who toggles tick ON hears it on **their** device (silent path fixed via gesture priming)
- [x] Blocked-audio state surfaces visible feedback instead of silence (existing banner retained)

### Test plan
- ✅ `npm run test:unit` — 227 passing (6 new audio tests).
- ✅ `npm run typecheck` — clean.
- Reproduction guard: the strict-policy test fails (`blocked` → silent) when priming is removed and passes with the fix.

**Two-browser note:** the regression is iOS Safari / WebKit-specific. Desktop Chrome is *lenient* (`resume()` alone unlocks), so it would not exhibit the bug either before or after — a desktop two-browser repro can't demonstrate the fix. For a faithful manual check: open the buddy session on **iOS Safari** as the non-host partner, let the host start, then toggle **tick** ON; the tick should now be audible on the partner's device. The deterministic strict-policy unit test stands in for this on CI/VM where only desktop browsers are available.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a59acd9-81f8-49bf-a301-3504ecae933e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a59acd9-81f8-49bf-a301-3504ecae933e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio playback unlocking on stricter mobile browsers, making tick, chime, and completion sounds more reliable after you interact with the app.
  * Updated the session audio message so it more accurately describes how sounds stay in sync across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Make buddy sounds unlock on the user's device and clarify they stay local

### What Changed
- Toggling buddy sounds now reliably turns audio on even in strict autoplay browsers, so tick, chime, and end sounds actually play on that device
- The sound setting text now says sounds play only on this device and stay aligned when both buddies enable them
- Added coverage for both permissive and strict browser audio behavior, including the case where audio stays silent without a real user gesture

### Impact
`✅ Fewer silent buddy ticks`
`✅ Clearer per-device sound behavior`
`✅ Fewer audio setup failures on iPhone and Safari`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
