### PR TITLE
ci(ios): always report StillPointShared swift test check (#463)

### DIFF
--- a/.github/workflows/ios-shared-tests.yml
+++ b/.github/workflows/ios-shared-tests.yml
@@ -36,7 +36,10 @@ jobs:
             echo "shared=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          files="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json files --jq '.files[].path' 2>/dev/null || true)"
+          # Use the paginated files API — `gh pr view --json files` caps the list
+          # (~100 files), which on a large PR could miss StillPointShared changes
+          # and skip the real test via the no-op. `--paginate` returns every file.
+          files="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].path' 2>/dev/null || true)"
           if [ -z "$files" ] || printf '%s\n' "$files" | grep -qE '^(ios/StillPointShared/|\.github/workflows/ios-shared-tests\.yml$)'; then
             echo "shared=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/ios-shared-tests.yml
+++ b/.github/workflows/ios-shared-tests.yml
@@ -1,19 +1,58 @@
 name: iOS Shared Unit Tests
 
+# The `StillPointShared swift test` job is a REQUIRED status check on `main`, so it
+# must report a result on every PR. Previously this workflow was path-filtered to the
+# package, so PRs that didn't touch `ios/StillPointShared/**` never ran it and sat at
+# mergeStateStatus=BLOCKED forever (needing an --admin override). Instead we now run
+# the job on every PR but only execute the real `swift test` (on macOS) when the
+# package — or this workflow — actually changed; otherwise it's a cheap ubuntu no-op
+# that still satisfies the required check. See issue #463.
+
 on:
   pull_request:
-    paths:
-      - "ios/StillPointShared/**"
-      - ".github/workflows/ios-shared-tests.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
+  changes:
+    name: detect StillPointShared changes
+    runs-on: ubuntu-latest
+    outputs:
+      shared: ${{ steps.filter.outputs.shared }}
+    steps:
+      - name: Detect changed paths
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # Fail safe toward MORE coverage: if we can't determine the diff
+          # (workflow_dispatch, or a transient API error), run the real suite.
+          if [ -z "${PR_NUMBER:-}" ]; then
+            echo "shared=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json files --jq '.files[].path' 2>/dev/null || true)"
+          if [ -z "$files" ] || printf '%s\n' "$files" | grep -qE '^(ios/StillPointShared/|\.github/workflows/ios-shared-tests\.yml$)'; then
+            echo "shared=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "shared=false" >> "$GITHUB_OUTPUT"
+          fi
+
   swift-test:
     name: StillPointShared swift test
-    runs-on: macos-26
+    needs: changes
+    # macOS only when we actually run the suite; a cheap ubuntu runner for the
+    # no-op pass so web-only PRs don't burn macOS minutes.
+    runs-on: ${{ needs.changes.outputs.shared == 'true' && 'macos-26' || 'ubuntu-latest' }}
     timeout-minutes: 20
     steps:
       - name: Checkout
+        if: needs.changes.outputs.shared == 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -22,8 +61,14 @@ jobs:
       # the suite without xcodegen/xcodebuild (the same path agents use locally,
       # where the app's Xcode project can't be parsed). The ~50 tests are
       # sub-second; wall-clock is dominated by macOS runner spin-up + the package
-      # build. Path-filtered to the package (and this workflow) so web-only PRs
-      # don't burn macOS minutes.
+      # build. Runs only when the package (or this workflow) changed.
       - name: Run StillPointShared unit tests
+        if: needs.changes.outputs.shared == 'true'
         working-directory: ios/StillPointShared
         run: swift test
+
+      # No-op pass for PRs that don't touch the package: keeps the required
+      # "StillPointShared swift test" check green without macOS minutes (issue #463).
+      - name: Skip (StillPointShared unchanged)
+        if: needs.changes.outputs.shared != 'true'
+        run: echo "StillPointShared unchanged on this PR — required check satisfied without running swift test (issue #463)."


### PR DESCRIPTION
## **User description**
## Summary

`StillPointShared swift test` is a **required** status check on `main`, but `ios-shared-tests.yml` was path-filtered to `ios/StillPointShared/**` — so PRs that didn't touch the package never ran it and sat at `mergeStateStatus=BLOCKED` indefinitely, forcing an `--admin` override on essentially every web/db/CI/dependabot PR (we hit this all day).

This restructures the workflow into two jobs:
- **`changes`** (ubuntu, cheap): detects whether the PR touched `ios/StillPointShared/**` or this workflow, via `gh pr view --json files` (fail-safe → `true` on `workflow_dispatch` or API error).
- **`swift-test`** (the required check): now runs on **every** PR. Executes the real `swift test` on **macOS only when the package/workflow changed**; otherwise a **no-op ubuntu pass**.

Net result: the required `StillPointShared swift test` context is satisfied on every PR (no more `--admin`), real package changes still gate on the suite, and web-only PRs don't burn macOS minutes.

Closes #463

## Test plan
- [ ] **Self-validating:** this PR changes the workflow, so `changes` reports `shared=true` and `swift-test` runs the **real** `swift test` on macOS and passes.
- [ ] This PR reaches `mergeStateStatus=CLEAN` and is mergeable **without `--admin`** (required check reports success natively).
- [ ] After merge — a web-only PR shows `StillPointShared swift test` = success via the ubuntu no-op (no macOS minutes) and reaches `CLEAN` without `--admin`.
- [ ] After merge — a PR touching `ios/StillPointShared/**` still runs the real `swift test` on macOS and gates on it.


___

## **CodeAnt-AI Description**
**Keep the required iOS shared test check green on every PR**

### What Changed
- The required `StillPointShared swift test` check now reports success on every pull request, including PRs that do not touch the shared Swift package.
- PRs that change `ios/StillPointShared/**` or the workflow still run the real Swift test suite on macOS.
- PRs that do not touch the shared package now finish the check with a quick no-op on Linux instead of waiting for macOS.
- Large PRs are handled safely so shared-package changes are not missed when deciding whether to run the real tests.

### Impact
`✅ Fewer blocked PRs`
`✅ No more manual admin overrides for unrelated PRs`
`✅ Lower macOS usage on web-only changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
