### PR TITLE
Flatten buddy-domain barrel re-export chain (#411)

### DIFF
--- a/src/app/api/buddy/sessions/calendar/[buddyId]/route.ts
+++ b/src/app/api/buddy/sessions/calendar/[buddyId]/route.ts
@@ -1,9 +1,7 @@
 import { NextResponse } from "next/server";
 import { getCurrentUser } from "@/lib/auth";
-import {
-  listBuddyCalendarSessionsForBuddy,
-  parseBuddyCalendarRange,
-} from "@/lib/buddyCalendar";
+import { listBuddyCalendarSessionsForBuddy } from "@/lib/buddyCalendar";
+import { parseBuddyCalendarRange } from "@/lib/buddyCalendarRange";
 import { isUuid } from "@/lib/friends";
 
 type Params = { params: Promise<{ buddyId: string }> };

--- a/src/app/api/buddy/sessions/calendar/route.test.ts
+++ b/src/app/api/buddy/sessions/calendar/route.test.ts
@@ -9,6 +9,9 @@ vi.mock("@/lib/auth", () => ({
 
 vi.mock("@/lib/buddyCalendar", () => ({
   listBuddyCalendarSessions,
+}));
+
+vi.mock("@/lib/buddyCalendarRange", () => ({
   parseBuddyCalendarRange: vi.fn(() => ({
     fromDate: "2025-03-01",
     toDate: "2025-05-29",

--- a/src/app/api/buddy/sessions/calendar/route.ts
+++ b/src/app/api/buddy/sessions/calendar/route.ts
@@ -1,9 +1,7 @@
 import { NextResponse } from "next/server";
 import { getCurrentUser } from "@/lib/auth";
-import {
-  listBuddyCalendarSessions,
-  parseBuddyCalendarRange,
-} from "@/lib/buddyCalendar";
+import { listBuddyCalendarSessions } from "@/lib/buddyCalendar";
+import { parseBuddyCalendarRange } from "@/lib/buddyCalendarRange";
 
 /**
  * Unified multi-buddy calendar session list (#350).

--- a/src/lib/buddyCalendar.ts
+++ b/src/lib/buddyCalendar.ts
@@ -25,17 +25,6 @@ import {
 } from "@/lib/buddyCalendarRange";
 import { and, desc, eq, exists, inArray, ne, sql } from "drizzle-orm";
 
-export {
-  BUDDY_CALENDAR_DEFAULT_DAYS,
-  BUDDY_CALENDAR_MAX_LIMIT,
-  type BuddyCalendarListResult,
-  type BuddyCalendarParticipant,
-  type BuddyCalendarSession,
-  buddySessionCalendarDate,
-  parseBuddyCalendarRange,
-  todayIsoDateUtc,
-} from "@/lib/buddyCalendarRange";
-
 async function assertFriendship(userId: string, buddyId: string): Promise<boolean> {
   if (!isUuid(buddyId) || buddyId === userId) return false;
   const [u1, u2] = orderedUserPair(userId, buddyId);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #411

## Summary
Redirect consumer imports to the **defining** modules and remove the public barrel re-export block in `buddyCalendar.ts`. Pure import redirect — no behavior change.

- `parseBuddyCalendarRange` is now imported from its defining module `@/lib/buddyCalendarRange` in both calendar route handlers.
- Listing functions (`listBuddyCalendarSessions`, `listBuddyCalendarSessionsForBuddy`) continue to import from `@/lib/buddyCalendar`, where they are defined.
- Removed the `export { ... } from "@/lib/buddyCalendarRange"` re-export block from `buddyCalendar.ts`. The internal `import` of range types/helpers used by `buddyCalendar.ts` is retained.
- `buddySession.ts`'s internal re-export (from `buddySessionDuration`) is left untouched per scope.
- Updated `route.test.ts` mocks to target the defining module (`@/lib/buddyCalendarRange` for `parseBuddyCalendarRange`).

## Test plan
- ✅ `npm run typecheck`
- ✅ `npx vitest run src/app/api/buddy/sessions/calendar/route.test.ts src/lib/buddyCalendar.test.ts` (9 passed)
- ✅ `npm run test:unit` (49 files, 394 tests passed)

## Notes
⚠️ Buddy domain overlaps held #413; this should land before #413.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35518cc0-7bb4-4a02-8e19-ce0e55e921a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35518cc0-7bb4-4a02-8e19-ce0e55e921a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

