### PR TITLE
ci(web-e2e): apply same smart-retry classifier to web lanes

### DIFF
--- a/docs/testing/e2e-policy.md
+++ b/docs/testing/e2e-policy.md
@@ -37,7 +37,13 @@ Rules:
 
 Note: detecting "same stack across attempts" (a stricter, repeated-crash signal) is intentionally out-of-scope — it would require diffing per-attempt diagnostic reports across runs (see [#324](https://github.com/auerbachb/still-point/issues/324)). Repeated identical simulator crashes will currently consume the full retry budget, then fail through the default branch; if cross-attempt stack-identity detection becomes important, file a follow-up.
 
-Web lanes still rely on Playwright's own retry handling.
+**Enforcement (web lanes):** `scripts/e2e/run-playwright-lane.mjs` runs Playwright with `--retries 0` and owns retries itself at the **whole-lane** level (not Playwright's per-test reporter), so a single non-retriable failure fails the lane fast instead of silently re-running. Each attempt tees its output to `artifacts/e2e/web/<lane>/attempt-<N>.log` and creates a start-of-attempt sentinel `artifacts/e2e/web/<lane>/attempt-<N>.start` (its mtime is fixed at attempt start — crash dumps are compared against it, never against the tee'd log whose mtime keeps advancing). After a failed attempt the runner consults `scripts/e2e/classify-web-failure.mjs`, which mirrors the iOS precedence:
+
+1. **Crash / browser-loss first** — if `$E2E_WEB_CRASH_DIR` (when set) holds a crash dump newer than the attempt-start sentinel, **or** the log shows a browser-process loss signature (`Target ... has been closed/crashed`, `Page crashed`, `Browser closed unexpectedly`, `browserType.launch:` failures, `Executable doesn't exist`), the failure is treated as infra and consumes a retry **regardless of any concurrent `expect(...)` line** — a crashed browser commonly surfaces as a failed assertion.
+2. **Non-retriable assertion / contract check second** — Playwright `expect(...)` failures (assertion mismatches **and** selector-contract drift both surface as `expect(locator).toBeVisible() failed`), visual/snapshot mismatches (`Screenshot comparison failed`, `toMatchSnapshot`/`toHaveScreenshot`), and schema/data-contract violations (`ZodError`, `…SchemaError`) exit the lane without consuming the retry budget.
+3. **Default** — any other failure (network timeouts such as `net::ERR_*`/`ECONNREFUSED`, dev-server boot stalls, runner disconnects, unknown crashes) is retriable up to the table value.
+
+Web intentionally diverges from iOS in one place: iOS treats timeout-shaped UI waits as auto-retriable, but web does **not**, because selector-contract drift is non-retriable here and presents as an `expect(...)` failure. Action/navigation `TimeoutError`s that are not `expect(...)` failures still fall through to the retriable default.
 
 ## 2) Test data isolation policy
 

--- a/scripts/e2e/classify-web-failure.mjs
+++ b/scripts/e2e/classify-web-failure.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+/**
+ * Web (Playwright) failure classifier — the web counterpart of the iOS
+ * `is_retriable_failure()` shell function in `scripts/e2e/run-ios-tests.sh`.
+ *
+ * Given a failed Playwright attempt log, decide whether the failure looks
+ * transient/infra (retriable — consume the retry budget) or carries a known
+ * assertion / contract signature (non-retriable — fail the lane fast without
+ * burning a retry). Aligns with the "Non-retriable failures" column in
+ * docs/testing/e2e-policy.md Section 1.
+ *
+ * Precedence mirrors iOS exactly:
+ *   1. Crash / browser-loss FIRST — a browser-process crash can surface as a
+ *      failed `expect(...)`; like the iOS crash-report check it overrides any
+ *      assertion-shaped line in the log, so it is evaluated before the strict
+ *      assertion check. Two inputs: (a) a crash-dump directory scanned for
+ *      files newer than the attempt-start sentinel (see `attemptMarker`), and
+ *      (b) browser-loss signatures in the log itself.
+ *   2. Non-retriable assertion / contract patterns — `expect(...)` failures
+ *      (assertion mismatch AND selector-contract drift both surface this way in
+ *      Playwright), snapshot/visual mismatches, and schema/data-contract errors
+ *      → exit fast, do NOT consume retry budget.
+ *   3. Default — everything else (network timeouts, runner disconnects, unknown
+ *      crashes) is retriable and consumes the budget.
+ *
+ * Web intentionally diverges from iOS in one place: iOS treats timeout-shaped
+ * UI waits as auto-retriable (tier 2). Web does NOT, because selector-contract
+ * drift is non-retriable per policy and shows up as `expect(locator).toBeVisible()
+ * failed`. Action/navigation `TimeoutError`s that are NOT expect failures still
+ * fall through to the retriable default.
+ *
+ * Usage (CLI):
+ *   node scripts/e2e/classify-web-failure.mjs <attempt-log> [attempt-marker]
+ *   exit 0 => retriable, exit 1 => non-retriable (matches iOS return codes).
+ *
+ * Usage (module):
+ *   import { classifyWebFailure } from "./classify-web-failure.mjs";
+ *   const { retriable, reason } = await classifyWebFailure({ logPath, attemptMarker });
+ */
+import { readFile, stat, readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Tier 1a — browser-process loss / crash signatures (retriable, overrides
+// any concurrent assertion line, same spirit as the iOS crash-report check).
+const BROWSER_CRASH_PATTERNS = [
+  /Target (?:page, context or browser has been closed|closed|crashed)/i,
+  /Browser(?:Type|Context)?[^\n]*?(?:closed unexpectedly|has been closed|has crashed)/i,
+  /\bPage crashed\b/i,
+  /browserType\.launch[:!]/i,
+  /Failed to launch[^\n]*?(?:browser|chromium|webkit|firefox)/i,
+  /Executable doesn'?t exist/i,
+  /Protocol error[^\n]*?(?:Target closed|Connection closed)/i,
+];
+
+// Tier 2 — non-retriable assertion / contract signatures. A failure matching
+// any of these is a real product/test bug; fail fast without a retry.
+const NON_RETRIABLE_PATTERNS = [
+  // Playwright expect() matcher failures. Covers both assertion mismatches
+  // (`expect(received).toBe(...)`) and selector-contract drift, which surfaces
+  // as `expect(locator).toBeVisible() failed`. Requiring the trailing `failed`
+  // (or the `Error: expect(` header) avoids matching the test's own source
+  // lines, which Playwright echoes in its code frame.
+  /Error:\s*expect(?:\.\w+)?\(/,
+  /\bexpect(?:\.\w+)?\([^\n]*\)[^\n]*\bfailed\b/i,
+  // Soft-assertion summary emitted by expect.soft on teardown.
+  /\d+ soft assertions? failed/i,
+  // Visual / snapshot baselines.
+  /Screenshot comparison failed/i,
+  /toMatchSnapshot|toHaveScreenshot/i,
+  /A snapshot doesn'?t (?:exist|match)/i,
+  // Schema / data-contract violations.
+  /\bZodError\b/,
+  /\b(?:Schema|Validation)Error\b/,
+  /does not (?:match|conform to)[^\n]*schema/i,
+];
+
+// Tier 3 (labelling only) — known transient/infra signatures. These are
+// retriable just like the default branch, but matching one yields a clearer
+// reason string in logs/artifacts.
+const TRANSIENT_PATTERNS = [
+  /net::ERR_[A-Z_]+/,
+  /\b(?:ECONNREFUSED|ECONNRESET|ETIMEDOUT|EAI_AGAIN|EPIPE)\b/,
+  /socket hang up/i,
+  /WebSocket (?:error|closed|connection closed)/i,
+  /Timed out waiting [^\n]*web server/i,
+  /Process from config\.webServer (?:was not able to start|exited)/i,
+  /(?:navigation|action) timeout|Timeout \d+ms exceeded/i,
+];
+
+// Crash-dump file shapes worth treating as a browser/runner crash on Linux/CI.
+const CRASH_FILE_PATTERN = /(?:\.dmp$|\.ips$|^core(?:\.\d+)?$|crash|minidump)/i;
+
+// Playwright colorizes output (FORCE_COLOR in CI), so strip ANSI escapes before
+// matching or `Error: \x1b[2mexpect(` would slip past anchored patterns.
+// eslint-disable-next-line no-control-regex
+const ANSI_PATTERN = /\u001B\[[0-9;]*m/g;
+
+// Playwright prints a source code frame for the failing test, e.g.
+// `> 15 |   await expect(page.getByRole(...)).toBeVisible({`. Those echoed
+// source lines must NOT be classified — the failure shape lives in the
+// `Error:` lines, not in the test's own source. Drop code-frame lines (with or
+// without the `>` pointer and the `^` caret line) before matching.
+const CODE_FRAME_LINE = /^\s*(?:>\s*)?\d+\s*\|/;
+const CARET_LINE = /^\s*\|\s*\^?\s*$/;
+
+function normalizeLog(raw) {
+  return raw
+    .replace(ANSI_PATTERN, "")
+    .split("\n")
+    .filter((line) => !CODE_FRAME_LINE.test(line) && !CARET_LINE.test(line))
+    .join("\n");
+}
+
+function firstMatch(haystack, patterns) {
+  for (const pattern of patterns) {
+    const match = haystack.match(pattern);
+    if (match) {
+      return match[0];
+    }
+  }
+  return null;
+}
+
+/**
+ * Returns true if `crashDir` contains a file whose mtime is newer than the
+ * attempt-start sentinel. The sentinel MUST be created before the attempt
+ * starts: comparing against the tee'd attempt log is wrong because `tee` keeps
+ * advancing the log's mtime until the browser exits, so a crash dump written
+ * mid-run can end up "older" than the log and be missed.
+ */
+async function hasNewerCrashDump(crashDir, attemptMarker) {
+  if (!crashDir || !attemptMarker) {
+    return false;
+  }
+  let sinceMs;
+  try {
+    sinceMs = (await stat(attemptMarker)).mtimeMs;
+  } catch {
+    return false;
+  }
+
+  async function walk(dir, depth) {
+    if (depth < 0) {
+      return false;
+    }
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return false;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (await walk(full, depth - 1)) {
+          return true;
+        }
+        continue;
+      }
+      if (!CRASH_FILE_PATTERN.test(entry.name)) {
+        continue;
+      }
+      try {
+        if ((await stat(full)).mtimeMs > sinceMs) {
+          return true;
+        }
+      } catch {
+        // ignore unreadable entries
+      }
+    }
+    return false;
+  }
+
+  return walk(crashDir, 4);
+}
+
+/**
+ * Classify a failed Playwright attempt.
+ * @param {object} opts
+ * @param {string} opts.logPath          Path to the attempt log (tee'd output).
+ * @param {string} [opts.attemptMarker]  Sentinel file created BEFORE the attempt.
+ * @param {string} [opts.crashDir]       Dir scanned for crash dumps newer than
+ *                                        the sentinel (default: $E2E_WEB_CRASH_DIR).
+ * @returns {Promise<{retriable: boolean, reason: string}>}
+ */
+export async function classifyWebFailure({ logPath, attemptMarker, crashDir } = {}) {
+  const resolvedCrashDir = crashDir ?? process.env.E2E_WEB_CRASH_DIR ?? null;
+
+  let log = "";
+  if (logPath) {
+    try {
+      log = normalizeLog(await readFile(logPath, "utf8"));
+    } catch {
+      // A missing/unreadable log is treated as infra (retriable), matching iOS
+      // (`[[ -f "$log" ]] || return 0`).
+      return { retriable: true, reason: "attempt log missing or unreadable (treated as infra)" };
+    }
+  }
+
+  // Tier 1 — crash / browser-loss first (overrides assertion-shaped lines).
+  if (await hasNewerCrashDump(resolvedCrashDir, attemptMarker)) {
+    return {
+      retriable: true,
+      reason: `crash dump newer than attempt start found under ${resolvedCrashDir}`,
+    };
+  }
+  const crashHit = firstMatch(log, BROWSER_CRASH_PATTERNS);
+  if (crashHit) {
+    return { retriable: true, reason: `browser/runner crash signature: ${crashHit.trim()}` };
+  }
+
+  // Tier 2 — non-retriable assertion / contract signatures.
+  const assertionHit = firstMatch(log, NON_RETRIABLE_PATTERNS);
+  if (assertionHit) {
+    return { retriable: false, reason: `assertion/contract signature: ${assertionHit.trim()}` };
+  }
+
+  // Tier 3 — default retriable, with a nicer reason when a known transient
+  // signature is present.
+  const transientHit = firstMatch(log, TRANSIENT_PATTERNS);
+  if (transientHit) {
+    return { retriable: true, reason: `transient/infra signature: ${transientHit.trim()}` };
+  }
+
+  return { retriable: true, reason: "no non-retriable signature found (default: infra/unknown)" };
+}
+
+const invokedDirectly =
+  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  const logPath = process.argv[2];
+  const attemptMarker = process.argv[3];
+  if (!logPath) {
+    console.error("usage: classify-web-failure.mjs <attempt-log> [attempt-marker]");
+    process.exit(2);
+  }
+  const { retriable, reason } = await classifyWebFailure({ logPath, attemptMarker });
+  console.log(`${retriable ? "retriable" : "non-retriable"}: ${reason}`);
+  process.exit(retriable ? 0 : 1);
+}

--- a/scripts/e2e/run-playwright-lane.mjs
+++ b/scripts/e2e/run-playwright-lane.mjs
@@ -81,7 +81,11 @@ function runAttempt(logPath) {
       logStream.end();
       reject(error);
     });
-    child.on("exit", (code) => {
+    // Resolve on `close`, not `exit`: `exit` can fire while stdout/stderr still
+    // have buffered `data` to deliver, so the tee'd log could miss the failure
+    // line (e.g. `Error: expect(`) and the classifier would mislabel a real
+    // assertion as retriable infra. `close` fires only after both pipes drain.
+    child.on("close", (code) => {
       logStream.end(() => resolve(code ?? 1));
     });
   });

--- a/scripts/e2e/run-playwright-lane.mjs
+++ b/scripts/e2e/run-playwright-lane.mjs
@@ -1,6 +1,8 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, open, utimes } from "node:fs/promises";
+import { createWriteStream } from "node:fs";
 import { spawn } from "node:child_process";
 import path from "node:path";
+import { classifyWebFailure } from "./classify-web-failure.mjs";
 
 function parseNonNegativeInt(raw, fallback) {
   const parsed = Number.parseInt(raw ?? "", 10);
@@ -12,6 +14,9 @@ function parseNonNegativeInt(raw, fallback) {
 
 const lane = process.argv[2] ?? "smoke";
 const tag = process.argv[3] ?? "@smoke";
+// `maxRetries` is the number of ADDITIONAL attempts after the first, matching
+// the "Max retries" column in docs/testing/e2e-policy.md (smoke=1, critical=2).
+// Total attempts = maxRetries + 1.
 const maxRetries = parseNonNegativeInt(process.argv[4], 1);
 const repeatEach = parseNonNegativeInt(process.env.E2E_REPEAT_EACH, 1);
 const workers = parseNonNegativeInt(process.env.E2E_WORKERS, 1);
@@ -19,13 +24,16 @@ const workers = parseNonNegativeInt(process.env.E2E_WORKERS, 1);
 const artifactsRoot = path.resolve(process.cwd(), "artifacts", "e2e", "web", lane);
 await mkdir(artifactsRoot, { recursive: true });
 
-const args = [
+// Playwright keeps its own per-test retries OFF: this runner owns retries at the
+// whole-lane level so a single non-retriable failure fails the lane fast,
+// consulting the classifier between attempts (CR plan for #335).
+const baseArgs = [
   "playwright",
   "test",
   "--grep",
   tag,
   "--retries",
-  String(maxRetries),
+  "0",
   "--workers",
   String(workers),
   "--repeat-each",
@@ -33,18 +41,86 @@ const args = [
 ];
 
 if (process.env.PW_OUTPUT_DIR) {
-  args.push("--output", process.env.PW_OUTPUT_DIR);
+  baseArgs.push("--output", process.env.PW_OUTPUT_DIR);
 }
 
-const child = spawn("npx", args, {
-  stdio: "inherit",
-  env: {
-    ...process.env,
-    E2E_ARTIFACTS_DIR: artifactsRoot,
-    E2E_LANE: lane,
-  },
-});
+/**
+ * Create a start-of-attempt sentinel whose mtime is fixed at attempt start.
+ * The classifier compares crash dumps against this, NOT against the tee'd log
+ * (whose mtime keeps advancing until the browser exits).
+ */
+async function createAttemptMarker(markerPath) {
+  const handle = await open(markerPath, "w");
+  await handle.close();
+  const now = new Date();
+  await utimes(markerPath, now, now);
+}
 
-child.on("exit", (code) => {
-  process.exit(code ?? 1);
-});
+function runAttempt(logPath) {
+  return new Promise((resolve, reject) => {
+    const logStream = createWriteStream(logPath, { flags: "w" });
+    const child = spawn("npx", baseArgs, {
+      stdio: ["inherit", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        E2E_ARTIFACTS_DIR: artifactsRoot,
+        E2E_LANE: lane,
+      },
+    });
+
+    const tee = (source, sink) => {
+      child[source].on("data", (chunk) => {
+        sink.write(chunk);
+        logStream.write(chunk);
+      });
+    };
+    tee("stdout", process.stdout);
+    tee("stderr", process.stderr);
+
+    child.on("error", (error) => {
+      logStream.end();
+      reject(error);
+    });
+    child.on("exit", (code) => {
+      logStream.end(() => resolve(code ?? 1));
+    });
+  });
+}
+
+let exitCode = 1;
+for (let attempt = 1; attempt <= maxRetries + 1; attempt += 1) {
+  const logPath = path.join(artifactsRoot, `attempt-${attempt}.log`);
+  const markerPath = path.join(artifactsRoot, `attempt-${attempt}.start`);
+  await createAttemptMarker(markerPath);
+
+  console.log(`Running web ${lane} lane attempt ${attempt}/${maxRetries + 1} (tag ${tag})`);
+  exitCode = await runAttempt(logPath);
+
+  if (exitCode === 0) {
+    console.log(`Web ${lane} lane passed on attempt ${attempt}.`);
+    process.exit(0);
+  }
+
+  const { retriable, reason } = await classifyWebFailure({
+    logPath,
+    attemptMarker: markerPath,
+  });
+
+  if (!retriable) {
+    console.error(
+      `Web ${lane} lane failed with non-retriable signature; skipping retry. Classifier: ${reason}`,
+    );
+    process.exit(exitCode || 1);
+  }
+
+  if (attempt >= maxRetries + 1) {
+    console.error(
+      `Web ${lane} lane failed after ${maxRetries + 1} attempt(s). Last classifier verdict: ${reason}`,
+    );
+    process.exit(exitCode || 1);
+  }
+
+  console.warn(`Web ${lane} lane failed with retriable signature; retrying. Classifier: ${reason}`);
+}
+
+process.exit(exitCode || 1);

--- a/scripts/e2e/run-playwright-lane.mjs
+++ b/scripts/e2e/run-playwright-lane.mjs
@@ -4,9 +4,9 @@ import { spawn } from "node:child_process";
 import path from "node:path";
 import { classifyWebFailure } from "./classify-web-failure.mjs";
 
-function parseNonNegativeInt(raw, fallback) {
+function parsePositiveInt(raw, fallback) {
   const parsed = Number.parseInt(raw ?? "", 10);
-  if (!Number.isFinite(parsed) || parsed < 0) {
+  if (!Number.isFinite(parsed) || parsed < 1) {
     return fallback;
   }
   return parsed;
@@ -17,9 +17,9 @@ const tag = process.argv[3] ?? "@smoke";
 // `maxRetries` is the number of ADDITIONAL attempts after the first, matching
 // the "Max retries" column in docs/testing/e2e-policy.md (smoke=1, critical=2).
 // Total attempts = maxRetries + 1.
-const maxRetries = parseNonNegativeInt(process.argv[4], 1);
-const repeatEach = parseNonNegativeInt(process.env.E2E_REPEAT_EACH, 1);
-const workers = parseNonNegativeInt(process.env.E2E_WORKERS, 1);
+const maxRetries = parsePositiveInt(process.argv[4], 1);
+const repeatEach = parsePositiveInt(process.env.E2E_REPEAT_EACH, 1);
+const workers = parsePositiveInt(process.env.E2E_WORKERS, 1);
 
 const artifactsRoot = path.resolve(process.cwd(), "artifacts", "e2e", "web", lane);
 await mkdir(artifactsRoot, { recursive: true });
@@ -57,8 +57,15 @@ async function createAttemptMarker(markerPath) {
 }
 
 function runAttempt(logPath) {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     const logStream = createWriteStream(logPath, { flags: "w" });
+    let settled = false;
+    const settle = (code) => {
+      if (settled) return;
+      settled = true;
+      logStream.end(() => resolve(code));
+    };
+
     const child = spawn("npx", baseArgs, {
       stdio: ["inherit", "pipe", "pipe"],
       env: {
@@ -77,16 +84,19 @@ function runAttempt(logPath) {
     tee("stdout", process.stdout);
     tee("stderr", process.stderr);
 
+    // Settle with a nonzero code on spawn error (e.g. missing npx/Playwright
+    // binary) so the failure flows through classifyWebFailure() and the lane
+    // retry loop rather than aborting with an unhandled rejection.
     child.on("error", (error) => {
-      logStream.end();
-      reject(error);
+      process.stderr.write(`spawn error: ${error.message}\n`);
+      settle(1);
     });
     // Resolve on `close`, not `exit`: `exit` can fire while stdout/stderr still
     // have buffered `data` to deliver, so the tee'd log could miss the failure
     // line (e.g. `Error: expect(`) and the classifier would mislabel a real
     // assertion as retriable infra. `close` fires only after both pipes drain.
     child.on("close", (code) => {
-      logStream.end(() => resolve(code ?? 1));
+      settle(code ?? 1);
     });
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CI-only change (no build). Brings the iOS `is_retriable_failure()` smart-retry behavior (PR #328) to the Playwright web lanes so real product/test failures fail the lane **fast** instead of silently burning a retry, while genuine infra flakes still self-heal.

- **New `scripts/e2e/classify-web-failure.mjs`** — standalone, importable + CLI classifier for a failed Playwright attempt log. Mirrors the iOS precedence:
  1. **Crash / browser-loss first** (retriable, overrides any concurrent `expect(...)` line): a crash dump in `$E2E_WEB_CRASH_DIR` newer than the attempt-start sentinel, or log signatures like `Target … has been closed/crashed`, `Page crashed`, `Browser closed unexpectedly`, `browserType.launch:` failures, `Executable doesn't exist`.
  2. **Non-retriable assertion / contract** (fail fast): `expect(...)` failures (assertion mismatch **and** selector-contract drift both surface this way), visual/snapshot mismatches, schema/data-contract errors (`ZodError`, `…SchemaError`).
  3. **Default**: network timeouts (`net::ERR_*`, `ECONNREFUSED`), dev-server boot stalls, runner disconnects, unknown → retriable.
  - Strips ANSI color codes and drops Playwright's echoed **source code-frame** lines before matching, so a test's own `await expect(...)` source never triggers a false assertion verdict.
- **`scripts/e2e/run-playwright-lane.mjs`** — now runs Playwright with `--retries 0` and owns retries at the **whole-lane** level (not the per-test reporter), consulting the classifier between attempts. Each attempt tees to `artifacts/e2e/web/<lane>/attempt-<N>.log` and writes a start-of-attempt sentinel `attempt-<N>.start` whose mtime is fixed at attempt start (the crash-dump check compares against it, never the tee'd log whose mtime keeps advancing).
- **`docs/testing/e2e-policy.md` §1** — expanded with a web-lane Enforcement note documenting the precedence, the sentinel-vs-tee'd-log gotcha, and where web intentionally diverges from iOS (timeout-shaped waits are **not** auto-retriable on web, since selector-contract drift is non-retriable here).

Lane retry budgets are unchanged: `maxRetries` is the additional-attempt count (`smoke=1`, `critical=2`), so total attempts = `maxRetries + 1`, matching the policy table.

## Test plan

Verified end-to-end with three throwaway `page.setContent` specs (no dev server) driven through the runner. Full output: `web_retry_classifier_demo.log` (below).

- ✅ **Green path** — passes on attempt 1, exit 0, only `attempt-1.{log,start}` written.
- ✅ **Deliberate assertion failure** — classifier verdict `non-retriable: assertion/contract signature: Error: expect(`, lane fails fast (exit 1), **no** `attempt-2` (retry skipped). Confirms ANSI-stripping: raw log was `Error: \x1b[2mexpect(` yet still matched.
- ✅ **Deliberate transient** — attempt 1 fails with `net::ERR_CONNECTION_RESET` → `retriable: transient/infra signature`, retries, attempt 2 passes (exit 0); both `attempt-1` and `attempt-2` logs written.
- ✅ Classifier unit checks over representative log snippets (assertion / value-assert / browser-close / launch / network / action-timeout / ZodError / snapshot / unknown) all classify as expected.
- ✅ Sentinel logic: crash dump newer than `attempt-N.start` overrides an assertion log (retriable); when the sentinel is newer, the assertion wins (non-retriable).
- ✅ `npm run e2e:policy:no-sleep`
- ✅ `npm run e2e:policy:secrets`
- ✅ `node --check` on both scripts.

[web_retry_classifier_demo.log](https://cursor.com/agents/bc-7da261b5-34b3-4b30-a9ff-3c37c9087797/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_retry_classifier_demo.log)

Closes #335

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7da261b5-34b3-4b30-a9ff-3c37c9087797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7da261b5-34b3-4b30-a9ff-3c37c9087797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * E2E web tests now use a lane-level retry flow with clearer failure handling.
  * Added automated classification for retryable vs. non-retryable test failures.

* **Bug Fixes**
  * Browser crashes, lost sessions, and similar infrastructure issues now consume retry attempts reliably.
  * Assertion, visual, snapshot, and schema/contract failures now stop retries sooner for faster feedback.

* **Documentation**
  * Updated E2E testing guidance to reflect the new retry and failure-classification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->