### PR TITLE
feat(notifications): meditation failure-reason log + 8 PM reminder (#441)

### DIFF
--- a/drizzle/failure_reasons_441_incremental.sql
+++ b/drizzle/failure_reasons_441_incremental.sql
@@ -1,0 +1,27 @@
+-- Meditation failure-reason log (#441). One row per user per local calendar day,
+-- revisable via upsert on the (user_id, reason_date) unique index.
+
+CREATE TABLE IF NOT EXISTS "failure_reasons" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"reason_date" date NOT NULL,
+	"text" varchar(1000) NOT NULL,
+	"created_at" timestamptz DEFAULT now() NOT NULL,
+	"updated_at" timestamptz DEFAULT now() NOT NULL
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'failure_reasons_user_id_users_id_fk'
+      AND conrelid = 'public.failure_reasons'::regclass
+  ) THEN
+    ALTER TABLE "failure_reasons"
+      ADD CONSTRAINT "failure_reasons_user_id_users_id_fk"
+      FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "failure_reasons_user_date_unique"
+  ON "failure_reasons" USING btree ("user_id", "reason_date");

--- a/drizzle/failure_reasons_text_not_blank_441_incremental.sql
+++ b/drizzle/failure_reasons_text_not_blank_441_incremental.sql
@@ -1,0 +1,17 @@
+-- #441 review: enforce the non-empty note invariant at the DB layer so a blank or
+-- whitespace-only row can't suppress the reminder via hasFailureReasonForDate().
+-- Added as a NEW incremental file because failure_reasons_441_incremental.sql is
+-- already applied to the shared preview branch (append-only migrations; #368/#370).
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'failure_reasons_text_not_blank'
+      AND conrelid = 'public.failure_reasons'::regclass
+  ) THEN
+    ALTER TABLE "failure_reasons"
+      ADD CONSTRAINT "failure_reasons_text_not_blank"
+      CHECK (char_length(btrim("text")) > 0);
+  END IF;
+END $$;

--- a/drizzle/failure_reasons_text_not_blank_v2_441_incremental.sql
+++ b/drizzle/failure_reasons_text_not_blank_v2_441_incremental.sql
@@ -1,0 +1,13 @@
+-- #441 review (CodeAnt): the v1 btrim()-based check only trims plain spaces, so a note
+-- made entirely of tabs/newlines still passed and would be treated as "logged",
+-- suppressing the reminder. Replace it with a whitespace-aware check that requires at
+-- least one non-whitespace character. New incremental file (append-only) because the v1
+-- file is already applied to the shared preview branch (#368/#370 checksum guard).
+
+DO $$
+BEGIN
+  ALTER TABLE "failure_reasons" DROP CONSTRAINT IF EXISTS "failure_reasons_text_not_blank";
+  ALTER TABLE "failure_reasons"
+    ADD CONSTRAINT "failure_reasons_text_not_blank"
+    CHECK ("text" ~ '[^[:space:]]');
+END $$;

--- a/drizzle/notification_preferences_failure_reason_441_incremental.sql
+++ b/drizzle/notification_preferences_failure_reason_441_incremental.sql
@@ -1,0 +1,5 @@
+-- Failure-reason reminder opt-in (issue #441). Fixed 8 PM local "log why you
+-- couldn't meditate" notification; defaults off like the other reminder flags.
+
+ALTER TABLE "notification_preferences"
+  ADD COLUMN IF NOT EXISTS "failure_reason_reminder_enabled" boolean DEFAULT false NOT NULL;

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -431,6 +431,11 @@ final class AppViewModel {
             openHomeFromNotification()
             return true
         }
+        if host == "log-reason" {
+            // Failure-reason log UI is web-only; land on home so the notification tap is not silently dropped.
+            openHomeFromNotification()
+            return true
+        }
         return false
     }
 

--- a/src/app/api/failure-reasons/route.test.ts
+++ b/src/app/api/failure-reasons/route.test.ts
@@ -1,0 +1,160 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const getCurrentUser = vi.fn();
+
+const selectLimit = vi.fn();
+const selectWhere = vi.fn(() => ({ limit: selectLimit }));
+const selectFrom = vi.fn(() => ({ where: selectWhere }));
+const dbSelect = vi.fn(() => ({ from: selectFrom }));
+
+const insertReturning = vi.fn();
+const onConflictDoUpdate = vi.fn(() => ({ returning: insertReturning }));
+const insertValues = vi.fn(() => ({ onConflictDoUpdate }));
+const dbInsert = vi.fn(() => ({ values: insertValues }));
+
+vi.mock("@/db", () => ({
+  db: {
+    select: dbSelect,
+    insert: dbInsert,
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  failureReasons: {
+    id: "id",
+    userId: "userId",
+    reasonDate: "reasonDate",
+    text: "text",
+    createdAt: "createdAt",
+    updatedAt: "updatedAt",
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({ getCurrentUser }));
+
+vi.mock("@/lib/readJsonObject", () => ({
+  readJsonObject: async (request: Request) => ({ ok: true, body: await request.json() }),
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn((...args) => ({ and: args })),
+  eq: vi.fn((left, right) => ({ left, right })),
+}));
+
+const sampleRow = {
+  id: "fr-1",
+  userId: "user-1",
+  reasonDate: "2026-05-28",
+  text: "Too tired after work.",
+  createdAt: new Date("2026-05-28T20:01:00.000Z"),
+  updatedAt: new Date("2026-05-28T20:01:00.000Z"),
+};
+
+describe("/api/failure-reasons", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    getCurrentUser.mockResolvedValue({ userId: "user-1", email: "test@example.com" });
+    selectLimit.mockResolvedValue([sampleRow]);
+    insertReturning.mockResolvedValue([sampleRow]);
+  });
+
+  test("GET returns existence and the stored reason for a valid date", async () => {
+    const { GET } = await import("./route");
+    const response = await GET(
+      new Request("http://test.local/api/failure-reasons?date=2026-05-28") as NextRequest,
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.exists).toBe(true);
+    expect(body.failureReason.text).toBe("Too tired after work.");
+  });
+
+  test("GET reports no reason when none is stored", async () => {
+    selectLimit.mockResolvedValue([]);
+    const { GET } = await import("./route");
+    const response = await GET(
+      new Request("http://test.local/api/failure-reasons?date=2026-05-28") as NextRequest,
+    );
+    const body = await response.json();
+
+    expect(body.exists).toBe(false);
+    expect(body.failureReason).toBeNull();
+  });
+
+  test("GET rejects an invalid date", async () => {
+    const { GET } = await import("./route");
+    const response = await GET(
+      new Request("http://test.local/api/failure-reasons?date=not-a-date") as NextRequest,
+    );
+    expect(response.status).toBe(400);
+  });
+
+  test("GET returns 401 when unauthenticated", async () => {
+    getCurrentUser.mockResolvedValue(null);
+    const { GET } = await import("./route");
+    const response = await GET(
+      new Request("http://test.local/api/failure-reasons?date=2026-05-28") as NextRequest,
+    );
+    expect(response.status).toBe(401);
+  });
+
+  test("POST upserts a trimmed reason", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://test.local/api/failure-reasons", {
+        method: "POST",
+        body: JSON.stringify({ reasonDate: "2026-05-28", text: "  Too tired after work.  " }),
+      }) as NextRequest,
+    );
+
+    expect(response.status).toBe(200);
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user-1", reasonDate: "2026-05-28", text: "Too tired after work." }),
+    );
+    expect(onConflictDoUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ set: expect.objectContaining({ text: "Too tired after work." }) }),
+    );
+  });
+
+  test("POST rejects empty text", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://test.local/api/failure-reasons", {
+        method: "POST",
+        body: JSON.stringify({ reasonDate: "2026-05-28", text: "   " }),
+      }) as NextRequest,
+    );
+
+    expect(response.status).toBe(400);
+    expect(dbInsert).not.toHaveBeenCalled();
+  });
+
+  test("POST rejects an invalid reasonDate", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://test.local/api/failure-reasons", {
+        method: "POST",
+        body: JSON.stringify({ reasonDate: "2026-13-99", text: "valid" }),
+      }) as NextRequest,
+    );
+
+    expect(response.status).toBe(400);
+    expect(dbInsert).not.toHaveBeenCalled();
+  });
+
+  test("POST rejects text over the length cap", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://test.local/api/failure-reasons", {
+        method: "POST",
+        body: JSON.stringify({ reasonDate: "2026-05-28", text: "x".repeat(1001) }),
+      }) as NextRequest,
+    );
+
+    expect(response.status).toBe(400);
+    expect(dbInsert).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/failure-reasons/route.test.ts
+++ b/src/app/api/failure-reasons/route.test.ts
@@ -1,22 +1,38 @@
 import type { NextRequest } from "next/server";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-const getCurrentUser = vi.fn();
