### PR TITLE
Post-session survey: focus + happiness ratings (#109)

### DIFF
--- a/drizzle/sessions_ratings_109_incremental.sql
+++ b/drizzle/sessions_ratings_109_incremental.sql
@@ -1,0 +1,22 @@
+-- #109: post-session self-report ratings (focus + happiness), 1-10, nullable
+-- until set via the sessions by-session PATCH route from the CompletionScreen
+-- sliders.
+-- Idempotent + safe to re-run on hand-migrated databases (matches the runner
+-- contract in scripts/apply-migrations.ts). Do NOT edit after it is applied
+-- (the schema_migrations checksum ledger will reject a changed body).
+
+ALTER TABLE "sessions"
+ADD COLUMN IF NOT EXISTS "focus_rating" integer;
+
+ALTER TABLE "sessions"
+ADD COLUMN IF NOT EXISTS "happiness_rating" integer;
+
+ALTER TABLE "sessions" DROP CONSTRAINT IF EXISTS "sessions_focus_rating_range";
+ALTER TABLE "sessions"
+ADD CONSTRAINT "sessions_focus_rating_range"
+CHECK ("focus_rating" is null or ("focus_rating" between 1 and 10));
+
+ALTER TABLE "sessions" DROP CONSTRAINT IF EXISTS "sessions_happiness_rating_range";
+ALTER TABLE "sessions"
+ADD CONSTRAINT "sessions_happiness_rating_range"
+CHECK ("happiness_rating" is null or ("happiness_rating" between 1 and 10));

--- a/src/app/api/sessions/by-session/[sessionId]/route.integration.test.ts
+++ b/src/app/api/sessions/by-session/[sessionId]/route.integration.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Issue #109 — post-session survey (focus + happiness).
+ *
+ * Route-level persistence tests for PATCH /api/sessions/by-session/[sessionId]
+ * against a real in-process Postgres (PGlite), mirroring the pattern used for
+ * POST /api/thoughts/batch (another post-hoc CompletionScreen add).
+ */
+import { NextRequest } from "next/server";
+import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { sessions, users } from "@/db/schema";
+import { closeTestDb, getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
+
+const { getCurrentUser } = vi.hoisted(() => ({ getCurrentUser: vi.fn() }));
+
+vi.mock("@/lib/auth", () => ({ getCurrentUser }));
+vi.mock("@/db", async () => ({ db: await getTestDb() }));
+
+import { PATCH } from "./route";
+
+let db: TestDb;
+let userId: string;
+let otherUserId: string;
+let sessionId: string;
+
+function patchRequest(sessionId: string, body: unknown): NextRequest {
+  return new NextRequest(`http://test.local/api/sessions/by-session/${sessionId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeAll(async () => {
+  db = await getTestDb();
+
+  const [user] = await db
+    .insert(users)
+    .values({ email: "ratings109@test.local", username: "ratings109" })
+    .returning({ id: users.id });
+  const [other] = await db
+    .insert(users)
+    .values({ email: "other109@test.local", username: "other109" })
+    .returning({ id: users.id });
+  userId = user!.id;
+  otherUserId = other!.id;
+});
+
+beforeEach(async () => {
+  getCurrentUser.mockResolvedValue({ userId, email: "ratings109@test.local" });
+
+  const [session] = await db
+    .insert(sessions)
+    .values({
+      userId,
+      dayNumber: 3,
+      sessionType: "standard",
+      duration: 80,
+      completed: true,
+      actualTime: 80,
+      clearPercent: 74,
+      thoughtCount: 0,
+      mindStateLog: [],
+      sessionDate: "2026-06-11",
+    })
+    .returning({ id: sessions.id });
+  sessionId = session!.id;
+});
+
+afterAll(async () => {
+  await closeTestDb();
+});
+
+describe("PATCH /api/sessions/by-session/[sessionId] — ratings", () => {
+  test("sets both focusRating and happinessRating", async () => {
+    const res = await PATCH(
+      patchRequest(sessionId, { focusRating: 7, happinessRating: 9 }),
+      { params: Promise.resolve({ sessionId }) },
+    );
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.session.focusRating).toBe(7);
+    expect(json.session.happinessRating).toBe(9);
+
+    const [row] = await db.select().from(sessions).where(eq(sessions.id, sessionId));
+    expect(row!.focusRating).toBe(7);
+    expect(row!.happinessRating).toBe(9);
+  });
+
+  test("sets a single rating, leaving the other null", async () => {
+    const res = await PATCH(
+      patchRequest(sessionId, { focusRating: 4 }),
+      { params: Promise.resolve({ sessionId }) },
+    );
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.session.focusRating).toBe(4);
+    expect(json.session.happinessRating).toBeNull();
+  });
+
+  test("a later PATCH overwrites a prior rating (revisable)", async () => {
+    await PATCH(
+      patchRequest(sessionId, { focusRating: 2, happinessRating: 2 }),
+      { params: Promise.resolve({ sessionId }) },
+    );
+    const res = await PATCH(
+      patchRequest(sessionId, { focusRating: 8 }),
+      { params: Promise.resolve({ sessionId }) },
+    );
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.session.focusRating).toBe(8);
+    expect(json.session.happinessRating).toBe(2);
+  });
+
+  test.each([0, 11, 1.5, -1])("rejects out-of-range/non-integer rating %s with 400", async (value) => {
+    const res = await PATCH(
+      patchRequest(sessionId, { focusRating: value }),
+      { params: Promise.resolve({ sessionId }) },
+    );
+
+    expect(res.status).toBe(400);
+    const [row] = await db.select().from(sessions).where(eq(sessions.id, sessionId));
+    expect(row!.focusRating).toBeNull();
+  });
+
+  test("rejects non-numeric rating with 400", async () => {
+    const res = await PATCH(
+      patchRequest(sessionId, { focusRating: "great" }),
+      { params: Promise.resolve({ sessionId }) },
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  test("empty body (no supported fields) fails visibly with 400", async () => {
+    const res = await PATCH(
+      patchRequest(sessionId, {}),
+      { params: Promise.resolve({ sessionId }) },
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("No supported ratings provided");
+  });
+
+  test("invalid session id returns 400", async () => {
+    const res = await PATCH(
+      patchRequest("not-a-uuid", { focusRating: 5 }),
+      { params: Promise.resolve({ sessionId: "not-a-uuid" }) },
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  test("another user's session id returns 404 and persists nothing", async () => {
+    getCurrentUser.mockResolvedValue({ userId: otherUserId, email: "other109@test.local" });
+
+    const res = await PATCH(
+      patchRequest(sessionId, { focusRating: 6, happinessRating: 6 }),
+      { params: Promise.resolve({ sessionId }) },
+    );
+
+    expect(res.status).toBe(404);
+    const [row] = await db.select().from(sessions).where(eq(sessions.id, sessionId));
+    expect(row!.focusRating).toBeNull();
+    expect(row!.happinessRating).toBeNull();
+  });
+
+  test("unauthenticated request returns 401", async () => {
+    getCurrentUser.mockResolvedValue(null);
+
+    const res = await PATCH(
+      patchRequest(sessionId, { focusRating: 5 }),
+      { params: Promise.resolve({ sessionId }) },
+    );
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/api/sessions/by-session/[sessionId]/route.ts
+++ b/src/app/api/sessions/by-session/[sessionId]/route.ts
@@ -58,3 +58,59 @@ export async function GET(
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }
+
+const RATING_FIELDS = ["focusRating", "happinessRating"] as const;
+
+function isValidRating(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 10;
+}
+
+/** #109: post-hoc CompletionScreen ratings update, matching the existing
+ *  pattern of adding data to a session after it was created (see
+ *  POST /api/thoughts/batch for the completion-note equivalent). */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> },
+) {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { sessionId } = await params;
+    if (!sessionId || !isUuid(sessionId)) {
+      return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
+    }
+
+    const body = await request.json();
+    const updates: Partial<Record<(typeof RATING_FIELDS)[number], number>> = {};
+
+    for (const field of RATING_FIELDS) {
+      if (body[field] === undefined) continue;
+      if (!isValidRating(body[field])) {
+        return NextResponse.json({ error: `Invalid ${field}` }, { status: 400 });
+      }
+      updates[field] = body[field];
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json({ error: "No supported ratings provided" }, { status: 400 });
+    }
+
+    const [updated] = await db
+      .update(sessions)
+      .set(updates)
+      .where(and(eq(sessions.id, sessionId), eq(sessions.userId, auth.userId)))
+      .returning();
+
+    if (!updated) {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ session: updated });
+  } catch (error) {
+    console.error("Update session ratings error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/sessions/by-session/[sessionId]/route.ts
+++ b/src/app/api/sessions/by-session/[sessionId]/route.ts
@@ -83,15 +83,24 @@ export async function PATCH(
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }
 
-    const body = await request.json();
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+    if (body === null || typeof body !== "object" || Array.isArray(body)) {
+      return NextResponse.json({ error: "Request body must be a JSON object" }, { status: 400 });
+    }
     const updates: Partial<Record<(typeof RATING_FIELDS)[number], number>> = {};
+    const bodyObj = body as Record<string, unknown>;
 
     for (const field of RATING_FIELDS) {
-      if (body[field] === undefined) continue;
-      if (!isValidRating(body[field])) {
+      if (bodyObj[field] === undefined) continue;
+      if (!isValidRating(bodyObj[field])) {
         return NextResponse.json({ error: `Invalid ${field}` }, { status: 400 });
       }
-      updates[field] = body[field];
+      updates[field] = bodyObj[field] as number;
     }
 
     if (Object.keys(updates).length === 0) {

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -797,6 +797,9 @@ export default function StillPoint() {
               throw new Error("Failed to save note");
             }
           } : undefined}
+          onSaveRatings={completionData.sessionId ? async (ratings) => {
+            await api.updateSessionRatings(completionData.sessionId!, ratings);
+          } : undefined}
           compact={isMobile}
         />
       )}

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -632,7 +632,11 @@ export default function StillPoint() {
       // Immersive flows (session/breath/buddy) can exceed the viewport on small
       // phones; centering would clip the timer off the top with no way to scroll
       // up to it. Pin them to the top so the timer is always visible (#473 P2).
-      alignItems: isImmersive ? "start" : "center",
+      // The completion overlay can also overflow on mobile now that it includes
+      // survey sliders; centering would clip content above the viewport and push
+      // the Return button behind the fixed bottom nav (#479). Use "start" on
+      // mobile so the bottom padding reliably clears the nav.
+      alignItems: (isImmersive || (overlay === "complete" && isMobile)) ? "start" : "center",
       fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
       padding: isMobile
         ? "var(--s4) var(--s3) calc(var(--nav-h) + env(safe-area-inset-bottom, 0px))"
@@ -695,8 +699,9 @@ export default function StillPoint() {
         </div>
       )}
 
-      {/* Welcome header */}
-      {!isImmersive && (
+      {/* Welcome header — hidden during the completion overlay on mobile to
+          keep the CompletionScreen content above the fixed bottom nav (#479). */}
+      {!isImmersive && !(overlay === "complete" && isMobile) && (
         <div style={{
           fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
           fontSize: "12px", color: "var(--fg-3)",

--- a/src/components/CompletionScreen.tsx
+++ b/src/components/CompletionScreen.tsx
@@ -61,9 +61,9 @@ export function CompletionScreen({
   return (
     <div style={{
       display: "flex", flexDirection: "column", alignItems: "center",
-      gap: compact ? "16px" : "32px", animation: "fadeIn 0.8s ease",
+      gap: compact ? "12px" : "32px", animation: "fadeIn 0.8s ease",
     }}>
-      <div style={{ fontSize: "64px", opacity: 0.8 }}>&#x25C9;</div>
+      <div style={{ fontSize: compact ? "48px" : "64px", opacity: 0.8 }}>&#x25C9;</div>
 
       <div style={{ textAlign: "center" }}>
         <h2 style={{

--- a/src/components/CompletionScreen.tsx
+++ b/src/components/CompletionScreen.tsx
@@ -15,8 +15,9 @@ type CompletionScreenProps = {
   onReturn: () => void;
   onSaveNote?: (text: string) => Promise<void>;
   /** #109: post-session self-report; omitted (no sliders rendered) when there is
-   *  no persisted session to attach ratings to. */
-  onSaveRatings?: (ratings: { focusRating: number; happinessRating: number }) => Promise<void>;
+   *  no persisted session to attach ratings to. Only touched slider values are
+   *  included in the payload; untouched ones are omitted for partial-update. */
+  onSaveRatings?: (ratings: { focusRating?: number; happinessRating?: number }) => Promise<void>;
   /** Tighten vertical spacing for narrow-viewport mobile layouts (#473). */
   compact?: boolean;
 };
@@ -61,8 +62,6 @@ export function CompletionScreen({
     <div style={{
       display: "flex", flexDirection: "column", alignItems: "center",
       gap: compact ? "16px" : "32px", animation: "fadeIn 0.8s ease",
-      // Ensure the Return button clears the fixed bottom nav on mobile (#479).
-      paddingBottom: compact ? "calc(var(--nav-h) + env(safe-area-inset-bottom, 0px))" : undefined,
     }}>
       <div style={{ fontSize: "64px", opacity: 0.8 }}>&#x25C9;</div>
 
@@ -273,41 +272,52 @@ export function CompletionScreen({
                   failed to save — tap to retry
                 </div>
               )}
-              {(focusTouched || happinessTouched || ratingsSaveError) && (
-                <button
-                  type="button"
-                  onClick={async () => {
-                    setSavingRatings(true);
-                    try {
-                      setRatingsSaveError(false);
-                      await onSaveRatings({ focusRating, happinessRating });
-                      setRatingsSaved(true);
-                    } catch (err) {
-                      console.error("Failed to save ratings:", err);
-                      setRatingsSaveError(true);
-                    } finally {
-                      setSavingRatings(false);
+              <button
+                type="button"
+                onClick={async () => {
+                  setSavingRatings(true);
+                  try {
+                    setRatingsSaveError(false);
+                    // Only send ratings the user explicitly touched; untouched
+                    // sliders stay at their default and are omitted from the
+                    // payload so the server-side partial-update logic is used
+                    // correctly and no unintended default-5 overwrites occur.
+                    const payload: { focusRating?: number; happinessRating?: number } = {};
+                    if (focusTouched) payload.focusRating = focusRating;
+                    if (happinessTouched) payload.happinessRating = happinessRating;
+                    // If neither was touched, send both (user explicitly clicked
+                    // save with the visible defaults — treat as intentional).
+                    if (!focusTouched && !happinessTouched) {
+                      payload.focusRating = focusRating;
+                      payload.happinessRating = happinessRating;
                     }
-                  }}
-                  disabled={savingRatings}
-                  style={{
-                    background: "none",
-                    border: ratingsSaveError
-                      ? "1px solid var(--accent-danger-border)"
-                      : "1px solid var(--accent-green-border)",
-                    color: ratingsSaveError
-                      ? "var(--accent-danger)"
-                      : "var(--accent-green-text)",
-                    fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-                    fontSize: "11px", letterSpacing: "0.12em", textTransform: "uppercase",
-                    padding: "8px 24px", borderRadius: "20px",
-                    cursor: savingRatings ? "default" : "pointer",
-                    opacity: savingRatings ? 0.5 : 1,
-                  }}
-                >
-                  {savingRatings ? "saving..." : ratingsSaveError ? "retry" : "save ratings"}
-                </button>
-              )}
+                    await onSaveRatings(payload);
+                    setRatingsSaved(true);
+                  } catch (err) {
+                    console.error("Failed to save ratings:", err);
+                    setRatingsSaveError(true);
+                  } finally {
+                    setSavingRatings(false);
+                  }
+                }}
+                disabled={savingRatings}
+                style={{
+                  background: "none",
+                  border: ratingsSaveError
+                    ? "1px solid var(--accent-danger-border)"
+                    : "1px solid var(--accent-green-border)",
+                  color: ratingsSaveError
+                    ? "var(--accent-danger)"
+                    : "var(--accent-green-text)",
+                  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                  fontSize: "11px", letterSpacing: "0.12em", textTransform: "uppercase",
+                  padding: "8px 24px", borderRadius: "20px",
+                  cursor: savingRatings ? "default" : "pointer",
+                  opacity: savingRatings ? 0.5 : 1,
+                }}
+              >
+                {savingRatings ? "saving..." : ratingsSaveError ? "retry" : "save ratings"}
+              </button>
             </>
           )}
         </div>
@@ -325,6 +335,11 @@ export function CompletionScreen({
           padding: "12px 36px", borderRadius: "30px",
           minHeight: "44px",
           cursor: "pointer", marginTop: "8px",
+          // scrollMarginBottom ensures scrollIntoViewIfNeeded respects the fixed
+          // bottom nav so the Return button never lands behind it on mobile (#479).
+          scrollMarginBottom: compact
+            ? "calc(var(--nav-h) + env(safe-area-inset-bottom, 0px))"
+            : undefined,
         }}
       >
         Return

--- a/src/components/CompletionScreen.tsx
+++ b/src/components/CompletionScreen.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { BLOCK_DURATION, durationForDay, type SessionType } from "@/lib/constants";
+import { RatingSlider } from "@/components/RatingSlider";
 
 type CompletionScreenProps = {
   dayNumber: number;
@@ -13,9 +14,14 @@ type CompletionScreenProps = {
   thoughts: Array<{ timeInSession: number; text: string }>;
   onReturn: () => void;
   onSaveNote?: (text: string) => Promise<void>;
+  /** #109: post-session self-report; omitted (no sliders rendered) when there is
+   *  no persisted session to attach ratings to. */
+  onSaveRatings?: (ratings: { focusRating: number; happinessRating: number }) => Promise<void>;
   /** Tighten vertical spacing for narrow-viewport mobile layouts (#473). */
   compact?: boolean;
 };
+
+const DEFAULT_RATING = 5;
 
 export function CompletionScreen({
   dayNumber,
@@ -27,12 +33,18 @@ export function CompletionScreen({
   thoughts,
   onReturn,
   onSaveNote,
+  onSaveRatings,
   compact = false,
 }: CompletionScreenProps) {
   const [note, setNote] = useState("");
   const [noteSaved, setNoteSaved] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState(false);
+  const [focusRating, setFocusRating] = useState(DEFAULT_RATING);
+  const [happinessRating, setHappinessRating] = useState(DEFAULT_RATING);
+  const [ratingsSaved, setRatingsSaved] = useState(false);
+  const [savingRatings, setSavingRatings] = useState(false);
+  const [ratingsSaveError, setRatingsSaveError] = useState(false);
   const isQuick = sessionType === "quick";
   const nextDuration = durationForDay(dayNumber + 1);
   const nextBlocks = Math.ceil(nextDuration / BLOCK_DURATION);
@@ -221,6 +233,75 @@ export function CompletionScreen({
                   {saving ? "saving..." : saveError ? "retry" : "save note"}
                 </button>
               )}
+            </>
+          )}
+        </div>
+      )}
+
+      {/* Post-session ratings (#109) */}
+      {onSaveRatings && (
+        <div style={{
+          width: "100%", maxWidth: "min(380px, calc(100vw - 40px))",
+          display: "flex", flexDirection: "column", alignItems: "center", gap: "14px",
+        }}>
+          {ratingsSaved ? (
+            <div style={{
+              fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+              fontSize: "11px", color: "var(--accent-green-dim)",
+              letterSpacing: "0.09em",
+            }}>
+              ratings saved
+            </div>
+          ) : (
+            <>
+              <RatingSlider label="Focus" value={focusRating} onChange={setFocusRating} disabled={savingRatings} />
+              <RatingSlider label="Happiness" value={happinessRating} onChange={setHappinessRating} disabled={savingRatings} />
+              {ratingsSaveError && (
+                <div
+                  role="alert"
+                  aria-live="assertive"
+                  style={{
+                    fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                    fontSize: "11px", color: "var(--accent-danger)",
+                    letterSpacing: "0.09em",
+                  }}
+                >
+                  failed to save — tap to retry
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={async () => {
+                  setSavingRatings(true);
+                  try {
+                    setRatingsSaveError(false);
+                    await onSaveRatings({ focusRating, happinessRating });
+                    setRatingsSaved(true);
+                  } catch (err) {
+                    console.error("Failed to save ratings:", err);
+                    setRatingsSaveError(true);
+                  } finally {
+                    setSavingRatings(false);
+                  }
+                }}
+                disabled={savingRatings}
+                style={{
+                  background: "none",
+                  border: ratingsSaveError
+                    ? "1px solid var(--accent-danger-border)"
+                    : "1px solid var(--accent-green-border)",
+                  color: ratingsSaveError
+                    ? "var(--accent-danger)"
+                    : "var(--accent-green-text)",
+                  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                  fontSize: "11px", letterSpacing: "0.12em", textTransform: "uppercase",
+                  padding: "8px 24px", borderRadius: "20px",
+                  cursor: savingRatings ? "default" : "pointer",
+                  opacity: savingRatings ? 0.5 : 1,
+                }}
+              >
+                {savingRatings ? "saving..." : ratingsSaveError ? "retry" : "save ratings"}
+              </button>
             </>
           )}
         </div>

--- a/src/components/CompletionScreen.tsx
+++ b/src/components/CompletionScreen.tsx
@@ -42,6 +42,8 @@ export function CompletionScreen({
   const [saveError, setSaveError] = useState(false);
   const [focusRating, setFocusRating] = useState(DEFAULT_RATING);
   const [happinessRating, setHappinessRating] = useState(DEFAULT_RATING);
+  const [focusTouched, setFocusTouched] = useState(false);
+  const [happinessTouched, setHappinessTouched] = useState(false);
   const [ratingsSaved, setRatingsSaved] = useState(false);
   const [savingRatings, setSavingRatings] = useState(false);
   const [ratingsSaveError, setRatingsSaveError] = useState(false);
@@ -59,6 +61,8 @@ export function CompletionScreen({
     <div style={{
       display: "flex", flexDirection: "column", alignItems: "center",
       gap: compact ? "16px" : "32px", animation: "fadeIn 0.8s ease",
+      // Ensure the Return button clears the fixed bottom nav on mobile (#479).
+      paddingBottom: compact ? "calc(var(--nav-h) + env(safe-area-inset-bottom, 0px))" : undefined,
     }}>
       <div style={{ fontSize: "64px", opacity: 0.8 }}>&#x25C9;</div>
 
@@ -254,8 +258,8 @@ export function CompletionScreen({
             </div>
           ) : (
             <>
-              <RatingSlider label="Focus" value={focusRating} onChange={setFocusRating} disabled={savingRatings} />
-              <RatingSlider label="Happiness" value={happinessRating} onChange={setHappinessRating} disabled={savingRatings} />
+              <RatingSlider label="Focus" value={focusRating} onChange={(v) => { setFocusRating(v); setFocusTouched(true); }} disabled={savingRatings} />
+              <RatingSlider label="Happiness" value={happinessRating} onChange={(v) => { setHappinessRating(v); setHappinessTouched(true); }} disabled={savingRatings} />
               {ratingsSaveError && (
                 <div
                   role="alert"
@@ -269,39 +273,41 @@ export function CompletionScreen({
                   failed to save — tap to retry
                 </div>
               )}
-              <button
-                type="button"
-                onClick={async () => {
-                  setSavingRatings(true);
-                  try {
-                    setRatingsSaveError(false);
-                    await onSaveRatings({ focusRating, happinessRating });
-                    setRatingsSaved(true);
-                  } catch (err) {
-                    console.error("Failed to save ratings:", err);
-                    setRatingsSaveError(true);
-                  } finally {
-                    setSavingRatings(false);
-                  }
-                }}
-                disabled={savingRatings}
-                style={{
-                  background: "none",
-                  border: ratingsSaveError
-                    ? "1px solid var(--accent-danger-border)"
-                    : "1px solid var(--accent-green-border)",
-                  color: ratingsSaveError
-                    ? "var(--accent-danger)"
-                    : "var(--accent-green-text)",
-                  fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-                  fontSize: "11px", letterSpacing: "0.12em", textTransform: "uppercase",
-                  padding: "8px 24px", borderRadius: "20px",
-                  cursor: savingRatings ? "default" : "pointer",
-                  opacity: savingRatings ? 0.5 : 1,
-                }}
-              >
-                {savingRatings ? "saving..." : ratingsSaveError ? "retry" : "save ratings"}
-              </button>
+              {(focusTouched || happinessTouched || ratingsSaveError) && (
+                <button
+                  type="button"
+                  onClick={async () => {
+                    setSavingRatings(true);
+                    try {
+                      setRatingsSaveError(false);
+                      await onSaveRatings({ focusRating, happinessRating });
+                      setRatingsSaved(true);
+                    } catch (err) {
+                      console.error("Failed to save ratings:", err);
+                      setRatingsSaveError(true);
+                    } finally {
+                      setSavingRatings(false);
+                    }
+                  }}
+                  disabled={savingRatings}
+                  style={{
+                    background: "none",
+                    border: ratingsSaveError
+                      ? "1px solid var(--accent-danger-border)"
+                      : "1px solid var(--accent-green-border)",
+                    color: ratingsSaveError
+                      ? "var(--accent-danger)"
+                      : "var(--accent-green-text)",
+                    fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+                    fontSize: "11px", letterSpacing: "0.12em", textTransform: "uppercase",
+                    padding: "8px 24px", borderRadius: "20px",
+                    cursor: savingRatings ? "default" : "pointer",
+                    opacity: savingRatings ? 0.5 : 1,
+                  }}
+                >
+                  {savingRatings ? "saving..." : ratingsSaveError ? "retry" : "save ratings"}
+                </button>
+              )}
             </>
           )}
         </div>

--- a/src/components/RatingSlider.tsx
+++ b/src/components/RatingSlider.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+type RatingSliderProps = {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+  min?: number;
+  max?: number;
+  disabled?: boolean;
+};
+
+/** #109: reusable 1-10 self-report slider (native range input) shared by the
+ *  post-session focus/happiness prompts in CompletionScreen. */
+export function RatingSlider({
+  label,
+  value,
+  onChange,
+  min = 1,
+  max = 10,
+  disabled = false,
+}: RatingSliderProps) {
+  return (
+    <div style={{ width: "100%", display: "flex", flexDirection: "column", gap: "6px" }}>
+      <div style={{
+        display: "flex", justifyContent: "space-between", alignItems: "baseline",
+        fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+      }}>
+        <span style={{
+          fontSize: "11px", color: "var(--fg-3)",
+          letterSpacing: "0.12em", textTransform: "uppercase",
+        }}>
+          {label}
+        </span>
+        <span style={{ fontSize: "13px", color: "var(--accent-green-text)" }}>{value}</span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={1}
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange(Number(e.target.value))}
+        aria-label={label}
+        style={{
+          width: "100%",
+          accentColor: "var(--accent-green)",
+          cursor: disabled ? "default" : "pointer",
+          opacity: disabled ? 0.6 : 1,
+        }}
+      />
+    </div>
+  );
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -342,6 +342,10 @@ export const sessions = pgTable("sessions", {
   breathCount: integer("breath_count"),
   mindStateLog: jsonb("mind_state_log").$type<Array<{ time: number; state: string }>>(),
   sessionDate: date("session_date").notNull(),
+  /** #109: post-session self-report ratings (1-10), null until set via the
+   *  by-session PATCH route from the CompletionScreen sliders. */
+  focusRating: integer("focus_rating"),
+  happinessRating: integer("happiness_rating"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 }, (table) => ({
   userIdx: index("idx_sessions_user").on(table.userId, table.dayNumber),
@@ -355,6 +359,14 @@ export const sessions = pgTable("sessions", {
     table.userId,
     table.buddySessionId,
   ).where(sql`${table.buddySessionId} is not null`),
+  focusRatingCheck: check(
+    "sessions_focus_rating_range",
+    sql`${table.focusRating} is null or (${table.focusRating} between 1 and 10)`,
+  ),
+  happinessRatingCheck: check(
+    "sessions_happiness_rating_range",
+    sql`${table.happinessRating} is null or (${table.happinessRating} between 1 and 10)`,
+  ),
 }));
 
 export const thoughts = pgTable("thoughts", {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -47,6 +47,9 @@ export type Session = {
   createdAt: string;
   /** Present when this row was created from a completed buddy sit (#119). */
   buddySessionId?: string | null;
+  /** #109: post-session self-report ratings (1-10), null until rated. */
+  focusRating?: number | null;
+  happinessRating?: number | null;
 };
 
 export type Thought = {
@@ -200,6 +203,16 @@ export const api = {
 
   getSession: (dayNumber: number) =>
     request<{ session: Session; thoughts: Thought[] }>(`/api/sessions/${dayNumber}`),
+
+  /** #109: post-hoc ratings update from the CompletionScreen sliders. */
+  updateSessionRatings: (
+    sessionId: string,
+    data: { focusRating?: number; happinessRating?: number },
+  ) =>
+    request<{ session: Session }>(`/api/sessions/by-session/${sessionId}`, {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    }),
 
   getThoughts: () =>
     request<{ thoughts: Thought[] }>("/api/thoughts"),


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #109

### Summary
- Add nullable `focus_rating`/`happiness_rating` columns to `sessions` via a new incremental migration (`drizzle/sessions_ratings_109_incremental.sql`) plus `src/db/schema.ts`, each range-checked 1-10 at the DB level.
- Add `PATCH /api/sessions/by-session/[sessionId]` to set ratings post-creation, matching the existing post-hoc CompletionScreen add pattern (`POST /api/thoughts/batch`). Auth + ownership scoped, validates integers 1-10, supports partial updates and re-saves.
- Add a reusable `RatingSlider` component (native `<input type="range">`, inline CSS per conventions).
- Wire two sliders (Focus, Happiness, default 5) into `CompletionScreen` with a save button (saving/error/saved states, mirroring the existing note-save UX), invoked from `page.tsx` via a new `api.updateSessionRatings` helper.

Independent of progression logic (#238/#240) — no session-count/streak changes.

### Test plan
- ✅ `npm run typecheck`
- ✅ `npm run test:unit` (334 passed, incl. 12 new PGlite integration tests for the PATCH route covering: set both/one rating, overwrite on re-save, out-of-range/non-integer/non-numeric rejection, empty body, invalid session id, cross-user 404, unauthenticated 401)
- ✅ Manual GUI test of `CompletionScreen` (temporary local preview, not committed): dragged both sliders, confirmed live value display, saved successfully (sliders replaced by "ratings saved"), and verified the failure path (error message + "retry", sliders stay visible). See screenshots below.
- `npm run test:unit` is not run in CI per repo convention; ran locally.

[Initial sliders at default value 5](https://cursor.com/agents/bc-8d9d302f-5299-4181-9c68-63c37b2ac436/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompletion_screen_ratings_initial.webp)
[Sliders adjusted to Focus 9, Happiness 2](https://cursor.com/agents/bc-8d9d302f-5299-4181-9c68-63c37b2ac436/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompletion_screen_ratings_adjusted.webp)
[Ratings saved state](https://cursor.com/agents/bc-8d9d302f-5299-4181-9c68-63c37b2ac436/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompletion_screen_ratings_saved.webp)
[Save failure state with retry](https://cursor.com/agents/bc-8d9d302f-5299-4181-9c68-63c37b2ac436/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcompletion_screen_ratings_error.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d9d302f-5299-4181-9c68-63c37b2ac436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d9d302f-5299-4181-9c68-63c37b2ac436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a post-session ratings flow with Focus and Happiness sliders on the completion screen.
  * Introduced an update endpoint to persist ratings for a session (with per-field updates).
* **Bug Fixes**
  * Enforced ratings validation (must be integers in the 1–10 range, or left unset).
  * Improved request handling for empty/invalid payloads, invalid session IDs, and unauthorized/unauthorized-access scenarios.
* **Tests**
  * Added integration coverage for saving ratings, validation failures, authentication, and access control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add post-session focus and happiness ratings**

### What Changed
- Added two 1–10 sliders to the completion screen so users can record focus and happiness after a session, then save those ratings to the session.
- Ratings are now stored with the session and can be updated again later; invalid values are rejected.
- On mobile, the completion screen now keeps the Return button and survey visible above the fixed bottom navigation.

### Impact
`✅ Post-session survey responses`
`✅ Fewer mobile layout overlaps`
`✅ Clearer rating save errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
