### PR TITLE
fix(mobile): clean up small-screen layout (nav, timer, tables, hints) (#473)

### DIFF
--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -52,6 +52,77 @@ const TAB_LABELS: Record<Tab, string> = {
   buddy: "buddy",
 };
 
+// Minimal line icons for the mobile bottom tab bar. Pairing each short label
+// with an icon lets the six tabs sit with clear spacing at 320px instead of
+// colliding as text-only labels did (#473 P1).
+const TAB_ICONS: Record<Tab, React.ReactNode> = {
+  progress: (
+    <>
+      <path d="M3 10.5 12 3l9 7.5" />
+      <path d="M5 9.5V20h14V9.5" />
+    </>
+  ),
+  history: (
+    <>
+      <circle cx="12" cy="12" r="8.5" />
+      <path d="M12 7.5V12l3 2" />
+    </>
+  ),
+  journal: (
+    <>
+      <rect x="5" y="3.5" width="14" height="17" rx="2" />
+      <path d="M9 8h6M9 12h6M9 16h4" />
+    </>
+  ),
+  board: (
+    <>
+      <path d="M6 20v-7M12 20V5M18 20v-9" />
+    </>
+  ),
+  friends: (
+    <>
+      <circle cx="9" cy="8" r="3" />
+      <path d="M3.5 19.5c0-3 2.6-5 5.5-5s5.5 2 5.5 5" />
+      <path d="M16 6.2a3 3 0 0 1 0 5.6" />
+      <path d="M16.5 14.6c2.3.4 4 2.3 4 4.9" />
+    </>
+  ),
+  settings: (
+    <>
+      <path d="M4 7h8M16 7h4M4 17h4M12 17h8" />
+      <circle cx="14" cy="7" r="2.2" />
+      <circle cx="9" cy="17" r="2.2" />
+    </>
+  ),
+  // Reached from the Progress screen, not the nav row; defined to satisfy the
+  // Record<Tab> type.
+  buddy: (
+    <>
+      <circle cx="9" cy="8" r="3" />
+      <circle cx="16" cy="9" r="2.4" />
+      <path d="M3.5 19.5c0-3 2.6-5 5.5-5s5.5 2 5.5 5" />
+    </>
+  ),
+};
+
+function TabIcon({ tab }: { tab: Tab }) {
+  return (
+    <svg
+      width="22"
+      height="22"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.6}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {TAB_ICONS[tab]}
+    </svg>
+  );
+}
+
 function isTab(value: string | undefined): value is Tab {
   return value !== undefined && (ALL_TABS as string[]).includes(value);
 }
@@ -216,6 +287,16 @@ export default function StillPoint() {
       buddyInviteInFlight.current = false;
     };
   }, [user, authChecked, rawTab, router]);
+
+  // Reset scroll to the top whenever the active view changes. Without this,
+  // opening a session/overlay from a scrolled tab (e.g. the long Home page)
+  // inherits the old scroll offset and lands mid-screen, hiding the timer at
+  // the top of the session view (#473 P2).
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.scrollTo(0, 0);
+    }
+  }, [overlay, tab, buddySessionId]);
 
   // Keep transient state in sync with the URL. Browser back/forward (and any
   // other navigation) changes the active tab via useParams without touching
@@ -541,7 +622,10 @@ export default function StillPoint() {
       minHeight: "100%",
       display: "grid",
       gridTemplateRows: isImmersive ? "1fr" : "auto 1fr auto",
-      alignItems: "center",
+      // Immersive flows (session/breath/buddy) can exceed the viewport on small
+      // phones; centering would clip the timer off the top with no way to scroll
+      // up to it. Pin them to the top so the timer is always visible (#473 P2).
+      alignItems: isImmersive ? "start" : "center",
       fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
       padding: isMobile
         ? "var(--s4) var(--s3) calc(var(--nav-h) + env(safe-area-inset-bottom, 0px))"
@@ -554,45 +638,53 @@ export default function StillPoint() {
           display: "flex", justifyContent: "space-around",
           background: "rgba(var(--bg-rgb), 0.92)", backdropFilter: "blur(10px)",
           borderTop: "1px solid var(--border-1)",
-          padding: "10px 0 env(safe-area-inset-bottom, 8px)",
+          padding: "10px 6px env(safe-area-inset-bottom, 8px)",
           zIndex: 100,
         } : {
           position: "fixed", top: "var(--s4)", right: "var(--s4)",
           display: "flex", gap: "var(--s3)",
           zIndex: 100,
         }}>