+// vi.mock factories are hoisted above module-level declarations, so the shared mock
+// handles they reference are created in vi.hoisted (runs alongside the hoisted mocks).
+const h = vi.hoisted(() => {
+  const selectLimit = vi.fn();
+  const selectWhere = vi.fn(() => ({ limit: selectLimit }));
+  const selectFrom = vi.fn(() => ({ where: selectWhere }));
+  const dbSelect = vi.fn(() => ({ from: selectFrom }));
 
-const selectLimit = vi.fn();
-const selectWhere = vi.fn(() => ({ limit: selectLimit }));
-const selectFrom = vi.fn(() => ({ where: selectWhere }));
-const dbSelect = vi.fn(() => ({ from: selectFrom }));
+  const insertReturning = vi.fn();
+  const onConflictDoUpdate = vi.fn(() => ({ returning: insertReturning }));
+  const insertValues = vi.fn(() => ({ onConflictDoUpdate }));
+  const dbInsert = vi.fn(() => ({ values: insertValues }));
 
-const insertReturning = vi.fn();
-const onConflictDoUpdate = vi.fn(() => ({ returning: insertReturning }));
-const insertValues = vi.fn(() => ({ onConflictDoUpdate }));
-const dbInsert = vi.fn(() => ({ values: insertValues }));
+  const getCurrentUser = vi.fn();
+
+  return {
+    selectLimit,
+    dbSelect,
+    insertReturning,
+    onConflictDoUpdate,
+    insertValues,
+    dbInsert,
+    getCurrentUser,
+  };
+});
+
+const { getCurrentUser, selectLimit, insertReturning, onConflictDoUpdate, insertValues, dbInsert } = h;
 
 vi.mock("@/db", () => ({
   db: {
-    select: dbSelect,
-    insert: dbInsert,
+    select: h.dbSelect,
+    insert: h.dbInsert,
   },
 }));
 
@@ -31,7 +47,7 @@ vi.mock("@/db/schema", () => ({
   },
 }));
 
