### PR TITLE
feat: aphorisms toggle — web + iOS parity (#88)

### DIFF
--- a/drizzle/users_aphorisms_enabled_88_incremental.sql
+++ b/drizzle/users_aphorisms_enabled_88_incremental.sql
@@ -1,0 +1,4 @@
+-- Aphorisms pre-session inspiration toggle (issue #88). Off by default, same
+-- boolean-preference pattern as users.is_public / users.email_deliverable.
+
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "aphorisms_enabled" boolean DEFAULT false NOT NULL;

--- a/ios/PARITY_CHECKLIST.md
+++ b/ios/PARITY_CHECKLIST.md
@@ -19,6 +19,7 @@ Release owner: iOS release DRI
 | Buddy calendar (unified + per-buddy, filters, pagination) | Implemented | Implemented | ✅ Complete | iOS `BuddyCalendarView` mirrors web `BuddyCalendarView`; entry via `BuddySessionHubView` until Friends tab ships. |
 | Buddy invite deep links | Implemented | Implemented | ✅ Complete | iOS handles `stillpoint://buddy` and web invite URL forms. |
 | Account deletion flow | Implemented | Implemented | ✅ Complete | iOS Settings includes two-step destructive confirmation. |
+| Aphorisms pre-session inspiration toggle (#88) | Implemented | Implemented | ✅ Complete | Shared quote list in `StillPointShared/Aphorisms.swift` mirrors `src/lib/aphorisms.ts`; both clients toggle via `PATCH /api/settings`. |
 
 ## Known parity gaps (critical + non-critical)
 

--- a/ios/StillPointApp/Views/HomeView.swift
+++ b/ios/StillPointApp/Views/HomeView.swift
@@ -41,6 +41,8 @@ struct HomeView: View {
 
                 appGatePill
 
+                aphorismSection
+
                 Spacer().frame(height: SPSpacing.s4)
 
                 // Begin button
@@ -170,6 +172,29 @@ struct HomeView: View {
             }
             .accessibilityIdentifier("home.appGatePill")
             .accessibilityLabel(manager.isUnlocked ? "Apps unlocked until midnight" : "Apps locked, meditate to unlock")
+        }
+    }
+
+    /// Opt-in pre-session inspiration quote (#88). Hidden unless the user has
+    /// enabled aphorisms in Settings.
+    @ViewBuilder
+    private var aphorismSection: some View {
+        if appVM.currentUser?.aphorismsEnabled == true {
+            let aphorism = Aphorisms.forDay(appVM.currentDay)
+            VStack(spacing: SPSpacing.s2) {
+                Text("\u{201C}\(aphorism.text)\u{201D}")
+                    .font(SPFont.serifItalic(15, weight: .light))
+                    .foregroundStyle(Color(SPColor.fg2))
+                    .multilineTextAlignment(.center)
+                Text("— \(aphorism.author)")
+                    .font(SPFont.mono(11, weight: .medium))
+                    .foregroundStyle(Color(SPColor.fg4))
+                    .tracking(1.5)
+                    .textCase(.uppercase)
+            }
+            .padding(.horizontal, SPSpacing.s4)
+            .accessibilityIdentifier("home.aphorism")
+            .accessibilityElement(children: .combine)
         }
     }
 

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -268,6 +268,12 @@ struct SettingsView: View {
                 syncFromCurrentUser()
             }
         }
+        .onChange(of: appVM.currentUser?.isPublic) { _, _ in
+            syncFromCurrentUser()
+        }
+        .onChange(of: appVM.currentUser?.aphorismsEnabled) { _, _ in
+            syncFromCurrentUser()
+        }
     }
 
     private var notificationsLinkSection: some View {

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -5,7 +5,9 @@ struct SettingsView: View {
     let appVM: AppViewModel
     @State private var notificationPrefs = NotificationPreferencesViewModel()
     @State private var isPublic: Bool = false
+    @State private var aphorismsEnabled: Bool = false
     @State private var isUpdating = false
+    @State private var isUpdatingAphorisms = false
     @State private var editingUsername = false
     @State private var usernameDraft = ""
     @State private var savingUsername = false
@@ -17,7 +19,7 @@ struct SettingsView: View {
     @State private var deleteAccountError = ""
     @State private var showDeleteAccountError = false
 
-    private var isSavingSettings: Bool { isUpdating || savingUsername }
+    private var isSavingSettings: Bool { isUpdating || isUpdatingAphorisms || savingUsername }
 
     var body: some View {
         NavigationStack {
@@ -126,6 +128,45 @@ struct SettingsView: View {
                             } catch {
                                 // Revert on failure
                                 isPublic = !newValue
+                            }
+                        }
+                    }
+                }
+                .padding(SPSpacing.s3)
+                .background(SPColor.surface1)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(SPColor.border1)
+                )
+
+                // Aphorisms toggle (#88)
+                VStack(alignment: .leading, spacing: SPSpacing.s2) {
+                    Toggle(isOn: $aphorismsEnabled) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Aphorisms")
+                                .font(SPFont.mono(13))
+                                .foregroundStyle(Color(SPColor.fg))
+                            Text("Show a short meditation quote before each session")
+                                .font(SPFont.serif(13, weight: .light))
+                                .foregroundStyle(Color(SPColor.fg4))
+                        }
+                    }
+                    .tint(SPColor.green)
+                    .disabled(isSavingSettings)
+                    .accessibilityIdentifier("settings.aphorismsToggle")
+                    .onChange(of: aphorismsEnabled) { _, newValue in
+                        guard !isUpdatingAphorisms else { return }
+                        guard appVM.currentUser?.aphorismsEnabled != newValue else { return }
+                        isUpdatingAphorisms = true
+                        Task {
+                            defer { isUpdatingAphorisms = false }
+                            do {
+                                let updated = try await APIClient.shared.updateSettings(aphorismsEnabled: newValue)
+                                appVM.applySettingsUser(updated)
+                            } catch {
+                                // Revert on failure
+                                aphorismsEnabled = !newValue
                             }
                         }
                     }
