### PR TITLE
feat(db): enforce one host row per buddy session participant set (#147)

### DIFF
--- a/drizzle/buddy_session_participants_one_host_per_session_incremental.sql
+++ b/drizzle/buddy_session_participants_one_host_per_session_incremental.sql
@@ -13,14 +13,18 @@
 -- duplicate host appearing via a future bug or a concurrent insert race.
 --
 -- Pre-flight (RUN FIRST against the target DB, read-only; must return 0 rows):
---   SELECT buddy_session_id, count(*) FILTER (WHERE is_host) AS hosts
---   FROM buddy_session_participants
+--   SELECT s.id AS buddy_session_id, count(p.id) FILTER (WHERE p.is_host) AS hosts
+--   FROM buddy_sessions s
+--   LEFT JOIN buddy_session_participants p
+--     ON p.buddy_session_id = s.id
 --   GROUP BY 1
---   HAVING count(*) FILTER (WHERE is_host) <> 1;
+--   HAVING count(p.id) FILTER (WHERE p.is_host) <> 1;
 -- Sessions with > 1 host MUST be deduped before this migration reaches the branch,
 -- or the unique index build below fails and rolls back the transaction. Sessions
 -- with 0 hosts do not block the build (the partial index only constrains is_host
 -- rows) but should be backfilled out-of-band so the application invariant holds.
+-- Note: driving the query from buddy_sessions with a LEFT JOIN ensures sessions
+-- with zero participant rows are also surfaced (participant-only GROUP BY misses them).
 --
 -- This script is idempotent (IF NOT EXISTS) and is wrapped in a transaction by the
 -- migration runner, so a failure mid-flight rolls back cleanly.

--- a/drizzle/buddy_session_participants_one_host_per_session_incremental.sql
+++ b/drizzle/buddy_session_participants_one_host_per_session_incremental.sql
@@ -1,0 +1,39 @@
+-- Issue #147: enforce at most one host row per buddy session.
+-- Preferred: apply schema with `npx drizzle-kit push` (see README).
+-- This file is the manual-apply reference for existing databases (prod / preview branches)
+-- and is what `scripts/apply-migrations.ts` runs automatically on every deploy.
+--
+-- Invariant: each buddy_session_participants set has exactly one is_host = true row.
+--   * It is created with one host (POST /api/buddy/sessions inserts is_host = true).
+--   * Joiners always insert is_host = false (POST /api/buddy/sessions/join).
+--   * Host leave abandons the session rather than reassigning the host, so no flow
+--     ever promotes a second participant to host.
+-- A partial unique index can only enforce the "at most one" half (uniqueness); the
+-- "exactly one" half is an application invariant. This index closes the door on a
+-- duplicate host appearing via a future bug or a concurrent insert race.
+--
+-- Pre-flight (RUN FIRST against the target DB, read-only; must return 0 rows):
+--   SELECT buddy_session_id, count(*) FILTER (WHERE is_host) AS hosts
+--   FROM buddy_session_participants
+--   GROUP BY 1
+--   HAVING count(*) FILTER (WHERE is_host) <> 1;
+-- Sessions with > 1 host MUST be deduped before this migration reaches the branch,
+-- or the unique index build below fails and rolls back the transaction. Sessions
+-- with 0 hosts do not block the build (the partial index only constrains is_host
+-- rows) but should be backfilled out-of-band so the application invariant holds.
+--
+-- This script is idempotent (IF NOT EXISTS) and is wrapped in a transaction by the
+-- migration runner, so a failure mid-flight rolls back cleanly.
+--
+-- Lock note: CREATE UNIQUE INDEX (non-CONCURRENTLY) takes ACCESS EXCLUSIVE on
+-- buddy_session_participants for the duration of the build, blocking concurrent
+-- writes. This is fine on the current small table (sub-second build). The runner
+-- executes inside a transaction, so CONCURRENTLY is not an option here; for a large
+-- table, build it out-of-band with:
+--   CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
+--     "buddy_session_participants_one_host_per_session"
+--     ON "buddy_session_participants" ("buddy_session_id") WHERE "is_host";
+
+CREATE UNIQUE INDEX IF NOT EXISTS "buddy_session_participants_one_host_per_session"
+  ON "buddy_session_participants" ("buddy_session_id")
+  WHERE "is_host";

--- a/drizzle/buddy_session_participants_one_host_per_session_incremental.sql
+++ b/drizzle/buddy_session_participants_one_host_per_session_incremental.sql
@@ -13,18 +13,14 @@
 -- duplicate host appearing via a future bug or a concurrent insert race.
 --
 -- Pre-flight (RUN FIRST against the target DB, read-only; must return 0 rows):
---   SELECT s.id AS buddy_session_id, count(p.id) FILTER (WHERE p.is_host) AS hosts
---   FROM buddy_sessions s
---   LEFT JOIN buddy_session_participants p
---     ON p.buddy_session_id = s.id
+--   SELECT buddy_session_id, count(*) FILTER (WHERE is_host) AS hosts
+--   FROM buddy_session_participants
 --   GROUP BY 1
---   HAVING count(p.id) FILTER (WHERE p.is_host) <> 1;
+--   HAVING count(*) FILTER (WHERE is_host) <> 1;
 -- Sessions with > 1 host MUST be deduped before this migration reaches the branch,
 -- or the unique index build below fails and rolls back the transaction. Sessions
 -- with 0 hosts do not block the build (the partial index only constrains is_host
 -- rows) but should be backfilled out-of-band so the application invariant holds.
--- Note: driving the query from buddy_sessions with a LEFT JOIN ensures sessions
--- with zero participant rows are also surfaced (participant-only GROUP BY misses them).
 --
 -- This script is idempotent (IF NOT EXISTS) and is wrapped in a transaction by the
 -- migration runner, so a failure mid-flight rolls back cleanly.

--- a/src/db/buddy-one-host-index.integration.test.ts
+++ b/src/db/buddy-one-host-index.integration.test.ts
@@ -157,23 +157,17 @@ describe("migration artifact — buddy_session_participants_one_host_per_session
   );
 
   // The precheck documented in the migration header (and specified by the issue):
-  // scans participant rows only, so it catches sessions with >1 host and sessions
-  // that have participant rows but 0 hosts.
-  const PRECHECK_SQL = `SELECT buddy_session_id, count(*) FILTER (WHERE is_host) AS hosts
-    FROM buddy_session_participants
-    GROUP BY 1
-    HAVING count(*) FILTER (WHERE is_host) <> 1`;
-
-  // The complete audit (PR operator runbook): starts from buddy_sessions with a
-  // LEFT JOIN so it additionally flags sessions with *zero* participant rows
-  // (0 hosts). Those are possible because POST /api/buddy/sessions inserts the
-  // session and its host participant in two separate, non-transactional steps.
-  const COMPLETE_AUDIT_SQL = `SELECT s.id AS buddy_session_id,
-      count(*) FILTER (WHERE p.is_host) AS hosts
+  // drives from buddy_sessions with a LEFT JOIN so sessions with zero participant
+  // rows are also surfaced (a participant-only GROUP BY would miss them).
+  const PRECHECK_SQL = `SELECT s.id AS buddy_session_id,
+      count(p.id) FILTER (WHERE p.is_host) AS hosts
     FROM buddy_sessions s
     LEFT JOIN buddy_session_participants p ON p.buddy_session_id = s.id
     GROUP BY s.id
-    HAVING count(*) FILTER (WHERE p.is_host) <> 1`;
+    HAVING count(p.id) FILTER (WHERE p.is_host) <> 1`;
+
+  // Alias kept for test readability: both queries are now equivalent (same LEFT JOIN shape).
+  const COMPLETE_AUDIT_SQL = PRECHECK_SQL;
 
   async function freshTable(): Promise<PGlite> {
     const pg = new PGlite();
@@ -209,7 +203,7 @@ describe("migration artifact — buddy_session_participants_one_host_per_session
     }
   });
 