-vi.mock("@/lib/auth", () => ({ getCurrentUser }));
+vi.mock("@/lib/auth", () => ({ getCurrentUser: h.getCurrentUser }));
 
 vi.mock("@/lib/readJsonObject", () => ({
   readJsonObject: async (request: Request) => ({ ok: true, body: await request.json() }),

--- a/src/app/api/failure-reasons/route.test.ts
+++ b/src/app/api/failure-reasons/route.test.ts
@@ -161,6 +161,20 @@ describe("/api/failure-reasons", () => {
     expect(dbInsert).not.toHaveBeenCalled();
   });
 
+  test("POST rejects a future reasonDate", async () => {
+    const future = new Date(Date.now() + 5 * 86_400_000).toISOString().slice(0, 10);
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://test.local/api/failure-reasons", {
+        method: "POST",
+        body: JSON.stringify({ reasonDate: future, text: "planning ahead" }),
+      }) as NextRequest,
+    );
+
+    expect(response.status).toBe(400);
+    expect(dbInsert).not.toHaveBeenCalled();
+  });
+
   test("POST rejects text over the length cap", async () => {
     const { POST } = await import("./route");
     const response = await POST(

--- a/src/app/api/failure-reasons/route.ts
+++ b/src/app/api/failure-reasons/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db";
+import { failureReasons } from "@/db/schema";
+import { getCurrentUser } from "@/lib/auth";
+import { readJsonObject } from "@/lib/readJsonObject";
+import { isValidSessionCalendarDate } from "@/lib/sessionCalendar";
+
+const MAX_REASON_LENGTH = 1000;
+
+function serializeFailureReason(row: typeof failureReasons.$inferSelect) {
+  return {
+    id: row.id,
+    reasonDate: row.reasonDate,
+    text: row.text,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const date = new URL(request.url).searchParams.get("date");
+    if (!date || !isValidSessionCalendarDate(date)) {
+      return NextResponse.json({ error: "date must be YYYY-MM-DD" }, { status: 400 });
+    }
+
+    const [row] = await db
+      .select()
+      .from(failureReasons)
+      .where(and(eq(failureReasons.userId, auth.userId), eq(failureReasons.reasonDate, date)))
+      .limit(1);
+
+    return NextResponse.json({
+      exists: !!row,
+      failureReason: row ? serializeFailureReason(row) : null,
+    });
+  } catch (error) {
+    console.error("Failure reasons GET error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const json = await readJsonObject(request);
+    if (!json.ok) {
+      return json.response;
+    }
+
+    const { reasonDate, text } = json.body;
+
+    if (typeof reasonDate !== "string" || !isValidSessionCalendarDate(reasonDate)) {
+      return NextResponse.json({ error: "reasonDate must be YYYY-MM-DD" }, { status: 400 });
+    }
+
+    if (typeof text !== "string") {
+      return NextResponse.json({ error: "text is required" }, { status: 400 });
+    }
+    const trimmed = text.trim();
+    if (trimmed.length === 0) {
+      return NextResponse.json({ error: "text must not be empty" }, { status: 400 });
+    }
+    if (trimmed.length > MAX_REASON_LENGTH) {
+      return NextResponse.json(
+        { error: `text must be at most ${MAX_REASON_LENGTH} characters` },
+        { status: 400 },
+      );
+    }
+
+    // Upsert so a user can revise an existing reason for the same day.
+    const now = new Date();
+    const [row] = await db
+      .insert(failureReasons)
+      .values({
+        userId: auth.userId,
+        reasonDate,
+        text: trimmed,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [failureReasons.userId, failureReasons.reasonDate],
+        set: { text: trimmed, updatedAt: now },
+      })
+      .returning();
+
+    return NextResponse.json({ failureReason: serializeFailureReason(row) });
+  } catch (error) {
+    // Log only the error message, never the raw error — a DB driver error's `detail`/
+    // `parameters` fields can echo the user's submitted reason text into server logs.
+    console.error("Failure reasons POST error:", error instanceof Error ? error.message : "unknown error");
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/failure-reasons/route.ts
+++ b/src/app/api/failure-reasons/route.ts
@@ -41,7 +41,7 @@ export async function GET(request: NextRequest) {
       failureReason: row ? serializeFailureReason(row) : null,
     });
   } catch (error) {
-    console.error("Failure reasons GET error:", error);
+    console.error("Failure reasons GET error:", error instanceof Error ? error.message : "unknown error");
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/src/app/api/failure-reasons/route.ts
+++ b/src/app/api/failure-reasons/route.ts
@@ -4,9 +4,19 @@ import { db } from "@/db";
 import { failureReasons } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
 import { readJsonObject } from "@/lib/readJsonObject";
-import { isValidSessionCalendarDate } from "@/lib/sessionCalendar";
+import { addDaysToIsoDate, isValidSessionCalendarDate } from "@/lib/sessionCalendar";
 
 const MAX_REASON_LENGTH = 1000;
+
+/**
+ * Latest date a reason may be logged for. The server doesn't know the caller's
+ * timezone, so allow UTC-today + 1 day to cover users ahead of UTC. This blocks
+ * pre-logging genuinely future days, which would otherwise make the scheduler
+ * treat them as "already logged" and suppress the reminder (#441 review).
+ */
+function maxReasonDate(): string {
+  return addDaysToIsoDate(new Date().toISOString().slice(0, 10), 1);
+}
 
 function serializeFailureReason(row: typeof failureReasons.$inferSelect) {
   return {
@@ -62,6 +72,9 @@ export async function POST(request: NextRequest) {
 
     if (typeof reasonDate !== "string" || !isValidSessionCalendarDate(reasonDate)) {
       return NextResponse.json({ error: "reasonDate must be YYYY-MM-DD" }, { status: 400 });
+    }
+    if (reasonDate > maxReasonDate()) {
+      return NextResponse.json({ error: "reasonDate cannot be in the future" }, { status: 400 });
     }
 
     if (typeof text !== "string") {

--- a/src/app/api/notifications/preferences/route.test.ts
+++ b/src/app/api/notifications/preferences/route.test.ts
@@ -24,6 +24,7 @@ vi.mock("@/db/schema", () => ({
     pushEnabled: "pushEnabled",
     dailyReminderEnabled: "dailyReminderEnabled",
     missADayEnabled: "missADayEnabled",
+    failureReasonReminderEnabled: "failureReasonReminderEnabled",
     friendRequestNotificationsEnabled: "friendRequestNotificationsEnabled",
     suppressDuringSession: "suppressDuringSession",
     dailyReminderTime: "dailyReminderTime",
@@ -61,6 +62,7 @@ const samplePrefs = {
   pushEnabled: true,
   dailyReminderEnabled: true,
   missADayEnabled: false,
+  failureReasonReminderEnabled: false,
   friendRequestNotificationsEnabled: true,
   suppressDuringSession: false,
   dailyReminderTime: "09:00",
@@ -162,6 +164,22 @@ describe("/api/notifications/preferences", () => {
     expect(response.status).toBe(200);
     expect(updateSet).toHaveBeenCalledWith(
       expect.objectContaining({ suppressDuringSession: true }),
+    );
+  });
+
+  test("PATCH updates failure reason reminder preference", async () => {
+    const { PATCH } = await import("./route");
+
+    const response = await PATCH(
+      new Request("http://test.local/api/notifications/preferences", {
+        method: "PATCH",
+        body: JSON.stringify({ failureReasonReminderEnabled: true }),
+      }) as NextRequest,
+    );
+
+    expect(response.status).toBe(200);
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ failureReasonReminderEnabled: true }),
     );
   });
 

--- a/src/app/api/notifications/preferences/route.ts
+++ b/src/app/api/notifications/preferences/route.ts
@@ -57,6 +57,10 @@ export async function PATCH(request: NextRequest) {
       updates.missADayEnabled = body.missADayEnabled;
       hasUpdate = true;
     }
+    if (typeof body.failureReasonReminderEnabled === "boolean") {
+      updates.failureReasonReminderEnabled = body.failureReasonReminderEnabled;
+      hasUpdate = true;
+    }
     if (typeof body.friendRequestNotificationsEnabled === "boolean") {
       updates.friendRequestNotificationsEnabled = body.friendRequestNotificationsEnabled;
       hasUpdate = true;

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -169,6 +169,17 @@ export default function StillPoint() {
     }
   }, [user, authChecked, rawTab, router]);
 
+  // Deep link to auto-start a sit, e.g. /app?session=quick from the failure-reason
+  // log page's post-save CTA (#441). Consume the param so a refresh won't re-trigger.
+  useEffect(() => {
+    if (!user || !authChecked) return;
+    const sessionParam = new URLSearchParams(window.location.search).get("session");
+    if (sessionParam !== "quick" && sessionParam !== "standard") return;
+    setActiveSessionType(sessionParam);
+    setOverlay("session");
+    router.replace(rawTab && isTab(rawTab) ? pathForTab(rawTab) : pathForTab(DEFAULT_TAB));
+  }, [user, authChecked, rawTab, router]);
+
   useEffect(() => {
     if (!user || !authChecked || buddyInviteInFlight.current) return;
     const params = new URLSearchParams(window.location.search);

--- a/src/app/app/log-reason/page.tsx
+++ b/src/app/app/log-reason/page.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { Suspense, useCallback, useEffect, useState, type CSSProperties } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { AppSubpageShell } from "@/components/AppSubpageShell";
+import { BuddyCalendarAuthGate } from "@/components/BuddyCalendarAuthGate";
+import { addDaysToIsoDate, isValidSessionCalendarDate, todayLocalIsoDate } from "@/lib/sessionCalendar";
+
+const MAX_REASON_LENGTH = 1000;
+
+export default function LogReasonPage() {
+  return (
+    <Suspense
+      fallback={
+        <div style={{ minHeight: "100%", display: "flex", alignItems: "center", justifyContent: "center", color: "var(--fg-4)" }}>
+          Loading…
+        </div>
+      }
+    >
+      <LogReasonContent />
+    </Suspense>
+  );
+}
+
+function LogReasonContent() {
+  const searchParams = useSearchParams();
+  const dateParam = searchParams.get("date");
+  const targetDate = dateParam && isValidSessionCalendarDate(dateParam) ? dateParam : todayLocalIsoDate();
+
+  const today = todayLocalIsoDate();
+  const yesterday = addDaysToIsoDate(today, -1);
+  const dayLabel = targetDate === yesterday ? "yesterday" : targetDate === today ? "today" : "that day";
+
+  return (
+    <BuddyCalendarAuthGate>
+      {() => (
+        <AppSubpageShell title="A gentle check-in" backHref="/app" backLabel="Back to app">
+          <LogReasonForm targetDate={targetDate} dayLabel={dayLabel} />
+        </AppSubpageShell>
+      )}
+    </BuddyCalendarAuthGate>
+  );
+}
+
+function LogReasonForm({ targetDate, dayLabel }: { targetDate: string; dayLabel: string }) {
+  const [text, setText] = useState("");
+  const [loadingExisting, setLoadingExisting] = useState(true);
+  const [hadExisting, setHadExisting] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    // Reset per-date state so navigating between dates (e.g. two different deep links
+    // in one session) never carries a prior day's note or success screen forward.
+    setSaved(false);
+    setError(null);
+    setText("");
+    setHadExisting(false);
+    setLoadingExisting(true);
+    (async () => {
+      try {
+        const res = await fetch(`/api/failure-reasons?date=${encodeURIComponent(targetDate)}`);
+        if (cancelled) return;
+        if (res.ok) {
+          const data = await res.json();
+          const existingText = typeof data?.failureReason?.text === "string"
+            ? data.failureReason.text
+            : null;
+          setText(existingText ?? "");
+          setHadExisting(existingText !== null);
+        }
+      } catch {
+        // Non-fatal: fall back to an empty textarea.
+      } finally {
+        if (!cancelled) setLoadingExisting(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [targetDate]);
+
+  const submit = useCallback(async () => {
+    const trimmed = text.trim();
+    if (trimmed.length === 0 || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/failure-reasons", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reasonDate: targetDate, text: trimmed }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.error ?? "Could not save your note. Please try again.");
+      }
+      setSaved(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not save your note. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [text, targetDate, submitting]);
+
+  if (saved) {
+    return (
+      <div style={confirmWrapStyle}>
+        <p style={confirmLeadStyle}>Thanks for logging. Every day is a fresh start.</p>
+        <Link href="/app" style={primaryCtaStyle}>
+          Start a quick 60-second session
+        </Link>
+        <Link href="/app" style={secondaryLinkStyle}>
+          Back to home
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div style={formWrapStyle}>
+      <p style={promptStyle}>Why couldn&apos;t you meditate {dayLabel}?</p>
+      <p style={hintStyle}>
+        No judgment — even a sentence helps you notice the patterns that get in the way.
+      </p>
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        rows={4}
+        maxLength={MAX_REASON_LENGTH}
+        disabled={loadingExisting || submitting}
+        placeholder="A few honest words about what made it hard today…"
+        style={textareaStyle}
+      />
+      <div style={counterRowStyle}>
+        {hadExisting && <span>Updating your earlier note for this day.</span>}
+        <span style={{ marginLeft: "auto" }}>
+          {text.length}/{MAX_REASON_LENGTH}
+        </span>
+      </div>
+      {error && (
+        <div role="alert" style={errorStyle}>
+          {error}
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={() => void submit()}
+        disabled={text.trim().length === 0 || submitting || loadingExisting}
+        style={{
+          ...primaryCtaStyle,
+          opacity: text.trim().length === 0 || submitting || loadingExisting ? 0.5 : 1,
+          cursor: text.trim().length === 0 || submitting || loadingExisting ? "not-allowed" : "pointer",
+        }}
+      >
+        {submitting ? "Saving…" : "Save note"}
+      </button>
+    </div>
+  );
+}
+
+const formWrapStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "var(--s3)",
+  width: "100%",
+};
+
+const confirmWrapStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "var(--s3)",
+  width: "100%",
+  alignItems: "center",
+  textAlign: "center",
+};
+
+const promptStyle: CSSProperties = {
+  fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+  fontSize: "20px",
+  fontStyle: "italic",
+  color: "var(--fg)",
+  margin: 0,
+  textAlign: "center",
+};
+
+const confirmLeadStyle: CSSProperties = {
+  fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+  fontSize: "20px",
+  fontStyle: "italic",
+  color: "var(--fg)",
+  margin: 0,
+  lineHeight: 1.5,
+};
+
+const hintStyle: CSSProperties = {
+  fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+  fontSize: "14px",
+  fontStyle: "italic",
+  color: "var(--fg-3)",
+  margin: 0,
+  textAlign: "center",
+  lineHeight: 1.5,
+};
+
+const textareaStyle: CSSProperties = {
+  fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+  fontSize: "16px",
+  color: "var(--fg)",
+  background: "var(--surface-2)",
+  border: "1px solid var(--border-3)",
+  borderRadius: "10px",
+  padding: "12px 14px",
+  resize: "vertical",
+  minHeight: "110px",
+  lineHeight: 1.5,
+  width: "100%",
+  boxSizing: "border-box",
+};
+
+const counterRowStyle: CSSProperties = {
+  display: "flex",
+  gap: "var(--s2)",
+  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+  fontSize: "11px",
+  color: "var(--fg-4)",
+  letterSpacing: "0.06em",
+};
+
+const primaryCtaStyle: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  border: "1px solid var(--border-2)",
+  background: "var(--accent-green-bg)",
+  color: "var(--fg)",
+  borderRadius: "999px",
+  padding: "12px 18px",
+  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+  fontSize: "12px",
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  textDecoration: "none",
+  cursor: "pointer",
+};
+
+const secondaryLinkStyle: CSSProperties = {
+  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+  fontSize: "11px",
+  letterSpacing: "0.1em",
+  textTransform: "uppercase",
+  color: "var(--fg-3)",
+  textDecoration: "none",
+};
+
+const errorStyle: CSSProperties = {
+  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+  fontSize: "11px",
+  color: "var(--accent-danger-muted)",
+  letterSpacing: "0.04em",
+};

--- a/src/app/app/log-reason/page.tsx
+++ b/src/app/app/log-reason/page.tsx
@@ -30,20 +30,36 @@ function LogReasonContent() {
 
   const today = todayLocalIsoDate();
   const yesterday = addDaysToIsoDate(today, -1);
-  const dayLabel = targetDate === yesterday ? "yesterday" : targetDate === today ? "today" : "that day";
+  const isYesterday = targetDate === yesterday;
+  const dayLabel = isYesterday ? "yesterday" : targetDate === today ? "today" : "that day";
 
   return (
     <BuddyCalendarAuthGate>
       {() => (
         <AppSubpageShell title="A gentle check-in" backHref="/app" backLabel="Back to app">
-          <LogReasonForm targetDate={targetDate} dayLabel={dayLabel} />
+          <LogReasonForm
+            targetDate={targetDate}
+            dayLabel={dayLabel}
+            isYesterday={isYesterday}
+            today={today}
+          />
         </AppSubpageShell>
       )}
     </BuddyCalendarAuthGate>
   );
 }
 
-function LogReasonForm({ targetDate, dayLabel }: { targetDate: string; dayLabel: string }) {
+function LogReasonForm({
+  targetDate,
+  dayLabel,
+  isYesterday,
+  today,
+}: {
+  targetDate: string;
+  dayLabel: string;
+  isYesterday: boolean;
+  today: string;
+}) {
   const [text, setText] = useState("");
   const [loadingExisting, setLoadingExisting] = useState(true);
   const [hadExisting, setHadExisting] = useState(false);
@@ -110,23 +126,40 @@ function LogReasonForm({ targetDate, dayLabel }: { targetDate: string; dayLabel:
     return (
       <div style={confirmWrapStyle}>
         <p style={confirmLeadStyle}>Thanks for logging. Every day is a fresh start.</p>
-        <Link href="/app" style={primaryCtaStyle}>
-          Start a quick 60-second session
-        </Link>
-        <Link href="/app" style={secondaryLinkStyle}>
-          Back to home
-        </Link>
+        {isYesterday ? (
+          <>
+            {/* They just logged yesterday — guide them to today next, per #441. */}
+            <Link href={`/app/log-reason?date=${today}`} style={primaryCtaStyle}>
+              Now: why not today?
+            </Link>
+            <Link href="/app" style={secondaryLinkStyle}>
+              Or start a quick 60-second session
+            </Link>
+          </>
+        ) : (
+          <>
+            <Link href="/app" style={primaryCtaStyle}>
+              Start a quick 60-second session
+            </Link>
+            <Link href="/app" style={secondaryLinkStyle}>
+              Back to home
+            </Link>
+          </>
+        )}
       </div>
     );
   }
 
   return (
     <div style={formWrapStyle}>
-      <p style={promptStyle}>Why couldn&apos;t you meditate {dayLabel}?</p>
+      <label htmlFor="failure-reason-text" style={promptStyle}>
+        Why couldn&apos;t you meditate {dayLabel}?
+      </label>
       <p style={hintStyle}>
         No judgment — even a sentence helps you notice the patterns that get in the way.
       </p>
       <textarea
+        id="failure-reason-text"
         value={text}
         onChange={(e) => setText(e.target.value)}
         rows={4}

--- a/src/app/app/log-reason/page.tsx
+++ b/src/app/app/log-reason/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useCallback, useEffect, useState, type CSSProperties } from "react";
+import { Suspense, useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { AppSubpageShell } from "@/components/AppSubpageShell";
@@ -64,6 +64,7 @@ function LogReasonForm({
   const [loadingExisting, setLoadingExisting] = useState(true);
   const [hadExisting, setHadExisting] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const submittingRef = useRef(false);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
 
@@ -101,7 +102,10 @@ function LogReasonForm({
 
   const submit = useCallback(async () => {
     const trimmed = text.trim();
-    if (trimmed.length === 0 || submitting) return;
+    // Guard on a ref, not the async `submitting` state, so rapid double-clicks in the
+    // same tick can't fire two POSTs before the disabled state has re-rendered.
+    if (trimmed.length === 0 || submittingRef.current) return;
+    submittingRef.current = true;
     setSubmitting(true);
     setError(null);
     try {
@@ -118,9 +122,10 @@ function LogReasonForm({
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not save your note. Please try again.");
     } finally {
+      submittingRef.current = false;
       setSubmitting(false);
     }
-  }, [text, targetDate, submitting]);
+  }, [text, targetDate]);
 
   if (saved) {
     return (
@@ -132,13 +137,13 @@ function LogReasonForm({
             <Link href={`/app/log-reason?date=${today}`} style={primaryCtaStyle}>
               Now: why not today?
             </Link>
-            <Link href="/app" style={secondaryLinkStyle}>
+            <Link href="/app?session=quick" style={secondaryLinkStyle}>
               Or start a quick 60-second session
             </Link>
           </>
         ) : (
           <>
-            <Link href="/app" style={primaryCtaStyle}>
+            <Link href="/app?session=quick" style={primaryCtaStyle}>
               Start a quick 60-second session
             </Link>
             <Link href="/app" style={secondaryLinkStyle}>

--- a/src/app/app/log-reason/page.tsx
+++ b/src/app/app/log-reason/page.tsx
@@ -68,6 +68,11 @@ function LogReasonForm({
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
 
+  // Always-current target date, so an in-flight save that resolves after the user
+  // navigated to another date can detect the change and skip stale state updates.
+  const activeDateRef = useRef(targetDate);
+  activeDateRef.current = targetDate;
+
   useEffect(() => {
     let cancelled = false;
     // Reset per-date state so navigating between dates (e.g. two different deep links
@@ -76,6 +81,8 @@ function LogReasonForm({
     setError(null);
     setText("");
     setHadExisting(false);
+    submittingRef.current = false;
+    setSubmitting(false);
     setLoadingExisting(true);
     (async () => {
       try {
@@ -83,6 +90,9 @@ function LogReasonForm({
         if (cancelled) return;
         if (res.ok) {
           const data = await res.json();
+          // Re-check after the awaited parse: the date may have changed (or the
+          // component unmounted) while JSON was streaming in.
+          if (cancelled) return;
           const existingText = typeof data?.failureReason?.text === "string"
             ? data.failureReason.text
             : null;
@@ -105,6 +115,7 @@ function LogReasonForm({
     // Guard on a ref, not the async `submitting` state, so rapid double-clicks in the
     // same tick can't fire two POSTs before the disabled state has re-rendered.
     if (trimmed.length === 0 || submittingRef.current) return;
+    const submittedDate = targetDate;
     submittingRef.current = true;
     setSubmitting(true);
     setError(null);
@@ -112,18 +123,24 @@ function LogReasonForm({
       const res = await fetch("/api/failure-reasons", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ reasonDate: targetDate, text: trimmed }),
+        body: JSON.stringify({ reasonDate: submittedDate, text: trimmed }),
       });
+      // Drop the result if the user navigated to a different date mid-save, so a stale
+      // success/error can't land on the new date's view.
+      if (activeDateRef.current !== submittedDate) return;
       if (!res.ok) {
         const data = await res.json().catch(() => null);
         throw new Error(data?.error ?? "Could not save your note. Please try again.");
       }
       setSaved(true);
     } catch (err) {
+      if (activeDateRef.current !== submittedDate) return;
       setError(err instanceof Error ? err.message : "Could not save your note. Please try again.");
     } finally {
-      submittingRef.current = false;
-      setSubmitting(false);
+      if (activeDateRef.current === submittedDate) {
+        submittingRef.current = false;
+        setSubmitting(false);
+      }
     }
   }, [text, targetDate]);
 

--- a/src/components/WebNotificationSettings.tsx
+++ b/src/components/WebNotificationSettings.tsx
@@ -293,6 +293,17 @@ export function WebNotificationSettings({ pageMode = false }: WebNotificationSet
             }); }}
           />
 
+          <SectionLabel>Reflect on a missed day</SectionLabel>
+          <ToggleRow
+            title="Log why you missed"
+            description="At 8 PM, if you haven't sat, a nudge to jot down what got in the way"
+            pressed={prefs.failureReasonReminderEnabled}
+            disabled={busy}
+            onToggle={() => { void runBusy(async () => {
+              await persist({ failureReasonReminderEnabled: !prefs.failureReasonReminderEnabled });
+            }); }}
+          />
+
           <SectionLabel>Friend activity</SectionLabel>
           <ToggleRow
             title="Friend requests"

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -102,10 +102,11 @@ export const failureReasons = pgTable("failure_reasons", {
     table.reasonDate,
   ),
   /** A blank/whitespace-only row would make hasFailureReasonForDate() suppress the
-   *  reminder for that day despite no real note. Enforce non-empty at the DB layer. */
+   *  reminder for that day despite no real note. Reject text with no non-whitespace
+   *  character (covers spaces, tabs, and newlines) at the DB layer. */
   textNotBlank: check(
     "failure_reasons_text_not_blank",
-    sql`char_length(btrim(${table.text})) > 0`,
+    sql`${table.text} ~ '[^[:space:]]'`,
   ),
 }));
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -101,6 +101,12 @@ export const failureReasons = pgTable("failure_reasons", {
     table.userId,
     table.reasonDate,
   ),
+  /** A blank/whitespace-only row would make hasFailureReasonForDate() suppress the
+   *  reminder for that day despite no real note. Enforce non-empty at the DB layer. */
+  textNotBlank: check(
+    "failure_reasons_text_not_blank",
+    sql`char_length(btrim(${table.text})) > 0`,
+  ),
 }));
 
 /** Browser Web Push subscriptions (#347). One row per Push API endpoint. */

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -43,6 +43,8 @@ export const notificationPreferences = pgTable("notification_preferences", {
   pushEnabled: boolean("push_enabled").default(false).notNull(),
   dailyReminderEnabled: boolean("daily_reminder_enabled").default(false).notNull(),
   missADayEnabled: boolean("miss_a_day_enabled").default(false).notNull(),
+  /** #441: opt-in for the fixed 8 PM "log why you couldn't meditate" reminder. */
+  failureReasonReminderEnabled: boolean("failure_reason_reminder_enabled").default(false).notNull(),
   friendRequestNotificationsEnabled: boolean("friend_request_notifications_enabled").default(true).notNull(),
   /** Opt-in (#431): suppress push display on this user's devices while a sit is in progress. */
   suppressDuringSession: boolean("suppress_during_session").default(false).notNull(),
@@ -81,6 +83,23 @@ export const notificationDispatches = pgTable("notification_dispatches", {
     table.userId,
     table.notificationType,
     table.windowKey,
+  ),
+}));
+
+/** #441: user-logged reason for not meditating on a given local calendar day.
+ *  At most one reason per user per day (revisable via upsert). */
+export const failureReasons = pgTable("failure_reasons", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  userId: uuid("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
+  /** Local calendar date the reason is about, `YYYY-MM-DD` (matches sessions.session_date). */
+  reasonDate: date("reason_date").notNull(),
+  text: varchar("text", { length: 1000 }).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  userDateUnique: uniqueIndex("failure_reasons_user_date_unique").on(
+    table.userId,
+    table.reasonDate,
   ),
 }));
 
@@ -391,6 +410,7 @@ export const usersRelations = relations(users, ({ one, many }) => ({
     references: [notificationPreferences.userId],
   }),
   notificationDispatches: many(notificationDispatches),
+  failureReasons: many(failureReasons),
   oauthAccounts: many(oauthAccounts),
   googleOAuthToken: one(googleOAuthTokens, {
     fields: [users.id],
@@ -413,6 +433,10 @@ export const notificationDispatchesRelations = relations(notificationDispatches,
 
 export const deviceTokensRelations = relations(deviceTokens, ({ one }) => ({
   user: one(users, { fields: [deviceTokens.userId], references: [users.id] }),
+}));
+
+export const failureReasonsRelations = relations(failureReasons, ({ one }) => ({
+  user: one(users, { fields: [failureReasons.userId], references: [users.id] }),
 }));
 
 export const webPushSubscriptionsRelations = relations(webPushSubscriptions, ({ one }) => ({

--- a/src/lib/notification-preferences.ts
+++ b/src/lib/notification-preferences.ts
@@ -9,6 +9,7 @@ export type NotificationPreferencesRow = {
   pushEnabled: boolean;
   dailyReminderEnabled: boolean;
   missADayEnabled: boolean;
+  failureReasonReminderEnabled: boolean;
   friendRequestNotificationsEnabled: boolean;
   suppressDuringSession: boolean;
   dailyReminderTime: string;
@@ -27,6 +28,7 @@ export const DEFAULT_NOTIFICATION_PREFERENCES = {
   pushEnabled: false,
   dailyReminderEnabled: false,
   missADayEnabled: false,
+  failureReasonReminderEnabled: false,
   friendRequestNotificationsEnabled: true,
   suppressDuringSession: false,
   dailyReminderTime: "09:00",
@@ -68,6 +70,7 @@ export function serializeNotificationPreferences(row: NotificationPreferencesRow
     pushEnabled: row.pushEnabled,
     dailyReminderEnabled: row.dailyReminderEnabled,
     missADayEnabled: row.missADayEnabled,
+    failureReasonReminderEnabled: row.failureReasonReminderEnabled,
     friendRequestNotificationsEnabled: row.friendRequestNotificationsEnabled,
     suppressDuringSession: row.suppressDuringSession,
     dailyReminderTime: row.dailyReminderTime,

--- a/src/lib/notification-scheduler.test.ts
+++ b/src/lib/notification-scheduler.test.ts
@@ -253,6 +253,23 @@ describe("notification scheduler", () => {
     });
   });
 
+  test("failure-reason send short-circuits daily accounting for the same candidate (#441)", async () => {
+    preferenceRows = [{
+      ...basePrefs,
+      dailyReminderTime: "20:00",
+      failureReasonReminderEnabled: true,
+    }];
+
+    const { dispatchDueNotifications } = await import("./notification-scheduler");
+    const result = await dispatchDueNotifications(new Date("2026-05-29T20:02:00.000Z"));
+
+    expect(result.sent).toBe(1);
+    expect(result.failureReasonSent).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(sendFailureReasonReminderNotification).toHaveBeenCalledTimes(1);
+    expect(sendDailyReminderNotification).not.toHaveBeenCalled();
+  });
+
   test("failure-reason reminder falls back to today when yesterday is handled (#441)", async () => {
     preferenceRows = [{
       ...basePrefs,

--- a/src/lib/notification-scheduler.test.ts
+++ b/src/lib/notification-scheduler.test.ts
@@ -270,6 +270,29 @@ describe("notification scheduler", () => {
     expect(sendDailyReminderNotification).not.toHaveBeenCalled();
   });
 
+  test("failure-reason send is not also counted as skipped when daily window is not due (#441)", async () => {
+    preferenceRows = [{
+      ...basePrefs,
+      dailyReminderEnabled: true,
+      dailyReminderTime: "09:00",
+      missADayEnabled: false,
+      failureReasonReminderEnabled: true,
+    }];
+
+    const { dispatchDueNotifications } = await import("./notification-scheduler");
+    const result = await dispatchDueNotifications(new Date("2026-05-29T20:02:00.000Z"));
+
+    expect(result.sent).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.failureReasonSent).toBe(1);
+    expect(sendFailureReasonReminderNotification).toHaveBeenCalledWith({
+      recipientUserId: "user-1",
+      targetDate: "2026-05-28",
+      isYesterday: true,
+    });
+    expect(sendDailyReminderNotification).not.toHaveBeenCalled();
+  });
+
   test("failure-reason reminder falls back to today when yesterday is handled (#441)", async () => {
     preferenceRows = [{
       ...basePrefs,

--- a/src/lib/notification-scheduler.test.ts
+++ b/src/lib/notification-scheduler.test.ts
@@ -10,6 +10,7 @@ const deleteWhere = vi.fn().mockResolvedValue(undefined);
 const dbDelete = vi.fn(() => ({ where: deleteWhere }));
 const sendDailyReminderNotification = vi.fn();
 const sendMissADayNotification = vi.fn();
+const sendFailureReasonReminderNotification = vi.fn();
 
 const dbSelect = vi.fn(() => ({
   from: vi.fn(() => ({
@@ -29,11 +30,13 @@ vi.mock("@/db/schema", () => ({
   notificationPreferences: { table: "notification_preferences" },
   notificationDispatches: { table: "notification_dispatches" },
   sessions: { table: "sessions" },
+  failureReasons: { table: "failure_reasons" },
 }));
 
 vi.mock("@/lib/notifications", () => ({
   sendDailyReminderNotification,
   sendMissADayNotification,
+  sendFailureReasonReminderNotification,
 }));
 
 const hasMissADayDispatchForDate = vi.fn();
@@ -44,6 +47,14 @@ vi.mock("@/lib/notifications/daily-reminder", () => ({
   hasMissADayDispatchForDate,
   userCompletedSessionOnDate,
   loadUserStreak,
+}));
+
+const hasFailureReasonForDate = vi.fn();
+
+vi.mock("@/lib/notifications/failure-reason", () => ({
+  FAILURE_REASON_NOTIFICATION_TYPE: "failure_reason_reminder",
+  FAILURE_REASON_REMINDER_MINUTES: 20 * 60,
+  hasFailureReasonForDate,
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -61,6 +72,7 @@ const basePrefs = {
   quietHoursEnd: null,
   dailyReminderEnabled: true,
   missADayEnabled: false,
+  failureReasonReminderEnabled: false,
 };
 
 describe("notification scheduler", () => {
@@ -70,12 +82,15 @@ describe("notification scheduler", () => {
     preferenceRows = [basePrefs];
     sendDailyReminderNotification.mockReset();
     sendMissADayNotification.mockReset();
+    sendFailureReasonReminderNotification.mockReset();
     sendDailyReminderNotification.mockResolvedValue({ delivered: true });
     sendMissADayNotification.mockResolvedValue({ delivered: true });
+    sendFailureReasonReminderNotification.mockResolvedValue({ delivered: true });
     insertReturning.mockReset();
     insertReturning.mockResolvedValue([{ id: "dispatch-1" }]);
     hasMissADayDispatchForDate.mockResolvedValue(false);
     userCompletedSessionOnDate.mockResolvedValue(false);
+    hasFailureReasonForDate.mockResolvedValue(false);
     loadUserStreak.mockResolvedValue(0);
   });
 
@@ -219,6 +234,112 @@ describe("notification scheduler", () => {
     expect(sendDailyReminderNotification).not.toHaveBeenCalled();
     expect(sendMissADayNotification).not.toHaveBeenCalled();
   });
+  test("failure-reason reminder asks about yesterday first at 8 PM local (#441)", async () => {
+    preferenceRows = [{
+      ...basePrefs,
+      dailyReminderEnabled: false,
+      missADayEnabled: false,
+      failureReasonReminderEnabled: true,
+    }];
+
+    const { dispatchDueNotifications } = await import("./notification-scheduler");
+    const result = await dispatchDueNotifications(new Date("2026-05-29T20:02:00.000Z"));
+
+    expect(result.failureReasonSent).toBe(1);
+    expect(sendFailureReasonReminderNotification).toHaveBeenCalledWith({
+      recipientUserId: "user-1",
+      targetDate: "2026-05-28",
+      isYesterday: true,
+    });
+  });
+
+  test("failure-reason reminder falls back to today when yesterday is handled (#441)", async () => {
+    preferenceRows = [{
+      ...basePrefs,
+      dailyReminderEnabled: false,
+      missADayEnabled: false,
+      failureReasonReminderEnabled: true,
+    }];
+    // Sat yesterday, nothing today.
+    userCompletedSessionOnDate.mockImplementation(async (_userId, date) => date === "2026-05-28");
+
+    const { dispatchDueNotifications } = await import("./notification-scheduler");
+    const result = await dispatchDueNotifications(new Date("2026-05-29T20:02:00.000Z"));
+
+    expect(result.failureReasonSent).toBe(1);
+    expect(sendFailureReasonReminderNotification).toHaveBeenCalledWith({
+      recipientUserId: "user-1",
+      targetDate: "2026-05-29",
+      isYesterday: false,
+    });
+  });
+
+  test("failure-reason reminder is skipped when both days are already covered (#441)", async () => {
+    preferenceRows = [{
+      ...basePrefs,
+      dailyReminderEnabled: false,
+      missADayEnabled: false,
+      failureReasonReminderEnabled: true,
+    }];
+    userCompletedSessionOnDate.mockResolvedValue(true);
+
+    const { dispatchDueNotifications } = await import("./notification-scheduler");
+    const result = await dispatchDueNotifications(new Date("2026-05-29T20:02:00.000Z"));
+
+    expect(result.failureReasonSent).toBe(0);
+    expect(sendFailureReasonReminderNotification).not.toHaveBeenCalled();
+  });
+
+  test("failure-reason reminder does not fire outside the fixed 8 PM window (#441)", async () => {
+    preferenceRows = [{
+      ...basePrefs,
+      dailyReminderEnabled: false,
+      missADayEnabled: false,
+      failureReasonReminderEnabled: true,
+    }];
+
+    const { dispatchDueNotifications } = await import("./notification-scheduler");
+    const result = await dispatchDueNotifications(new Date("2026-05-29T09:02:00.000Z"));
+
+    expect(result.failureReasonSent).toBe(0);
+    expect(sendFailureReasonReminderNotification).not.toHaveBeenCalled();
+  });
+
+  test("failure-reason reminder is idempotent for the firing day (#441)", async () => {
+    preferenceRows = [{
+      ...basePrefs,
+      dailyReminderEnabled: false,
+      missADayEnabled: false,
+      failureReasonReminderEnabled: true,
+    }];
+
+    const { dispatchDueNotifications } = await import("./notification-scheduler");
+    const first = await dispatchDueNotifications(new Date("2026-05-29T20:00:00.000Z"));
+    // Adjacent boundary run: the claim already exists -> no second send.
+    insertReturning.mockResolvedValueOnce([]);
+    const second = await dispatchDueNotifications(new Date("2026-05-29T20:05:00.000Z"));
+
+    expect(first.failureReasonSent).toBe(1);
+    expect(second.failureReasonSent).toBe(0);
+    expect(sendFailureReasonReminderNotification).toHaveBeenCalledTimes(1);
+  });
+
+  test("failure-reason send exception releases the claim instead of blocking the day (#441)", async () => {
+    preferenceRows = [{
+      ...basePrefs,
+      dailyReminderEnabled: false,
+      missADayEnabled: false,
+      failureReasonReminderEnabled: true,
+    }];
+    sendFailureReasonReminderNotification.mockRejectedValueOnce(new Error("APNs exploded"));
+
+    const { dispatchDueNotifications } = await import("./notification-scheduler");
+    const result = await dispatchDueNotifications(new Date("2026-05-29T20:02:00.000Z"));
+
+    expect(result.failureReasonSent).toBe(0);
+    expect(dbDelete).toHaveBeenCalled();
+  });
+
   test("weekly 23:55 reminder sends on cross-midnight 00:00 run (#440 frequency gate)", async () => {
     // 2026-05-25 is a Monday (dayIndex 1). A weekly reminder at 23:55 is covered by
     // both the 23:55 run (delta=0) and the next-day 00:00 run (delta=5). Before this fix

--- a/src/lib/notification-scheduler.ts
+++ b/src/lib/notification-scheduler.ts
@@ -326,10 +326,8 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
       const local = getLocalParts(now, prefs.tz);
 
       // Failure-reason reminder fires at a fixed 8 PM local time, independent of the
-      // user's daily reminder time. Handle it first, then fall through only when daily /
-      // miss-a-day are also enabled (their gates below `continue` out of this iteration
-      // when their own window — the daily reminder time — does not match this run).
-      let sentForCandidate = false;
+      // user's daily reminder time. A successful send completes this candidate for
+      // metrics purposes, so it must not also fall through into daily / miss-a-day work.
       if (prefs.failureReasonReminderEnabled) {
         const frWindow = isWithinCronWindow(local.minutesSinceMidnight, FAILURE_REASON_REMINDER_MINUTES);
         if (
@@ -341,7 +339,7 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
           if (outcome === "sent") {
             failureReasonSent += 1;
             sent += 1;
-            sentForCandidate = true;
+            continue;
           }
         }
       }
@@ -349,9 +347,7 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
       // A failure-reason-only candidate has no further work; don't let it fall through
       // into the daily flow where it would be double-counted as skipped.
       if (!prefs.dailyReminderEnabled && !prefs.missADayEnabled) {
-        if (!sentForCandidate) {
-          skipped += 1;
-        }
+        skipped += 1;
         continue;
       }
 
@@ -359,11 +355,7 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
 
       const { within, dayOffset } = isWithinCronWindow(local.minutesSinceMidnight, reminderMinutes);
       if (!within) {
-        // Don't count a candidate that already sent its failure-reason reminder this run
-        // as skipped — the daily/miss-a-day window simply isn't due (they share this gate).
-        if (!sentForCandidate) {
-          skipped += 1;
-        }
+        skipped += 1;
         continue;
       }
 

--- a/src/lib/notification-scheduler.ts
+++ b/src/lib/notification-scheduler.ts
@@ -359,7 +359,11 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
 
       const { within, dayOffset } = isWithinCronWindow(local.minutesSinceMidnight, reminderMinutes);
       if (!within) {
-        skipped += 1;
+        // Don't count a candidate that already sent its failure-reason reminder this run
+        // as skipped — the daily/miss-a-day window simply isn't due (they share this gate).
+        if (!sentForCandidate) {
+          skipped += 1;
+        }
         continue;
       }
 

--- a/src/lib/notification-scheduler.ts
+++ b/src/lib/notification-scheduler.ts
@@ -7,7 +7,16 @@ import {
   loadUserStreak,
   userCompletedSessionOnDate,
 } from "@/lib/notifications/daily-reminder";
-import { sendDailyReminderNotification, sendMissADayNotification } from "@/lib/notifications";
+import {
+  FAILURE_REASON_NOTIFICATION_TYPE,
+  FAILURE_REASON_REMINDER_MINUTES,
+  hasFailureReasonForDate,
+} from "@/lib/notifications/failure-reason";
+import {
+  sendDailyReminderNotification,
+  sendFailureReasonReminderNotification,
+  sendMissADayNotification,
+} from "@/lib/notifications";
 
 const CRON_WINDOW_MINUTES = 5;
 
@@ -202,6 +211,84 @@ async function releaseMissADayClaim(userId: string, windowKey: string): Promise<
     );
 }
 
+async function releaseFailureReasonClaim(userId: string, windowKey: string): Promise<void> {
+  await db
+    .delete(notificationDispatches)
+    .where(
+      and(
+        eq(notificationDispatches.userId, userId),
+        eq(notificationDispatches.notificationType, FAILURE_REASON_NOTIFICATION_TYPE),
+        eq(notificationDispatches.windowKey, windowKey),
+      ),
+    );
+}
+
+/**
+ * Failure-reason reminder (#441): fixed 8 PM local nudge to log why the user could
+ * not meditate. Yesterday's missed day takes priority over today, so the morning-after
+ * "you missed yesterday" framing wins when both are open.
+ *
+ * Idempotency is anchored to `triggerDate` (the local date the 8 PM run fires on), NOT
+ * the day being asked about. A day the user never logs is therefore surfaced twice — once
+ * that evening ("today" framing) and once the next evening ("yesterday" framing) — which
+ * is the behavior the ticket asks for, while still capping sends to one per user per day.
+ * Returns "sent" only when a push was actually delivered on some channel.
+ */
+async function dispatchFailureReasonReminder(
+  userId: string,
+  triggerDate: string,
+): Promise<"sent" | "skipped"> {
+  const yesterday = addCalendarDays(triggerDate, -1);
+
+  let targetDate: string | null = null;
+  let isYesterday = false;
+
+  const satYesterday = await userCompletedSessionOnDate(userId, yesterday);
+  const loggedYesterday = satYesterday || (await hasFailureReasonForDate(userId, yesterday));
+  if (!loggedYesterday) {
+    targetDate = yesterday;
+    isYesterday = true;
+  } else {
+    const satToday = await userCompletedSessionOnDate(userId, triggerDate);
+    const loggedToday = satToday || (await hasFailureReasonForDate(userId, triggerDate));
+    if (!loggedToday) {
+      targetDate = triggerDate;
+      isYesterday = false;
+    }
+  }
+
+  if (!targetDate) {
+    return "skipped";
+  }
+
+  const claimed = await claimNotificationDispatch({
+    userId,
+    notificationType: FAILURE_REASON_NOTIFICATION_TYPE,
+    windowKey: triggerDate,
+  });
+  if (!claimed) {
+    return "skipped";
+  }
+
+  try {
+    const { delivered } = await sendFailureReasonReminderNotification({
+      recipientUserId: userId,
+      targetDate,
+      isYesterday,
+    });
+    if (delivered) {
+      return "sent";
+    }
+    await releaseFailureReasonClaim(userId, triggerDate);
+    return "skipped";
+  } catch (sendError) {
+    // Release the claim so a later run can retry rather than permanently blocking this date.
+    console.error(`Failed to send failure-reason reminder to user ${userId}:`, sendError);
+    await releaseFailureReasonClaim(userId, triggerDate);
+    return "skipped";
+  }
+}
+
 function addCalendarDays(dateKey: string, deltaDays: number): string {
   const [y, m, d] = dateKey.split("-").map(Number);
   const utc = new Date(Date.UTC(y, m - 1, d + deltaDays));
@@ -213,6 +300,7 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
   sent: number;
   skipped: number;
   missADaySent: number;
+  failureReasonSent: number;
 }> {
   const candidates = await db
     .select()
@@ -223,6 +311,7 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
         or(
           eq(notificationPreferences.dailyReminderEnabled, true),
           eq(notificationPreferences.missADayEnabled, true),
+          eq(notificationPreferences.failureReasonReminderEnabled, true),
         ),
       ),
     );
@@ -230,10 +319,42 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
   let sent = 0;
   let skipped = 0;
   let missADaySent = 0;
+  let failureReasonSent = 0;
 
   for (const prefs of candidates) {
     try {
       const local = getLocalParts(now, prefs.tz);
+
+      // Failure-reason reminder fires at a fixed 8 PM local time, independent of the
+      // user's daily reminder time. Handle it first, then fall through only when daily /
+      // miss-a-day are also enabled (their gates below `continue` out of this iteration
+      // when their own window — the daily reminder time — does not match this run).
+      let sentForCandidate = false;
+      if (prefs.failureReasonReminderEnabled) {
+        const frWindow = isWithinCronWindow(local.minutesSinceMidnight, FAILURE_REASON_REMINDER_MINUTES);
+        if (
+          frWindow.within &&
+          !isInQuietHours(local.minutesSinceMidnight, prefs.quietHoursStart, prefs.quietHoursEnd)
+        ) {
+          const triggerDate = addCalendarDays(local.dateKey, frWindow.dayOffset);
+          const outcome = await dispatchFailureReasonReminder(prefs.userId, triggerDate);
+          if (outcome === "sent") {
+            failureReasonSent += 1;
+            sent += 1;
+            sentForCandidate = true;
+          }
+        }
+      }
+
+      // A failure-reason-only candidate has no further work; don't let it fall through
+      // into the daily flow where it would be double-counted as skipped.
+      if (!prefs.dailyReminderEnabled && !prefs.missADayEnabled) {
+        if (!sentForCandidate) {
+          skipped += 1;
+        }
+        continue;
+      }
+
       const reminderMinutes = parseReminderMinutes(prefs.dailyReminderTime);
 
       const { within, dayOffset } = isWithinCronWindow(local.minutesSinceMidnight, reminderMinutes);
@@ -354,5 +475,5 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
     }
   }
 
-  return { scanned: candidates.length, sent, skipped, missADaySent };
+  return { scanned: candidates.length, sent, skipped, missADaySent, failureReasonSent };
 }

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -169,6 +169,41 @@ describe("sendFriendRequestNotification", () => {
     });
   });
 
+  test("sends the failure-reason reminder to APNs and Web Push with the dated deep link", async () => {
+    tokenRows.push({ id: "dt-1", token: "a".repeat(64), apnsEnvironment: "development" });
+    sendWebPushToUser.mockResolvedValue({ delivered: false });
+    const { sendFailureReasonReminderNotification } = await import("./notifications");
+
+    const result = await sendFailureReasonReminderNotification({
+      recipientUserId: "recipient-id",
+      targetDate: "2026-05-28",
+      isYesterday: true,
+    });
+
+    expect(result.delivered).toBe(true);
+    expect(sendApnsNotification).toHaveBeenCalledWith("a".repeat(64), "development", {
+      aps: {
+        alert: {
+          title: "Still Point",
+          body: "You didn't meditate yesterday. Take a moment to log why.",
+        },
+        sound: "default",
+        "thread-id": "meditation-reminders",
+      },
+      type: "failure_reason_reminder",
+      deepLink: "stillpoint://log-reason?date=2026-05-28",
+    });
+    expect(sendWebPushToUser).toHaveBeenCalledWith({
+      recipientUserId: "recipient-id",
+      payload: {
+        title: "Still Point",
+        body: "You didn't meditate yesterday. Take a moment to log why.",
+        type: "failure_reason_reminder",
+        url: "/app/log-reason?date=2026-05-28",
+      },
+    });
+  });
+
   test("miss-a-day is not delivered when APNs and Web Push both fail", async () => {
     tokenRows.push({ id: "dt-1", token: "a".repeat(64), apnsEnvironment: "development" });
     sendApnsNotification.mockResolvedValue({ ok: false, status: 500 });

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -7,6 +7,11 @@ import {
   buildDailyReminderWebPushPayload,
   MISS_A_DAY_NOTIFICATION_TYPE,
 } from "@/lib/notifications/daily-reminder";
+import {
+  buildFailureReasonReminderPayload,
+  buildFailureReasonReminderWebPushPayload,
+  FAILURE_REASON_NOTIFICATION_TYPE,
+} from "@/lib/notifications/failure-reason";
 import { sendWebPushToUser } from "@/lib/web-push";
 
 const invalidTokenReasons = new Set(["BadDeviceToken", "DeviceTokenNotForTopic", "Unregistered"]);
@@ -145,6 +150,25 @@ export async function sendMissADayNotification(params: {
         type: MISS_A_DAY_NOTIFICATION_TYPE,
         url: "/app",
       },
+    }),
+  ]);
+
+  return { delivered };
+}
+
+export async function sendFailureReasonReminderNotification(params: {
+  recipientUserId: string;
+  targetDate: string;
+  isYesterday: boolean;
+}): Promise<{ delivered: boolean }> {
+  const delivered = await fanOutChannels(FAILURE_REASON_NOTIFICATION_TYPE, [
+    () => sendPushNotificationToUser({
+      recipientUserId: params.recipientUserId,
+      payload: buildFailureReasonReminderPayload(params.targetDate, params.isYesterday),
+    }),
+    () => sendWebPushToUser({
+      recipientUserId: params.recipientUserId,
+      payload: buildFailureReasonReminderWebPushPayload(params.targetDate, params.isYesterday),
     }),
   ]);
 

--- a/src/lib/notifications/failure-reason.test.ts
+++ b/src/lib/notifications/failure-reason.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildFailureReasonReminderPayload,
+  buildFailureReasonReminderWebPushPayload,
+  FAILURE_REASON_NOTIFICATION_TYPE,
+  FAILURE_REASON_REMINDER_MINUTES,
+} from "./failure-reason";
+
+describe("failure reason reminder helpers", () => {
+  test("fixed trigger is 8 PM local (1200 minutes since midnight)", () => {
+    expect(FAILURE_REASON_REMINDER_MINUTES).toBe(20 * 60);
+  });
+
+  test("yesterday APNs payload uses the catch-up copy and dated deep link", () => {
+    const payload = buildFailureReasonReminderPayload("2026-05-28", true);
+    expect(payload.aps.alert).toMatchObject({
+      title: "Still Point",
+      body: "You didn't meditate yesterday. Take a moment to log why.",
+    });
+    expect(payload.type).toBe(FAILURE_REASON_NOTIFICATION_TYPE);
+    expect(payload.deepLink).toBe("stillpoint://log-reason?date=2026-05-28");
+  });
+
+  test("today APNs payload uses the still-time copy", () => {
+    const payload = buildFailureReasonReminderPayload("2026-05-29", false);
+    expect(payload.aps.alert).toMatchObject({
+      body: "Still time to meditate! Log why you can't, or start a quick session.",
+    });
+    expect(payload.deepLink).toBe("stillpoint://log-reason?date=2026-05-29");
+  });
+
+  test("web push payload mirrors the copy and points at the log page", () => {
+    const yesterday = buildFailureReasonReminderWebPushPayload("2026-05-28", true);
+    expect(yesterday).toEqual({
+      title: "Still Point",
+      body: "You didn't meditate yesterday. Take a moment to log why.",
+      type: FAILURE_REASON_NOTIFICATION_TYPE,
+      url: "/app/log-reason?date=2026-05-28",
+    });
+
+    const today = buildFailureReasonReminderWebPushPayload("2026-05-29", false);
+    expect(today.url).toBe("/app/log-reason?date=2026-05-29");
+    expect(today.body).toContain("Still time to meditate");
+  });
+});

--- a/src/lib/notifications/failure-reason.ts
+++ b/src/lib/notifications/failure-reason.ts
@@ -1,0 +1,84 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db";
+import { failureReasons } from "@/db/schema";
+import type { ApnsPayload } from "@/lib/apns";
+
+export const FAILURE_REASON_NOTIFICATION_TYPE = "failure_reason_reminder";
+
+/** Fixed 8 PM local trigger for the failure-reason reminder, as minutes since midnight. */
+export const FAILURE_REASON_REMINDER_MINUTES = 20 * 60;
+
+export type FailureReasonReminderWebPushPayload = {
+  title: string;
+  body: string;
+  type: typeof FAILURE_REASON_NOTIFICATION_TYPE;
+  url: string;
+};
+
+function deepLinkForDate(targetDate: string): string {
+  return `stillpoint://log-reason?date=${targetDate}`;
+}
+
+function webUrlForDate(targetDate: string): string {
+  return `/app/log-reason?date=${targetDate}`;
+}
+
+function copyForTarget(isYesterday: boolean): { title: string; body: string } {
+  return isYesterday
+    ? {
+      title: "Still Point",
+      body: "You didn't meditate yesterday. Take a moment to log why.",
+    }
+    : {
+      title: "Still Point",
+      body: "Still time to meditate! Log why you can't, or start a quick session.",
+    };
+}
+
+export function buildFailureReasonReminderPayload(
+  targetDate: string,
+  isYesterday: boolean,
+): ApnsPayload {
+  const { title, body } = copyForTarget(isYesterday);
+  return {
+    aps: {
+      alert: { title, body },
+      sound: "default",
+      "thread-id": "meditation-reminders",
+    },
+    type: FAILURE_REASON_NOTIFICATION_TYPE,
+    deepLink: deepLinkForDate(targetDate),
+  };
+}
+
+export function buildFailureReasonReminderWebPushPayload(
+  targetDate: string,
+  isYesterday: boolean,
+): FailureReasonReminderWebPushPayload {
+  const { title, body } = copyForTarget(isYesterday);
+  return {
+    title,
+    body,
+    type: FAILURE_REASON_NOTIFICATION_TYPE,
+    url: webUrlForDate(targetDate),
+  };
+}
+
+/** Whether the user has already logged a failure reason for the given local date. */
+export async function hasFailureReasonForDate(
+  userId: string,
+  date: string,
+): Promise<boolean> {
+  const [row] = await db
+    .select({ id: failureReasons.id })
+    .from(failureReasons)
+    .where(
+      and(
+        eq(failureReasons.userId, userId),
+        eq(failureReasons.reasonDate, date),
+      ),
+    )
+    .limit(1);
+
+  return !!row;
+}

--- a/src/lib/web-push-client.ts
+++ b/src/lib/web-push-client.ts
@@ -4,6 +4,7 @@ export type NotificationPreferencesDto = {
   pushEnabled: boolean;
   dailyReminderEnabled: boolean;
   missADayEnabled: boolean;
+  failureReasonReminderEnabled: boolean;
   friendRequestNotificationsEnabled: boolean;
   suppressDuringSession: boolean;
   dailyReminderTime: string;


### PR DESCRIPTION
## **User description**
## Summary

Implements #441: an opt-in **failure-reason log** so that when a user hasn't meditated, an **8 PM local** push nudges them to a page to jot down why they couldn't sit — even for 60 seconds.

- **DB**: new `failure_reasons` table (one revisable row per user per local day, unique on `(user_id, reason_date)`) + a `failure_reason_reminder_enabled` preference flag. Two **append-only** incremental migrations (`failure_reasons_441_incremental.sql`, `notification_preferences_failure_reason_441_incremental.sql`).
- **Notification type** (`failure_reason_reminder`): fixed 8 PM trigger, wired into the existing #440 dispatch core. Checks **yesterday first** (catch-up framing), then **today**; standard claim/rollback idempotency. Idempotency is keyed to the *firing day*, so an unlogged day is surfaced twice — once that evening ("today") and once the next ("yesterday") — matching the ticket, capped at one send/day.
- **API**: `/api/failure-reasons` `GET` (existence + text for a date) and `POST` (upsert, trimmed, non-empty, ≤1000 chars). POST error logging is redacted so a DB driver error can't echo user text into logs.
- **UI**: `/app/log-reason` (`AppSubpageShell`) — empathetic prompt + textarea (rows=4, max 1000), pre-fills an existing note, post-save confirmation with a **"Start a quick 60-second session"** CTA. Settings toggle added to `WebNotificationSettings`.
- Web + server only; no iOS app change (APNs payload still emitted for parity).

## Repo-gotcha compliance

- Migrations are **new incremental files only** (no edits to applied files → no #368/#370 checksum drift).
- New notification type mirrors the #356/#360 registration pattern (preference flag → scheduler branch → send helper → payload builder).

## Test plan

- [x] `npm run test:unit` — 321 pass (new scheduler, route, payload-builder, preference tests)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean; `/app/log-reason` prerenders, `/api/failure-reasons` builds
- [x] Local CodeRabbit review — clean pass (3 findings from first pass fixed: form-state reset on date change, scheduler short-circuit for failure-reason-only candidates, redacted POST error log)
- [x] Scheduler: at 8 PM with no session/reason for yesterday → "yesterday" push; with yesterday handled → "today" push; both handled → no send — verified by `notification-scheduler.test.ts`
- [ ] Manual (device-only, not automatable here): enable toggle, receive push, log a reason, see quick-sit CTA; revisit page shows saved note

Closes #441

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Log reason” screen and an authenticated API to load/save one failure-reason entry per user per date.
  * Added a “Reflect on a missed day” toggle (“Log why you missed”) and enabled a new 8 PM reminder flow.
  * Extended iOS notification deep-link handling for “log reason”.
* **Bug Fixes**
  * Strengthened reminder behavior with quiet-hours filtering, idempotency, and safe retry/rollback; added DB validation to prevent blank/duplicate entries.
* **Tests**
  * Expanded coverage for API routes, notification preferences, scheduler dispatch, and reminder payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Add an 8 PM reminder to log why a meditation was missed

### What Changed
- Added a new reminder option that nudges users at 8 PM to write down why they did not meditate, with a direct link to a new log page
- Added a page to save or update a reason for a specific day, with a short character limit, clear validation, and a follow-up prompt to start a quick session
- Added a new settings toggle so users can turn this reminder on or off
- Kept reminders from showing for days that already have a logged reason, and ensured the same missed day can be surfaced again the next day if it was still not logged
- Prevented empty notes from being saved and stopped user-entered text from appearing in server error logs

### Impact
`✅ Fewer missed meditation follow-ups`
`✅ Clearer reminder flow after skipped sessions`
`✅ Safer note saving and error logging`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