@@ -339,6 +380,7 @@ struct SettingsView: View {
 
     private func syncFromCurrentUser() {
         isPublic = appVM.currentUser?.isPublic ?? false
+        aphorismsEnabled = appVM.currentUser?.aphorismsEnabled ?? false
         if !editingUsername, let u = appVM.currentUser {
             usernameDraft = u.username
         }

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -269,9 +269,11 @@ struct SettingsView: View {
             }
         }
         .onChange(of: appVM.currentUser?.isPublic) { _, _ in
+            guard appVM.currentUser != nil else { return }
             syncFromCurrentUser()
         }
         .onChange(of: appVM.currentUser?.aphorismsEnabled) { _, _ in
+            guard appVM.currentUser != nil else { return }
             syncFromCurrentUser()
         }
     }

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -558,8 +558,8 @@ public actor APIClient {
             email: email,
             username: username,
             isPublic: store.user.isPublic,
-            currentDay: max(store.user.currentDay, 1),
-            aphorismsEnabled: store.user.aphorismsEnabled
+            currentDay: 1,
+            aphorismsEnabled: false
         )
         store.loginEmail = email
         store.loginPassword = password

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -296,11 +296,16 @@ public actor APIClient {
     // MARK: - Settings
 
     public func updateSettings(isPublic: Bool) async throws -> UserDTO {
-        try await updateSettings(body: SettingsPatchBody(isPublic: isPublic, username: nil))
+        try await updateSettings(body: SettingsPatchBody(isPublic: isPublic))
     }
 
     public func updateSettings(username: String) async throws -> UserDTO {
-        try await updateSettings(body: SettingsPatchBody(isPublic: nil, username: username))
+        try await updateSettings(body: SettingsPatchBody(username: username))
+    }
+
+    /// #88: opt-in pre-session aphorism toggle.
+    public func updateSettings(aphorismsEnabled: Bool) async throws -> UserDTO {
+        try await updateSettings(body: SettingsPatchBody(aphorismsEnabled: aphorismsEnabled))
     }
 
     private func updateSettings(body: SettingsPatchBody) async throws -> UserDTO {
@@ -553,7 +558,8 @@ public actor APIClient {
             email: email,
             username: username,
             isPublic: store.user.isPublic,
-            currentDay: max(store.user.currentDay, 1)
+            currentDay: max(store.user.currentDay, 1),
+            aphorismsEnabled: store.user.aphorismsEnabled
         )
         store.loginEmail = email
         store.loginPassword = password
@@ -657,7 +663,8 @@ public actor APIClient {
                 email: store.user.email,
                 username: store.user.username,
                 isPublic: store.user.isPublic,
-                currentDay: max(store.user.currentDay, data.dayNumber + 1)
+                currentDay: max(store.user.currentDay, data.dayNumber + 1),
+                aphorismsEnabled: store.user.aphorismsEnabled
             )
         }
 
@@ -743,6 +750,7 @@ public actor APIClient {
 
         var nextUsername = store.user.username
         var nextIsPublic = store.user.isPublic
+        var nextAphorismsEnabled = store.user.aphorismsEnabled
 
         if let usernamePatch = body.username {
             let trimmed = usernamePatch.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -759,12 +767,17 @@ public actor APIClient {
             nextIsPublic = isPublicPatch
         }
 
+        if let aphorismsEnabledPatch = body.aphorismsEnabled {
+            nextAphorismsEnabled = aphorismsEnabledPatch
+        }
+
         store.user = UserDTO(
             id: store.user.id,
             email: store.user.email,
             username: nextUsername,
             isPublic: nextIsPublic,
-            currentDay: store.user.currentDay
+            currentDay: store.user.currentDay,
+            aphorismsEnabled: nextAphorismsEnabled
         )
         uiTestStore = store
         persistUITestStore()
@@ -837,16 +850,25 @@ public actor APIClient {
 private struct SettingsPatchBody: Encodable {
     let isPublic: Bool?
     let username: String?
+    let aphorismsEnabled: Bool?
+
+    init(isPublic: Bool? = nil, username: String? = nil, aphorismsEnabled: Bool? = nil) {
+        self.isPublic = isPublic
+        self.username = username
+        self.aphorismsEnabled = aphorismsEnabled
+    }
 
     func encode(to encoder: Encoder) throws {
         var c = encoder.container(keyedBy: CodingKeys.self)
         if let isPublic { try c.encode(isPublic, forKey: .isPublic) }
         if let username { try c.encode(username, forKey: .username) }
+        if let aphorismsEnabled { try c.encode(aphorismsEnabled, forKey: .aphorismsEnabled) }
     }
 
     private enum CodingKeys: String, CodingKey {
         case isPublic
         case username
+        case aphorismsEnabled
     }
 }
 
@@ -917,7 +939,8 @@ private struct UITestStore: Codable, Sendable {
             email: "snapshot@stillpoint.test",
             username: "still_snapshot",
             isPublic: true,
-            currentDay: 9
+            currentDay: 9,
+            aphorismsEnabled: true
         )
 
         let sessions: [SessionDTO] = [

--- a/ios/StillPointShared/Sources/StillPointShared/Aphorisms.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/Aphorisms.swift
@@ -17,7 +17,7 @@ public struct Aphorism: Equatable, Sendable {
 }
 
 public enum Aphorisms {
-    /// Ordered so `aphorismForDay(_:)` can pick a stable, slowly-rotating quote
+    /// Ordered so `forDay(_:)` can pick a stable, slowly-rotating quote
     /// per user without any extra state. Order is otherwise not meaningful.
     public static let all: [Aphorism] = [
         Aphorism(text: "You can't stop the waves, but you can learn to surf.", author: "Jon Kabat-Zinn"),

--- a/ios/StillPointShared/Sources/StillPointShared/Aphorisms.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/Aphorisms.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Aphorisms content module (#88).
+///
+/// Short quotes from established meditation teachers and digital-minimalism
+/// researchers/authors, shown as optional pre-session inspiration on Home when
+/// a user turns on `aphorismsEnabled`. Mirrors `src/lib/aphorisms.ts` on web —
+/// keep both lists in sync.
+public struct Aphorism: Equatable, Sendable {
+    public let text: String
+    public let author: String
+
+    public init(text: String, author: String) {
+        self.text = text
+        self.author = author
+    }
+}
+
+public enum Aphorisms {
+    /// Ordered so `aphorismForDay(_:)` can pick a stable, slowly-rotating quote
+    /// per user without any extra state. Order is otherwise not meaningful.
+    public static let all: [Aphorism] = [
+        Aphorism(text: "You can't stop the waves, but you can learn to surf.", author: "Jon Kabat-Zinn"),
+        Aphorism(text: "Wherever you go, there you are.", author: "Jon Kabat-Zinn"),
+        Aphorism(
+            text: "Feelings come and go like clouds in a windy sky. Conscious breathing is my anchor.",
+            author: "Thich Nhat Hanh"
+        ),
+        Aphorism(
+            text: "The present moment is filled with joy and happiness. If you are attentive, you will see it.",
+            author: "Thich Nhat Hanh"
+        ),
+        Aphorism(text: "You are the sky. Everything else is just the weather.", author: "Pema Chödrön"),
+        Aphorism(text: "Mindfulness isn't difficult. We just need to remember to do it.", author: "Sharon Salzberg"),
+        Aphorism(
+            text: "Digital minimalism is a philosophy of technology use in which you focus your online time on a small number of carefully selected activities that strongly support things you value.",
+            author: "Cal Newport"
+        ),
+        Aphorism(
+            text: "Solitude is a subjective state in which you're free from input from other minds.",
+            author: "Cal Newport"
+        ),
+        Aphorism(text: "We expect more from technology and less from each other.", author: "Sherry Turkle"),
+        Aphorism(text: "The mind is everything. What you think you become.", author: "attributed to the Buddha"),
+        Aphorism(text: "Be here now.", author: "Ram Dass"),
+    ]
+
+    /// Deterministically pick an aphorism for a given practice day so it stays
+    /// stable across re-renders and slowly rotates as the user progresses,
+    /// mirroring the pathway's day-driven derivation (#336).
+    public static func forDay(_ day: Int) -> Aphorism {
+        let safeDay = max(1, day)
+        let index = (safeDay - 1) % all.count
+        return all[index]
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -8,13 +8,39 @@ public struct UserDTO: Codable, Sendable {
     public let username: String
     public let isPublic: Bool
     public let currentDay: Int
+    /// #88: opt-in pre-session aphorism shown on Home. Decoded permissively so
+    /// responses from a server that predates this field (or cached fixtures)
+    /// still decode, defaulting to off.
+    public let aphorismsEnabled: Bool
 
-    public init(id: String, email: String, username: String, isPublic: Bool, currentDay: Int) {
+    public init(
+        id: String,
+        email: String,
+        username: String,
+        isPublic: Bool,
+        currentDay: Int,
+        aphorismsEnabled: Bool = false
+    ) {
         self.id = id
         self.email = email
         self.username = username
         self.isPublic = isPublic
         self.currentDay = currentDay
+        self.aphorismsEnabled = aphorismsEnabled
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        email = try c.decode(String.self, forKey: .email)
+        username = try c.decode(String.self, forKey: .username)
+        isPublic = try c.decode(Bool.self, forKey: .isPublic)
+        currentDay = try c.decode(Int.self, forKey: .currentDay)
+        aphorismsEnabled = try c.decodeIfPresent(Bool.self, forKey: .aphorismsEnabled) ?? false
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, email, username, isPublic, currentDay, aphorismsEnabled
     }
 }
 

--- a/ios/StillPointShared/Tests/StillPointSharedTests/AphorismsTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/AphorismsTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+import StillPointShared
+
+final class AphorismsTests: XCTestCase {
+    func testAllEntriesHaveNonEmptyTextAndAuthor() {
+        XCTAssertFalse(Aphorisms.all.isEmpty)
+        for aphorism in Aphorisms.all {
+            XCTAssertFalse(aphorism.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            XCTAssertFalse(aphorism.author.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+    }
+
+    func testForDayIsDeterministic() {
+        XCTAssertEqual(Aphorisms.forDay(3), Aphorisms.forDay(3))
+    }
+
+    func testForDayRotatesThroughTheList() {
+        let first = Aphorisms.forDay(1)
+        let wrapped = Aphorisms.forDay(1 + Aphorisms.all.count)
+        XCTAssertEqual(wrapped, first)
+    }
+
+    func testForDayClampsNonPositiveInputToDayOne() {
+        XCTAssertEqual(Aphorisms.forDay(0), Aphorisms.forDay(1))
+        XCTAssertEqual(Aphorisms.forDay(-5), Aphorisms.forDay(1))
+    }
+
+    func testForDayAlwaysReturnsAValueFromTheContentList() {
+        for day in 1...(Aphorisms.all.count * 2) {
+            XCTAssertTrue(Aphorisms.all.contains(Aphorisms.forDay(day)))
+        }
+    }
+}

--- a/ios/StillPointShared/Tests/StillPointSharedTests/UserDTOTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/UserDTOTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+import StillPointShared
+
+final class UserDTOTests: XCTestCase {
+    func testDecodesAphorismsEnabledWhenPresent() throws {
+        let json = """
+        {"id":"u1","email":"a@b.com","username":"alice","isPublic":false,"currentDay":3,"aphorismsEnabled":true}
+        """.data(using: .utf8)!
+
+        let user = try JSONDecoder().decode(UserDTO.self, from: json)
+        XCTAssertTrue(user.aphorismsEnabled)
+    }
+
+    /// #88 shipped as an additive field; a server or cached fixture that predates
+    /// it must still decode, defaulting the toggle to off.
+    func testDefaultsAphorismsEnabledToFalseWhenMissing() throws {
+        let json = """
+        {"id":"u1","email":"a@b.com","username":"alice","isPublic":false,"currentDay":3}
+        """.data(using: .utf8)!
+
+        let user = try JSONDecoder().decode(UserDTO.self, from: json)
+        XCTAssertFalse(user.aphorismsEnabled)
+    }
+
+    func testRoundTripsThroughEncodeAndDecode() throws {
+        let user = UserDTO(
+            id: "u1",
+            email: "a@b.com",
+            username: "alice",
+            isPublic: true,
+            currentDay: 5,
+            aphorismsEnabled: true
+        )
+        let data = try JSONEncoder().encode(user)
+        let decoded = try JSONDecoder().decode(UserDTO.self, from: data)
+        XCTAssertEqual(decoded.aphorismsEnabled, true)
+        XCTAssertEqual(decoded.id, user.id)
+    }
+}

--- a/src/app/api/auth/apple-native/route.ts
+++ b/src/app/api/auth/apple-native/route.ts
@@ -104,6 +104,7 @@ export async function POST(request: NextRequest) {
       username: user.username,
       isPublic: user.isPublic,
       currentDay: user.currentDay,
+      aphorismsEnabled: user.aphorismsEnabled,
     },
     token,
   });

--- a/src/app/api/auth/google-native/route.ts
+++ b/src/app/api/auth/google-native/route.ts
@@ -112,6 +112,7 @@ export async function POST(request: NextRequest) {
       username: user.username,
       isPublic: user.isPublic,
       currentDay: user.currentDay,
+      aphorismsEnabled: user.aphorismsEnabled,
     },
     token,
   });

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -57,6 +57,7 @@ export async function POST(request: NextRequest) {
         username: user.username,
         isPublic: user.isPublic,
         currentDay: user.currentDay,
+        aphorismsEnabled: user.aphorismsEnabled,
       },
       ...(includeToken ? { token } : {}),
     });

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -17,6 +17,7 @@ export async function GET() {
       username: users.username,
       isPublic: users.isPublic,
       currentDay: users.currentDay,
+      aphorismsEnabled: users.aphorismsEnabled,
     }).from(users).where(eq(users.id, auth.userId)).limit(1);
 
     if (!user) {

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -77,6 +77,7 @@ export async function POST(request: NextRequest) {
         username: newUser.username,
         isPublic: newUser.isPublic,
         currentDay: newUser.currentDay,
+        aphorismsEnabled: newUser.aphorismsEnabled,
       },
       ...(includeToken ? { token } : {}),
     });

--- a/src/app/api/settings/route.test.ts
+++ b/src/app/api/settings/route.test.ts
@@ -35,6 +35,7 @@ vi.mock("@/db/schema", () => ({
     username: "username",
     isPublic: "isPublic",
     currentDay: "currentDay",
+    aphorismsEnabled: "aphorismsEnabled",
   },
 }));
 
@@ -195,5 +196,38 @@ describe("PATCH /api/settings", () => {
     const updates = dbUpdateSet.mock.calls[0]![0];
     expect(updates.isPublic).toBe(true);
     expect(updates).not.toHaveProperty("username");
+  });
+
+  test("aphorismsEnabled-only updates skip the transaction and use the HTTP driver", async () => {
+    dbUpdateReturning.mockResolvedValue([
+      {
+        id: userId,
+        email: "user@example.com",
+        username: "existing",
+        isPublic: true,
+        currentDay: 1,
+        aphorismsEnabled: true,
+      },
+    ]);
+    const { PATCH } = await import("./route");
+
+    const res = await PATCH(buildRequest({ aphorismsEnabled: true }));
+
+    expect(res.status).toBe(200);
+    expect(poolTransaction).not.toHaveBeenCalled();
+    expect(dbUpdate).toHaveBeenCalledTimes(1);
+    const updates = dbUpdateSet.mock.calls[0]![0];
+    expect(updates.aphorismsEnabled).toBe(true);
+    expect(updates).not.toHaveProperty("username");
+    await expect(res.json()).resolves.toEqual({
+      user: {
+        id: userId,
+        email: "user@example.com",
+        username: "existing",
+        isPublic: true,
+        currentDay: 1,
+        aphorismsEnabled: true,
+      },
+    });
   });
 });

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -14,6 +14,7 @@ const RETURN_FIELDS = {
   username: users.username,
   isPublic: users.isPublic,
   currentDay: users.currentDay,
+  aphorismsEnabled: users.aphorismsEnabled,
 };
 
 export async function PATCH(request: NextRequest) {
@@ -29,6 +30,11 @@ export async function PATCH(request: NextRequest) {
 
     if (typeof body.isPublic === "boolean") {
       updates.isPublic = body.isPublic;
+      hasSupportedUpdate = true;
+    }
+
+    if (typeof body.aphorismsEnabled === "boolean") {
+      updates.aphorismsEnabled = body.aphorismsEnabled;
       hasSupportedUpdate = true;
     }
 

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -805,6 +805,7 @@ export default function StillPoint() {
       {!overlay && tab === "progress" && (
         <HomeView
           currentDay={user.currentDay}
+          aphorismsEnabled={user.aphorismsEnabled}
           onBegin={() => handleBegin("standard")}
           onQuickBegin={() => handleBegin("quick")}
           onBreath={() => setOverlay("breath")}
@@ -856,6 +857,9 @@ export default function StillPoint() {
           user={user}
           onTogglePublic={(isPublic) =>
             setUser((prev) => (prev ? { ...prev, isPublic } : prev))
+          }
+          onToggleAphorisms={(aphorismsEnabled) =>
+            setUser((prev) => (prev ? { ...prev, aphorismsEnabled } : prev))
           }
           onUsernameChange={(username) =>
             setUser((prev) => (prev ? { ...prev, username } : prev))

--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -5,7 +5,14 @@ import { signIn } from "next-auth/react";
 import { loadLastAuthProvider, type OAuthProvider } from "@/lib/lastAuthProvider";
 
 type AuthScreenProps = {
-  onLogin: (user: { id: string; email: string; username: string; isPublic: boolean; currentDay: number }) => void;
+  onLogin: (user: {
+    id: string;
+    email: string;
+    username: string;
+    isPublic: boolean;
+    currentDay: number;
+    aphorismsEnabled: boolean;
+  }) => void;
 };
 
 const OAUTH_ERROR_MESSAGES: Record<string, string> = {

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -2,18 +2,29 @@
 
 import { BLOCK_DURATION, QUICK_DURATION, durationForDay } from "@/lib/constants";
 import { Pathway } from "@/components/Pathway";
+import { aphorismForDay } from "@/lib/aphorisms";
 
 type HomeViewProps = {
   currentDay: number;
+  /** #88: opt-in pre-session inspiration quote. */
+  aphorismsEnabled?: boolean;
   onBegin: () => void;
   onQuickBegin: () => void;
   onBreath?: () => void;
   onBuddy?: () => void;
 };
 
-export function HomeView({ currentDay, onBegin, onQuickBegin, onBreath, onBuddy }: HomeViewProps) {
+export function HomeView({
+  currentDay,
+  aphorismsEnabled,
+  onBegin,
+  onQuickBegin,
+  onBreath,
+  onBuddy,
+}: HomeViewProps) {
   const todayDuration = durationForDay(currentDay);
   const totalBlocks = Math.ceil(todayDuration / BLOCK_DURATION);
+  const aphorism = aphorismsEnabled ? aphorismForDay(currentDay) : null;
 
   return (
     <div style={{
@@ -65,6 +76,31 @@ export function HomeView({ currentDay, onBegin, onQuickBegin, onBreath, onBuddy 
 
       {/* Block B2: Lesson pathway (#336) */}
       <Pathway currentDay={currentDay} />
+
+      {/* Block B3: pre-session aphorism, opt-in (#88) */}
+      {aphorism && (
+        <div style={{
+          textAlign: "center",
+          maxWidth: "min(360px, calc(100vw - 40px))",
+          padding: "0 var(--s2)",
+        }}>
+          <p style={{
+            fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+            fontSize: "15px", fontStyle: "italic", fontWeight: 300,
+            color: "var(--fg-2)", margin: 0, lineHeight: 1.5,
+          }}>
+            &ldquo;{aphorism.text}&rdquo;
+          </p>
+          <p style={{
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+            fontSize: "11px", color: "var(--fg-4)",
+            letterSpacing: "0.1em", textTransform: "uppercase",
+            marginTop: "var(--s2)",
+          }}>
+            &mdash; {aphorism.author}
+          </p>
+        </div>
+      )}
 
       {/* Block C: CTA */}
       <button

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -28,11 +28,14 @@ type User = {
   username: string;
   isPublic: boolean;
   currentDay: number;
+  /** #88: opt-in pre-session aphorism shown on Home. */
+  aphorismsEnabled: boolean;
 };
 
 type SettingsViewProps = {
   user: User;
   onTogglePublic: (isPublic: boolean) => void;
+  onToggleAphorisms: (aphorismsEnabled: boolean) => void;
   onUsernameChange: (username: string) => void;
   onLogout: () => void;
 };
@@ -40,10 +43,12 @@ type SettingsViewProps = {
 export function SettingsView({
   user,
   onTogglePublic,
+  onToggleAphorisms,
   onUsernameChange,
   onLogout,
 }: SettingsViewProps) {
   const [toggling, setToggling] = useState(false);
+  const [togglingAphorisms, setTogglingAphorisms] = useState(false);
   // Both stay false during SSR/hydration; the Session card only appears after
   // mount when the browser actually supports the Screen Wake Lock API (#317).
   const [wakeLockSupported, setWakeLockSupported] = useState(false);
@@ -121,6 +126,24 @@ export function SettingsView({
       // silent fail
     } finally {
       setToggling(false);
+    }
+  };
+
+  const handleAphorismsToggle = async () => {
+    setTogglingAphorisms(true);
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ aphorismsEnabled: !user.aphorismsEnabled }),
+      });
+      if (res.ok) {
+        onToggleAphorisms(!user.aphorismsEnabled);
+      }
+    } catch {
+      // silent fail
+    } finally {
+      setTogglingAphorisms(false);
     }
   };
 
@@ -497,6 +520,56 @@ export function SettingsView({
               background: user.isPublic ? "var(--accent-green)" : "var(--border-3)",
               position: "absolute", top: "3px",
               left: user.isPublic ? "25px" : "3px",
+              transition: "all 0.3s",
+            }} />
+          </button>
+        </div>
+
+        {/* Aphorisms toggle (#88) */}
+        <div style={{
+          padding: "16px 20px",
+          background: "var(--surface-1)",
+          borderRadius: "10px",
+          display: "flex", alignItems: "center", justifyContent: "space-between",
+        }}>
+          <div>
+            <div style={{
+              fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+              fontSize: "12px", color: "var(--fg)", marginBottom: "4px",
+            }}>
+              Aphorisms
+            </div>
+            <div style={{
+              fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+              fontSize: "13px", fontStyle: "italic",
+              color: "var(--fg-3)",
+            }}>
+              Show a short meditation quote before each session
+            </div>
+          </div>
+          <button
+            type="button"
+            aria-label={user.aphorismsEnabled ? "Disable aphorisms" : "Enable aphorisms"}
+            aria-pressed={user.aphorismsEnabled}
+            onClick={handleAphorismsToggle}
+            disabled={togglingAphorisms}
+            style={{
+              width: "48px", height: "26px",
+              borderRadius: "13px", border: "none",
+              background: user.aphorismsEnabled
+                ? "var(--accent-green-bg)"
+                : "var(--surface-3)",
+              position: "relative", cursor: "pointer",
+              transition: "background 0.3s",
+              flexShrink: 0, marginLeft: "16px",
+            }}
+          >
+            <div style={{
+              width: "20px", height: "20px",
+              borderRadius: "10px",
+              background: user.aphorismsEnabled ? "var(--accent-green)" : "var(--border-3)",
+              position: "absolute", top: "3px",
+              left: user.aphorismsEnabled ? "25px" : "3px",
               transition: "all 0.3s",
             }} />
           </button>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -28,6 +28,9 @@ export const users = pgTable("users", {
   /** #338: flipped by Apple `email-disabled` / `email-enabled` relay notifications.
    *  False means mail to this address (private relay) will bounce. */
   emailDeliverable: boolean("email_deliverable").default(true).notNull(),
+  /** #88: opt-in for a short meditation / digital-minimalism aphorism shown as
+   *  pre-session inspiration on the Home view. Defaults off. */
+  aphorismsEnabled: boolean("aphorisms_enabled").default(false).notNull(),
   currentDay: integer("current_day").default(1).notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),

--- a/src/lib/aphorisms.test.ts
+++ b/src/lib/aphorisms.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+import { APHORISMS, aphorismForDay } from "./aphorisms";
+
+describe("APHORISMS", () => {
+  test("every entry has non-empty text and author", () => {
+    expect(APHORISMS.length).toBeGreaterThan(0);
+    for (const { text, author } of APHORISMS) {
+      expect(text.trim().length).toBeGreaterThan(0);
+      expect(author.trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("aphorismForDay", () => {
+  test("is deterministic for a given day", () => {
+    expect(aphorismForDay(3)).toEqual(aphorismForDay(3));
+  });
+
+  test("rotates through the list as the day advances", () => {
+    const first = aphorismForDay(1);
+    const wrapped = aphorismForDay(1 + APHORISMS.length);
+    expect(wrapped).toEqual(first);
+  });
+
+  test("clamps non-finite or sub-1 input to day 1", () => {
+    expect(aphorismForDay(0)).toEqual(aphorismForDay(1));
+    expect(aphorismForDay(-5)).toEqual(aphorismForDay(1));
+    expect(aphorismForDay(Number.NaN)).toEqual(aphorismForDay(1));
+  });
+
+  test("always returns a value from the content list", () => {
+    for (let day = 1; day <= APHORISMS.length * 2; day++) {
+      expect(APHORISMS).toContainEqual(aphorismForDay(day));
+    }
+  });
+});

--- a/src/lib/aphorisms.ts
+++ b/src/lib/aphorisms.ts
@@ -1,0 +1,54 @@
+/**
+ * Aphorisms content module (#88).
+ *
+ * Short quotes from established meditation teachers and digital-minimalism
+ * researchers/authors, shown as optional pre-session inspiration on Home when
+ * a user turns on `aphorismsEnabled`. Kept intentionally small and dependency
+ * free so it can be mirrored verbatim in the iOS app (`StillPointShared`).
+ */
+
+export type Aphorism = {
+  text: string;
+  author: string;
+};
+
+/**
+ * Ordered so `aphorismForDay` can pick a stable, slowly-rotating quote per
+ * user without any extra state. Order is otherwise not meaningful.
+ */
+export const APHORISMS: Aphorism[] = [
+  { text: "You can't stop the waves, but you can learn to surf.", author: "Jon Kabat-Zinn" },
+  { text: "Wherever you go, there you are.", author: "Jon Kabat-Zinn" },
+  {
+    text: "Feelings come and go like clouds in a windy sky. Conscious breathing is my anchor.",
+    author: "Thich Nhat Hanh",
+  },
+  {
+    text: "The present moment is filled with joy and happiness. If you are attentive, you will see it.",
+    author: "Thich Nhat Hanh",
+  },
+  { text: "You are the sky. Everything else is just the weather.", author: "Pema Chödrön" },
+  { text: "Mindfulness isn't difficult. We just need to remember to do it.", author: "Sharon Salzberg" },
+  {
+    text: "Digital minimalism is a philosophy of technology use in which you focus your online time on a small number of carefully selected activities that strongly support things you value.",
+    author: "Cal Newport",
+  },
+  {
+    text: "Solitude is a subjective state in which you're free from input from other minds.",
+    author: "Cal Newport",
+  },
+  { text: "We expect more from technology and less from each other.", author: "Sherry Turkle" },
+  { text: "The mind is everything. What you think you become.", author: "attributed to the Buddha" },
+  { text: "Be here now.", author: "Ram Dass" },
+];
+
+/**
+ * Deterministically pick an aphorism for a given practice day so it stays
+ * stable across re-renders and slowly rotates as the user progresses,
+ * mirroring the pathway's day-driven derivation (#336).
+ */
+export function aphorismForDay(day: number): Aphorism {
+  const safeDay = Number.isFinite(day) ? Math.max(1, Math.floor(day)) : 1;
+  const index = (safeDay - 1) % APHORISMS.length;
+  return APHORISMS[index]!;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -27,6 +27,8 @@ export type User = {
   username: string;
   isPublic: boolean;
   currentDay: number;
+  /** #88: opt-in pre-session aphorism shown on Home. */
+  aphorismsEnabled: boolean;
 };
 
 export type Session = {
@@ -212,7 +214,7 @@ export const api = {
   getBoard: () =>
     request<{ board: BoardEntry[] }>("/api/board"),
 
-  updateSettings: (data: { isPublic?: boolean }) =>
+  updateSettings: (data: { isPublic?: boolean; aphorismsEnabled?: boolean }) =>
     request<{ user: User }>("/api/settings", { method: "PATCH", body: JSON.stringify(data) }),
 
   getFriends: () => request<{ friends: FriendPublicUser[] }>("/api/friends"),


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #88

### Summary
- New `users.aphorisms_enabled` boolean preference (new incremental migration, off by default) mirroring the existing `is_public` pattern.
- `PATCH /api/settings` accepts `aphorismsEnabled`; all user-returning auth routes (`signup`, `login`, `me`, `google-native`, `apple-native`) now include it.
- Centralized aphorisms content module (`src/lib/aphorisms.ts`) with curated meditation / digital-minimalism quotes (Jon Kabat-Zinn, Thich Nhat Hanh, Pema Chödrön, Sharon Salzberg, Cal Newport, Sherry Turkle, Ram Dass, etc.), deterministically rotated by practice day.
- `HomeView` shows the quote as pre-session inspiration (existing italic Newsreader typography) when enabled; `SettingsView` gets a new "Aphorisms" toggle mirroring "Public Board".
- iOS parity: `StillPointShared/Aphorisms.swift` mirrors the web content module exactly, `UserDTO` gains `aphorismsEnabled` (permissive decode, defaults `false` for older payloads), `APIClient.updateSettings(aphorismsEnabled:)`, and matching `SettingsView`/`HomeView` UI in SwiftUI. Updated `PARITY_CHECKLIST.md`.

### Migration notes
- New incremental-only migration `drizzle/users_aphorisms_enabled_88_incremental.sql` (`ADD COLUMN IF NOT EXISTS`), does not touch or reorder any existing users-schema migration.

### Test plan
- ✅ `npm run typecheck`
- ✅ `npm run test:unit` (328/328, incl. new `aphorisms.test.ts` + settings route test for `aphorismsEnabled`)
- ✅ Manual end-to-end: stood up a local Postgres + a local Neon HTTP/WS proxy shim (temporary, not committed) to run the real Next.js dev server; signed up a user via `/api/auth/signup`, toggled `aphorismsEnabled` via `PATCH /api/settings`, confirmed persistence via `/api/auth/me`.
- ✅ Manual browser walkthrough (see screenshots): default Home view has no quote block; enabling "Aphorisms" in Settings immediately shows a quote on Home; quote persists after a full page reload.
- ⚠️ iOS: `StillPointShared` compiles/tests only in CI (`swift test` on macOS) — no local Swift toolchain in this environment. Added `AphorismsTests.swift` and `UserDTOTests.swift` (incl. permissive-decode-of-missing-field coverage) for that CI run to exercise. Code closely mirrors existing `isPublic` patterns throughout `APIClient.swift`/`DTOs.swift`.

[Home view, aphorisms disabled (default)](https://cursor.com/agents/bc-a6d1e6e6-6573-4f22-80b4-b28a88174be9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomeview_aphorism_disabled_default.webp)
[Settings page, Aphorisms toggle switched on](https://cursor.com/agents/bc-a6d1e6e6-6573-4f22-80b4-b28a88174be9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_aphorisms_toggle_on.webp)
[Home view showing pre-session aphorism after enabling](https://cursor.com/agents/bc-a6d1e6e6-6573-4f22-80b4-b28a88174be9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomeview_aphorism_enabled.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6d1e6e6-6573-4f22-80b4-b28a88174be9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6d1e6e6-6573-4f22-80b4-b28a88174be9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional “Aphorisms” setting for users to enable pre-session inspirational quotes.
  * Home screens now display a daily aphorism when the setting is turned on.
  * Aphorism content is selected consistently by day and rotates through a shared quote list.

* **Bug Fixes**
  * Settings and login flows now preserve the new preference across app updates and sessions.
  * Older accounts and responses continue to work with the setting defaulting off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add an optional aphorism quote before each session on web and iOS**

### What Changed
- Users can now turn on a new Aphorisms setting, and the choice is saved with the rest of their profile.
- When enabled, Home shows a short quote and author before the session starts on both web and iOS.
- The same quote list is shared across both apps and rotates by day so the quote stays stable for a given day.
- User sign-in, account, and settings responses now include the new Aphorisms preference.
- Added tests for quote selection, user decoding, and settings updates.

### Impact
`✅ Optional pre-session inspiration`
`✅ Consistent web and iOS settings`
`✅ Fewer missing-profile errors after sign-in`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