-          {NAV_TABS.map(t => (
+          {NAV_TABS.map(t => {
+            const active = !overlay && tab === t;
+            return (
             <button
               type="button"
               key={t}
+              aria-label={TAB_LABELS[t]}
+              aria-current={active ? "page" : undefined}
               onClick={() => goToTab(t)}
               style={{
                 background: "none", border: "none",
-                color: !overlay && tab === t ? "var(--fg)" : "var(--fg-2)",
+                color: active ? "var(--fg)" : "var(--fg-2)",
                 fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-                fontSize: isMobile ? "13px" : "11px",
-                letterSpacing: "0.1em",
+                fontSize: isMobile ? "9px" : "11px",
+                letterSpacing: isMobile ? "0.02em" : "0.1em",
                 textTransform: "uppercase",
                 cursor: "pointer",
-                padding: isMobile ? "12px 14px" : "8px",
+                padding: isMobile ? "6px 2px 8px" : "8px",
                 minWidth: isMobile ? "44px" : undefined,
                 minHeight: isMobile ? "44px" : undefined,
                 lineHeight: 1.2,
-                display: "inline-flex", alignItems: "center", justifyContent: "center",
+                display: "inline-flex",
+                flexDirection: isMobile ? "column" : "row",
+                alignItems: "center", justifyContent: "center",
+                gap: isMobile ? "3px" : undefined,
                 transition: "color 0.3s",
                 position: "relative",
               }}
             >
-              {TAB_LABELS[t]}
-              {!overlay && tab === t && isMobile && (
+              {isMobile && <TabIcon tab={t} />}
+              <span>{TAB_LABELS[t]}</span>
+              {active && isMobile && (
                 <span style={{
-                  position: "absolute", bottom: "4px", left: "50%", transform: "translateX(-50%)",
+                  position: "absolute", bottom: "2px", left: "50%", transform: "translateX(-50%)",
                   width: "16px", height: "2px", borderRadius: "1px",
                   background: "var(--fg)",
                 }} />
               )}
             </button>
-          ))}
+          );})}
         </div>
       )}
 

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -790,6 +790,7 @@ export default function StillPoint() {
               throw new Error("Failed to save note");
             }
           } : undefined}
+          compact={isMobile}
         />
       )}
 

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -292,11 +292,18 @@ export default function StillPoint() {
   // opening a session/overlay from a scrolled tab (e.g. the long Home page)
   // inherits the old scroll offset and lands mid-screen, hiding the timer at
   // the top of the session view (#473 P2).
+  // Only scroll when an overlay OPENS (becomes non-null); closing an overlay
+  // should restore the underlying tab's scroll position, not reset it.
+  useEffect(() => {
+    if (typeof window !== "undefined" && overlay !== null) {
+      window.scrollTo(0, 0);
+    }
+  }, [overlay]);
   useEffect(() => {
     if (typeof window !== "undefined") {
       window.scrollTo(0, 0);
     }
-  }, [overlay, tab, buddySessionId]);
+  }, [tab, buddySessionId]);
 
   // Keep transient state in sync with the URL. Browser back/forward (and any
   // other navigation) changes the active tab via useParams without touching