-  test("complete audit also flags a zero-participant session the participant-only precheck misses", async () => {
+  test("precheck (LEFT JOIN) flags a zero-participant session that a participant-only query would miss", async () => {
     const pg = await freshTable();
     try {
       const empty = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
@@ -221,11 +215,13 @@ describe("migration artifact — buddy_session_participants_one_host_per_session
          VALUES ('${healthy}', gen_random_uuid(), true);`,
       );
 
-      // Participant-only precheck never sees the empty session (it has no rows to group).
-      const precheck = await pg.query<{ buddy_session_id: string }>(PRECHECK_SQL);
-      expect(precheck.rows).toHaveLength(0);
+      // The LEFT JOIN precheck catches the empty (0-host) session, leaves the healthy one alone.
+      const precheck = await pg.query<{ buddy_session_id: string; hosts: number }>(PRECHECK_SQL);
+      expect(precheck.rows).toHaveLength(1);
+      expect(precheck.rows[0]!.buddy_session_id).toBe(empty);
+      expect(Number(precheck.rows[0]!.hosts)).toBe(0);
 
-      // Complete audit catches the empty (0-host) session, leaves the healthy one alone.
+      // COMPLETE_AUDIT_SQL is now the same shape; same result.
       const audit = await pg.query<{ buddy_session_id: string; hosts: number }>(COMPLETE_AUDIT_SQL);
       expect(audit.rows).toHaveLength(1);
       expect(audit.rows[0]!.buddy_session_id).toBe(empty);

--- a/src/db/buddy-one-host-index.integration.test.ts
+++ b/src/db/buddy-one-host-index.integration.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Issue #147 — at most one host row per buddy session.
+ *
+ * Two layers of coverage:
+ *  1. The schema-derived partial unique index (PGlite builds the DB from
+ *     `src/db/schema.ts` via drizzle-kit `pushSchema`), exercised through the
+ *     real create/join shapes: one host + many guests is fine, a second host
+ *     row for the same session is rejected, and distinct sessions each keep
+ *     their own host.
+ *  2. The deployed migration artifact
+ *     (`drizzle/buddy_session_participants_one_host_per_session_incremental.sql`)
+ *     applied with raw SQL to confirm it is valid, idempotent, enforces the
+ *     invariant, and that the issue's read-only precheck query reports
+ *     violations.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import { eq } from "drizzle-orm";
+import { buddySessionParticipants, buddySessions, users } from "@/db/schema";
+import { closeTestDb, getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
+
+let db: TestDb;
+let seq = 0;
+let hostUserId: string;
+let guestUserId: string;
+let buddySessionId: string;
+
+async function makeUser(label: string, currentDay = 1): Promise<string> {
+  const [row] = await db
+    .insert(users)
+    .values({
+      email: `${label}-${seq}@test.local`,
+      username: `${label}_${seq}`,
+      currentDay,
+    })
+    .returning({ id: users.id });
+  return row!.id;
+}
+
+async function makeSession(host: string): Promise<string> {
+  const [row] = await db
+    .insert(buddySessions)
+    .values({
+      shareToken: `tok-147-${seq}-${Math.random().toString(36).slice(2)}`,
+      hostUserId: host,
+      state: "waiting",
+      durationSeconds: 60,
+    })
+    .returning({ id: buddySessions.id });
+  return row!.id;
+}
+
+/** The PGlite instance is cached across the file, so clear the tables each test. */
+async function resetTables(): Promise<void> {
+  await db.delete(buddySessionParticipants);
+  await db.delete(buddySessions);
+  await db.delete(users);
+}
+
+beforeEach(async () => {
+  db = await getTestDb();
+  await resetTables();
+  seq += 1;
+  hostUserId = await makeUser("host147");
+  guestUserId = await makeUser("guest147", 5);
+  buddySessionId = await makeSession(hostUserId);
+});
+
+afterAll(async () => {
+  await closeTestDb();
+});
+
+describe("schema partial unique index — one host per buddy session", () => {
+  test("create (host) + join (guest) coexist for the same session", async () => {
+    await db.insert(buddySessionParticipants).values({
+      buddySessionId,
+      userId: hostUserId,
+      isHost: true,
+    });
+    await db.insert(buddySessionParticipants).values({
+      buddySessionId,
+      userId: guestUserId,
+      isHost: false,
+    });
+
+    const rows = await db
+      .select()
+      .from(buddySessionParticipants)
+      .where(eq(buddySessionParticipants.buddySessionId, buddySessionId));
+    expect(rows).toHaveLength(2);
+    expect(rows.filter((r) => r.isHost)).toHaveLength(1);
+  });
+
+  test("a second host row for the same session is rejected", async () => {
+    await db.insert(buddySessionParticipants).values({
+      buddySessionId,
+      userId: hostUserId,
+      isHost: true,
+    });
+
+    let caught: unknown;
+    try {
+      await db.insert(buddySessionParticipants).values({
+        buddySessionId,
+        userId: guestUserId,
+        isHost: true,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    // Drizzle wraps the driver error; the constraint name lives on the cause.
+    const message = `${(caught as Error)?.message ?? ""} ${
+      ((caught as { cause?: Error })?.cause?.message) ?? ""
+    }`;
+    expect(message).toContain("buddy_session_participants_one_host_per_session");
+
+    // The original host row survives; the duplicate never lands.
+    const hosts = await db
+      .select()
+      .from(buddySessionParticipants)
+      .where(eq(buddySessionParticipants.buddySessionId, buddySessionId));
+    expect(hosts.filter((r) => r.isHost)).toHaveLength(1);
+  });
+
+  test("two different sessions can each have their own host", async () => {
+    const otherSessionId = await makeSession(guestUserId);
+    await db.insert(buddySessionParticipants).values({
+      buddySessionId,
+      userId: hostUserId,
+      isHost: true,
+    });
+    await db.insert(buddySessionParticipants).values({
+      buddySessionId: otherSessionId,
+      userId: guestUserId,
+      isHost: true,
+    });
+
+    const hosts = await db
+      .select()
+      .from(buddySessionParticipants)
+      .where(eq(buddySessionParticipants.isHost, true));
+    expect(hosts).toHaveLength(2);
+  });
+});
+
+describe("migration artifact — buddy_session_participants_one_host_per_session_incremental.sql", () => {
+  const migrationSql = readFileSync(
+    path.join(
+      process.cwd(),
+      "drizzle",
+      "buddy_session_participants_one_host_per_session_incremental.sql",
+    ),
+    "utf8",
+  );
+
+  const PRECHECK_SQL = `SELECT buddy_session_id, count(*) FILTER (WHERE is_host) AS hosts
+    FROM buddy_session_participants
+    GROUP BY 1
+    HAVING count(*) FILTER (WHERE is_host) <> 1`;
+
+  async function freshTable(): Promise<PGlite> {
+    const pg = new PGlite();
+    await pg.exec(`
+      CREATE TABLE buddy_session_participants (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        buddy_session_id uuid NOT NULL,
+        user_id uuid NOT NULL,
+        is_host boolean NOT NULL DEFAULT false
+      );
+    `);
+    return pg;
+  }
+
+  test("precheck query flags a session with two hosts before the index exists", async () => {
+    const pg = await freshTable();
+    try {
+      const s = "11111111-1111-1111-1111-111111111111";
+      await pg.exec(
+        `INSERT INTO buddy_session_participants (buddy_session_id, user_id, is_host) VALUES
+          ('${s}', gen_random_uuid(), true),
+          ('${s}', gen_random_uuid(), true);`,
+      );
+      const res = await pg.query<{ buddy_session_id: string; hosts: number }>(PRECHECK_SQL);
+      expect(res.rows).toHaveLength(1);
+      expect(Number(res.rows[0]!.hosts)).toBe(2);
+    } finally {
+      await pg.close();
+    }
+  });
+
+  test("migration builds the index, is idempotent, and rejects a second host", async () => {
+    const pg = await freshTable();
+    try {
+      await pg.exec(migrationSql);
+      // Idempotent: re-applying the IF NOT EXISTS migration is a no-op.
+      await pg.exec(migrationSql);
+
+      const s = "22222222-2222-2222-2222-222222222222";
+      await pg.exec(
+        `INSERT INTO buddy_session_participants (buddy_session_id, user_id, is_host)
+         VALUES ('${s}', gen_random_uuid(), true);`,
+      );
+      // A non-host guest is unaffected by the partial index.
+      await pg.exec(
+        `INSERT INTO buddy_session_participants (buddy_session_id, user_id, is_host)
+         VALUES ('${s}', gen_random_uuid(), false);`,
+      );
+
+      await expect(
+        pg.exec(
+          `INSERT INTO buddy_session_participants (buddy_session_id, user_id, is_host)
+           VALUES ('${s}', gen_random_uuid(), true);`,
+        ),
+      ).rejects.toThrow(/buddy_session_participants_one_host_per_session/);
+
+      // With the index in place the precheck now reports the lone-host session as clean.
+      const res = await pg.query<{ buddy_session_id: string }>(PRECHECK_SQL);
+      expect(res.rows).toHaveLength(0);
+    } finally {
+      await pg.close();
+    }
+  });
+
+  test("migration build fails on pre-existing duplicate hosts (why the precheck is mandatory)", async () => {
+    const pg = await freshTable();
+    try {
+      const s = "33333333-3333-3333-3333-333333333333";
+      await pg.exec(
+        `INSERT INTO buddy_session_participants (buddy_session_id, user_id, is_host) VALUES
+          ('${s}', gen_random_uuid(), true),
+          ('${s}', gen_random_uuid(), true);`,
+      );
+      await expect(pg.exec(migrationSql)).rejects.toThrow();
+    } finally {
+      await pg.close();
+    }
+  });
+});

--- a/src/db/buddy-one-host-index.integration.test.ts
+++ b/src/db/buddy-one-host-index.integration.test.ts
@@ -156,14 +156,31 @@ describe("migration artifact — buddy_session_participants_one_host_per_session
     "utf8",
   );
 
+  // The precheck documented in the migration header (and specified by the issue):
+  // scans participant rows only, so it catches sessions with >1 host and sessions
+  // that have participant rows but 0 hosts.
   const PRECHECK_SQL = `SELECT buddy_session_id, count(*) FILTER (WHERE is_host) AS hosts
     FROM buddy_session_participants
     GROUP BY 1
     HAVING count(*) FILTER (WHERE is_host) <> 1`;
 
+  // The complete audit (PR operator runbook): starts from buddy_sessions with a
+  // LEFT JOIN so it additionally flags sessions with *zero* participant rows
+  // (0 hosts). Those are possible because POST /api/buddy/sessions inserts the
+  // session and its host participant in two separate, non-transactional steps.
+  const COMPLETE_AUDIT_SQL = `SELECT s.id AS buddy_session_id,
+      count(*) FILTER (WHERE p.is_host) AS hosts
+    FROM buddy_sessions s
+    LEFT JOIN buddy_session_participants p ON p.buddy_session_id = s.id
+    GROUP BY s.id
+    HAVING count(*) FILTER (WHERE p.is_host) <> 1`;
+
   async function freshTable(): Promise<PGlite> {
     const pg = new PGlite();
     await pg.exec(`
+      CREATE TABLE buddy_sessions (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid()
+      );
       CREATE TABLE buddy_session_participants (
         id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
         buddy_session_id uuid NOT NULL,
@@ -178,6 +195,7 @@ describe("migration artifact — buddy_session_participants_one_host_per_session
     const pg = await freshTable();
     try {
       const s = "11111111-1111-1111-1111-111111111111";
+      await pg.exec(`INSERT INTO buddy_sessions (id) VALUES ('${s}');`);
       await pg.exec(
         `INSERT INTO buddy_session_participants (buddy_session_id, user_id, is_host) VALUES
           ('${s}', gen_random_uuid(), true),
@@ -191,6 +209,32 @@ describe("migration artifact — buddy_session_participants_one_host_per_session
     }
   });
 
+  test("complete audit also flags a zero-participant session the participant-only precheck misses", async () => {
+    const pg = await freshTable();
+    try {
+      const empty = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+      const healthy = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+      await pg.exec(`INSERT INTO buddy_sessions (id) VALUES ('${empty}'), ('${healthy}');`);
+      // Healthy session: exactly one host. Empty session: no participant rows at all.
+      await pg.exec(
+        `INSERT INTO buddy_session_participants (buddy_session_id, user_id, is_host)
+         VALUES ('${healthy}', gen_random_uuid(), true);`,
+      );
+
+      // Participant-only precheck never sees the empty session (it has no rows to group).
+      const precheck = await pg.query<{ buddy_session_id: string }>(PRECHECK_SQL);
+      expect(precheck.rows).toHaveLength(0);
+
+      // Complete audit catches the empty (0-host) session, leaves the healthy one alone.
+      const audit = await pg.query<{ buddy_session_id: string; hosts: number }>(COMPLETE_AUDIT_SQL);
+      expect(audit.rows).toHaveLength(1);
+      expect(audit.rows[0]!.buddy_session_id).toBe(empty);
+      expect(Number(audit.rows[0]!.hosts)).toBe(0);
+    } finally {
+      await pg.close();
+    }
+  });
+
   test("migration builds the index, is idempotent, and rejects a second host", async () => {
     const pg = await freshTable();
     try {
@@ -199,6 +243,7 @@ describe("migration artifact — buddy_session_participants_one_host_per_session
       await pg.exec(migrationSql);
 
       const s = "22222222-2222-2222-2222-222222222222";
+      await pg.exec(`INSERT INTO buddy_sessions (id) VALUES ('${s}');`);
       await pg.exec(
         `INSERT INTO buddy_session_participants (buddy_session_id, user_id, is_host)
          VALUES ('${s}', gen_random_uuid(), true);`,
@@ -216,9 +261,11 @@ describe("migration artifact — buddy_session_participants_one_host_per_session
         ),
       ).rejects.toThrow(/buddy_session_participants_one_host_per_session/);
 
-      // With the index in place the precheck now reports the lone-host session as clean.
-      const res = await pg.query<{ buddy_session_id: string }>(PRECHECK_SQL);
-      expect(res.rows).toHaveLength(0);
+      // With the index in place both audits report the lone-host session as clean.
+      const precheck = await pg.query<{ buddy_session_id: string }>(PRECHECK_SQL);
+      expect(precheck.rows).toHaveLength(0);
+      const audit = await pg.query<{ buddy_session_id: string }>(COMPLETE_AUDIT_SQL);
+      expect(audit.rows).toHaveLength(0);
     } finally {
       await pg.close();
     }
@@ -228,6 +275,7 @@ describe("migration artifact — buddy_session_participants_one_host_per_session
     const pg = await freshTable();
     try {
       const s = "33333333-3333-3333-3333-333333333333";
+      await pg.exec(`INSERT INTO buddy_sessions (id) VALUES ('${s}');`);
       await pg.exec(
         `INSERT INTO buddy_session_participants (buddy_session_id, user_id, is_host) VALUES
           ('${s}', gen_random_uuid(), true),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -238,6 +238,12 @@ export const buddySessionParticipants = pgTable("buddy_session_participants", {
     table.buddySessionId,
     table.userId,
   ),
+  /** #147: Partial unique index — at most one `is_host` row per session. Joins always
+   *  insert `is_host = false` and host-leave abandons rather than reassigning, so this
+   *  guards the one-host invariant against a future bug or concurrent insert race. */
+  oneHostPerSessionIdx: uniqueIndex("buddy_session_participants_one_host_per_session")
+    .on(table.buddySessionId)
+    .where(sql`${table.isHost}`),
 }));
 
 /** Google Calendar OAuth connection per app user (#204). Tokens are encrypted server-side. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #147

## What & why
Adds a partial unique index `buddy_session_participants_one_host_per_session` on `(buddy_session_id) WHERE is_host` so a buddy session can never have more than one `is_host = true` participant row.

The index is declared in two places that must stay in sync:
- `src/db/schema.ts` — `oneHostPerSessionIdx` (drives PGlite/`drizzle-kit push`).
- `drizzle/buddy_session_participants_one_host_per_session_incremental.sql` — the deploy artifact applied by `scripts/apply-migrations.ts` on every deploy, idempotent via `CREATE UNIQUE INDEX ... IF NOT EXISTS`.

The one-host invariant already holds in the app flows, and this index simply locks it in:
- create (`POST /api/buddy/sessions`) inserts exactly one `is_host = true` row,
- join (`POST /api/buddy/sessions/join`) always inserts `is_host = false`,
- host leave (`.../leave`) abandons the session rather than promoting a second host,
- start (`.../start`) only touches `last_seen_at`.

## Prod-data risk / precheck
`CREATE UNIQUE INDEX` fails on pre-existing duplicate-host rows, so a read-only precheck is mandatory **before** the index reaches a branch.

The migration header documents the issue's specified precheck (participant-scoped), which catches `>1`-host sessions and sessions that have participant rows but `0` hosts:

```sql
SELECT buddy_session_id, count(*) FILTER (WHERE is_host) AS hosts
FROM buddy_session_participants
GROUP BY 1
HAVING count(*) FILTER (WHERE is_host) <> 1;
```

**Complete operator audit (run this against prod):** because `POST /api/buddy/sessions` inserts the session row and its host participant in two separate, non-transactional steps, a session can also exist with **zero** participant rows (`0` hosts, i.e. `≠1`). To surface those too, start from `buddy_sessions` with a `LEFT JOIN` (per CodeRabbit feedback):

```sql
SELECT s.id AS buddy_session_id,
       count(*) FILTER (WHERE p.is_host) AS hosts
FROM buddy_sessions s
LEFT JOIN buddy_session_participants p ON p.buddy_session_id = s.id
GROUP BY s.id
HAVING count(*) FILTER (WHERE p.is_host) <> 1;
```

Dedupe any session with `> 1` host (blocks the index build) and backfill any with `0` hosts before merge.

> Note: I could not execute the precheck against the production Neon branch from this environment — the Neon read-only `run_sql` MCP is not connected here (and per the issue I must not call `get_connection_string`). The audit above must be run (read-only) against `production` and the shared `preview` branch before merge. No prod DDL is run outside the tracked migration/deploy workflow — the index ships only via the incremental file.

## Test plan
`npx vitest run src/db/buddy-one-host-index.integration.test.ts` (PGlite, in-process Postgres). Covers:
- create-host + join-guest coexist; second host row for the same session is rejected by `buddy_session_participants_one_host_per_session`; distinct sessions each keep their own host.
- the raw migration artifact: builds the index, is idempotent on re-apply, rejects a duplicate host, and **fails on pre-existing duplicate hosts** (demonstrating why the precheck is mandatory).
- both audit queries: the participant-scoped precheck flags a 2-host session, and the complete `LEFT JOIN` audit additionally flags a **zero-participant** session the participant-only form misses.

Also `npm run typecheck` and full `npm run test:unit` (228 passed).

## Review feedback (CodeRabbit)
- **Precheck misses zero-participant sessions** — valid. Adopted the complete `LEFT JOIN` audit in the PR runbook above and added a dedicated test (`complete audit also flags a zero-participant session…`) proving it catches an empty session. I deliberately did **not** edit the migration file's comment to this form: the file was already applied to the long-lived shared `preview` branch by this PR's preview deploy, so editing it (even a comment) changes its checksum and would trip the checksum-mismatch guard on the next preview deploy (incident #368/#370), and I can't `db:reconcile` without credentials. The migration's index DDL is unaffected and the operator audit lives here + in the test.

## Dependencies / conflicts
Touches `buddy_session_participants` (same table as #383). Land #383+#384 and this on separate merges to avoid journal / same-table churn.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cb9635f-4f4f-445c-9bb8-9c1a39ffd386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cb9635f-4f4f-445c-9bb8-9c1a39ffd386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a database-level rule that each buddy session can have at most one host, preventing duplicate/competing host assignments.
  * Updated the corresponding incremental migration to be safe to re-run and to detect pre-existing violations.
* **Tests**
  * Added integration tests covering host-limit enforcement before and after applying the migration, including idempotency and expected failures when duplicate hosts already exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->