### PR TITLE
ci: close out #435 — all actions already at current major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
   # opens weekly PRs that bump each pinned commit SHA (and its trailing # vX.Y.Z
   # comment) to the latest release, so pinning for supply-chain safety does not
   # mean the actions silently rot. Scoped to github-actions only by design.
+  #
+  # As of the v7/v6/v9 bumps (PRs #447-450) every actions/* ref in
+  # .github/workflows/ already sits on its current major, so the manual
+  # "upgrade remaining @v4" sweep tracked by issue #435 has nothing left to do.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Issue #435 (`ci: upgrade remaining workflows from actions@v4 to @v5`) is **already fully satisfied** on `main` by the merged Dependabot PRs #447–450. There are **no remaining `actions/*@v4` references** anywhere in `.github/workflows/`, and nothing to bump.

This is a cosmetic-only PR: it documents that fact with a short note in `.github/dependabot.yml` so the issue can be closed via merge.

## Audit of current `main`

Every `actions/*` reference is SHA-pinned to its current major, matching the merged Dependabot bumps exactly (no regressions):

| Action | Occurrences | Pinned version | Dependabot PR |
|---|---|---|---|
| `actions/checkout` | 17 | `9c091bb…` `# v7.0.0` | #447 |
| `actions/setup-node` | 13 | `48b55a0…` `# v6.4.0` | #450 |
| `actions/upload-artifact` | 13 | `043fb46…` `# v7.0.1` | #448 |
| `actions/github-script` | 1 | `3a2844b…` `# v9.0.0` | #449 |

- No floating tags, no `@v4` pins, no leftover `# v4` comments.
- Dependabot bumps **every** occurrence of an action, so its merges left no manual stragglers for #435.
- Excluded files per the CR plan need nothing: `neon-preview-reset.yml` has no `actions/*` steps; `cr-plan-on-issue.yml`'s only action (`github-script`) was bumped by #449; `ios-testflight.yml` is a reusable caller.
- The only non-`actions/*` ref, `ruby/setup-ruby@… # v1.314.0`, is current and out of scope.

## Test plan

- `rg 'actions/[a-z-]+@[0-9a-f]+ # v[0-9.]+' .github/workflows | sort | uniq -c` confirms all refs are at the current major.
- `rg '@v4|# v4'` over `.github/workflows/` returns no matches.
- No workflow logic changes; the only edit is a comment in `dependabot.yml`.

Closes #435
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-813a88a4-636a-41ab-9882-fe48f50da5ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-813a88a4-636a-41ab-9882-fe48f50da5ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