--- a/src/components/BlockTimer.tsx
+++ b/src/components/BlockTimer.tsx
@@ -380,7 +380,7 @@ export function BlockTimer({
   const boxesAreaWidth = `min(${boxesAreaMaxPx}px, calc(100vw - ${boxesAreaViewportInset}px))`;
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "32px" }}>
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: isMobile ? "18px" : "32px" }}>
       <div
         style={{
           width: "min(560px, calc(100vw - 24px))",
@@ -394,7 +394,7 @@ export function BlockTimer({
           aria-hidden={!showTimer}
           style={{
             fontFamily: "var(--font-jetbrains), 'JetBrains Mono', 'SF Mono', monospace",
-            fontSize: "min(120px, 18vw)",
+            fontSize: isMobile ? "min(72px, 19vw)" : "min(120px, 18vw)",
             fontWeight: 200,
             letterSpacing: "0.05em",
             color: elapsed >= totalSeconds ? "var(--accent-green)" : "var(--fg)",
@@ -426,7 +426,9 @@ export function BlockTimer({
             fontSize: "11px",
             letterSpacing: "0.08em",
             textTransform: "uppercase",
-            padding: "8px 12px",
+            padding: "12px 16px",
+            minHeight: "44px",
+            minWidth: "44px",
             transition: "opacity 0.2s, border-color 0.2s, color 0.2s",
             opacity: showTimer ? 0.9 : 1,
           }}

--- a/src/components/CompletionScreen.tsx
+++ b/src/components/CompletionScreen.tsx
@@ -13,6 +13,8 @@ type CompletionScreenProps = {
   thoughts: Array<{ timeInSession: number; text: string }>;
   onReturn: () => void;
   onSaveNote?: (text: string) => Promise<void>;
+  /** Tighten vertical spacing for narrow-viewport mobile layouts (#473). */
+  compact?: boolean;
 };
 
 export function CompletionScreen({
@@ -25,6 +27,7 @@ export function CompletionScreen({
   thoughts,
   onReturn,
   onSaveNote,
+  compact = false,
 }: CompletionScreenProps) {
   const [note, setNote] = useState("");
   const [noteSaved, setNoteSaved] = useState(false);
@@ -43,7 +46,7 @@ export function CompletionScreen({
   return (
     <div style={{
       display: "flex", flexDirection: "column", alignItems: "center",
-      gap: "32px", animation: "fadeIn 0.8s ease",
+      gap: compact ? "16px" : "32px", animation: "fadeIn 0.8s ease",
     }}>
       <div style={{ fontSize: "64px", opacity: 0.8 }}>&#x25C9;</div>
 

--- a/src/components/FlashHint.tsx
+++ b/src/components/FlashHint.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
+
+type FlashHintProps = {
+  children: ReactNode;
+  /** How long the hint stays fully visible before it begins to fade (ms). */
+  delayMs?: number;
+  /** Fade-out duration (ms). */
+  fadeMs?: number;
+  /** Wrapper style applied while the hint is mounted. */
+  style?: CSSProperties;
+};
+
+/**
+ * Shows instructional/explanatory copy briefly on mount, then fades it out and
+ * unmounts so it stops consuming vertical space during a session (#473 P5).
+ * Honors `prefers-reduced-motion` by skipping the fade transition.
+ */
+export function FlashHint({ children, delayMs = 5000, fadeMs = 700, style }: FlashHintProps) {
+  const [phase, setPhase] = useState<"visible" | "fading" | "gone">("visible");
+  const reduceMotion = useRef(false);
+
+  useEffect(() => {
+    reduceMotion.current =
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const t = setTimeout(() => setPhase("fading"), delayMs);
+    return () => clearTimeout(t);
+  }, [delayMs]);
+
+  useEffect(() => {
+    if (phase !== "fading") return;
+    const t = setTimeout(() => setPhase("gone"), reduceMotion.current ? 0 : fadeMs);
+    return () => clearTimeout(t);
+  }, [phase, fadeMs]);
+
+  if (phase === "gone") return null;
+
+  return (
+    <div
+      aria-hidden={phase === "fading"}
+      style={{
+        opacity: phase === "fading" ? 0 : 1,
+        transition: reduceMotion.current ? undefined : `opacity ${fadeMs}ms ease`,
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/FriendsView.tsx
+++ b/src/components/FriendsView.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useState, useEffect, useCallback } from "react";
 import { api, ApiError, type FriendPublicUser, type FriendRequestRow } from "@/lib/api";
+import { FlashHint } from "./FlashHint";
 
 const labelStyle: React.CSSProperties = {
   fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
@@ -164,18 +165,20 @@ export function FriendsView() {
         Friends
       </h2>
 
-      <p
-        style={{
-          fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-          fontSize: "11px",
-          color: "var(--fg-3)",
-          textAlign: "center",
-          margin: 0,
-          lineHeight: 1.5,
-        }}
-      >
-        Search finds public profiles only. Usernames never expose email.
-      </p>
+      <FlashHint style={{ textAlign: "center" }}>
+        <p
+          style={{
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+            fontSize: "11px",
+            color: "var(--fg-3)",
+            textAlign: "center",
+            margin: 0,
+            lineHeight: 1.5,
+          }}
+        >
+          Search finds public profiles only. Usernames never expose email.
+        </p>
+      </FlashHint>
 
       {banner && (
         <div

--- a/src/components/PublicBoard.tsx
+++ b/src/components/PublicBoard.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect } from "react";
 import type { BoardEntry } from "@/lib/api";
+import { useIsMobile } from "@/lib/useIsMobile";
+import { FlashHint } from "./FlashHint";
 
 type PublicBoardProps = {
   currentUsername: string;
@@ -10,6 +12,12 @@ type PublicBoardProps = {
 export function PublicBoard({ currentUsername }: PublicBoardProps) {
   const [board, setBoard] = useState<BoardEntry[]>([]);
   const [loading, setLoading] = useState(true);
+  const isMobile = useIsMobile();
+  // Tighter columns + gap on small screens so the CLEAR column no longer clips
+  // off the right edge at 320px (#473 P4).
+  const gridColumns = isMobile ? "20px 1fr 40px 44px 48px" : "32px 1fr 64px 64px 64px";
+  const rowGap = isMobile ? "8px" : "12px";
+  const rowPadX = isMobile ? "8px" : "12px";
   const containerStyle: React.CSSProperties = {
     display: "flex", flexDirection: "column", alignItems: "center",
     gap: "32px", animation: "fadeIn 0.6s ease", width: "100%", maxWidth: "min(560px, calc(100vw - 24px))",
@@ -58,15 +66,15 @@ export function PublicBoard({ currentUsername }: PublicBoardProps) {
         </p>
       </div>
 
-      <div style={{ width: "100%", display: "flex", flexDirection: "column", gap: "2px" }}>
+      <div style={{ width: "100%", display: "flex", flexDirection: "column", gap: "2px", overflowX: "auto" }}>
         {/* Header */}
         <div style={{
           display: "grid",
-          gridTemplateColumns: "32px 1fr 64px 64px 64px",
-          gap: "12px", padding: "8px 12px",
+          gridTemplateColumns: gridColumns,
+          gap: rowGap, padding: `8px ${rowPadX}`,
           fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
           fontSize: "11px", color: "var(--fg-4)",
-          letterSpacing: "0.12em", textTransform: "uppercase",
+          letterSpacing: isMobile ? "0.06em" : "0.12em", textTransform: "uppercase",
         }}>
           <span>#</span>
           <span>user</span>
@@ -82,8 +90,8 @@ export function PublicBoard({ currentUsername }: PublicBoardProps) {
               key={user.username}
               style={{
                 display: "grid",
-                gridTemplateColumns: "32px 1fr 64px 64px 64px",
-                gap: "12px", padding: "10px 12px", borderRadius: "6px",
+                gridTemplateColumns: gridColumns,
+                gap: rowGap, padding: `10px ${rowPadX}`, borderRadius: "6px",
                 background: isMe
                   ? "var(--accent-green-bg-faint)"
                   : i % 2 === 0
@@ -108,6 +116,7 @@ export function PublicBoard({ currentUsername }: PublicBoardProps) {
                 fontSize: "15px",
                 color: isMe ? "var(--accent-green)" : "var(--fg)",
                 fontStyle: isMe ? "italic" : "normal",
+                minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
               }}>
                 {user.username}{" "}
                 {isMe && <span style={{ fontSize: "11px", opacity: 0.5 }}>(you)</span>}
@@ -150,15 +159,17 @@ export function PublicBoard({ currentUsername }: PublicBoardProps) {
         )}
       </div>
 
-      <p style={{
-        fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
-        fontSize: "13px", fontStyle: "italic",
-        color: "var(--fg-4)", textAlign: "center", lineHeight: 1.5,
-      }}>
-        Not a competition &mdash; a community of people training attention together.
-        <br />
-        Opt in via Settings.
-      </p>
+      <FlashHint style={{ textAlign: "center" }}>
+        <p style={{
+          fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+          fontSize: "13px", fontStyle: "italic",
+          color: "var(--fg-4)", textAlign: "center", lineHeight: 1.5,
+        }}>
+          Not a competition &mdash; a community of people training attention together.
+          <br />
+          Opt in via Settings.
+        </p>
+      </FlashHint>
     </div>
   );
 }

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -418,7 +418,7 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
               type="button"
               disabled={!isActive}
               aria-pressed={mindState === "thinking"}
-              aria-label="Hold for light distraction, or hold Space. Release when aware again."
+              aria-label={isMobile ? "Hold for light distraction. Release when aware again." : "Hold for light distraction, or hold Space. Release when aware again."}
               onMouseDown={e => {
                 e.preventDefault();
                 handlePointerDistractionDown();
@@ -456,7 +456,7 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
               type="button"
               disabled={!isActive}
               aria-pressed={mindState === "hyperfocus"}
-              aria-label="Hold for hyperfocus, or hold Comma. Release to return to aware."
+              aria-label={isMobile ? "Hold for hyperfocus. Release to return to aware." : "Hold for hyperfocus, or hold Comma. Release to return to aware."}
               onMouseDown={e => {
                 e.preventDefault();
                 handlePointerHyperfocusDown();

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -4,6 +4,8 @@ import { useState, useRef, useCallback, useEffect, type CSSProperties } from "re
 import { durationForSession, type SessionType } from "@/lib/constants";
 import { BlockTimer } from "./BlockTimer";
 import { ThoughtCapture } from "./ThoughtCapture";
+import { FlashHint } from "./FlashHint";
+import { useIsMobile } from "@/lib/useIsMobile";
 import { loadSoundPrefs, saveSoundPrefs, type SoundPrefs } from "@/lib/audio";
 import { computeClearPercentFromLog } from "@/lib/mindStateSession";
 import { useMindStateHold } from "@/lib/useMindStateHold";
@@ -46,6 +48,7 @@ const mono: CSSProperties = {
 };
 
 export function SessionView({ currentDay, sessionType = "standard", onComplete, onAbandon }: SessionViewProps) {
+  const isMobile = useIsMobile();
   const plannedSeconds = durationForSession(sessionType, currentDay);
   const [bonusSeconds, setBonusSeconds] = useState(0);
   const totalSeconds = plannedSeconds + bonusSeconds;
@@ -318,13 +321,15 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
     fontSize: "12px",
     letterSpacing: "0.12em",
     textTransform: "uppercase",
-    padding: "12px 16px",
+    padding: "12px 14px",
     borderRadius: "16px",
     cursor: isActive ? "pointer" : "default",
     transition: "all 0.25s",
-    flex: "1 1 140px",
-    minWidth: "min(160px, 42vw)",
-    maxWidth: "200px",
+    // On phones keep both holds on one row (was wrapping to two, adding height).
+    flex: isMobile ? "1 1 0" : "1 1 140px",
+    minWidth: isMobile ? 0 : "min(160px, 42vw)",
+    maxWidth: isMobile ? "none" : "200px",
+    minHeight: "44px",
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
@@ -440,9 +445,11 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
               }}
             >
               <span>{mindState === "thinking" ? "Release" : "Hold"} — light distraction</span>
-              <span style={{ ...mono, fontSize: "9px", letterSpacing: "0.14em", opacity: 0.85, textTransform: "none" }}>
-                or hold Space
-              </span>
+              {!isMobile && (
+                <span style={{ ...mono, fontSize: "9px", letterSpacing: "0.14em", opacity: 0.85, textTransform: "none" }}>
+                  or hold Space
+                </span>
+              )}
             </button>
 
             <button
@@ -476,25 +483,29 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
               }}
             >
               <span>{mindState === "hyperfocus" ? "Release" : "Hold"} — hyperfocus</span>
-              <span style={{ ...mono, fontSize: "9px", letterSpacing: "0.14em", opacity: 0.85, textTransform: "none" }}>
-                or hold ,
-              </span>
+              {!isMobile && (
+                <span style={{ ...mono, fontSize: "9px", letterSpacing: "0.14em", opacity: 0.85, textTransform: "none" }}>
+                  or hold ,
+                </span>
+              )}
             </button>
           </div>
 
-          <p
-            style={{
-              margin: "12px 0 0",
-              textAlign: "center",
-              ...mono,
-              fontSize: "10px",
-              color: "var(--fg-4)",
-              letterSpacing: "0.05em",
-              lineHeight: 1.45,
-            }}
-          >
-            Light distraction holds only log awareness segments. Captured notes are reserved for explicit capture paths.
-          </p>
+          <FlashHint>
+            <p
+              style={{
+                margin: "12px 0 0",
+                textAlign: "center",
+                ...mono,
+                fontSize: "10px",
+                color: "var(--fg-4)",
+                letterSpacing: "0.05em",
+                lineHeight: 1.45,
+              }}
+            >
+              Light distraction holds only log awareness segments. Captured notes are reserved for explicit capture paths.
+            </p>
+          </FlashHint>
 
           <div
             style={{
@@ -512,7 +523,7 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
           </div>
 
           {!showPostDistractionCapture && (
-            <div style={{ marginTop: "18px", display: "flex", justifyContent: "center", width: "100%" }}>
+            <div style={{ marginTop: isMobile ? "12px" : "18px", display: "flex", justifyContent: "center", width: "100%" }}>
               <button
                 type="button"
                 onClick={handleOpenThoughtCapture}
@@ -539,7 +550,7 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
       )}
 
       {!sessionFinished && !showPostDistractionCapture && (
-        <div style={{ display: "flex", justifyContent: "center", gap: "10px", marginTop: "20px", flexWrap: "wrap" }}>
+        <div style={{ display: "flex", justifyContent: "center", gap: "10px", marginTop: isMobile ? "12px" : "20px", flexWrap: "wrap" }}>
           <button
             type="button"
             disabled={sessionFinished || showPostDistractionCapture || !isActive}
@@ -597,7 +608,7 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
         }}
       >
         {!showPostDistractionCapture && (
-          <div style={{ display: "flex", justifyContent: "center", gap: "12px", marginTop: "32px", flexWrap: "wrap" }}>
+          <div style={{ display: "flex", justifyContent: "center", gap: "12px", marginTop: isMobile ? "16px" : "32px", flexWrap: "wrap" }}>
             <button
               type="button"
               onClick={togglePause}
@@ -663,7 +674,7 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
             display: "flex",
             justifyContent: "center",
             gap: "16px",
-            marginTop: "24px",
+            marginTop: isMobile ? "8px" : "24px",
             ...mono,
             fontSize: "11px",
             letterSpacing: "0.1em",
@@ -690,7 +701,11 @@ export function SessionView({ currentDay, sessionType = "standard", onComplete, 
                 cursor: "pointer",
                 color: soundPrefs[key] ? "var(--fg-3)" : "var(--fg-4)",
                 transition: "color 0.3s",
-                padding: "4px 8px",
+                padding: "12px 14px",
+                minHeight: "44px",
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
               }}
             >
               {soundPrefs[key] ? "\u266A" : "\u2022"} {label}

--- a/src/components/ThoughtJournal.tsx
+++ b/src/components/ThoughtJournal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import type { Thought } from "@/lib/api";
+import { FlashHint } from "./FlashHint";
 
 type ThoughtJournalProps = {
   username: string;
@@ -71,13 +72,15 @@ export function ThoughtJournal({ username }: ThoughtJournalProps) {
       </div>
 
       <div style={{ width: "100%", maxWidth: "min(500px, calc(100vw - 40px))" }}>
-        <p style={{
-          fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
-          fontSize: "14px", fontStyle: "italic", color: "var(--fg-4)",
-          marginBottom: "24px", lineHeight: 1.6,
-        }}>
-          Every thought that felt urgent in the moment. Looking back &mdash; how many actually needed your attention right then?
-        </p>
+        <FlashHint>
+          <p style={{
+            fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+            fontSize: "14px", fontStyle: "italic", color: "var(--fg-4)",
+            marginBottom: "24px", lineHeight: 1.6,
+          }}>
+            Every thought that felt urgent in the moment. Looking back &mdash; how many actually needed your attention right then?
+          </p>
+        </FlashHint>
 
         {Object.entries(grouped).reverse().map(([day, dayThoughts]) => (
           <div key={day} style={{ marginBottom: "20px" }}>

--- a/src/lib/useIsMobile.ts
+++ b/src/lib/useIsMobile.ts
@@ -1,22 +1,23 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useSyncExternalStore } from "react";
 
-function getIsMobile() {
-  if (typeof window === "undefined") return false;
-  return window.matchMedia("(max-width: 600px)").matches;
+const MOBILE_QUERY = "(max-width: 600px)";
+
+function subscribe(callback: () => void) {
+  const mql = window.matchMedia(MOBILE_QUERY);
+  mql.addEventListener("change", callback);
+  return () => mql.removeEventListener("change", callback);
+}
+
+function getSnapshot() {
+  return window.matchMedia(MOBILE_QUERY).matches;
+}
+
+function getServerSnapshot() {
+  return false;
 }
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = useState(getIsMobile);
-
-  useEffect(() => {
-    const mql = window.matchMedia("(max-width: 600px)");
-    setIsMobile(mql.matches);
-    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    mql.addEventListener("change", handler);
-    return () => mql.removeEventListener("change", handler);
-  }, []);
-
-  return isMobile;
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/src/lib/useIsMobile.ts
+++ b/src/lib/useIsMobile.ts
@@ -2,8 +2,13 @@
 
 import { useState, useEffect } from "react";
 
+function getIsMobile() {
+  if (typeof window === "undefined") return false;
+  return window.matchMedia("(max-width: 600px)").matches;
+}
+
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = useState(false);
+  const [isMobile, setIsMobile] = useState(getIsMobile);
 
   useEffect(() => {
     const mql = window.matchMedia("(max-width: 600px)");


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes all five mobile-web layout problems in #473, verified at **320px (iPhone SE)** and **375px**. Web-only; iOS native untouched.

| # | Problem | Fix |
|---|---------|-----|
| P1 | Bottom tab labels collided / `SETTINGS` clipped | Mobile tab bar now uses **icon + small label** with real spacing — measured label gaps 13–22px, `settings` ends 12px from the edge, every button ≥44px. |
| P2 | Session/timer screen overflowed ~2× and the timer was centered off-screen | Immersive flows are **top-pinned** and the view **scrolls to top** on change, so the big readout is always at the top; compacted vertical spacing, shrank the readout, and kept the two hold buttons on one row. |
| P3 | Tiny tap targets (sound row, hide/show) | Enlarged the `tick/chime/end` row and the `hide/show` pill to ≥44px. |
| P4 | Board `CLEAR` column clipped off-screen | `Practitioners` board uses tighter responsive columns, a truncating user cell, and a horizontal-scroll fallback — nothing clips at 320px. |
| P5 | Persistent instructional paragraphs wasted space | New `FlashHint` component flashes guidance briefly then fades it out (timer, journal, board, friends); desktop `Space`/`,` keyboard hints are hidden on touch. |

## Walkthrough

Mobile demo (320px): journal hint flashes then fades, tab bar stays clean across tabs, Board `CLEAR` is fully visible, and a sit starts with the timer at the top.

[mobile_layout_after_demo.webm](https://cursor.com/agents/bc-019f18bc-a8a5-7e54-b652-f2f2d14feeeb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_layout_after_demo.webm)

Timer at the top with hold buttons on one row, and the instructional paragraph after it fades:

[Timer at 320px](https://cursor.com/agents/bc-019f18bc-a8a5-7e54-b652-f2f2d14feeeb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_timer_320.png)
[Timer at 320px after hint fades](https://cursor.com/agents/bc-019f18bc-a8a5-7e54-b652-f2f2d14feeeb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_timer_320_faded.png)

Bottom nav (icon + label, clearly separated) and the Board `CLEAR` column fully visible:

[Bottom nav at 320px](https://cursor.com/agents/bc-019f18bc-a8a5-7e54-b652-f2f2d14feeeb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_nav_320.png)
[Board at 320px, CLEAR not clipped](https://cursor.com/agents/bc-019f18bc-a8a5-7e54-b652-f2f2d14feeeb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_board_320.png)

Journal intro flashes then fades (reclaims vertical space):

[Journal intro visible](https://cursor.com/agents/bc-019f18bc-a8a5-7e54-b652-f2f2d14feeeb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_journal_text_320.png)
[Journal intro faded out](https://cursor.com/agents/bc-019f18bc-a8a5-7e54-b652-f2f2d14feeeb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_journal_faded_320.png)

### Before (from #473)
[Before: nav collision](https://cursor.com/agents/bc-019f18bc-a8a5-7e54-b652-f2f2d14feeeb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_nav_collision.png)
[Before: timer overflow](https://cursor.com/agents/bc-019f18bc-a8a5-7e54-b652-f2f2d14feeeb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_timer_full.png)

## Acceptance criteria
- [x] At 320px the bottom tabs are visually separated, nothing clipped, each ≥44px
- [x] Core sit UI (timer + blocks + primary action) fits one iPhone SE viewport
- [x] Session controls (sound row, hide/show pill) meet ≥44px touch targets
- [x] Board shows no clipped content at 320px
- [x] Instructional paragraphs flash-then-fade; Space/comma hints hidden on touch
- [x] Verified at both 320px and 375px

## Testing
- `npx tsc --noEmit` — passes
- `npm run test:unit` — 321 passed (41 files)
- Manual Playwright mobile-emulation capture at 320px and 375px across Home, Timer, Completion, History, Board, Journal, Friends, Settings (ran locally against an in-process PGlite DB; all test scaffolding reverted — only the 7 component files changed).

Closes #473

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f18bc-a8a5-7e54-b652-f2f2d14feeeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f18bc-a8a5-7e54-b652-f2f2d14feeeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mobile bottom-tab icons with stacked label/underline styling, including a dedicated icon for the buddy tab.
  * Introduced brief on-screen hint messages that fade away and don’t leave empty space after dismissal.

* **Improvements**
  * Refined mobile UI across sessions, timers, public boards, friends, and journaling (responsive spacing, sizing, and text handling).
  * Updated immersive layouts to keep the timer visible at the top.
  * Added a more compact completion screen layout option for mobile.

* **Bug Fixes**
  * Improved scroll behavior by resetting scroll when overlays open or when switching tabs/buddy sessions.
  * Reduced layout clipping on narrow screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Fix mobile layouts so key screens stay usable on small phones**

### What Changed
- The bottom tab bar on mobile now uses icons with short labels, so the tabs stay separated and readable on narrow screens.
- Session and timer screens now stay pinned to the top and reset to the top when opened, keeping the timer visible instead of landing mid-screen.
- Mobile session controls and the completion screen use tighter spacing, and several small controls now meet easier touch-target size.
- The public board table now fits small screens without clipping the final column, and usernames truncate cleanly when space is tight.
- Instructional text on session, journal, board, and friends screens now fades away after a short time instead of taking up permanent space.

### Impact
`✅ Fewer clipped mobile tabs`
`✅ Fewer off-screen timers on small phones`
`✅ Easier tapping on mobile controls`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
