### PR TITLE
refactor(web): split google.ts into OAuth + Calendar modules (#415)

### DIFF
--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -4,7 +4,7 @@ import {
   exchangeGoogleCodeForTokens,
   getGoogleStateCookieName,
   verifyGoogleOAuthState,
-} from "@/lib/google";
+} from "@/lib/googleOAuth";
 
 export async function GET(request: NextRequest) {
   const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim()?.replace(/\/+$/, "") ?? "https://still-point.me";

--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -4,7 +4,7 @@ import {
   GoogleCalendarUnavailableError,
   buildGoogleAuthUrl,
   makeGoogleOAuthState,
-} from "@/lib/google";
+} from "@/lib/googleOAuth";
 
 export async function GET() {
   try {

--- a/src/app/api/auth/google/status/route.ts
+++ b/src/app/api/auth/google/status/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getCurrentUser } from "@/lib/auth";
-import { loadGoogleCalendarStatus } from "@/lib/google";
+import { loadGoogleCalendarStatus } from "@/lib/googleOAuth";
 
 export async function GET() {
   try {

--- a/src/app/api/buddy/sessions/join/route.ts
+++ b/src/app/api/buddy/sessions/join/route.ts
@@ -11,10 +11,10 @@ import {
 import {
   GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE,
   syncBuddySessionCalendarForUser,
-} from "@/lib/google";
+} from "@/lib/googleCalendar";
 import { and, eq } from "drizzle-orm";
 import { readJsonObject } from "@/lib/readJsonObject";
-import type { CalendarSyncResult } from "@/lib/google";
+import type { CalendarSyncResult } from "@/lib/googleCalendar";
 
 async function syncCalendarBestEffort(
   session: typeof buddySessions.$inferSelect,

--- a/src/app/api/buddy/sessions/route.test.ts
+++ b/src/app/api/buddy/sessions/route.test.ts
@@ -35,7 +35,7 @@ vi.mock("@/lib/buddySession", () => ({
   normalizedBuddySessionDurationSeconds: vi.fn(() => 600),
 }));
 
-vi.mock("@/lib/google", () => ({
+vi.mock("@/lib/googleCalendar", () => ({
   GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE: "Could not sync Google Calendar",
   syncBuddySessionCalendarForUser,
 }));

--- a/src/app/api/buddy/sessions/route.ts
+++ b/src/app/api/buddy/sessions/route.ts
@@ -5,7 +5,7 @@ import { buddySessions, buddySessionParticipants, users } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
 import { normalizedBuddySessionDurationSeconds } from "@/lib/buddySession";
 import { readBuddySessionCreateBody } from "@/lib/buddySessionCreateBody";
-import { GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE, syncBuddySessionCalendarForUser } from "@/lib/google";
+import { GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE, syncBuddySessionCalendarForUser } from "@/lib/googleCalendar";
 import { eq } from "drizzle-orm";
 
 export async function POST(request: NextRequest) {

--- a/src/lib/googleCalendar.ts
+++ b/src/lib/googleCalendar.ts
@@ -1,0 +1,208 @@
+import "server-only";
+
+import crypto from "crypto";
+import { db } from "@/db";
+import { poolDb } from "@/db/pool";
+import {
+  buddySessionCalendarEvents,
+  buddySessionParticipants,
+  buddySessions,
+  users,
+} from "@/db/schema";
+import { and, eq, isNull, sql } from "drizzle-orm";
+import { projectedCalendarDurationSeconds } from "@/lib/buddySessionDuration";
+import {
+  GoogleCalendarApiError,
+  GoogleCalendarUnavailableError,
+  getValidAccessToken,
+  googleJsonFetch,
+} from "@/lib/googleOAuth";
+
+const GOOGLE_CALENDAR_EVENTS_URL =
+  "https://www.googleapis.com/calendar/v3/calendars/primary/events";
+
+export type CalendarSyncResult =
+  | { status: "created"; userId: string; eventId: string; htmlLink: string | null }
+  | { status: "skipped"; userId: string; reason: "not_connected" | "not_scheduled" }
+  | { status: "failed"; userId: string; error: string };
+
+export const GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE = "Could not sync Google Calendar";
+
+type GoogleCalendarEventResponse = {
+  id?: string;
+  htmlLink?: string;
+};
+
+function isGoogleCalendarEventConflict(error: unknown): error is GoogleCalendarApiError {
+  return error instanceof GoogleCalendarApiError && error.status === 409;
+}
+
+function eventDescription(shareToken: string): string {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim()?.replace(/\/+$/, "");
+  const joinLine = appUrl ? `Join: ${appUrl}/app?buddy=${encodeURIComponent(shareToken)}` : "";
+  return [
+    "Still Point shared buddy meditation.",
+    joinLine,
+    "Open Still Point at the scheduled time, join the room, and mark ready.",
+  ].filter(Boolean).join("\n\n");
+}
+
+function googleCalendarEventId(sessionId: string, userId: string): string {
+  return `sp${crypto.createHash("sha256").update(`${sessionId}:${userId}`).digest("hex")}`;
+}
+
+async function insertCalendarEvent(
+  userId: string,
+  session: typeof buddySessions.$inferSelect,
+  accessToken: string,
+  durationSeconds: number,
+): Promise<GoogleCalendarEventResponse> {
+  if (!session.scheduledStartAt) {
+    throw new GoogleCalendarUnavailableError("Cannot create a calendar event without scheduledStartAt.");
+  }
+  const start = session.scheduledStartAt;
+  const end = new Date(start.getTime() + durationSeconds * 1000);
+  const eventId = googleCalendarEventId(session.id, userId);
+  const headers = {
+    Authorization: `Bearer ${accessToken}`,
+    "Content-Type": "application/json",
+  };
+  try {
+    return await googleJsonFetch<GoogleCalendarEventResponse>(GOOGLE_CALENDAR_EVENTS_URL, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        id: eventId,
+        summary: "Still Point buddy session",
+        description: eventDescription(session.shareToken),
+        start: { dateTime: start.toISOString() },
+        end: { dateTime: end.toISOString() },
+        reminders: { useDefault: true },
+        extendedProperties: {
+          private: {
+            stillPointBuddySessionId: session.id,
+            stillPointUserId: userId,
+          },
+        },
+      }),
+    });
+  } catch (error) {
+    if (!isGoogleCalendarEventConflict(error)) throw error;
+    return googleJsonFetch<GoogleCalendarEventResponse>(
+      `${GOOGLE_CALENDAR_EVENTS_URL}/${encodeURIComponent(eventId)}`,
+      { headers },
+    );
+  }
+}
+
+export async function syncBuddySessionCalendarForUser(
+  session: typeof buddySessions.$inferSelect,
+  userId: string,
+): Promise<CalendarSyncResult> {
+  if (!session.scheduledStartAt) {
+    return { status: "skipped", userId, reason: "not_scheduled" };
+  }
+  const scheduledStartAt = session.scheduledStartAt;
+  try {
+    return await poolDb.transaction(async (tx) => {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtext(${`buddy-calendar:${session.id}:${userId}`}))`,
+      );
+
+      const [existingEvent] = await tx
+        .select({
+          googleEventId: buddySessionCalendarEvents.googleEventId,
+          htmlLink: buddySessionCalendarEvents.htmlLink,
+        })
+        .from(buddySessionCalendarEvents)
+        .where(
+          and(
+            eq(buddySessionCalendarEvents.buddySessionId, session.id),
+            eq(buddySessionCalendarEvents.userId, userId),
+            eq(buddySessionCalendarEvents.status, "created"),
+          ),
+        )
+        .limit(1);
+      if (existingEvent?.googleEventId) {
+        return {
+          status: "created",
+          userId,
+          eventId: existingEvent.googleEventId,
+          htmlLink: existingEvent.htmlLink ?? null,
+        };
+      }
+      const accessToken = await getValidAccessToken(userId);
+      if (!accessToken) return { status: "skipped", userId, reason: "not_connected" };
+      // #361: project the invite duration from the shortest active participant at sync time
+      // (+10s/day until the session) so a future scheduled sit shows the length we expect it to
+      // reach, not today's length. The in-app timer is still normalized live at start (#349).
+      const participantDays = await tx
+        .select({ currentDay: users.currentDay })
+        .from(buddySessionParticipants)
+        .innerJoin(users, eq(buddySessionParticipants.userId, users.id))
+        .where(
+          and(
+            eq(buddySessionParticipants.buddySessionId, session.id),
+            isNull(buddySessionParticipants.leftAt),
+          ),
+        );
+      const calendarDurationSeconds = projectedCalendarDurationSeconds(
+        participantDays.map((row) => row.currentDay),
+        new Date(),
+        scheduledStartAt,
+      );
+      const event = await insertCalendarEvent(userId, session, accessToken, calendarDurationSeconds);
+      if (!event.id) {
+        throw new GoogleCalendarApiError("Google Calendar event response was incomplete", 200, event);
+      }
+      await tx
+        .insert(buddySessionCalendarEvents)
+        .values({
+          buddySessionId: session.id,
+          userId,
+          googleEventId: event.id,
+          htmlLink: event.htmlLink ?? null,
+          status: "created",
+          error: null,
+          updatedAt: new Date(),
+        })
+        .onConflictDoUpdate({
+          target: [
+            buddySessionCalendarEvents.buddySessionId,
+            buddySessionCalendarEvents.userId,
+          ],
+          set: {
+            googleEventId: event.id,
+            htmlLink: event.htmlLink ?? null,
+            status: "created",
+            error: null,
+            updatedAt: new Date(),
+          },
+        });
+      return { status: "created", userId, eventId: event.id, htmlLink: event.htmlLink ?? null };
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Could not create Google Calendar event";
+    await db
+      .insert(buddySessionCalendarEvents)
+      .values({
+        buddySessionId: session.id,
+        userId,
+        status: "failed",
+        error: message,
+        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: [
+          buddySessionCalendarEvents.buddySessionId,
+          buddySessionCalendarEvents.userId,
+        ],
+        set: {
+          status: "failed",
+          error: message,
+          updatedAt: new Date(),
+        },
+      });
+    return { status: "failed", userId, error: GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE };
+  }
+}

--- a/src/lib/googleOAuth.ts
+++ b/src/lib/googleOAuth.ts
@@ -2,22 +2,12 @@ import "server-only";
 
 import crypto from "crypto";
 import { db } from "@/db";
-import { poolDb } from "@/db/pool";
-import {
-  buddySessionCalendarEvents,
-  buddySessionParticipants,
-  buddySessions,
-  googleOAuthTokens,
-  users,
-} from "@/db/schema";
-import { and, eq, isNull, sql } from "drizzle-orm";
-import { projectedCalendarDurationSeconds } from "@/lib/buddySessionDuration";
+import { googleOAuthTokens } from "@/db/schema";
+import { eq, sql } from "drizzle-orm";
 
 const GOOGLE_AUTH_BASE = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const GOOGLE_USERINFO_URL = "https://openidconnect.googleapis.com/v1/userinfo";
-const GOOGLE_CALENDAR_EVENTS_URL =
-  "https://www.googleapis.com/calendar/v3/calendars/primary/events";
 const GOOGLE_SCOPES = [
   "openid",
   "email",
@@ -34,7 +24,7 @@ export class GoogleCalendarUnavailableError extends Error {
   }
 }
 
-class GoogleCalendarApiError extends Error {
+export class GoogleCalendarApiError extends Error {
   readonly status: number;
   readonly body: unknown;
 
@@ -59,13 +49,6 @@ export type GoogleOAuthState = {
   };
 };
 
-export type CalendarSyncResult =
-  | { status: "created"; userId: string; eventId: string; htmlLink: string | null }
-  | { status: "skipped"; userId: string; reason: "not_connected" | "not_scheduled" }
-  | { status: "failed"; userId: string; error: string };
-
-export const GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE = "Could not sync Google Calendar";
-
 type GoogleCalendarStatus = {
   connected: boolean;
   email: string | null;
@@ -80,15 +63,6 @@ type GoogleTokenResponse = {
   error?: string;
   error_description?: string;
 };
-
-type GoogleCalendarEventResponse = {
-  id?: string;
-  htmlLink?: string;
-};
-
-function isGoogleCalendarEventConflict(error: unknown): error is GoogleCalendarApiError {
-  return error instanceof GoogleCalendarApiError && error.status === 409;
-}
 
 function requireGoogleClientConfig() {
   const clientId = process.env.GOOGLE_CLIENT_ID?.trim();
@@ -230,7 +204,7 @@ function googleErrorMessage(body: unknown, fallback: string): string {
   return fallback;
 }
 
-async function googleJsonFetch<T>(url: string, init: RequestInit): Promise<T> {
+export async function googleJsonFetch<T>(url: string, init: RequestInit): Promise<T> {
   const res = await fetch(url, {
     ...init,
     signal: init.signal ?? AbortSignal.timeout(GOOGLE_HTTP_TIMEOUT_MS),
@@ -341,7 +315,7 @@ async function refreshAccessToken(userId: string, refreshTokenEncrypted: string)
   return token.access_token;
 }
 
-async function getValidAccessToken(userId: string): Promise<string | null> {
+export async function getValidAccessToken(userId: string): Promise<string | null> {
   const token = await getGoogleOAuthToken(userId);
   if (!token) return null;
   if (token.expiryDate.getTime() > Date.now() + TOKEN_REFRESH_SKEW_MS) {
@@ -351,177 +325,7 @@ async function getValidAccessToken(userId: string): Promise<string | null> {
   return refreshAccessToken(userId, token.refreshTokenEncrypted);
 }
 
-function eventDescription(shareToken: string): string {
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim()?.replace(/\/+$/, "");
-  const joinLine = appUrl ? `Join: ${appUrl}/app?buddy=${encodeURIComponent(shareToken)}` : "";
-  return [
-    "Still Point shared buddy meditation.",
-    joinLine,
-    "Open Still Point at the scheduled time, join the room, and mark ready.",
-  ].filter(Boolean).join("\n\n");
-}
-
-function googleCalendarEventId(sessionId: string, userId: string): string {
-  return `sp${crypto.createHash("sha256").update(`${sessionId}:${userId}`).digest("hex")}`;
-}
-
-async function insertCalendarEvent(
-  userId: string,
-  session: typeof buddySessions.$inferSelect,
-  accessToken: string,
-  durationSeconds: number,
-): Promise<GoogleCalendarEventResponse> {
-  if (!session.scheduledStartAt) {
-    throw new GoogleCalendarUnavailableError("Cannot create a calendar event without scheduledStartAt.");
-  }
-  const start = session.scheduledStartAt;
-  const end = new Date(start.getTime() + durationSeconds * 1000);
-  const eventId = googleCalendarEventId(session.id, userId);
-  const headers = {
-    Authorization: `Bearer ${accessToken}`,
-    "Content-Type": "application/json",
-  };
-  try {
-    return await googleJsonFetch<GoogleCalendarEventResponse>(GOOGLE_CALENDAR_EVENTS_URL, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        id: eventId,
-        summary: "Still Point buddy session",
-        description: eventDescription(session.shareToken),
-        start: { dateTime: start.toISOString() },
-        end: { dateTime: end.toISOString() },
-        reminders: { useDefault: true },
-        extendedProperties: {
-          private: {
-            stillPointBuddySessionId: session.id,
-            stillPointUserId: userId,
-          },
-        },
-      }),
-    });
-  } catch (error) {
-    if (!isGoogleCalendarEventConflict(error)) throw error;
-    return googleJsonFetch<GoogleCalendarEventResponse>(
-      `${GOOGLE_CALENDAR_EVENTS_URL}/${encodeURIComponent(eventId)}`,
-      { headers },
-    );
-  }
-}
-
-export async function syncBuddySessionCalendarForUser(
-  session: typeof buddySessions.$inferSelect,
-  userId: string,
-): Promise<CalendarSyncResult> {
-  if (!session.scheduledStartAt) {
-    return { status: "skipped", userId, reason: "not_scheduled" };
-  }
-  const scheduledStartAt = session.scheduledStartAt;
-  try {
-    return await poolDb.transaction(async (tx) => {
-      await tx.execute(
-        sql`select pg_advisory_xact_lock(hashtext(${`buddy-calendar:${session.id}:${userId}`}))`,
-      );
-
-      const [existingEvent] = await tx
-        .select({
-          googleEventId: buddySessionCalendarEvents.googleEventId,
-          htmlLink: buddySessionCalendarEvents.htmlLink,
-        })
-        .from(buddySessionCalendarEvents)
-        .where(
-          and(
-            eq(buddySessionCalendarEvents.buddySessionId, session.id),
-            eq(buddySessionCalendarEvents.userId, userId),
-            eq(buddySessionCalendarEvents.status, "created"),
-          ),
-        )
-        .limit(1);
-      if (existingEvent?.googleEventId) {
-        return {
-          status: "created",
-          userId,
-          eventId: existingEvent.googleEventId,
-          htmlLink: existingEvent.htmlLink ?? null,
-        };
-      }
-      const accessToken = await getValidAccessToken(userId);
-      if (!accessToken) return { status: "skipped", userId, reason: "not_connected" };
-      // #361: project the invite duration from the shortest active participant at sync time
-      // (+10s/day until the session) so a future scheduled sit shows the length we expect it to
-      // reach, not today's length. The in-app timer is still normalized live at start (#349).
-      const participantDays = await tx
-        .select({ currentDay: users.currentDay })
-        .from(buddySessionParticipants)
-        .innerJoin(users, eq(buddySessionParticipants.userId, users.id))
-        .where(
-          and(
-            eq(buddySessionParticipants.buddySessionId, session.id),
-            isNull(buddySessionParticipants.leftAt),
-          ),
-        );
-      const calendarDurationSeconds = projectedCalendarDurationSeconds(
-        participantDays.map((row) => row.currentDay),
-        new Date(),
-        scheduledStartAt,
-      );
-      const event = await insertCalendarEvent(userId, session, accessToken, calendarDurationSeconds);
-      if (!event.id) {
-        throw new GoogleCalendarApiError("Google Calendar event response was incomplete", 200, event);
-      }
-      await tx
-        .insert(buddySessionCalendarEvents)
-        .values({
-          buddySessionId: session.id,
-          userId,
-          googleEventId: event.id,
-          htmlLink: event.htmlLink ?? null,
-          status: "created",
-          error: null,
-          updatedAt: new Date(),
-        })
-        .onConflictDoUpdate({
-          target: [
-            buddySessionCalendarEvents.buddySessionId,
-            buddySessionCalendarEvents.userId,
-          ],
-          set: {
-            googleEventId: event.id,
-            htmlLink: event.htmlLink ?? null,
-            status: "created",
-            error: null,
-            updatedAt: new Date(),
-          },
-        });
-      return { status: "created", userId, eventId: event.id, htmlLink: event.htmlLink ?? null };
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "Could not create Google Calendar event";
-    await db
-      .insert(buddySessionCalendarEvents)
-      .values({
-        buddySessionId: session.id,
-        userId,
-        status: "failed",
-        error: message,
-        updatedAt: new Date(),
-      })
-      .onConflictDoUpdate({
-        target: [
-          buddySessionCalendarEvents.buddySessionId,
-          buddySessionCalendarEvents.userId,
-        ],
-        set: {
-          status: "failed",
-          error: message,
-          updatedAt: new Date(),
-        },
-      });
-    return { status: "failed", userId, error: GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE };
-  }
-}
-
-export async function loadGoogleCalendarStatus(userId: string) {
+export async function loadGoogleCalendarStatus(userId: string): Promise<GoogleCalendarStatus> {
   const token = await getGoogleOAuthToken(userId);
   if (!token) return { connected: false, email: null };
   const hasUsableAccessToken = token.expiryDate.getTime() > Date.now() + TOKEN_REFRESH_SKEW_MS;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #415

## What

Splits the ~532-line `src/lib/google.ts` at its natural seam (`getValidAccessToken`, ~line 344) into two focused modules:

- **`src/lib/googleOAuth.ts`** (base module) — state cookie, redirect URI, `code↔token` exchange, token encrypt/refresh, `getValidAccessToken()`, the `googleJsonFetch` HTTP util, error classes, and `loadGoogleCalendarStatus`.
- **`src/lib/googleCalendar.ts`** — calendar event upsert + 409-conflict handling and `syncBuddySessionCalendarForUser`. Imports the OAuth base module.

To let Calendar consume OAuth, `getValidAccessToken`, `googleJsonFetch`, and `GoogleCalendarApiError` are promoted to public exports.

## Public API preservation

All public APIs are unchanged in shape — consumers only change import paths:

| Symbol | New module |
| --- | --- |
| `exchangeGoogleCodeForTokens`, `makeGoogleOAuthState`, `verifyGoogleOAuthState`, `getGoogleStateCookieName`, `buildGoogleAuthUrl`, `loadGoogleCalendarStatus`, `GoogleOAuthState`, `GoogleCalendarUnavailableError` | `@/lib/googleOAuth` |
| `syncBuddySessionCalendarForUser`, `GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE`, `CalendarSyncResult` | `@/lib/googleCalendar` |

Updated consumers: `api/auth/google/{route,callback,status}`, `api/buddy/sessions/{route,join,route.test}`.

## Test plan

- `npm run typecheck` — passes (0 errors)
- `npm run test:unit` — 49 files, 394 tests passing
- No stale `@/lib/google` import references remain (verified via search)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6be604cf-16f4-4991-9f51-fd03fbc63ee0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6be604cf-16f4-4991-9f51-fd03fbc63ee0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Buddy session calendar syncing is now handled more reliably, including automatic event creation and updates in Google Calendar.
  * Calendar sync now better handles missing availability, token issues, and duplicate event creation.

* **Bug Fixes**
  * Improved consistency in Google login and calendar status flows.
  * Reduced the chance of duplicate calendar events when sessions are joined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->