### PR TITLE
feat(web): breath-counting mode with tap + configurable key (#376)

### DIFF
--- a/e2e/fixtures/auth.fixture.ts
+++ b/e2e/fixtures/auth.fixture.ts
@@ -1,5 +1,5 @@
 import { test as base, expect, type Page, type Route } from "@playwright/test";
-import { calculateSessionStats } from "../../src/lib/constants";
+import { calculateSessionStats, type SessionType } from "../../src/lib/constants";
 import { tap } from "../utils/mobile-helpers";
 
 type UserRecord = {
@@ -13,12 +13,13 @@ type UserRecord = {
 type SessionRecord = {
   id: string;
   dayNumber: number;
-  sessionType: "standard" | "quick";
+  sessionType: SessionType;
   duration: number;
   completed: boolean;
   actualTime: number;
   clearPercent: number;
   thoughtCount: number;
+  breathCount?: number;
   mindStateLog: Array<{ time: number; state: string }>;
   sessionDate: string;
 };
@@ -173,12 +174,16 @@ async function installMockApiRoutes(page: Page, state: MockApiState) {
       const session: SessionRecord = {
         id: `session-${state.ids.session++}`,
         dayNumber: Number(body.dayNumber ?? state.user.currentDay),
-        sessionType: body.sessionType === "quick" ? "quick" : "standard",
+        sessionType:
+          body.sessionType === "quick" || body.sessionType === "breath"
+            ? body.sessionType
+            : "standard",
         duration: Number(body.duration ?? 60),
         completed: Boolean(body.completed ?? true),
         actualTime: Number(body.actualTime ?? body.duration ?? 60),
         clearPercent: Number(body.clearPercent ?? 100),
         thoughtCount: Number(body.thoughtCount ?? 0),
+        breathCount: typeof body.breathCount === "number" ? body.breathCount : undefined,
         mindStateLog: Array.isArray(body.mindStateLog) ? body.mindStateLog : [],
         sessionDate: String(body.sessionDate ?? getLocalIsoDate()),
       };

--- a/e2e/session/session-flow.spec.ts
+++ b/e2e/session/session-flow.spec.ts
@@ -82,6 +82,30 @@ test.describe("mobile session flow", () => {
     expect(mockApiState.sessions[0]?.sessionType, "quick minute should be persisted as quick").toBe("quick");
   });
 
+  test("single-tap breath session ending within first second is persisted", async ({
+    page,
+    ensureLoggedIn,
+    mockApiState,
+  }) => {
+    await page.addInitScript(() => {
+      Date.now = () => 1_700_000_000_000;
+    });
+    await ensureLoggedIn();
+
+    await tap(page.getByRole("button", { name: "Breath counting" }));
+    await expect(page.getByTestId("breath-elapsed")).toHaveText("0:00");
+
+    await page.keyboard.press("Space");
+    await tap(page.getByRole("button", { name: "End breath counting session" }));
+
+    await expect(page.getByRole("button", { name: "Begin" })).toBeVisible();
+    expect(mockApiState.sessions.length, "one-tap breath session should be saved").toBe(1);
+    expect(mockApiState.sessions[0]?.sessionType, "session should be persisted as breath").toBe("breath");
+    expect(mockApiState.sessions[0]?.duration, "stored duration should meet API minimum").toBe(1);
+    expect(mockApiState.sessions[0]?.actualTime, "raw elapsed time should remain sub-second").toBe(0);
+    expect(mockApiState.sessions[0]?.breathCount, "one tap is not yet a full breath").toBe(0);
+  });
+
   test("pull-to-refresh style overscroll does not break active session", async ({ page, ensureLoggedIn }) => {
     await ensureLoggedIn();
     await tap(page.getByRole("button", { name: "Begin" }));

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -6,6 +6,7 @@ import type { CalendarSyncResult, User } from "@/lib/api";
 import { AuthScreen } from "@/components/AuthScreen";
 import { HomeView } from "@/components/HomeView";
 import { SessionView } from "@/components/SessionView";
+import { BreathCountView, type BreathSessionResult } from "@/components/BreathCountView";
 import { CompletionScreen } from "@/components/CompletionScreen";
 import { HistoryView } from "@/components/HistoryView";
 import { ThoughtJournal } from "@/components/ThoughtJournal";
@@ -60,7 +61,9 @@ function pathForTab(tab: Tab): string {
 }
 
 // Transient flows that overlay the active tab without changing the URL.
-type Overlay = "session" | "complete";
+// "breath" hides nav/header and renders BreathCountView full-screen, matching
+// the iOS breath-counting mode (#376).
+type Overlay = "session" | "breath" | "complete";
 
 type CompletionData = {
   sessionId: string | null;
@@ -400,8 +403,53 @@ export default function StillPoint() {
     setOverlay(null);
   }, []);
 
+  // #376: log a breath-counting session, mirroring iOS `completeBreathSession`
+  // (#374). Empty sessions (entered then ended with no taps) are not logged.
+  // Breath sits do not advance the daily progression, and there is no
+  // completion screen — End returns straight to the Progress tab.
+  const breathSavingRef = useRef(false);
+  const handleBreathEnd = useCallback(async (result: BreathSessionResult) => {
+    // A session is empty only when no tap was ever recorded. Using tapCount
+    // (not the derived elapsedSeconds/breathCount) avoids dropping a real
+    // session where End was pressed within the first second of the first tap,
+    // which produces elapsedSeconds=0 and breathCount=0 but tapCount>0.
+    if (result.tapCount <= 0) {
+      setOverlay(null);
+      return;
+    }
+    if (breathSavingRef.current) return;
+    breathSavingRef.current = true;
+    try {
+      const res = await fetch("/api/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          dayNumber: user?.currentDay ?? 1,
+          sessionType: "breath",
+          duration: Math.max(result.elapsedSeconds, 1),
+          bonusSeconds: 0,
+          completed: true,
+          actualTime: result.elapsedSeconds,
+          clearPercent: 0,
+          thoughtCount: 0,
+          breathCount: result.breathCount,
+          mindStateLog: [],
+          sessionDate: todayLocalIsoDate(),
+        }),
+      });
+      if (!res.ok) {
+        console.error("Failed to save breath session: HTTP", res.status);
+      }
+    } catch (error) {
+      console.error("Failed to save breath session:", error);
+    } finally {
+      breathSavingRef.current = false;
+      setOverlay(null);
+    }
+  }, [user]);
+
   const inBuddyRoom = tab === "buddy" && !!buddySessionId;
-  const isImmersive = overlay === "session" || inBuddyRoom;
+  const isImmersive = overlay === "session" || overlay === "breath" || inBuddyRoom;
 
   // Loading state
   if (!authChecked) {
@@ -604,6 +652,10 @@ export default function StillPoint() {
         />
       )}
 
+      {overlay === "breath" && (
+        <BreathCountView onEnd={handleBreathEnd} />
+      )}
+
       {overlay === "complete" && completionData && (
         <CompletionScreen
           dayNumber={completionData.dayNumber}
@@ -644,6 +696,7 @@ export default function StillPoint() {
           currentDay={user.currentDay}
           onBegin={() => handleBegin("standard")}
           onQuickBegin={() => handleBegin("quick")}
+          onBreath={() => setOverlay("breath")}
           onBuddy={() => {
             setBuddySessionId(null);
             setBuddyCalendarMessage(null);

--- a/src/components/BreathCountView.tsx
+++ b/src/components/BreathCountView.tsx
@@ -21,6 +21,10 @@ export type BreathSessionResult = {
   elapsedSeconds: number;
   /** Complete breaths (2 taps = 1 breath). */
   breathCount: number;
+  /** Raw tap count — lets callers distinguish a started-but-short session
+   *  (tapCount > 0) from End pressed before any tap (tapCount = 0), since
+   *  both can produce elapsedSeconds=0 and breathCount=0. */
+  tapCount: number;
 };
 
 type BreathCountViewProps = {
@@ -80,6 +84,7 @@ export function BreathCountView({ onEnd }: BreathCountViewProps) {
     onEnd({
       elapsedSeconds: finalElapsed,
       breathCount: breathCountForTaps(tapCountRef.current),
+      tapCount: tapCountRef.current,
     });
   }, [onEnd]);
 
@@ -112,6 +117,7 @@ export function BreathCountView({ onEnd }: BreathCountViewProps) {
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [keyBinding, recordTap]);
 
+  const [focusVisible, setFocusVisible] = useState(false);
   const running = startMs !== null;
   const phase = phaseForTaps(tapCount);
   const breaths = breathCountForTaps(tapCount);
@@ -123,6 +129,12 @@ export function BreathCountView({ onEnd }: BreathCountViewProps) {
       tabIndex={0}
       aria-label="Breath counting. Tap anywhere to register a breath."
       onClick={recordTap}
+      onFocus={(e) => {
+        // Only show focus ring for keyboard navigation, not mouse clicks.
+        if (e.target === e.currentTarget) setFocusVisible(true);
+      }}
+      onBlur={() => setFocusVisible(false)}
+      onMouseDown={() => setFocusVisible(false)}
       onKeyDown={(e) => {
         // Enter triggers a tap from keyboard focus; the configured key binding
         // is handled by the global listener above.
@@ -144,7 +156,8 @@ export function BreathCountView({ onEnd }: BreathCountViewProps) {
         cursor: "pointer",
         userSelect: "none",
         WebkitUserSelect: "none",
-        outline: "none",
+        outline: focusVisible ? "2px solid var(--accent-green-text)" : "none",
+        outlineOffset: focusVisible ? "-2px" : undefined,
         fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
         padding: "var(--s4)",
         animation: "fadeIn 0.6s ease",
@@ -208,10 +221,14 @@ export function BreathCountView({ onEnd }: BreathCountViewProps) {
           handleEnd();
         }}
         onKeyDown={(e) => {
-          // Keep Enter/Space on the button from bubbling to the container tap
-          // handler. The configured breath key still records via the global
-          // listener (preventDefault there stops button activation).
-          e.stopPropagation();
+          // Always stop propagation so the container tap handler never fires
+          // from a button keypress. But allow the configured breath key to
+          // reach the window-level listener by NOT stopping propagation for it.
+          // (React 17+ delegates to the root element, which is below window, so
+          // stopPropagation() would prevent the window listener from seeing it.)
+          if (!eventMatchesBreathKeyBinding(e.nativeEvent, keyBinding)) {
+            e.stopPropagation();
+          }
         }}
         style={{
           position: "absolute",

--- a/src/components/BreathCountView.tsx
+++ b/src/components/BreathCountView.tsx
@@ -52,29 +52,31 @@ export function BreathCountView({ onEnd }: BreathCountViewProps) {
   // Re-entrancy guard so a second End (button + key in the same frame) can't
   // double-report. Mirrors iOS `isSavingBreathSession`.
   const endedRef = useRef(false);
-  // Latest values for the End handler / unmount path without re-binding listeners.
+  // Refs are the source of truth for tap count and start time: they are mutated
+  // synchronously inside `recordTap` (not assigned during render) so `handleEnd`
+  // always sees the latest values even when End fires in the same tick as a tap,
+  // before React has re-rendered. State mirrors the refs only to drive the UI.
   const startMsRef = useRef<number | null>(null);
   const tapCountRef = useRef(0);
-  const secondsRef = useRef(0);
-  startMsRef.current = startMs;
-  tapCountRef.current = tapCount;
-  secondsRef.current = seconds;
 
   const recordTap = useCallback(() => {
     if (endedRef.current) return;
-    setTapCount((prev) => prev + 1);
-    setStartMs((prev) => (prev === null ? Date.now() : prev));
+    tapCountRef.current += 1;
+    setTapCount(tapCountRef.current);
+    if (startMsRef.current === null) {
+      startMsRef.current = Date.now();
+      setStartMs(startMsRef.current);
+    }
   }, []);
 
   const handleEnd = useCallback(() => {
     if (endedRef.current) return;
     endedRef.current = true;
     // Recompute elapsed from the wall clock so ending between 1-second ticks
-    // (or right after the first tap) doesn't under-report the duration.
+    // (or right after the first tap) doesn't under-report the duration. When
+    // no tap was recorded, startMsRef is null and the session is empty (0s).
     const finalElapsed =
-      startMsRef.current !== null
-        ? elapsedSeconds(startMsRef.current, Date.now())
-        : secondsRef.current;
+      startMsRef.current !== null ? elapsedSeconds(startMsRef.current, Date.now()) : 0;
     onEnd({
       elapsedSeconds: finalElapsed,
       breathCount: breathCountForTaps(tapCountRef.current),

--- a/src/components/BreathCountView.tsx
+++ b/src/components/BreathCountView.tsx
@@ -102,7 +102,11 @@ export function BreathCountView({ onEnd }: BreathCountViewProps) {
   // Global key handler: the bound key registers a breath and is prevented from
   // its default action (Space scrolling the page / activating a focused button)
   // while the breath view is active. Auto-repeat (held key) is ignored so a tap
-  // stays discrete.
+  // stays discrete. When the End button has focus the breath key is intentionally
+  // allowed to bubble to this handler (the button's onKeyDown does not
+  // stopPropagation for it), but we skip tap recording in that case so the End
+  // button's own click handler can fire normally via the browser's default
+  // button-activation behaviour.
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (!eventMatchesBreathKeyBinding(event, keyBinding)) return;
@@ -110,6 +114,9 @@ export function BreathCountView({ onEnd }: BreathCountViewProps) {
         event.preventDefault();
         return;
       }
+      // If focus is on the End button, don't record a tap — let the button
+      // handle the key activation itself (e.g. Space triggers onClick).
+      if (event.target instanceof HTMLButtonElement) return;
       event.preventDefault();
       recordTap();
     };

--- a/src/components/BreathCountView.tsx
+++ b/src/components/BreathCountView.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import {
+  breathCountForTaps,
+  elapsedDisplay,
+  elapsedSeconds,
+  phaseForTaps,
+} from "@/lib/breathCounting";
+import {
+  breathKeyBindingLabel,
+  eventMatchesBreathKeyBinding,
+  loadBreathKeyBinding,
+  subscribeBreathKeyBinding,
+  type BreathKeyBinding,
+} from "@/lib/breathKeyBinding";
+import { useKeepScreenAwakePref, useWakeLock } from "@/lib/useWakeLock";
+
+export type BreathSessionResult = {
+  /** Whole seconds from the first input to End (wall-clock). */
+  elapsedSeconds: number;
+  /** Complete breaths (2 taps = 1 breath). */
+  breathCount: number;
+};
+
+type BreathCountViewProps = {
+  /** Called on End. The parent persists the session (#374 data semantics) and
+   *  navigates home. An empty session (no taps, no elapsed time) is reported as
+   *  `{ elapsedSeconds: 0, breathCount: 0 }` so the parent can skip logging it. */
+  onEnd: (result: BreathSessionResult) => void;
+};
+
+/** Live view of the configured breath key binding (re-renders on Settings save / cross-tab). */
+function useBreathKeyBinding(): BreathKeyBinding {
+  return useSyncExternalStore(
+    subscribeBreathKeyBinding,
+    () => loadBreathKeyBinding(),
+    () => "Space" as BreathKeyBinding,
+  );
+}
+
+export function BreathCountView({ onEnd }: BreathCountViewProps) {
+  const [tapCount, setTapCount] = useState(0);
+  const [startMs, setStartMs] = useState<number | null>(null);
+  const [seconds, setSeconds] = useState(0);
+  const keyBinding = useBreathKeyBinding();
+
+  // Wake lock parity with sits (#317): keep the screen awake once running.
+  const keepAwakePref = useKeepScreenAwakePref();
+  useWakeLock(keepAwakePref && startMs !== null);
+
+  // Re-entrancy guard so a second End (button + key in the same frame) can't
+  // double-report. Mirrors iOS `isSavingBreathSession`.
+  const endedRef = useRef(false);
+  // Latest values for the End handler / unmount path without re-binding listeners.
+  const startMsRef = useRef<number | null>(null);
+  const tapCountRef = useRef(0);
+  const secondsRef = useRef(0);
+  startMsRef.current = startMs;
+  tapCountRef.current = tapCount;
+  secondsRef.current = seconds;
+
+  const recordTap = useCallback(() => {
+    if (endedRef.current) return;
+    setTapCount((prev) => prev + 1);
+    setStartMs((prev) => (prev === null ? Date.now() : prev));
+  }, []);
+
+  const handleEnd = useCallback(() => {
+    if (endedRef.current) return;
+    endedRef.current = true;
+    // Recompute elapsed from the wall clock so ending between 1-second ticks
+    // (or right after the first tap) doesn't under-report the duration.
+    const finalElapsed =
+      startMsRef.current !== null
+        ? elapsedSeconds(startMsRef.current, Date.now())
+        : secondsRef.current;
+    onEnd({
+      elapsedSeconds: finalElapsed,
+      breathCount: breathCountForTaps(tapCountRef.current),
+    });
+  }, [onEnd]);
+
+  // Count-up timer from the first input. Wall-clock based so backgrounding the
+  // tab doesn't drift the counter.
+  useEffect(() => {
+    if (startMs === null) return;
+    setSeconds(elapsedSeconds(startMs, Date.now()));
+    const id = setInterval(() => {
+      setSeconds(elapsedSeconds(startMs, Date.now()));
+    }, 250);
+    return () => clearInterval(id);
+  }, [startMs]);
+
+  // Global key handler: the bound key registers a breath and is prevented from
+  // its default action (Space scrolling the page / activating a focused button)
+  // while the breath view is active. Auto-repeat (held key) is ignored so a tap
+  // stays discrete.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!eventMatchesBreathKeyBinding(event, keyBinding)) return;
+      if (event.repeat) {
+        event.preventDefault();
+        return;
+      }
+      event.preventDefault();
+      recordTap();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [keyBinding, recordTap]);
+
+  const running = startMs !== null;
+  const phase = phaseForTaps(tapCount);
+  const breaths = breathCountForTaps(tapCount);
+  const bindingLabel = breathKeyBindingLabel(keyBinding);
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label="Breath counting. Tap anywhere to register a breath."
+      onClick={recordTap}
+      onKeyDown={(e) => {
+        // Enter triggers a tap from keyboard focus; the configured key binding
+        // is handled by the global listener above.
+        if (e.key === "Enter") {
+          e.preventDefault();
+          recordTap();
+        }
+      }}
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 200,
+        background: "rgb(var(--bg-rgb))",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "var(--s5)",
+        cursor: "pointer",
+        userSelect: "none",
+        WebkitUserSelect: "none",
+        outline: "none",
+        fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+        padding: "var(--s4)",
+        animation: "fadeIn 0.6s ease",
+      }}
+    >
+      <div
+        data-testid="breath-elapsed"
+        style={{
+          fontSize: "min(120px, 22vw)",
+          fontWeight: 200,
+          lineHeight: 1,
+          color: "var(--fg)",
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {elapsedDisplay(seconds)}
+      </div>
+
+      {/* Phase indicator — the next expected action. */}
+      <div
+        data-testid="breath-phase"
+        style={{
+          fontSize: "28px",
+          fontWeight: 200,
+          letterSpacing: "0.3em",
+          textTransform: "lowercase",
+          transition: "color 0.2s ease",
+          color: !running
+            ? "var(--fg-4)"
+            : phase === "inhale"
+              ? "var(--accent-green-text)"
+              : "var(--fg-3)",
+        }}
+      >
+        {!running ? "tap to begin" : phase === "inhale" ? "in" : "out"}
+      </div>
+
+      {breaths > 0 ? (
+        <div
+          data-testid="breath-count"
+          style={{
+            fontSize: "16px",
+            letterSpacing: "0.15em",
+            color: "var(--accent-green-text)",
+          }}
+        >
+          {breaths} breath{breaths === 1 ? "" : "s"}
+        </div>
+      ) : (
+        <div style={{ fontSize: "13px", letterSpacing: "0.08em", color: "var(--fg-4)" }}>
+          tap each inhale and exhale &middot; or press {bindingLabel}
+        </div>
+      )}
+
+      {/* End — explicit, interactive, pinned near the bottom. stopPropagation so
+          ending the session never also registers a breath on the tap target. */}
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          handleEnd();
+        }}
+        onKeyDown={(e) => {
+          // Keep Enter/Space on the button from bubbling to the container tap
+          // handler. The configured breath key still records via the global
+          // listener (preventDefault there stops button activation).
+          e.stopPropagation();
+        }}
+        style={{
+          position: "absolute",
+          bottom: "calc(var(--s5) + env(safe-area-inset-bottom, 0px))",
+          left: "50%",
+          transform: "translateX(-50%)",
+          background: "var(--surface-1)",
+          border: "1px solid var(--border-1)",
+          color: "var(--fg-3)",
+          borderRadius: "999px",
+          padding: "12px 32px",
+          fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+          fontSize: "13px",
+          fontWeight: 500,
+          letterSpacing: "0.08em",
+          cursor: "pointer",
+        }}
+        aria-label="End breath counting session"
+      >
+        End
+      </button>
+    </div>
+  );
+}

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -7,10 +7,11 @@ type HomeViewProps = {
   currentDay: number;
   onBegin: () => void;
   onQuickBegin: () => void;
+  onBreath?: () => void;
   onBuddy?: () => void;
 };
 
-export function HomeView({ currentDay, onBegin, onQuickBegin, onBuddy }: HomeViewProps) {
+export function HomeView({ currentDay, onBegin, onQuickBegin, onBreath, onBuddy }: HomeViewProps) {
   const todayDuration = durationForDay(currentDay);
   const totalBlocks = Math.ceil(todayDuration / BLOCK_DURATION);
 
@@ -117,6 +118,27 @@ export function HomeView({ currentDay, onBegin, onQuickBegin, onBuddy }: HomeVie
       >
         Quick minute &middot; {QUICK_DURATION}s
       </button>
+
+      {onBreath && (
+        <button
+          type="button"
+          onClick={onBreath}
+          style={{
+            background: "transparent",
+            border: "1px solid var(--border-2)",
+            color: "var(--fg-2)",
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+            fontSize: "11px",
+            letterSpacing: "0.12em",
+            textTransform: "uppercase",
+            padding: "12px 24px",
+            borderRadius: "40px",
+            cursor: "pointer",
+          }}
+        >
+          Breath counting
+        </button>
+      )}
 
       {onBuddy && (
         <button

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -14,6 +14,13 @@ import {
   loadWakeLockPrefs,
   saveWakeLockPrefs,
 } from "@/lib/wakeLockPrefs";
+import {
+  BREATH_KEY_BINDINGS,
+  breathKeyBindingLabel,
+  loadBreathKeyBinding,
+  saveBreathKeyBinding,
+  type BreathKeyBinding,
+} from "@/lib/breathKeyBinding";
 
 type User = {
   id: string;
@@ -41,6 +48,7 @@ export function SettingsView({
   // mount when the browser actually supports the Screen Wake Lock API (#317).
   const [wakeLockSupported, setWakeLockSupported] = useState(false);
   const [keepScreenAwake, setKeepScreenAwake] = useState(false);
+  const [breathKeyBinding, setBreathKeyBinding] = useState<BreathKeyBinding>("Space");
   const [editingUsername, setEditingUsername] = useState(false);
   const [usernameInput, setUsernameInput] = useState(user.username);
   const [savingUsername, setSavingUsername] = useState(false);
@@ -119,12 +127,18 @@ export function SettingsView({
   useEffect(() => {
     setWakeLockSupported(isWakeLockSupported());
     setKeepScreenAwake(loadWakeLockPrefs().keepScreenAwakeDuringSession);
+    setBreathKeyBinding(loadBreathKeyBinding());
   }, []);
 
   const handleKeepScreenAwakeToggle = () => {
     const next = !keepScreenAwake;
     setKeepScreenAwake(next);
     saveWakeLockPrefs({ keepScreenAwakeDuringSession: next });
+  };
+
+  const handleBreathKeyBindingChange = (binding: BreathKeyBinding) => {
+    setBreathKeyBinding(binding);
+    saveBreathKeyBinding(binding);
   };
 
   const handleLogout = async () => {
@@ -377,6 +391,66 @@ export function SettingsView({
             </button>
           </div>
         )}
+
+        {/* Breath counting: key binding (#376) */}
+        <div style={{
+          padding: "16px 20px",
+          background: "var(--surface-1)",
+          borderRadius: "10px",
+          display: "flex", alignItems: "center", justifyContent: "space-between",
+          gap: "16px",
+        }}>
+          <div>
+            <div style={{
+              fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+              fontSize: "12px", color: "var(--fg)", marginBottom: "4px",
+            }}>
+              Breath counting key
+            </div>
+            <div style={{
+              fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+              fontSize: "13px", fontStyle: "italic",
+              color: "var(--fg-3)",
+            }}>
+              Key that registers a breath during a breath-counting session
+            </div>
+          </div>
+          <div
+            role="radiogroup"
+            aria-label="Breath counting key binding"
+            style={{ display: "flex", gap: "8px", flexShrink: 0 }}
+          >
+            {BREATH_KEY_BINDINGS.map((binding) => {
+              const selected = breathKeyBinding === binding;
+              return (
+                <button
+                  key={binding}
+                  type="button"
+                  role="radio"
+                  aria-checked={selected}
+                  onClick={() => handleBreathKeyBindingChange(binding)}
+                  style={{
+                    fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                    fontSize: "11px",
+                    letterSpacing: "0.08em",
+                    padding: "8px 14px",
+                    borderRadius: "999px",
+                    cursor: "pointer",
+                    whiteSpace: "nowrap",
+                    border: selected
+                      ? "1px solid var(--accent-green-border)"
+                      : "1px solid var(--border-2)",
+                    background: selected ? "var(--accent-green-bg-subtle)" : "transparent",
+                    color: selected ? "var(--accent-green-text)" : "var(--fg-2)",
+                    transition: "all 0.2s",
+                  }}
+                >
+                  {breathKeyBindingLabel(binding)}
+                </button>
+              );
+            })}
+          </div>
+        </div>
 
         {/* Public board toggle */}
         <div style={{

--- a/src/lib/breathCounting.test.ts
+++ b/src/lib/breathCounting.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  breathCountForTaps,
+  elapsedDisplay,
+  elapsedSeconds,
+  phaseForTaps,
+} from "./breathCounting";
+
+// Ports ios/StillPointShared/Tests/StillPointSharedTests/BreathCountingLogicTests.swift
+// so the web breath-counting semantics stay locked to iOS (#374 → #376).
+
+describe("breathCountForTaps", () => {
+  it("is 0 for zero taps", () => {
+    expect(breathCountForTaps(0)).toBe(0);
+  });
+
+  it("is 0 after one tap (inhale registered, no full breath yet)", () => {
+    expect(breathCountForTaps(1)).toBe(0);
+  });
+
+  it("is 1 after two taps (inhale + exhale)", () => {
+    expect(breathCountForTaps(2)).toBe(1);
+  });
+
+  it("is 2 after five taps (4 taps = 2 breaths + 1 pending inhale)", () => {
+    expect(breathCountForTaps(5)).toBe(2);
+  });
+
+  it("is 5 for ten taps", () => {
+    expect(breathCountForTaps(10)).toBe(5);
+  });
+
+  it("clamps negative taps to 0", () => {
+    expect(breathCountForTaps(-4)).toBe(0);
+  });
+});
+
+describe("phaseForTaps", () => {
+  it("is inhale at zero taps (next action is inhale)", () => {
+    expect(phaseForTaps(0)).toBe("inhale");
+  });
+
+  it("is exhale after one tap (inhale done → next is exhale)", () => {
+    expect(phaseForTaps(1)).toBe("exhale");
+  });
+
+  it("is inhale after two taps (full breath done → next is inhale)", () => {
+    expect(phaseForTaps(2)).toBe("inhale");
+  });
+
+  it("alternates: even = inhale, odd = exhale", () => {
+    for (let taps = 0; taps <= 10; taps++) {
+      const expected = taps % 2 === 0 ? "inhale" : "exhale";
+      expect(phaseForTaps(taps)).toBe(expected);
+    }
+  });
+});
+
+describe("elapsedSeconds", () => {
+  it("is 0 when start equals now", () => {
+    const now = 1_000_000;
+    expect(elapsedSeconds(now, now)).toBe(0);
+  });
+
+  it("is positive for a forward diff", () => {
+    const start = 1_000_000;
+    expect(elapsedSeconds(start, start + 65_000)).toBe(65);
+  });
+
+  it("clamps to 0 for a negative diff (now before start)", () => {
+    const start = 1_000_000;
+    expect(elapsedSeconds(start, start - 5_000)).toBe(0);
+  });
+
+  it("handles spans across a minute boundary", () => {
+    const start = 1_000_000;
+    expect(elapsedSeconds(start, start + 90_000)).toBe(90);
+  });
+
+  it("truncates rather than rounds (59.9s → 59)", () => {
+    const start = 1_000_000;
+    expect(elapsedSeconds(start, start + 59_900)).toBe(59);
+  });
+});
+
+describe("elapsedDisplay", () => {
+  it("formats zero", () => {
+    expect(elapsedDisplay(0)).toBe("0:00");
+  });
+
+  it("formats one minute five seconds", () => {
+    expect(elapsedDisplay(65)).toBe("1:05");
+  });
+
+  it("formats ten minutes", () => {
+    expect(elapsedDisplay(600)).toBe("10:00");
+  });
+
+  it("zero-pads single-digit seconds", () => {
+    expect(elapsedDisplay(9)).toBe("0:09");
+  });
+
+  it("formats one hour as 60:00", () => {
+    expect(elapsedDisplay(3600)).toBe("60:00");
+  });
+
+  it("treats negative input as 0", () => {
+    expect(elapsedDisplay(-5)).toBe("0:00");
+  });
+});

--- a/src/lib/breathCounting.ts
+++ b/src/lib/breathCounting.ts
@@ -1,0 +1,57 @@
+// Pure breath-counting helpers — web port of iOS `BreathCounting`
+// (ios/StillPointShared/Sources/StillPointShared/BreathCountingLogic.swift, #374).
+// No DOM/timer state lives here so the logic stays unit-testable; the view owns
+// the tap count and wall-clock start time and calls into these functions.
+
+/**
+ * Which side of a breath the user is on.
+ *
+ * Phase semantics: taps alternate inhale / exhale.
+ *   - tap 1 → first inhale  → tapCount 1 (odd)  → next expected phase is "exhale"
+ *   - tap 2 → first exhale  → tapCount 2 (even) → one full breath done, next is "inhale"
+ *   - tap 3 → second inhale → tapCount 3 (odd)  → next expected phase is "exhale"
+ *
+ * So `phaseForTaps` returns the *next expected* action:
+ *   even tapCount (incl. 0) → "inhale"
+ *   odd  tapCount           → "exhale"
+ */
+export type BreathPhase = "inhale" | "exhale";
+
+/** Number of complete breaths (1 breath = 1 inhale + 1 exhale = 2 taps). */
+export function breathCountForTaps(taps: number): number {
+  return Math.floor(Math.max(0, taps) / 2);
+}
+
+/**
+ * The *next expected* breath phase given how many taps have been recorded.
+ *
+ * - Even tapCount (0, 2, 4, …): inhale is next.
+ * - Odd tapCount (1, 3, 5, …): exhale is next.
+ */
+export function phaseForTaps(taps: number): BreathPhase {
+  return Math.max(0, taps) % 2 === 0 ? "inhale" : "exhale";
+}
+
+/**
+ * Elapsed whole seconds between two epoch-millisecond timestamps, clamped to a
+ * minimum of 0. Uses wall-clock difference so the count survives tab
+ * backgrounding without drift (matches the iOS wall-clock approach).
+ */
+export function elapsedSeconds(startMs: number, nowMs: number): number {
+  return Math.max(0, Math.floor((nowMs - startMs) / 1000));
+}
+
+/**
+ * Format a second count as "M:SS" or "MM:SS".
+ *
+ * Examples:
+ *   0   → "0:00"
+ *   65  → "1:05"
+ *   600 → "10:00"
+ */
+export function elapsedDisplay(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(s / 60);
+  const secs = s % 60;
+  return `${minutes}:${String(secs).padStart(2, "0")}`;
+}

--- a/src/lib/breathKeyBinding.test.ts
+++ b/src/lib/breathKeyBinding.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_BREATH_KEY_BINDING,
+  breathKeyBindingLabel,
+  eventMatchesBreathKeyBinding,
+  loadBreathKeyBinding,
+  saveBreathKeyBinding,
+  subscribeBreathKeyBinding,
+} from "./breathKeyBinding";
+
+const STORAGE_KEY = "stillpoint_breath_key_binding";
+
+function stubBrowserStorage(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial));
+  const localStorageMock = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  };
+  vi.stubGlobal("window", {
+    localStorage: localStorageMock,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+  vi.stubGlobal("localStorage", localStorageMock);
+  return store;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("loadBreathKeyBinding", () => {
+  it("defaults to Space without window (SSR guard)", () => {
+    expect(loadBreathKeyBinding()).toBe("Space");
+    expect(DEFAULT_BREATH_KEY_BINDING).toBe("Space");
+  });
+
+  it("returns default when nothing is stored", () => {
+    stubBrowserStorage();
+    expect(loadBreathKeyBinding()).toBe("Space");
+  });
+
+  it("reads a stored ArrowRight binding", () => {
+    stubBrowserStorage({ [STORAGE_KEY]: JSON.stringify({ binding: "ArrowRight" }) });
+    expect(loadBreathKeyBinding()).toBe("ArrowRight");
+  });
+
+  it("falls back to default on corrupt JSON", () => {
+    stubBrowserStorage({ [STORAGE_KEY]: "{not json" });
+    expect(loadBreathKeyBinding()).toBe("Space");
+  });
+
+  it.each([
+    ["non-object JSON", JSON.stringify("ArrowRight")],
+    ["null", JSON.stringify(null)],
+    ["unknown binding value", JSON.stringify({ binding: "Enter" })],
+    ["missing field", JSON.stringify({ other: true })],
+  ])("falls back to default for %s", (_label, raw) => {
+    stubBrowserStorage({ [STORAGE_KEY]: raw });
+    expect(loadBreathKeyBinding()).toBe("Space");
+  });
+});
+
+describe("saveBreathKeyBinding", () => {
+  it("is a no-op without window (SSR guard)", () => {
+    expect(() => saveBreathKeyBinding("ArrowRight")).not.toThrow();
+  });
+
+  it("round-trips through storage", () => {
+    const store = stubBrowserStorage();
+    saveBreathKeyBinding("ArrowRight");
+    expect(JSON.parse(store.get(STORAGE_KEY) ?? "")).toEqual({ binding: "ArrowRight" });
+    expect(loadBreathKeyBinding()).toBe("ArrowRight");
+  });
+});
+
+describe("eventMatchesBreathKeyBinding", () => {
+  it("matches Space by code", () => {
+    expect(eventMatchesBreathKeyBinding({ code: "Space", key: " " }, "Space")).toBe(true);
+  });
+
+  it("matches Space by legacy key values", () => {
+    expect(eventMatchesBreathKeyBinding({ code: "", key: " " }, "Space")).toBe(true);
+    expect(eventMatchesBreathKeyBinding({ code: "", key: "Spacebar" }, "Space")).toBe(true);
+  });
+
+  it("matches ArrowRight by code and key", () => {
+    expect(eventMatchesBreathKeyBinding({ code: "ArrowRight", key: "ArrowRight" }, "ArrowRight")).toBe(true);
+    expect(eventMatchesBreathKeyBinding({ code: "", key: "ArrowRight" }, "ArrowRight")).toBe(true);
+  });
+
+  it("does not cross-match between bindings", () => {
+    expect(eventMatchesBreathKeyBinding({ code: "Space", key: " " }, "ArrowRight")).toBe(false);
+    expect(eventMatchesBreathKeyBinding({ code: "ArrowRight", key: "ArrowRight" }, "Space")).toBe(false);
+  });
+
+  it("does not match unrelated keys", () => {
+    expect(eventMatchesBreathKeyBinding({ code: "Enter", key: "Enter" }, "Space")).toBe(false);
+    expect(eventMatchesBreathKeyBinding({ code: "KeyA", key: "a" }, "ArrowRight")).toBe(false);
+  });
+});
+
+describe("breathKeyBindingLabel", () => {
+  it("labels bindings for the UI", () => {
+    expect(breathKeyBindingLabel("Space")).toBe("Space");
+    expect(breathKeyBindingLabel("ArrowRight")).toBe("Right Arrow");
+  });
+});
+
+describe("subscribeBreathKeyBinding", () => {
+  it("notifies subscribers on save and stops after unsubscribe", () => {
+    stubBrowserStorage();
+    const listener = vi.fn();
+    const unsubscribe = subscribeBreathKeyBinding(listener);
+
+    saveBreathKeyBinding("ArrowRight");
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    saveBreathKeyBinding("Space");
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers a cross-tab storage listener while subscribed", () => {
+    stubBrowserStorage();
+    const win = window as unknown as {
+      addEventListener: ReturnType<typeof vi.fn>;
+      removeEventListener: ReturnType<typeof vi.fn>;
+    };
+    const unsubscribe = subscribeBreathKeyBinding(() => {});
+    expect(win.addEventListener).toHaveBeenCalledWith("storage", expect.any(Function));
+    unsubscribe();
+    expect(win.removeEventListener).toHaveBeenCalledWith("storage", expect.any(Function));
+  });
+});

--- a/src/lib/breathKeyBinding.ts
+++ b/src/lib/breathKeyBinding.ts
@@ -53,8 +53,9 @@ export function saveBreathKeyBinding(binding: BreathKeyBinding): void {
 
 /**
  * True when `event` matches `binding`. Compares `KeyboardEvent.code` first
- * (layout-independent), and also accepts the legacy `" "` / "Spacebar"
- * `event.key` values for Space so older browsers still register.
+ * (layout-independent), and also accepts legacy `event.key` values for Space
+ * (`" "` / `"Spacebar"`) and ArrowRight (`"Right"`) so older browsers that
+ * don't populate `event.code` still register taps.
  */
 export function eventMatchesBreathKeyBinding(
   event: Pick<KeyboardEvent, "code" | "key">,
@@ -62,7 +63,7 @@ export function eventMatchesBreathKeyBinding(
 ): boolean {
   if (event.code === binding) return true;
   if (binding === "Space") return event.key === " " || event.key === "Spacebar";
-  if (binding === "ArrowRight") return event.key === "ArrowRight";
+  if (binding === "ArrowRight") return event.key === "ArrowRight" || event.key === "Right";
   return false;
 }
 

--- a/src/lib/breathKeyBinding.ts
+++ b/src/lib/breathKeyBinding.ts
@@ -1,0 +1,98 @@
+// localStorage preference for the breath-counting key binding (#376).
+// Mirrors the audio.ts / wakeLockPrefs.ts persistence + cross-tab subscription
+// pattern. The breath view binds a single key that registers a breath (tap);
+// the default is Space, with Right Arrow as the alternate.
+
+/** Canonical key bindings the breath view understands. Values are
+ *  `KeyboardEvent.code` strings so they are layout-independent. */
+export const BREATH_KEY_BINDINGS = ["Space", "ArrowRight"] as const;
+export type BreathKeyBinding = (typeof BREATH_KEY_BINDINGS)[number];
+
+export const DEFAULT_BREATH_KEY_BINDING: BreathKeyBinding = "Space";
+
+/** Human-readable label for a binding (settings UI + view hint). */
+export function breathKeyBindingLabel(binding: BreathKeyBinding): string {
+  switch (binding) {
+    case "Space":
+      return "Space";
+    case "ArrowRight":
+      return "Right Arrow";
+  }
+}
+
+function isBreathKeyBinding(value: unknown): value is BreathKeyBinding {
+  return typeof value === "string" && (BREATH_KEY_BINDINGS as readonly string[]).includes(value);
+}
+
+const STORAGE_KEY = "stillpoint_breath_key_binding";
+
+export function loadBreathKeyBinding(): BreathKeyBinding {
+  if (typeof window === "undefined") return DEFAULT_BREATH_KEY_BINDING;
+
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_BREATH_KEY_BINDING;
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return DEFAULT_BREATH_KEY_BINDING;
+    const value = (parsed as Record<string, unknown>).binding;
+    return isBreathKeyBinding(value) ? value : DEFAULT_BREATH_KEY_BINDING;
+  } catch {
+    return DEFAULT_BREATH_KEY_BINDING;
+  }
+}
+
+export function saveBreathKeyBinding(binding: BreathKeyBinding): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ binding }));
+  } catch {
+    // Best-effort persistence: ignore storage write failures.
+  }
+  notifyBreathKeyBindingListeners();
+}
+
+/**
+ * True when `event` matches `binding`. Compares `KeyboardEvent.code` first
+ * (layout-independent), and also accepts the legacy `" "` / "Spacebar"
+ * `event.key` values for Space so older browsers still register.
+ */
+export function eventMatchesBreathKeyBinding(
+  event: Pick<KeyboardEvent, "code" | "key">,
+  binding: BreathKeyBinding,
+): boolean {
+  if (event.code === binding) return true;
+  if (binding === "Space") return event.key === " " || event.key === "Spacebar";
+  if (binding === "ArrowRight") return event.key === "ArrowRight";
+  return false;
+}
+
+type BreathKeyBindingListener = () => void;
+
+const listeners = new Set<BreathKeyBindingListener>();
+
+function onStorageEvent(e: StorageEvent): void {
+  // key === null means the whole storage area was cleared.
+  if (e.key === STORAGE_KEY || e.key === null) notifyBreathKeyBindingListeners();
+}
+
+function notifyBreathKeyBindingListeners(): void {
+  for (const listener of [...listeners]) listener();
+}
+
+/**
+ * Subscribe to breath key-binding changes: same-tab saves via
+ * `saveBreathKeyBinding` and cross-tab changes via the `storage` event.
+ * Returns an unsubscribe function (`useSyncExternalStore`-compatible).
+ */
+export function subscribeBreathKeyBinding(listener: BreathKeyBindingListener): () => void {
+  if (typeof window !== "undefined" && listeners.size === 0) {
+    window.addEventListener("storage", onStorageEvent);
+  }
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+    if (typeof window !== "undefined" && listeners.size === 0) {
+      window.removeEventListener("storage", onStorageEvent);
+    }
+  };
+}


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #376

Web port of the iOS tap-to-breathe mode (#374, merged #430), matching its data semantics.

## What this adds
- **Pure state machine** (`src/lib/breathCounting.ts`): `breathCountForTaps`, `phaseForTaps`, `elapsedSeconds`, `elapsedDisplay` — a 1:1 port of `BreathCountingLogic.swift`. Fully unit-tested (`breathCounting.test.ts`).
- **Configurable key binding** (`src/lib/breathKeyBinding.ts`): localStorage pref following the `audio.ts` / `wakeLockPrefs.ts` pattern, with cross-tab `storage` subscription. Default **Space**, alternate **Right Arrow**. Unit-tested (`breathKeyBinding.test.ts`), including `event.code`/legacy `event.key` matching.
- **`BreathCountView`** (`src/components/BreathCountView.tsx`): full-screen click/tap target; the bound key also registers a breath. Count-up timer from the first input (wall-clock, survives backgrounding), in/out phase indicator, live breath count, and an explicit **End**. `preventDefault` on the bound key stops Space from scrolling the page or activating focused controls while active; auto-repeat is ignored so taps stay discrete. Holds a screen wake lock when the user opted in (parity with sits).
- **SPA routing**: new `breath` view in `src/app/app/page.tsx` reachable from a "Breath counting" button on the home screen; nav/header are hidden while active. End logs the session (`sessionType: "breath"`, `breathCount`, `duration = max(elapsed, 1)`, `completed: true`) and returns home; empty sessions (no taps) are not logged — mirrors iOS `completeBreathSession`.
- **Settings**: a card to choose the breath key binding.

## Migration note (coordinated landing)
The `breath` session type + `breath_count` column (schema, `drizzle/sessions_breath_count_incremental.sql`, and the server-side handling in `src/app/api/sessions/route.ts`) **already landed on `main` via iOS #430**. This is the shared migration referenced in the journal note, so this PR reuses it and does **not** add or edit any migration file (no checksum-ledger drift). Breath sits are already filtered from streak/journey stats by `calculateSessionStats`.

## Test plan
- `npm run test:unit` — 260 passed (35 files), including 39 new breath tests. Not in CI, run locally.
- `npm run typecheck` — clean.
- Manual GUI test: enter Breath counting, tap + use the bound key (Space/Right Arrow) to register breaths, verify the timer / phase / count, switch the key binding in Settings, End the session, and confirm it appears in History as a Breath entry. See walkthrough in the PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6314489d-799b-43b0-9556-5150aae6ccbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6314489d-799b-43b0-9556-5150aae6ccbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Add breath-counting mode with saved key binding and fix short-session saving**

### What Changed
- Added a full-screen breath-counting mode from the home screen where each tap or the chosen key registers a breath, shows inhale/exhale progress, and includes an explicit End button
- Added a settings option to choose the breath key, with Space as the default and Right Arrow as the alternate
- Breath sessions are now saved with breath count and duration, and ending before any tap leaves no saved session
- Fixed a short-session case so ending right after the first tap still saves the session instead of dropping it

### Impact
`✅ Breath sessions can be started and ended from the web app`
`✅ Users can choose the key that counts breaths`
`✅ Short breath sessions are saved instead of being lost` 
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new breath-counting session mode with full-screen tracking, live inhale/exhale guidance, and session timing.
  * Added a configurable key binding for breath counting, with a new setting in the app.
  * Added a new entry point on the home screen for starting breath counting.

* **Bug Fixes**
  * Improved session saving so very short breath-counting sessions are recorded correctly.
  * Prevented empty breath sessions from being saved.
  * Added broader keyboard support and more reliable timing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->