### PR TITLE
Most meditated with buddy: per-friend session stats

### DIFF
--- a/src/app/api/friends/route.integration.test.ts
+++ b/src/app/api/friends/route.integration.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Issue #343 — "most meditated with buddy": route-level test for
+ * GET /api/friends against a real in-process Postgres (PGlite), verifying
+ * the sessions <-> buddy_session_participants join computes per-friend
+ * sessionCount + totalDurationSeconds correctly and sorts by them.
+ */
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { and, eq } from "drizzle-orm";
+import {
+  buddySessionParticipants,
+  buddySessions,
+  friendships,
+  sessions,
+  users,
+} from "@/db/schema";
+import { orderedUserPair } from "@/lib/friends";
+import { closeTestDb, getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
+
+const { getCurrentUser } = vi.hoisted(() => ({ getCurrentUser: vi.fn() }));
+
+vi.mock("@/lib/auth", () => ({ getCurrentUser }));
+vi.mock("@/db", async () => ({ db: await getTestDb() }));
+
+import { GET } from "./route";
+
+let db: TestDb;
+let seq = 0;
+
+async function createUser(prefix: string) {
+  seq += 1;
+  const [row] = await db
+    .insert(users)
+    .values({ email: `${prefix}${seq}@test.local`, username: `${prefix}${seq}` })
+    .returning({ id: users.id });
+  return row!.id;
+}
+
+async function befriend(a: string, b: string) {
+  const [user1Id, user2Id] = orderedUserPair(a, b);
+  await db.insert(friendships).values({ user1Id, user2Id });
+}
+
+/** Creates a completed shared buddy sit between `hostId` and `buddyId`, with
+ * each participant's own `sessions` row (mirrors record-personal-session). */
+async function createSharedSit(
+  hostId: string,
+  buddyId: string,
+  opts: { durationSeconds: number; hostActualTime?: number; buddyActualTime?: number },
+) {
+  seq += 1;
+  const [bs] = await db
+    .insert(buddySessions)
+    .values({
+      shareToken: `tok-${seq}`,
+      hostUserId: hostId,
+      state: "completed",
+      durationSeconds: opts.durationSeconds,
+    })
+    .returning({ id: buddySessions.id });
+  const buddySessionId = bs!.id;
+
+  await db.insert(buddySessionParticipants).values([
+    { buddySessionId, userId: hostId, isHost: true, ready: true },
+    { buddySessionId, userId: buddyId, isHost: false, ready: true },
+  ]);
+
+  await db.insert(sessions).values([
+    {
+      userId: hostId,
+      buddySessionId,
+      dayNumber: 1,
+      duration: opts.durationSeconds,
+      actualTime: opts.hostActualTime ?? opts.durationSeconds,
+      completed: true,
+      clearPercent: 100,
+      sessionDate: "2026-01-01",
+    },
+    {
+      userId: buddyId,
+      buddySessionId,
+      dayNumber: 1,
+      duration: opts.durationSeconds,
+      actualTime: opts.buddyActualTime ?? opts.durationSeconds,
+      completed: true,
+      clearPercent: 100,
+      sessionDate: "2026-01-01",
+    },
+  ]);
+
+  return buddySessionId;
+}
+
+beforeEach(async () => {
+  db = await getTestDb();
+});
+
+afterAll(async () => {
+  await closeTestDb();
+});
+
+describe("GET /api/friends — most meditated with buddy (#343)", () => {
+  test("returns sessionCount + totalDurationSeconds per friend, sorted by most sat together", async () => {
+    const me = await createUser("me");
+    const alice = await createUser("alice");
+    const bob = await createUser("bob");
+    await befriend(me, alice);
+    await befriend(me, bob);
+
+    // Two shared sits with alice (600s each, actualTime 600 for `me`).
+    await createSharedSit(me, alice, { durationSeconds: 600 });
+    await createSharedSit(me, alice, { durationSeconds: 600 });
+    // One shared sit with bob (300s).
+    await createSharedSit(me, bob, { durationSeconds: 300 });
+
+    getCurrentUser.mockResolvedValue({ userId: me, email: "me@test.local" });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+
+    expect(json.friends).toEqual([
+      { id: alice, username: expect.stringContaining("alice"), sessionCount: 2, totalDurationSeconds: 1200 },
+      { id: bob, username: expect.stringContaining("bob"), sessionCount: 1, totalDurationSeconds: 300 },
+    ]);
+  });
+
+  test("friends with no shared sessions report zero stats", async () => {
+    const me = await createUser("me");
+    const carol = await createUser("carol");
+    await befriend(me, carol);
+
+    getCurrentUser.mockResolvedValue({ userId: me, email: "me@test.local" });
+    const res = await GET();
+    const json = await res.json();
+
+    expect(json.friends).toEqual([
+      { id: carol, username: expect.stringContaining("carol"), sessionCount: 0, totalDurationSeconds: 0 },
+    ]);
+  });
+
+  test("uses actualTime over nominal duration, and only counts the current user's own session rows", async () => {
+    const me = await createUser("me");
+    const dave = await createUser("dave");
+    await befriend(me, dave);
+
+    // `me` sat 90s of a scheduled 120s sit; dave's own actualTime shouldn't count toward `me`'s total.
+    await createSharedSit(me, dave, { durationSeconds: 120, hostActualTime: 90, buddyActualTime: 120 });
+
+    getCurrentUser.mockResolvedValue({ userId: me, email: "me@test.local" });
+    const res = await GET();
+    const json = await res.json();
+
+    expect(json.friends).toEqual([
+      { id: dave, username: expect.stringContaining("dave"), sessionCount: 1, totalDurationSeconds: 90 },
+    ]);
+  });
+
+  test("uncompleted buddy sits are excluded from the stats", async () => {
+    const me = await createUser("me");
+    const erin = await createUser("erin");
+    await befriend(me, erin);
+
+    const completedSitId = await createSharedSit(me, erin, { durationSeconds: 300 });
+    const abandonedSitId = await createSharedSit(me, erin, { durationSeconds: 600 });
+    // Simulate an abandoned sit: `me`'s personal session row was never marked completed.
+    await db
+      .update(sessions)
+      .set({ completed: false })
+      .where(and(eq(sessions.buddySessionId, abandonedSitId), eq(sessions.userId, me)));
+    void completedSitId;
+
+    getCurrentUser.mockResolvedValue({ userId: me, email: "me@test.local" });
+    const res = await GET();
+    const json = await res.json();
+    expect(json.friends).toEqual([
+      { id: erin, username: expect.stringContaining("erin"), sessionCount: 1, totalDurationSeconds: 300 },
+    ]);
+  });
+
+  test("returns 401 when unauthenticated", async () => {
+    getCurrentUser.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/api/friends/route.ts
+++ b/src/app/api/friends/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import { db } from "@/db";
-import { friendships, users } from "@/db/schema";
+import { buddySessionParticipants, friendships, sessions, users } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
-import { eq } from "drizzle-orm";
+import { and, eq, isNotNull, ne, sql } from "drizzle-orm";
 
 export async function GET() {
   try {
@@ -27,9 +27,58 @@ export async function GET() {
       .innerJoin(users, eq(friendships.user1Id, users.id))
       .where(eq(friendships.user2Id, uid));
 
-    const rows = await asUser1.union(asUser2);
+    // #343: "most meditated with" per friend. Joins the current user's own
+    // completed `sessions` rows created from shared buddy sits (see
+    // record-personal-session/route.ts) against `buddy_session_participants`
+    // on the same `buddy_session_id` to find the other participant, then
+    // aggregates per friend.
+    const meditatedWithSelect = db
+      .select({
+        friendId: buddySessionParticipants.userId,
+        sessionCount: sql<number>`count(distinct ${sessions.id})`.mapWith(Number),
+        totalDurationSeconds: sql<number>`coalesce(sum(coalesce(${sessions.actualTime}, ${sessions.duration})), 0)`.mapWith(Number),
+      })
+      .from(sessions)
+      .innerJoin(
+        buddySessionParticipants,
+        eq(buddySessionParticipants.buddySessionId, sessions.buddySessionId),
+      )
+      .where(
+        and(
+          eq(sessions.userId, uid),
+          eq(sessions.completed, true),
+          isNotNull(sessions.buddySessionId),
+          ne(buddySessionParticipants.userId, uid),
+        ),
+      )
+      .groupBy(buddySessionParticipants.userId);
 
-    return NextResponse.json({ friends: rows });
+    const [rows, meditatedWith] = await Promise.all([
+      asUser1.union(asUser2),
+      meditatedWithSelect,
+    ]);
+
+    const statsByFriendId = new Map(
+      meditatedWith.map((row) => [
+        row.friendId,
+        { sessionCount: row.sessionCount, totalDurationSeconds: row.totalDurationSeconds },
+      ]),
+    );
+
+    const friends = rows
+      .map((row) => {
+        const stats = statsByFriendId.get(row.id) ?? { sessionCount: 0, totalDurationSeconds: 0 };
+        return { ...row, ...stats };
+      })
+      .sort((a, b) => {
+        if (b.sessionCount !== a.sessionCount) return b.sessionCount - a.sessionCount;
+        if (b.totalDurationSeconds !== a.totalDurationSeconds) {
+          return b.totalDurationSeconds - a.totalDurationSeconds;
+        }
+        return a.username.localeCompare(b.username);
+      });
+
+    return NextResponse.json({ friends });
   } catch (error) {
     console.error("Friends list error:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/src/app/api/friends/route.ts
+++ b/src/app/api/friends/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { buddySessionParticipants, friendships, sessions, users } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
-import { and, eq, isNotNull, ne, sql } from "drizzle-orm";
+import { and, eq, isNotNull, ne, or, sql } from "drizzle-orm";
 
 export async function GET() {
   try {
@@ -32,6 +32,10 @@ export async function GET() {
     // record-personal-session/route.ts) against `buddy_session_participants`
     // on the same `buddy_session_id` to find the other participant, then
     // aggregates per friend.
+    //
+    // The friendships table enforces user1Id < user2Id, so a friend can appear
+    // in either column. We join against friendships to restrict aggregation to
+    // actual friends, avoiding work for non-friend participants.
     const meditatedWithSelect = db
       .select({
         friendId: buddySessionParticipants.userId,
@@ -42,6 +46,13 @@ export async function GET() {
       .innerJoin(
         buddySessionParticipants,
         eq(buddySessionParticipants.buddySessionId, sessions.buddySessionId),
+      )
+      .innerJoin(
+        friendships,
+        or(
+          and(eq(friendships.user1Id, uid), eq(friendships.user2Id, buddySessionParticipants.userId)),
+          and(eq(friendships.user2Id, uid), eq(friendships.user1Id, buddySessionParticipants.userId)),
+        ),
       )
       .where(
         and(

--- a/src/components/FriendsView.tsx
+++ b/src/components/FriendsView.tsx
@@ -24,7 +24,7 @@ const cardStyle: React.CSSProperties = {
 };
 
 function formatMeditatedDuration(totalDurationSeconds: number): string {
-  const totalMinutes = Math.round(totalDurationSeconds / 60);
+  const totalMinutes = Math.floor(totalDurationSeconds / 60);
   if (totalMinutes < 60) return `${totalMinutes}m`;
   const hours = Math.floor(totalMinutes / 60);
   const minutes = totalMinutes % 60;

--- a/src/components/FriendsView.tsx
+++ b/src/components/FriendsView.tsx
@@ -23,6 +23,14 @@ const cardStyle: React.CSSProperties = {
   width: "100%",
 };
 
+function formatMeditatedDuration(totalDurationSeconds: number): string {
+  const totalMinutes = Math.round(totalDurationSeconds / 60);
+  if (totalMinutes < 60) return `${totalMinutes}m`;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes === 0 ? `${hours}h` : `${hours}h ${minutes}m`;
+}
+
 const btnOutline: React.CSSProperties = {
   border: "1px solid var(--border-2)",
   background: "transparent",
@@ -346,42 +354,56 @@ export function FriendsView() {
           <span style={{ color: "var(--fg-3)", fontSize: "14px" }}>No friends yet.</span>
         ) : (
           <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: "12px" }}>
-            {friends.map((f) => (
-              <li
-                key={f.id}
-                style={{
-                  display: "flex",
-                  flexWrap: "wrap",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  gap: "12px",
-                }}
-              >
-                <span style={{ color: "var(--fg)", flex: "1 1 120px" }}>{f.username}</span>
-                <div style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
-                  <Link
-                    href={`/app/buddies/${f.id}/calendar`}
-                    style={{
-                      ...btnOutline,
-                      textDecoration: "none",
-                      display: "inline-flex",
-                      alignItems: "center",
-                      fontSize: "10px",
-                    }}
-                  >
-                    View calendar
-                  </Link>
-                  <button
-                    type="button"
-                    disabled={actionId === f.id}
-                    onClick={() => unfriend(f.id)}
-                    style={{ ...btnOutline, fontSize: "10px" }}
-                  >
-                    Remove
-                  </button>
-                </div>
-              </li>
-            ))}
+            {friends.map((f, i) => {
+              const sessionCount = f.sessionCount ?? 0;
+              const rank = sessionCount > 0 ? i + 1 : null;
+              return (
+                <li
+                  key={f.id}
+                  style={{
+                    display: "flex",
+                    flexWrap: "wrap",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: "12px",
+                  }}
+                >
+                  <div style={{ display: "flex", flexDirection: "column", gap: "2px", flex: "1 1 160px" }}>
+                    <span style={{ color: "var(--fg)" }}>
+                      {rank && <span style={{ ...labelStyle, marginRight: "6px" }}>#{rank}</span>}
+                      {f.username}
+                    </span>
+                    <span style={{ ...labelStyle, textTransform: "none", letterSpacing: "0.04em" }}>
+                      {sessionCount > 0
+                        ? `${sessionCount} session${sessionCount === 1 ? "" : "s"} together · ${formatMeditatedDuration(f.totalDurationSeconds ?? 0)}`
+                        : "No shared sessions yet"}
+                    </span>
+                  </div>
+                  <div style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}>
+                    <Link
+                      href={`/app/buddies/${f.id}/calendar`}
+                      style={{
+                        ...btnOutline,
+                        textDecoration: "none",
+                        display: "inline-flex",
+                        alignItems: "center",
+                        fontSize: "10px",
+                      }}
+                    >
+                      View calendar
+                    </Link>
+                    <button
+                      type="button"
+                      disabled={actionId === f.id}
+                      onClick={() => unfriend(f.id)}
+                      style={{ ...btnOutline, fontSize: "10px" }}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -66,6 +66,9 @@ export type BoardEntry = {
 export type FriendPublicUser = {
   id: string;
   username: string;
+  /** #343: aggregated over shared, completed buddy sits. Omitted for search results. */
+  sessionCount?: number;
+  totalDurationSeconds?: number;
 };
 
 export type FriendRequestRow = {


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #343

## Summary
- `GET /api/friends` now joins the current user's completed `sessions` rows (created per participant from shared buddy sits, see `record-personal-session/route.ts`) against `buddy_session_participants` on the same `buddy_session_id` to compute per-friend `sessionCount` and `totalDurationSeconds` (using `actualTime` with fallback to `duration`, matching the pattern used elsewhere in the app).
- Friends are sorted by `sessionCount` desc, then `totalDurationSeconds` desc, then username, so the "most meditated with" buddy sorts first.
- `FriendPublicUser` gains optional `sessionCount` / `totalDurationSeconds` fields (optional since search results don't include them).
- `FriendsView` renders the stats inline per friend (`"N sessions together · Xh Ym"`, or `"No shared sessions yet"`) with a `#rank` badge for friends with shared sessions.
- No migration — reuses existing `sessions` + `buddy_session_participants` tables/columns.

## Test plan
- Added `src/app/api/friends/route.integration.test.ts`: route-level tests against a real in-process Postgres (PGlite), covering sorted stats across multiple friends, zero-stats for friends with no shared sits, `actualTime`-over-`duration` precedence and per-user isolation (a friend's own actualTime doesn't leak into your total), exclusion of non-completed sits, and the 401 unauthenticated path.
- Manually verified end-to-end in a browser: seeded three friends (3 shared completed sits / 38m, 1 sit / 5m, 0 sits) via a temporary local PGlite-backed dev db, logged in, and confirmed the Friends page renders `#1 alice_buddy — 3 sessions together · 38m`, `#2 bob_sits — 1 session together · 5m`, and `carol_new — No shared sessions yet`, correctly ordered.

[Friends list showing ranked most-meditated-with stats](https://cursor.com/agents/bc-1063526b-fd29-4290-a938-6f50500d95d8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffriends_view_stats_ranked.png)

**Testing**
- ✅ `npm run test:unit` (327/327, incl. 5 new integration tests)
- ✅ `npx tsc --noEmit`
- ✅ `npm run build`
- ✅ Manual browser walkthrough (screenshot above)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1063526b-fd29-4290-a938-6f50500d95d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1063526b-fd29-4290-a938-6f50500d95d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Show each friend’s shared session count and total time together**

### What Changed
- The friends list now shows how many completed sessions you have shared with each friend and the total time spent together
- Friends are ordered by the number of shared sessions, then by shared time, so the person you’ve meditated with most appears first
- Friends with no shared sessions now clearly show “No shared sessions yet,” and the duration display no longer rounds up past the time actually recorded
- Added route tests for ranked results, zero-session friends, completed-session filtering, time calculation, and unauthenticated access

### Impact
`✅ Clearer friends ranking`
`✅ Faster finding your top meditation buddy`
`✅ More accurate shared-time display`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
