### PR TITLE
refactor(ios): extract UsernameEditView from SettingsView

### DIFF
--- a/ios/StillPoint.xcodeproj/project.pbxproj
+++ b/ios/StillPoint.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		13177552A26E700472836E9A /* NotificationPreferencesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E16CD986E277DA88A2EB6F1 /* NotificationPreferencesViewModel.swift */; };
 		15177B86F124B5A10AB03456 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C683A9F0586D58020E60DD87 /* RootView.swift */; };
 		1649BE1D765A6851D5802BBA /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D356465C1B0F69C57FE47A80 /* SettingsView.swift */; };
+		A1B2C3D4E5F60718293A4B5C /* UsernameEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E4D3C2B1A0918273645566 /* UsernameEditView.swift */; };
 		1AD1C504911C0820878EFAA4 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14BEE5E52F5249E22EA4DB08 /* SnapshotHelper.swift */; };
 		1BE60070F826B7B31DFAB315 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FA6DAE71EE23FAF8EE0F12 /* HomeView.swift */; };
 		2E31C1B6A86E612EF7171348 /* ThoughtJournalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44912B427658554F984CCC3A /* ThoughtJournalView.swift */; };
@@ -152,6 +153,7 @@
 		CDB4B1423B22DD22F5B6E069 /* DesignTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignTokens.swift; sourceTree = "<group>"; };
 		D15A7FF17302B1E2FD147920 /* StillPoint.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = StillPoint.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D356465C1B0F69C57FE47A80 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		F5E4D3C2B1A0918273645566 /* UsernameEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsernameEditView.swift; sourceTree = "<group>"; };
 		D7B5A3374B6B8AC64C22F537 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		DDFD4FE5B2BFD74718DC3CE1 /* AppBlockingShared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBlockingShared.swift; sourceTree = "<group>"; };
 		E1C10719A1709CEE1EAEBE17 /* StillPointAppUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = StillPointAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -197,6 +199,7 @@
 				2F95E6E47148AEF494393FDB /* SessionView.swift */,
 				D356465C1B0F69C57FE47A80 /* SettingsView.swift */,
 				44912B427658554F984CCC3A /* ThoughtJournalView.swift */,
+				F5E4D3C2B1A0918273645566 /* UsernameEditView.swift */,
 				3CF33E14AFF118C76854F60A /* BuddyCalendar */,
 				8BFB3AFE8B8A4AFB50ADB37B /* BuddySession */,
 			);
@@ -577,6 +580,7 @@
 				B41D20D3939E0F51F7471F44 /* ThoughtCaptureView.swift in Sources */,
 				2E31C1B6A86E612EF7171348 /* ThoughtJournalView.swift in Sources */,
 				3E8960D90E815E3462FF241B /* ThoughtJournalViewModel.swift in Sources */,
