### PR TITLE
Consolidate duplicated local-date helper into sessionCalendar

### DIFF
--- a/e2e/buddy/buddy-session-length.integration.spec.ts
+++ b/e2e/buddy/buddy-session-length.integration.spec.ts
@@ -1,13 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { BASE_DURATION, durationForDay } from "../../src/lib/constants";
-
-function localIsoDate() {
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  const day = String(now.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-}
+import { getLocalIsoDate } from "../../src/lib/sessionCalendar";
 
 async function signup(
   request: import("@playwright/test").APIRequestContext,
@@ -40,7 +33,7 @@ async function advanceToDay(
         clearPercent: 80,
         thoughtCount: 0,
         mindStateLog: [],
-        sessionDate: localIsoDate(),
+        sessionDate: getLocalIsoDate(),
       },
     });
     expect(response.status(), await response.text()).toBe(200);

--- a/e2e/fixtures/auth.fixture.ts
+++ b/e2e/fixtures/auth.fixture.ts
@@ -1,5 +1,6 @@
 import { test as base, expect, type Page, type Route } from "@playwright/test";
 import { calculateSessionStats, type SessionType } from "../../src/lib/constants";
+import { getLocalIsoDate } from "../../src/lib/sessionCalendar";
 import { tap } from "../utils/mobile-helpers";
 
 type UserRecord = {
@@ -61,15 +62,6 @@ function uniqueIdentity(): AuthedContext {
     username: `mobile_${suffix.replace(/[^a-z0-9]/gi, "")}`,
     password: "password123",
   };
-}
-
-function getLocalIsoDate(offsetDays = 0) {
-  const now = new Date();
-  now.setDate(now.getDate() + offsetDays);
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  const day = String(now.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
 }
 
 function computeStats(sessions: SessionRecord[]) {

--- a/src/lib/sessionCalendar.test.ts
+++ b/src/lib/sessionCalendar.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { todayLocalIsoDate, isValidSessionCalendarDate } from "./sessionCalendar";
+import {
+  getLocalIsoDate,
+  todayLocalIsoDate,
+  isValidSessionCalendarDate,
+} from "./sessionCalendar";
 
 describe("todayLocalIsoDate", () => {
   afterEach(() => vi.useRealTimers());
@@ -15,5 +19,28 @@ describe("todayLocalIsoDate", () => {
     vi.setSystemTime(new Date(2026, 11, 31, 23, 59, 0)); // local Dec 31, 2026
     expect(todayLocalIsoDate()).toBe("2026-12-31");
     expect(isValidSessionCalendarDate(todayLocalIsoDate())).toBe(true);
+  });
+});
+
+describe("getLocalIsoDate", () => {
+  afterEach(() => vi.useRealTimers());
+
+  test("defaults to today's local calendar day (matches todayLocalIsoDate)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 5, 10, 30, 0)); // local Jan 5, 2026
+    expect(getLocalIsoDate()).toBe("2026-01-05");
+    expect(getLocalIsoDate()).toBe(todayLocalIsoDate());
+  });
+
+  test("applies a negative offset across a month boundary", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 3, 12, 0, 0)); // local Mar 3, 2026
+    expect(getLocalIsoDate(-5)).toBe("2026-02-26");
+  });
+
+  test("applies a positive offset across a year boundary", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 11, 31, 12, 0, 0)); // local Dec 31, 2026
+    expect(getLocalIsoDate(1)).toBe("2027-01-01");
   });
 });

--- a/src/lib/sessionCalendar.ts
+++ b/src/lib/sessionCalendar.ts
@@ -1,4 +1,9 @@
-/** ISO calendar date `YYYY-MM-DD` helpers (UTC date arithmetic; matches stored `session_date`). */
+/**
+ * ISO calendar date `YYYY-MM-DD` helpers. UTC date arithmetic (validation,
+ * add/diff) matches the stored `session_date`; the local-day stamps
+ * (`getLocalIsoDate`/`todayLocalIsoDate`) match the client's LOCAL timezone used
+ * on the write path.
+ */
 
 const ISO_CALENDAR_DAY = /^\d{4}-\d{2}-\d{2}$/;
 

--- a/src/lib/sessionCalendar.ts
+++ b/src/lib/sessionCalendar.ts
@@ -33,15 +33,29 @@ export function daysBetweenIsoDatesInclusive(fromIso: string, toIso: string): nu
 }
 
 /**
+ * Calendar day as `YYYY-MM-DD` in the client's LOCAL timezone, offset by
+ * `offsetDays` (negative = past, positive = future). This reads the LOCAL
+ * calendar components (`getFullYear`/`getMonth`/`getDate`) and advances via
+ * local `Date#setDate`, so it deliberately does NOT use UTC arithmetic — the
+ * result matches the convention used to stamp `session_date` on the write path
+ * for non-UTC users. Use {@link addDaysToIsoDate}/{@link daysBetweenIsoDatesInclusive}
+ * instead when you need pure UTC date math on an already-stored `session_date`.
+ */
+export function getLocalIsoDate(offsetDays = 0): string {
+  const now = new Date();
+  now.setDate(now.getDate() + offsetDays);
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
  * Today's calendar day as `YYYY-MM-DD` in the client's LOCAL timezone — the same
  * convention used to stamp `session_date` on the write path (solo + buddy session
  * saves). History/journey gap math must use this rather than a UTC day so the
  * trailing gap to "today" lines up with locally-dated sessions for non-UTC users.
  */
 export function todayLocalIsoDate(): string {
-  const now = new Date();
-  const y = now.getFullYear();
-  const m = String(now.getMonth() + 1).padStart(2, "0");
-  const d = String(now.getDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
+  return getLocalIsoDate();
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #412

## Summary
- Adds a single `getLocalIsoDate(offsetDays = 0)` to `src/lib/sessionCalendar.ts` with explicit UTC-vs-local docs, and refactors `todayLocalIsoDate()` to delegate to it (no behavior change).
- Points the two former call sites at the shared helper:
  - `e2e/fixtures/auth.fixture.ts` (was a local `getLocalIsoDate(offsetDays)`).
  - `e2e/buddy/buddy-session-length.integration.spec.ts` (was a local `localIsoDate()`).

The helper deliberately uses LOCAL calendar components + local `Date#setDate`, matching the convention used to stamp `session_date` on the write path for non-UTC users; the docstring contrasts this with the UTC-based `addDaysToIsoDate`/`daysBetweenIsoDatesInclusive`.

## Test plan
- `npm run typecheck` — passes (covers `e2e/**` via `**/*.ts`).
- `npm run test:unit` — 397 passed, including new `getLocalIsoDate` cases (default matches `todayLocalIsoDate`, negative offset across month boundary, positive offset across year boundary).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86cd3e76-2fcf-4cba-9fdd-04efd8d85f89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86cd3e76-2fcf-4cba-9fdd-04efd8d85f89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how session dates are generated so day changes now behave correctly across month and year boundaries.
  * Made local-date stamping more consistent when creating or advancing sessions, reducing date mismatches.

* **Tests**
  * Added coverage for local date offsets to verify correct behavior for today, past days, and future days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->