+				A1B2C3D4E5F60718293A4B5C /* UsernameEditView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -8,13 +8,14 @@ struct SettingsView: View {
     @State private var aphorismsEnabled: Bool = false
     @State private var isUpdating = false
     @State private var isUpdatingAphorisms = false
+    @State private var isSavingUsername = false
     @State private var showDeleteAccountDialog = false
     @State private var showDeleteAccountConfirm = false
     @State private var isDeletingAccount = false
     @State private var deleteAccountError = ""
     @State private var showDeleteAccountError = false
 
-    private var isSavingSettings: Bool { isUpdating || isUpdatingAphorisms }
+    private var isSavingSettings: Bool { isUpdating || isUpdatingAphorisms || isSavingUsername }
 
     var body: some View {
         NavigationStack {
@@ -39,7 +40,12 @@ struct SettingsView: View {
                         .tracking(2)
 
                     if let user = appVM.currentUser {
-                        UsernameEditView(user: user, appVM: appVM, updating: isSavingSettings)
+                        UsernameEditView(
+                            user: user,
+                            appVM: appVM,
+                            updating: isUpdating || isUpdatingAphorisms,
+                            savingUsername: $isSavingUsername
+                        )
 
                         HStack {
                             Text("Email")

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -8,18 +8,13 @@ struct SettingsView: View {
     @State private var aphorismsEnabled: Bool = false
     @State private var isUpdating = false
     @State private var isUpdatingAphorisms = false
-    @State private var editingUsername = false
-    @State private var usernameDraft = ""
-    @State private var savingUsername = false
-    @State private var usernameFieldError: String?
-    @State private var usernameSuccessMessage: String?
     @State private var showDeleteAccountDialog = false
     @State private var showDeleteAccountConfirm = false
     @State private var isDeletingAccount = false
     @State private var deleteAccountError = ""
     @State private var showDeleteAccountError = false
 
-    private var isSavingSettings: Bool { isUpdating || isUpdatingAphorisms || savingUsername }
+    private var isSavingSettings: Bool { isUpdating || isUpdatingAphorisms }
 
     var body: some View {
         NavigationStack {
@@ -44,7 +39,7 @@ struct SettingsView: View {
                         .tracking(2)
 
                     if let user = appVM.currentUser {
-                        usernameSection(for: user)
+                        UsernameEditView(user: user, appVM: appVM, updating: isSavingSettings)
 
                         HStack {
                             Text("Email")
@@ -263,11 +258,6 @@ struct SettingsView: View {
         .onAppear {
             syncFromCurrentUser()
         }
-        .onChange(of: appVM.currentUser?.username) { _, _ in
-            if !editingUsername {
-                syncFromCurrentUser()
-            }
-        }
         .onChange(of: appVM.currentUser?.isPublic) { _, _ in
             guard appVM.currentUser != nil else { return }
             syncFromCurrentUser()
@@ -307,152 +297,9 @@ struct SettingsView: View {
         .accessibilityIdentifier("settings.notificationsLink")
     }
 
-    @ViewBuilder
-    private func usernameSection(for user: UserDTO) -> some View {
-        VStack(alignment: .leading, spacing: SPSpacing.s2) {
-            if editingUsername {
-                TextField("Username", text: $usernameDraft)
-                    .font(SPFont.mono(15))
-                    .foregroundStyle(Color(SPColor.fg))
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    .disabled(isSavingSettings)
-                    .accessibilityIdentifier("settings.usernameField")
-                    .onChange(of: usernameDraft) { _, newValue in
-                        if newValue.count > UsernameValidation.maxLength {
-                            usernameDraft = String(newValue.prefix(UsernameValidation.maxLength))
-                        }
-                    }
-
-                HStack(spacing: SPSpacing.s2) {
-                    Button {
-                        Task { @MainActor in
-                            await saveUsername(currentUsername: user.username)
-                        }
-                    } label: {
-                        Text(savingUsername ? "Saving…" : "Save")
-                            .font(SPFont.mono(11, weight: .medium))
-                            .tracking(2)
-                    }
-                    .buttonStyle(.bordered)
-                    .disabled(isSavingSettings)
-                    .accessibilityIdentifier("settings.usernameSaveButton")
-
-                    Button("Cancel") {
-                        cancelUsernameEdit(savedUsername: user.username)
-                    }
-                    .font(SPFont.mono(11, weight: .medium))
-                    .tracking(2)
-                    .buttonStyle(.bordered)
-                    .disabled(isSavingSettings)
-                    .accessibilityIdentifier("settings.usernameCancelButton")
-                }
-
-                if let usernameFieldError {
-                    Text(usernameFieldError)
-                        .font(SPFont.mono(11))
-                        .foregroundStyle(SPColor.dangerMuted)
-                        .accessibilityIdentifier("settings.usernameError")
-                }
-            } else {
-                HStack(alignment: .center, spacing: SPSpacing.s2) {
-                    Text("Username")
-                        .font(SPFont.mono(13))
-                        .foregroundStyle(Color(SPColor.fg3))
-                    Spacer(minLength: SPSpacing.s2)
-                    Text(user.username)
-                        .font(SPFont.mono(13))
-                        .foregroundStyle(Color(SPColor.fg))
-                        .lineLimit(1)
-                        .accessibilityIdentifier("settings.usernameDisplay")
-                    Button("Edit") {
-                        beginUsernameEdit(savedUsername: user.username)
-                    }
-                    .font(SPFont.mono(10, weight: .medium))
-                    .tracking(2)
-                    .buttonStyle(.bordered)
-                    .accessibilityLabel("Edit username")
-                    .accessibilityIdentifier("settings.usernameEditButton")
-                    .disabled(isSavingSettings)
-                }
-
-                if let usernameSuccessMessage {
-                    Text(usernameSuccessMessage)
-                        .font(SPFont.mono(11))
-                        .foregroundStyle(SPColor.green)
-                        .accessibilityIdentifier("settings.usernameSuccess")
-                }
-            }
-        }
-    }
-
     private func syncFromCurrentUser() {
         isPublic = appVM.currentUser?.isPublic ?? false
         aphorismsEnabled = appVM.currentUser?.aphorismsEnabled ?? false
-        if !editingUsername, let u = appVM.currentUser {
-            usernameDraft = u.username
-        }
-    }
-
-    private func beginUsernameEdit(savedUsername: String) {
-        usernameDraft = savedUsername
-        usernameFieldError = nil
-        usernameSuccessMessage = nil
-        editingUsername = true
-    }
-
-    private func cancelUsernameEdit(savedUsername: String) {
-        editingUsername = false
-        usernameFieldError = nil
-        usernameDraft = savedUsername
-    }
-
-    @MainActor
-    private func saveUsername(currentUsername: String) async {
-        guard !isSavingSettings else { return }
-
-        let trimmed = usernameDraft.trimmingCharacters(in: .whitespacesAndNewlines)
-        usernameFieldError = nil
-        usernameSuccessMessage = nil
-
-        if trimmed == currentUsername {
-            editingUsername = false
-            return
-        }
-
-        guard UsernameValidation.isValid(trimmed) else {
-            usernameFieldError = UsernameValidation.errorMessage
-            return
-        }
-
-        savingUsername = true
-        defer { savingUsername = false }
-
-        do {
-            let updated = try await APIClient.shared.updateSettings(username: trimmed)
-            appVM.applySettingsUser(updated)
-            usernameDraft = updated.username
-            editingUsername = false
-            usernameSuccessMessage = "Username updated"
-        } catch let error as APIError {
-            usernameFieldError = Self.message(for: error)
-        } catch {
-            usernameFieldError = "Could not update username. Please try again."
-        }
-    }
-
-    private static func message(for error: APIError) -> String {
-        switch error.status {
-        case 409:
-            return error.message
-        case 400:
-            if error.message == UsernameValidation.errorMessage {
-                return UsernameValidation.errorMessage
-            }
-            return error.message
-        default:
-            return "Could not update username. Please try again."
-        }
     }
 
     private var appVersionFooter: String {

--- a/ios/StillPointApp/Views/UsernameEditView.swift
+++ b/ios/StillPointApp/Views/UsernameEditView.swift
@@ -3,20 +3,25 @@ import StillPointShared
 
 /// Username display + inline edit block for the Settings "ACCOUNT" card.
 ///
-/// Owns its own edit state internally. The parent passes the current user, an
-/// `AppViewModel` reference (to persist updates), and an external `updating`
-/// flag reflecting other in-flight Settings writes so the controls disable in
-/// lockstep with the rest of the screen.
+/// Owns its edit UI state internally (editing flag, draft, error/success
+/// messages). The parent passes the current user, an `AppViewModel` reference
+/// (to persist updates), and an external `updating` flag reflecting other
+/// in-flight Settings writes so the controls disable in lockstep with the rest
+/// of the screen. The `savingUsername` flag is bound back up to the parent so
+/// its other controls stay disabled while a username save is in flight.
 struct UsernameEditView: View {
     let user: UserDTO
     let appVM: AppViewModel
     /// True while another Settings write (e.g. visibility / aphorisms) is in
     /// flight. Combined with the local save state to gate the controls.
     let updating: Bool
+    /// Lifted so the parent Settings screen can keep its other controls (Public
+    /// Board / Aphorisms toggles) disabled while a username save is in flight,
+    /// matching the pre-extraction `isSavingSettings` behavior.
+    @Binding var savingUsername: Bool
 
     @State private var editingUsername = false
     @State private var usernameDraft = ""
-    @State private var savingUsername = false
     @State private var usernameFieldError: String?
     @State private var usernameSuccessMessage: String?
 

--- a/ios/StillPointApp/Views/UsernameEditView.swift
+++ b/ios/StillPointApp/Views/UsernameEditView.swift
@@ -167,9 +167,6 @@ struct UsernameEditView: View {
         case 409:
             return error.message
         case 400:
-            if error.message == UsernameValidation.errorMessage {
-                return UsernameValidation.errorMessage
-            }
             return error.message
         default:
             return "Could not update username. Please try again."

--- a/ios/StillPointApp/Views/UsernameEditView.swift
+++ b/ios/StillPointApp/Views/UsernameEditView.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+import StillPointShared
+
+/// Username display + inline edit block for the Settings "ACCOUNT" card.
+///
+/// Owns its own edit state internally. The parent passes the current user, an
+/// `AppViewModel` reference (to persist updates), and an external `updating`
+/// flag reflecting other in-flight Settings writes so the controls disable in
+/// lockstep with the rest of the screen.
+struct UsernameEditView: View {
+    let user: UserDTO
+    let appVM: AppViewModel
+    /// True while another Settings write (e.g. visibility / aphorisms) is in
+    /// flight. Combined with the local save state to gate the controls.
+    let updating: Bool
+
+    @State private var editingUsername = false
+    @State private var usernameDraft = ""
+    @State private var savingUsername = false
+    @State private var usernameFieldError: String?
+    @State private var usernameSuccessMessage: String?
+
+    private var isSaving: Bool { updating || savingUsername }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: SPSpacing.s2) {
+            if editingUsername {
+                TextField("Username", text: $usernameDraft)
+                    .font(SPFont.mono(15))
+                    .foregroundStyle(Color(SPColor.fg))
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .disabled(isSaving)
+                    .accessibilityIdentifier("settings.usernameField")
+                    .onChange(of: usernameDraft) { _, newValue in
+                        if newValue.count > UsernameValidation.maxLength {
+                            usernameDraft = String(newValue.prefix(UsernameValidation.maxLength))
+                        }
+                    }
+
+                HStack(spacing: SPSpacing.s2) {
+                    Button {
+                        Task { @MainActor in
+                            await saveUsername(currentUsername: user.username)
+                        }
+                    } label: {
+                        Text(savingUsername ? "Saving…" : "Save")
+                            .font(SPFont.mono(11, weight: .medium))
+                            .tracking(2)
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(isSaving)
+                    .accessibilityIdentifier("settings.usernameSaveButton")
+
+                    Button("Cancel") {
+                        cancelUsernameEdit(savedUsername: user.username)
+                    }
+                    .font(SPFont.mono(11, weight: .medium))
+                    .tracking(2)
+                    .buttonStyle(.bordered)
+                    .disabled(isSaving)
+                    .accessibilityIdentifier("settings.usernameCancelButton")
+                }
+
+                if let usernameFieldError {
+                    Text(usernameFieldError)
+                        .font(SPFont.mono(11))
+                        .foregroundStyle(SPColor.dangerMuted)
+                        .accessibilityIdentifier("settings.usernameError")
+                }
+            } else {
+                HStack(alignment: .center, spacing: SPSpacing.s2) {
+                    Text("Username")
+                        .font(SPFont.mono(13))
+                        .foregroundStyle(Color(SPColor.fg3))
+                    Spacer(minLength: SPSpacing.s2)
+                    Text(user.username)
+                        .font(SPFont.mono(13))
+                        .foregroundStyle(Color(SPColor.fg))
+                        .lineLimit(1)
+                        .accessibilityIdentifier("settings.usernameDisplay")
+                    Button("Edit") {
+                        beginUsernameEdit(savedUsername: user.username)
+                    }
+                    .font(SPFont.mono(10, weight: .medium))
+                    .tracking(2)
+                    .buttonStyle(.bordered)
+                    .accessibilityLabel("Edit username")
+                    .accessibilityIdentifier("settings.usernameEditButton")
+                    .disabled(isSaving)
+                }
+
+                if let usernameSuccessMessage {
+                    Text(usernameSuccessMessage)
+                        .font(SPFont.mono(11))
+                        .foregroundStyle(SPColor.green)
+                        .accessibilityIdentifier("settings.usernameSuccess")
+                }
+            }
+        }
+        .onAppear {
+            if !editingUsername {
+                usernameDraft = user.username
+            }
+        }
+        .onChange(of: appVM.currentUser?.username) { _, newValue in
+            if !editingUsername, let newValue {
+                usernameDraft = newValue
+            }
+        }
+    }
+
+    private func beginUsernameEdit(savedUsername: String) {
+        usernameDraft = savedUsername
+        usernameFieldError = nil
+        usernameSuccessMessage = nil
+        editingUsername = true
+    }
+
+    private func cancelUsernameEdit(savedUsername: String) {
+        editingUsername = false
+        usernameFieldError = nil
+        usernameDraft = savedUsername
+    }
+
+    @MainActor
+    private func saveUsername(currentUsername: String) async {
+        guard !isSaving else { return }
+
+        let trimmed = usernameDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        usernameFieldError = nil
+        usernameSuccessMessage = nil
+
+        if trimmed == currentUsername {
+            editingUsername = false
+            return
+        }
+
+        guard UsernameValidation.isValid(trimmed) else {
+            usernameFieldError = UsernameValidation.errorMessage
+            return
+        }
+
+        savingUsername = true
+        defer { savingUsername = false }
+
+        do {
+            let updated = try await APIClient.shared.updateSettings(username: trimmed)
+            appVM.applySettingsUser(updated)
+            usernameDraft = updated.username
+            editingUsername = false
+            usernameSuccessMessage = "Username updated"
+        } catch let error as APIError {
+            usernameFieldError = Self.message(for: error)
+        } catch {
+            usernameFieldError = "Could not update username. Please try again."
+        }
+    }
+
+    private static func message(for error: APIError) -> String {
+        switch error.status {
+        case 409:
+            return error.message
+        case 400:
+            if error.message == UsernameValidation.errorMessage {
+                return UsernameValidation.errorMessage
+            }
+            return error.message
+        default:
+            return "Could not update username. Please try again."
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pure view extraction — no behavior change. Moves the username display / inline-edit block out of `SettingsView.swift` into a new `UsernameEditView.swift` alongside it.

- New `UsernameEditView` owns its edit UI state internally: `editingUsername`, `usernameDraft`, `usernameFieldError`, `usernameSuccessMessage`.
- Props: `user: UserDTO`, `appVM: AppViewModel`, an external `updating: Bool` flag (other in-flight Settings writes), and a `savingUsername` `Binding` lifted back to the parent (see below). Internally combined as `isSaving = updating || savingUsername`, preserving the original `isSavingSettings` gating for the username controls.
- The 5 username-only methods (`beginUsernameEdit`, `cancelUsernameEdit`, `saveUsername`, static `message(for:)`, plus the section builder) move into the new view. The external-username-change sync (`onChange(of: appVM.currentUser?.username)`) and initial `onAppear` draft seed now live in `UsernameEditView`.
- `SettingsView` instantiates `UsernameEditView(...)` in place; its `syncFromCurrentUser()` now only handles visibility/aphorisms.
- All `accessibilityIdentifier`s, validation, and API calls are unchanged, so existing UI tests keep passing.
- Registered the new file in `StillPoint.xcodeproj` (build file, file reference, `Views` group, app Sources phase).

## Review fixes

- **Cursor Bugbot (Medium): toggles active during username save.** Lifting `savingUsername` into the child initially dropped it from the parent's `isSavingSettings`, so Public Board / Aphorisms toggles could be changed mid username-save. Fixed by binding `savingUsername` back up to `SettingsView` (`@State isSavingUsername`) so `isSavingSettings = isUpdating || isUpdatingAphorisms || isSavingUsername` again — fully restoring the pre-extraction gating. The child still owns its edit UI state.

## Test plan

The iOS app target can only be compiled with Xcode on macOS (agents can't parse the `.xcodeproj` on Linux; `StillPointShared` is untouched, so its required `swift test` check no-ops), so verification here is static:

- ✅ Swift syntax parse of both `UsernameEditView.swift` and `SettingsView.swift` via `swiftc -parse` (Swift 6.0.3) — both exit 0.
- ✅ Behavior parity re-derived: child `isSaving = (isUpdating || isUpdatingAphorisms) || savingUsername` and parent `isSavingSettings = isUpdating || isUpdatingAphorisms || isSavingUsername` both match the original single `isSavingSettings`.
- ✅ All `settings.username*` accessibility identifiers preserved (referenced by `StillPointAppUITests`).
- ✅ `.xcodeproj` updated with unique UUIDs across all four required sections.

Recommended CI/manual check on macOS:
- Build the app and run the `StillPointAppUITests` username edit/validation flows.
- Manually: edit username (save/cancel), trigger validation + conflict errors, confirm the field disables while visibility/aphorisms toggles are saving — and that those toggles stay disabled while a username save is in flight.

Closes #419
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd40e88b-1c8e-400a-9bf7-57db939f073f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd40e88b-1c8e-400a-9bf7-57db939f073f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline username editing directly in Settings, with clear save, cancel, and success/error feedback.

* **Bug Fixes**
  * Improved settings behavior so username changes stay in sync correctly and saving states are handled more consistently.
  * Simplified account settings updates to avoid interfering with other profile changes while editing a username.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->