### PR TITLE
Extract UITestAPIStore out of iOS APIClient (#416)

### DIFF
--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -15,21 +15,11 @@ public actor APIClient {
     private var baseURL: URL
 
     private let session: URLSession
-    private let uiTestConfig: UITestConfig?
-    private var uiTestStore: UITestStore?
-    private let uiTestStoreDefaultsKey = "StillPoint.UITest.Store"
-    private var uiTestNotificationPreferences = NotificationPreferencesDTO(
-        pushEnabled: false,
-        dailyReminderEnabled: false,
-        missADayEnabled: false,
-        friendRequestNotificationsEnabled: true,
-        suppressDuringSession: false,
-        dailyReminderTime: "09:00",
-        dailyReminderFrequency: .daily,
-        quietHoursStart: nil,
-        quietHoursEnd: nil,
-        tz: TimeZone.current.identifier
-    )
+
+    /// The single UI-test seam. Non-nil only when the app launches in UI-test
+    /// mode (`SP_UI_TEST_MODE`); every request checks this and delegates to the
+    /// fake backend instead of hitting the network (issue #416).
+    private let uiTestAPIStore: UITestAPIStore?
 
     private init() {
         #if DEBUG
@@ -44,49 +34,15 @@ public actor APIClient {
         config.httpCookieStorage = .shared
         self.session = URLSession(configuration: config)
 
-        let parsedUITestConfig = UITestConfig.fromProcessInfo()
-        self.uiTestConfig = parsedUITestConfig
-        if let parsedUITestConfig {
-            let defaults = UserDefaults.standard
-            if parsedUITestConfig.resetStore {
-                // Wipe ALL persisted state, not just the UI-test store. State that
-                // bled across tests previously: Keychain auth tokens, cookies, URL
-                // credentials, AudioEngine sound prefs. Issue #266 surfaced this
-                // when the runner script started actually running tests after the
-                // silent-skip fix from issue #253.
-                // Note: the SwiftData store is wiped earlier in
-                // `StillPointApp.init()`, before `.modelContainer(...)` opens
-                // its SQLite files (issue #276 — APIClient.init runs lazily
-                // from RootView's .task, which is too late to delete an
-                // already-open store).
-                defaults.removeObject(forKey: uiTestStoreDefaultsKey)
-                AudioEngine.resetPersistedPrefs()
-                Self.clearPersistedSessionArtifacts(session: session)
-                // Flush the in-memory cache to cfprefsd so the immediately
-                // following read sees the cleared state. Issue #266 follow-up.
-                defaults.synchronize()
-            }
+        let store = UITestAPIStore.fromProcessInfo()
+        self.uiTestAPIStore = store
 
-            let resolvedStore: UITestStore
-            if parsedUITestConfig.snapshotSeed {
-                resolvedStore = UITestStore.makeSnapshot(seedAuthenticated: parsedUITestConfig.seedAuthenticated)
-                Self.persist(store: resolvedStore, key: uiTestStoreDefaultsKey)
-            } else if let persistedData = defaults.data(forKey: uiTestStoreDefaultsKey),
-                      let persistedStore = try? JSONDecoder().decode(UITestStore.self, from: persistedData) {
-                resolvedStore = persistedStore
-            } else {
-                resolvedStore = UITestStore.makeDefault(seedAuthenticated: parsedUITestConfig.seedAuthenticated)
-                Self.persist(store: resolvedStore, key: uiTestStoreDefaultsKey)
-            }
-            self.uiTestStore = resolvedStore
-
-            // Diagnostic for issue #266 / #276. Use os_log so the line lands
-            // in the xcresult bundle — `print()` from the app process is not
-            // captured by Xcode UI test runs, which is why the prior
-            // [E2E-DIAG] prints from PR #261 never showed up in CI logs.
-            Self.diagLog.notice("[E2E-DIAG] APIClient.init uiTestMode=YES seedAuth=\(parsedUITestConfig.seedAuthenticated, privacy: .public) resetStore=\(parsedUITestConfig.resetStore, privacy: .public) forceOffline=\(parsedUITestConfig.forceLaunchOffline, privacy: .public) forceTokenExpired=\(parsedUITestConfig.forceTokenExpired, privacy: .public) finalIsAuthenticated=\(resolvedStore.isAuthenticated, privacy: .public)")
-        } else {
-            Self.diagLog.notice("[E2E-DIAG] APIClient.init uiTestMode=NO")
+        // The UI-test store owns wiping the UITest/AudioEngine defaults on a
+        // reset launch, but the session artifacts (auth token, cookies, URL
+        // credentials) live here on the client — so clear them too when a
+        // reset was requested. See issue #266 for why a full wipe is needed.
+        if let store, store.resetStore {
+            Self.clearPersistedSessionArtifacts(session: session)
         }
     }
 
@@ -115,8 +71,8 @@ public actor APIClient {
     // MARK: - Auth
 
     public func signup(email: String, username: String, password: String) async throws -> UserDTO {
-        if let user = try uiTestSignup(email: email, username: username, password: password) {
-            return user
+        if let uiTestAPIStore {
+            return await uiTestAPIStore.signup(email: email, username: username, password: password)
         }
         let body: [String: String] = ["email": email, "username": username, "password": password]
         let response: UserResponse = try await post("/api/auth/signup", body: body)
@@ -131,8 +87,8 @@ public actor APIClient {
     }
 
     public func login(email: String, password: String) async throws -> UserDTO {
-        if let user = try uiTestLogin(email: email, password: password) {
-            return user
+        if let uiTestAPIStore {
+            return try await uiTestAPIStore.login(email: email, password: password)
         }
         // Web app sends username too but only uses email+password for login
         let body: [String: String] = ["email": email, "username": "", "password": password]
@@ -149,8 +105,8 @@ public actor APIClient {
 
     /// Native Sign in with Apple → server verifies JWT and returns `user` + `token` (same as login with ios header).
     public func signInWithApple(_ request: AppleNativeSignInRequest) async throws -> UserDTO {
-        if uiTestConfig != nil {
-            throw APIError(status: 0, message: "Apple sign-in is not available in UI test mode")
+        if let uiTestAPIStore {
+            return try await uiTestAPIStore.signInWithApple()
         }
         let response: UserResponse = try await post("/api/auth/apple-native", body: request)
         if let token = response.token, !token.isEmpty {
@@ -165,8 +121,8 @@ public actor APIClient {
 
     /// Native Sign in with Google → server verifies the Google ID token and returns `user` + `token` (same as login with ios header).
     public func signInWithGoogle(_ request: GoogleNativeSignInRequest) async throws -> UserDTO {
-        if uiTestConfig != nil {
-            throw APIError(status: 0, message: "Google sign-in is not available in UI test mode")
+        if let uiTestAPIStore {
+            return try await uiTestAPIStore.signInWithGoogle()
         }
         let response: UserResponse = try await post("/api/auth/google-native", body: request)
         if let token = response.token, !token.isEmpty {
@@ -180,8 +136,8 @@ public actor APIClient {
     }
 
     public func requestPasswordReset(email: String) async throws -> String {
-        if let message = try uiTestRequestPasswordReset(email: email) {
-            return message
+        if let uiTestAPIStore {
+            return try await uiTestAPIStore.requestPasswordReset(email: email)
         }
         let body: [String: String] = ["email": email]
         let response: PasswordResetRequestResponse = try await post("/api/auth/password-reset/request", body: body)
@@ -189,7 +145,10 @@ public actor APIClient {
     }
 
     public func logout() async throws {
-        if uiTestLogout() {
+        if let uiTestAPIStore {
+            if await uiTestAPIStore.logout() {
+                clearLocalSessionArtifacts()
+            }
             return
         }
         defer { clearLocalSessionArtifacts() }
@@ -197,7 +156,10 @@ public actor APIClient {
     }
 
     public func deleteAccount() async throws {
-        if uiTestDeleteAccount() {
+        if let uiTestAPIStore {
+            if await uiTestAPIStore.deleteAccount() {
+                clearLocalSessionArtifacts()
+            }
             return
         }
         try await delete("/api/account")
@@ -205,8 +167,8 @@ public actor APIClient {
     }
 
     public func me() async throws -> UserDTO? {
-        if let uiTestResult = try uiTestMe() {
-            return uiTestResult
+        if let uiTestAPIStore {
+            return try await uiTestAPIStore.me()
         }
         do {
             let response: UserResponse = try await get("/api/auth/me")
@@ -219,19 +181,15 @@ public actor APIClient {
     // MARK: - Device Tokens
 
     public func registerDeviceToken(_ request: DeviceTokenRegistrationRequest) async throws -> DeviceTokenResponse.RegisteredDeviceToken {
-        if uiTestConfig != nil {
-            return DeviceTokenResponse.RegisteredDeviceToken(
-                id: "ui-device-token",
-                platform: request.platform,
-                apnsEnvironment: request.apnsEnvironment
-            )
+        if let uiTestAPIStore {
+            return await uiTestAPIStore.registerDeviceToken(request)
         }
         let response: DeviceTokenResponse = try await post("/api/device-token", body: request)
         return response.deviceToken
     }
 
     public func unregisterDeviceToken(_ request: DeviceTokenRegistrationRequest) async throws {
-        if uiTestConfig != nil {
+        if uiTestAPIStore != nil {
             return
         }
         var urlRequest = makeRequest(method: "DELETE", path: "/api/device-token")
@@ -242,24 +200,24 @@ public actor APIClient {
     // MARK: - Sessions
 
     public func getSessions() async throws -> (sessions: [SessionDTO], stats: StatsDTO) {
-        if let uiTestResult = try uiTestGetSessions() {
-            return uiTestResult
+        if let uiTestAPIStore {
+            return try await uiTestAPIStore.getSessions()
         }
         let response: SessionsResponse = try await get("/api/sessions")
         return (response.sessions, response.stats)
     }
 
     public func createSession(_ data: CreateSessionRequest) async throws -> SessionDTO {
-        if let session = try uiTestCreateSession(data) {
-            return session
+        if let uiTestAPIStore {
+            return try await uiTestAPIStore.createSession(data)
         }
         let response: SessionResponse = try await post("/api/sessions", body: data)
         return response.session
     }
 
     public func getSessionBySessionId(_ sessionId: String) async throws -> (session: SessionDTO, thoughts: [ThoughtDTO]) {
-        if let uiTestResult = try uiTestGetSession(sessionId: sessionId) {
-            return uiTestResult
+        if let uiTestAPIStore {
+            return try await uiTestAPIStore.getSession(sessionId: sessionId)
         }
         let response: SessionDetailResponse = try await get("/api/sessions/by-session/\(sessionId)")
         return (response.session, response.thoughts)
@@ -268,16 +226,16 @@ public actor APIClient {
     // MARK: - Thoughts
 
     public func getThoughts() async throws -> [ThoughtDTO] {
-        if let thoughts = try uiTestGetThoughts() {
-            return thoughts
+        if let uiTestAPIStore {
+            return try await uiTestAPIStore.getThoughts()
         }
         let response: ThoughtsResponse = try await get("/api/thoughts")
         return response.thoughts
     }
 
     public func batchThoughts(_ data: BatchThoughtsRequest) async throws -> [ThoughtDTO] {
-        if let thoughts = try uiTestBatchThoughts(data) {
-            return thoughts
+        if let uiTestAPIStore {
+            return try await uiTestAPIStore.batchThoughts(data)
         }
         let response: ThoughtsResponse = try await post("/api/thoughts/batch", body: data)
         return response.thoughts
@@ -286,8 +244,8 @@ public actor APIClient {
     // MARK: - Board
 
     public func getBoard() async throws -> [BoardEntryDTO] {
-        if uiTestConfig != nil {
-            return uiTestGetBoard()
+        if let uiTestAPIStore {
+            return await uiTestAPIStore.getBoard()
         }
         let response: BoardResponse = try await get("/api/board")
         return response.board
@@ -309,8 +267,12 @@ public actor APIClient {
     }
 
     private func updateSettings(body: SettingsPatchBody) async throws -> UserDTO {
-        if let user = try uiTestUpdateSettings(body: body) {
-            return user
+        if let uiTestAPIStore {
+            return try await uiTestAPIStore.updateSettings(
+                isPublic: body.isPublic,
+                username: body.username,
+                aphorismsEnabled: body.aphorismsEnabled
+            )
         }
         let response: UserResponse = try await patch("/api/settings", body: body)
         return response.user
@@ -319,16 +281,16 @@ public actor APIClient {
     // MARK: - Notification preferences
 
     public func getNotificationPreferences() async throws -> NotificationPreferencesDTO {
-        if uiTestConfig != nil {
-            return uiTestNotificationPreferences
+        if let uiTestAPIStore {
+            return await uiTestAPIStore.getNotificationPreferences()
         }
         let response: NotificationPreferencesResponse = try await get("/api/notifications/preferences")
         return response.preferences
     }
 
     public func updateNotificationPreferences(_ preferencesPatch: NotificationPreferencesPatch) async throws -> NotificationPreferencesDTO {
-        if let updated = try uiTestUpdateNotificationPreferences(preferencesPatch) {
-            return updated
+        if let uiTestAPIStore {
+            return try await uiTestAPIStore.updateNotificationPreferences(preferencesPatch)
         }
         let response: NotificationPreferencesResponse = try await patch(
             "/api/notifications/preferences",
@@ -518,333 +480,6 @@ public actor APIClient {
         return request
     }
 
-    // MARK: - UI Test Overrides
-
-    /// Returns a handled value in UI test mode, or `nil` when normal network flow should continue.
-    private func uiTestMe() throws -> UserDTO?? {
-        guard let uiTestConfig else { return nil }
-        guard var store = uiTestStore else {
-            throw APIError(status: 0, message: "UI test store is unavailable")
-        }
-
-        if uiTestConfig.forceLaunchOffline {
-            throw APIError(status: 0, message: "No internet connection")
-        }
-
-        if uiTestConfig.forceTokenExpired {
-            if store.isAuthenticated {
-                store.isAuthenticated = false
-                uiTestStore = store
-                persistUITestStore()
-            }
-            throw APIError(
-                status: 401,
-                message: "Session expired. Please log in again.",
-                code: "TOKEN_EXPIRED"
-            )
-        }
-
-        return store.isAuthenticated ? store.user : .some(nil)
-    }
-
-    private func uiTestSignup(email: String, username: String, password: String) throws -> UserDTO? {
-        guard uiTestConfig != nil else { return nil }
-        guard var store = uiTestStore else {
-            throw APIError(status: 0, message: "UI test store is unavailable")
-        }
-
-        store.user = UserDTO(
-            id: store.user.id,
-            email: email,
-            username: username,
-            isPublic: store.user.isPublic,
-            currentDay: 1,
-            aphorismsEnabled: false
-        )
-        store.loginEmail = email
-        store.loginPassword = password
-        store.isAuthenticated = true
-        uiTestStore = store
-        persistUITestStore()
-        return store.user
-    }
-
-    private func uiTestLogin(email: String, password: String) throws -> UserDTO? {
-        guard uiTestConfig != nil else { return nil }
-        guard var store = uiTestStore else {
-            throw APIError(status: 0, message: "UI test store is unavailable")
-        }
-
-        guard email.lowercased() == store.loginEmail.lowercased(),
-              password == store.loginPassword else {
-            throw APIError(status: 401, message: "Invalid email or password")
-        }
-
-        store.isAuthenticated = true
-        uiTestStore = store
-        persistUITestStore()
-        return store.user
-    }
-
-    private func uiTestRequestPasswordReset(email: String) throws -> String? {
-        guard uiTestConfig != nil else { return nil }
-        guard !email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw APIError(status: 400, message: "Email required")
-        }
-        return "If an account exists for that email, a reset link will arrive shortly."
-    }
-
-    private func uiTestLogout() -> Bool {
-        guard uiTestConfig != nil else { return false }
-        guard var store = uiTestStore else { return true }
-        store.isAuthenticated = false
-        uiTestStore = store
-        persistUITestStore()
-        clearLocalSessionArtifacts()
-        return true
-    }
-
-    private func uiTestDeleteAccount() -> Bool {
-        guard uiTestConfig != nil else { return false }
-        guard var store = uiTestStore else { return true }
-        store.isAuthenticated = false
-        store.sessions = []
-        store.thoughts = []
-        uiTestStore = store
-        persistUITestStore()
-        clearLocalSessionArtifacts()
-        return true
-    }
-
-    private func uiTestGetSessions() throws -> (sessions: [SessionDTO], stats: StatsDTO)? {
-        guard let uiTestConfig else { return nil }
-        guard let store = uiTestStore else {
-            throw APIError(status: 0, message: "UI test store is unavailable")
-        }
-        try ensureUITestAuthenticated(store: store)
-
-        if uiTestConfig.forceSessionsFailure {
-            throw APIError(status: 503, message: "Failed to load sessions. Check your connection.")
-        }
-
-        let sortedSessions = store.sessions.sorted { $0.sessionDate < $1.sessionDate }
-        return (sortedSessions, SessionStatistics.calculateStats(for: sortedSessions))
-    }
-
-    private func uiTestCreateSession(_ data: CreateSessionRequest) throws -> SessionDTO? {
-        guard uiTestConfig != nil else { return nil }
-        guard var store = uiTestStore else {
-            throw APIError(status: 0, message: "UI test store is unavailable")
-        }
-        try ensureUITestAuthenticated(store: store)
-
-        let nextOrdinal = store.nextSessionOrdinal
-        let session = SessionDTO(
-            id: "ui-session-\(nextOrdinal)",
-            dayNumber: data.dayNumber,
-            sessionType: data.sessionType,
-            duration: data.duration,
-            bonusSeconds: data.bonusSeconds == 0 ? nil : data.bonusSeconds,
-            completed: data.completed,
-            actualTime: data.actualTime,
-            clearPercent: data.clearPercent,
-            thoughtCount: data.thoughtCount,
-            mindStateLog: data.mindStateLog,
-            sessionDate: data.sessionDate,
-            createdAt: nil,
-            buddySessionId: nil
-        )
-        store.nextSessionOrdinal += 1
-        store.sessions.append(session)
-
-        if data.completed && data.sessionType == .standard {
-            store.user = UserDTO(
-                id: store.user.id,
-                email: store.user.email,
-                username: store.user.username,
-                isPublic: store.user.isPublic,
-                currentDay: max(store.user.currentDay, data.dayNumber + 1),
-                aphorismsEnabled: store.user.aphorismsEnabled
-            )
-        }
-
-        uiTestStore = store
-        persistUITestStore()
-        return session
-    }
-
-    private func uiTestGetSession(sessionId: String) throws -> (session: SessionDTO, thoughts: [ThoughtDTO])? {
-        guard uiTestConfig != nil else { return nil }
-        guard let store = uiTestStore else {
-            throw APIError(status: 0, message: "UI test store is unavailable")
-        }
-        try ensureUITestAuthenticated(store: store)
-
-        guard let session = store.sessions.first(where: { $0.id == sessionId }) else {
-            throw APIError(status: 404, message: "Session not found")
-        }
-
-        let thoughts = store.thoughts.filter { $0.sessionId == session.id }
-            .sorted { $0.timeInSession < $1.timeInSession }
-        return (session, thoughts)
-    }
-
-    private func uiTestGetThoughts() throws -> [ThoughtDTO]? {
-        guard uiTestConfig != nil else { return nil }
-        guard let store = uiTestStore else {
-            throw APIError(status: 0, message: "UI test store is unavailable")
-        }
-        try ensureUITestAuthenticated(store: store)
-        return store.thoughts
-            .sorted {
-                if $0.dayNumber == $1.dayNumber {
-                    return $0.timeInSession < $1.timeInSession
-                }
-                return $0.dayNumber > $1.dayNumber
-            }
-    }
-
-    private func uiTestBatchThoughts(_ data: BatchThoughtsRequest) throws -> [ThoughtDTO]? {
-        guard uiTestConfig != nil else { return nil }
-        guard var store = uiTestStore else {
-            throw APIError(status: 0, message: "UI test store is unavailable")
-        }
-        try ensureUITestAuthenticated(store: store)
-
-        let createdThoughts = data.thoughts.map { input -> ThoughtDTO in
-            let thought = ThoughtDTO(
-                id: "ui-thought-\(store.nextThoughtOrdinal)",
-                sessionId: data.sessionId,
-                dayNumber: data.dayNumber,
-                timeInSession: input.timeInSession,
-                text: input.text
-            )
-            store.nextThoughtOrdinal += 1
-            return thought
-        }
-        store.thoughts.append(contentsOf: createdThoughts)
-        uiTestStore = store
-        persistUITestStore()
-        return createdThoughts
-    }
-
-    /// Board data in UI test mode: empty unless snapshot seed is enabled (marketing screenshots).
-    private func uiTestGetBoard() -> [BoardEntryDTO] {
-        guard let uiTestConfig, uiTestConfig.snapshotSeed else { return [] }
-        guard let store = uiTestStore, store.isAuthenticated else { return [] }
-        let me = store.user.username
-        return [
-            BoardEntryDTO(username: "quietledger", currentDay: 24, streak: 18, avgClear: 84, totalSessions: 52),
-            BoardEntryDTO(username: me, currentDay: store.user.currentDay, streak: 6, avgClear: 77, totalSessions: 22),
-            BoardEntryDTO(username: "morningstill", currentDay: 11, streak: 9, avgClear: 71, totalSessions: 30),
-            BoardEntryDTO(username: "deepamber", currentDay: 9, streak: 4, avgClear: 68, totalSessions: 17),
-        ]
-    }
-
-    private func uiTestUpdateSettings(body: SettingsPatchBody) throws -> UserDTO? {
-        guard let uiTestConfig else { return nil }
-        guard var store = uiTestStore else {
-            throw APIError(status: 0, message: "UI test store is unavailable")
-        }
-        try ensureUITestAuthenticated(store: store)
-
-        var nextUsername = store.user.username
-        var nextIsPublic = store.user.isPublic
-        var nextAphorismsEnabled = store.user.aphorismsEnabled
-
-        if let usernamePatch = body.username {
-            let trimmed = usernamePatch.trimmingCharacters(in: .whitespacesAndNewlines)
-            if uiTestConfig.forceUsernameConflict {
-                throw APIError(status: 409, message: "Username already taken")
-            }
-            guard UsernameValidation.isValid(trimmed) else {
-                throw APIError(status: 400, message: UsernameValidation.errorMessage)
-            }
-            nextUsername = trimmed
-        }
-
-        if let isPublicPatch = body.isPublic {
-            nextIsPublic = isPublicPatch
-        }
-
-        if let aphorismsEnabledPatch = body.aphorismsEnabled {
-            nextAphorismsEnabled = aphorismsEnabledPatch
-        }
-
-        store.user = UserDTO(
-            id: store.user.id,
-            email: store.user.email,
-            username: nextUsername,
-            isPublic: nextIsPublic,
-            currentDay: store.user.currentDay,
-            aphorismsEnabled: nextAphorismsEnabled
-        )
-        uiTestStore = store
-        persistUITestStore()
-        return store.user
-    }
-
-    private func uiTestUpdateNotificationPreferences(
-        _ patch: NotificationPreferencesPatch
-    ) throws -> NotificationPreferencesDTO? {
-        guard uiTestConfig != nil else { return nil }
-        guard let store = uiTestStore else {
-            throw APIError(status: 0, message: "UI test store is unavailable")
-        }
-        try ensureUITestAuthenticated(store: store)
-
-        let current = uiTestNotificationPreferences
-        var quietStart = current.quietHoursStart
-        var quietEnd = current.quietHoursEnd
-        if let quietHoursStart = patch.quietHoursStart {
-            switch quietHoursStart {
-            case .none: quietStart = nil
-            case .some(let value): quietStart = value
-            }
-        }
-        if let quietHoursEnd = patch.quietHoursEnd {
-            switch quietHoursEnd {
-            case .none: quietEnd = nil
-            case .some(let value): quietEnd = value
-            }
-        }
-
-        let next = NotificationPreferencesDTO(
-            pushEnabled: patch.pushEnabled ?? current.pushEnabled,
-            dailyReminderEnabled: patch.dailyReminderEnabled ?? current.dailyReminderEnabled,
-            missADayEnabled: patch.missADayEnabled ?? current.missADayEnabled,
-            friendRequestNotificationsEnabled: patch.friendRequestNotificationsEnabled ?? current.friendRequestNotificationsEnabled,
-            suppressDuringSession: patch.suppressDuringSession ?? current.suppressDuringSession,
-            dailyReminderTime: patch.dailyReminderTime ?? current.dailyReminderTime,
-            dailyReminderFrequency: patch.dailyReminderFrequency ?? current.dailyReminderFrequency,
-            quietHoursStart: quietStart,
-            quietHoursEnd: quietEnd,
-            tz: patch.tz ?? current.tz,
-            updatedAt: current.updatedAt
-        )
-
-        uiTestNotificationPreferences = next
-        return next
-    }
-
-    private func ensureUITestAuthenticated(store: UITestStore) throws {
-        guard store.isAuthenticated else {
-            throw APIError(status: 401, message: "Please log in", code: "UNAUTHORIZED")
-        }
-    }
-
-    private func persistUITestStore() {
-        guard let uiTestStore else { return }
-        Self.persist(store: uiTestStore, key: uiTestStoreDefaultsKey)
-    }
-
-    /// Nonisolated static analog of `persistUITestStore()`. Used during
-    /// `init` (which is nonisolated) so we don't trip Swift 6 actor-isolation
-    /// errors by calling an actor-isolated instance method from there.
-    private static func persist(store: UITestStore, key: String) {
-        guard let encoded = try? JSONEncoder().encode(store) else { return }
-        UserDefaults.standard.set(encoded, forKey: key)
-    }
 }
 
 private struct SettingsPatchBody: Encodable {
@@ -869,208 +504,6 @@ private struct SettingsPatchBody: Encodable {
         case isPublic
         case username
         case aphorismsEnabled
-    }
-}
-
-private struct UITestConfig: Sendable {
-    let seedAuthenticated: Bool
-    let resetStore: Bool
-    let forceLaunchOffline: Bool
-    let forceTokenExpired: Bool
-    let forceSessionsFailure: Bool
-    let forceUsernameConflict: Bool
-    /// Deterministic marketing/scenario data for Fastlane snapshot runs (Issue #325).
-    let snapshotSeed: Bool
-
-    static func fromProcessInfo() -> UITestConfig? {
-        let env = ProcessInfo.processInfo.environment
-        guard truthy(env["SP_UI_TEST_MODE"]) else { return nil }
-        return UITestConfig(
-            seedAuthenticated: truthy(env["SP_UI_TEST_SEED_AUTH"]),
-            resetStore: truthy(env["SP_UI_TEST_RESET_STORE"]),
-            forceLaunchOffline: truthy(env["SP_UI_TEST_FORCE_LAUNCH_OFFLINE"]),
-            forceTokenExpired: truthy(env["SP_UI_TEST_FORCE_TOKEN_EXPIRED"]),
-            forceSessionsFailure: truthy(env["SP_UI_TEST_FORCE_SESSIONS_FAILURE"]),
-            forceUsernameConflict: truthy(env["SP_UI_TEST_FORCE_USERNAME_CONFLICT"]),
-            snapshotSeed: truthy(env["SP_UI_TEST_SNAPSHOT_SEED"])
-        )
-    }
-
-    private static func truthy(_ value: String?) -> Bool {
-        guard let value else { return false }
-        return ["1", "true", "yes", "on"].contains(value.lowercased())
-    }
-}
-
-private struct UITestStore: Codable, Sendable {
-    var user: UserDTO
-    var loginEmail: String
-    var loginPassword: String
-    var isAuthenticated: Bool
-    var sessions: [SessionDTO]
-    var thoughts: [ThoughtDTO]
-    var nextSessionOrdinal: Int
-    var nextThoughtOrdinal: Int
-
-    static func makeDefault(seedAuthenticated: Bool) -> UITestStore {
-        let fixtureUser = UserDTO(
-            id: "ui-user-1",
-            email: "ios.fixture@stillpoint.test",
-            username: "ios_fixture",
-            isPublic: false,
-            currentDay: 1
-        )
-        return UITestStore(
-            user: fixtureUser,
-            loginEmail: fixtureUser.email,
-            loginPassword: "stillpoint-pass",
-            isAuthenticated: seedAuthenticated,
-            sessions: [],
-            thoughts: [],
-            nextSessionOrdinal: 1,
-            nextThoughtOrdinal: 1
-        )
-    }
-
-    /// Rich canned history, journal rows, and board-relevant profile for Fastlane screenshots.
-    static func makeSnapshot(seedAuthenticated: Bool) -> UITestStore {
-        let fixtureUser = UserDTO(
-            id: "snapshot-user-1",
-            email: "snapshot@stillpoint.test",
-            username: "still_snapshot",
-            isPublic: true,
-            currentDay: 9,
-            aphorismsEnabled: true
-        )
-
-        let sessions: [SessionDTO] = [
-            SessionDTO(
-                id: "snap-sess-1",
-                dayNumber: 4,
-                sessionType: .standard,
-                duration: 120,
-                bonusSeconds: 60,
-                completed: true,
-                actualTime: 125,
-                clearPercent: 74,
-                thoughtCount: 2,
-                mindStateLog: [],
-                sessionDate: "2026-01-05",
-                createdAt: "2026-01-05T08:30:00Z",
-                buddySessionId: nil
-            ),
-            SessionDTO(
-                id: "snap-sess-2",
-                dayNumber: 4,
-                sessionType: .standard,
-                duration: 120,
-                bonusSeconds: nil,
-                completed: true,
-                actualTime: 118,
-                clearPercent: 81,
-                thoughtCount: 1,
-                mindStateLog: [],
-                sessionDate: "2026-01-05",
-                createdAt: "2026-01-05T19:15:00Z",
-                buddySessionId: nil
-            ),
-            SessionDTO(
-                id: "snap-sess-3",
-                dayNumber: 5,
-                sessionType: .standard,
-                duration: 130,
-                bonusSeconds: 300,
-                completed: true,
-                actualTime: 400,
-                clearPercent: 69,
-                thoughtCount: 4,
-                mindStateLog: [],
-                sessionDate: "2026-01-06",
-                createdAt: "2026-01-06T07:00:00Z",
-                buddySessionId: nil
-            ),
-            SessionDTO(
-                id: "snap-sess-4",
-                dayNumber: 6,
-                sessionType: .standard,
-                duration: 140,
-                bonusSeconds: nil,
-                completed: true,
-                actualTime: 140,
-                clearPercent: 88,
-                thoughtCount: 0,
-                mindStateLog: [],
-                sessionDate: "2026-01-07",
-                createdAt: "2026-01-07T12:20:00Z",
-                buddySessionId: nil
-            ),
-            SessionDTO(
-                id: "snap-sess-5",
-                dayNumber: 7,
-                sessionType: .standard,
-                duration: 150,
-                bonusSeconds: nil,
-                completed: true,
-                actualTime: 150,
-                clearPercent: 72,
-                thoughtCount: 3,
-                mindStateLog: [],
-                sessionDate: "2026-01-08",
-                createdAt: "2026-01-08T06:45:00Z",
-                buddySessionId: nil
-            ),
-            SessionDTO(
-                id: "snap-sess-6",
-                dayNumber: 8,
-                sessionType: .standard,
-                duration: 160,
-                bonusSeconds: 120,
-                completed: true,
-                actualTime: 265,
-                clearPercent: 79,
-                thoughtCount: 2,
-                mindStateLog: [],
-                sessionDate: "2026-01-09",
-                createdAt: "2026-01-09T21:05:00Z",
-                buddySessionId: nil
-            ),
-            SessionDTO(
-                id: "snap-quick-1",
-                dayNumber: 8,
-                sessionType: .quick,
-                duration: StillPoint.quickDuration,
-                bonusSeconds: nil,
-                completed: true,
-                actualTime: StillPoint.quickDuration,
-                clearPercent: 62,
-                thoughtCount: 1,
-                mindStateLog: [],
-                sessionDate: "2026-01-09",
-                createdAt: "2026-01-09T08:10:00Z",
-                buddySessionId: nil
-            ),
-        ]
-
-        let thoughts: [ThoughtDTO] = [
-            ThoughtDTO(id: "snap-th-1", sessionId: "snap-sess-1", dayNumber: 4, timeInSession: 42, text: "Planning the week instead of watching the timer."),
-            ThoughtDTO(id: "snap-th-2", sessionId: "snap-sess-1", dayNumber: 4, timeInSession: 96, text: "Sound of traffic — came back to the breath."),
-            ThoughtDTO(id: "snap-th-3", sessionId: "snap-sess-3", dayNumber: 5, timeInSession: 55, text: "Should I adjust tomorrow's sit length?"),
-            ThoughtDTO(id: "snap-th-4", sessionId: "snap-sess-3", dayNumber: 5, timeInSession: 200, text: "Lost thread for a moment; noticed and returned."),
-            ThoughtDTO(id: "snap-th-5", sessionId: "snap-sess-5", dayNumber: 7, timeInSession: 22, text: "Flash of an old conversation."),
-            ThoughtDTO(id: "snap-th-6", sessionId: "snap-sess-6", dayNumber: 8, timeInSession: 140, text: "Room felt quieter toward the end."),
-            ThoughtDTO(id: "snap-th-7", sessionId: "snap-quick-1", dayNumber: 8, timeInSession: 12, text: "Quick reset between meetings."),
-        ]
-
-        return UITestStore(
-            user: fixtureUser,
-            loginEmail: fixtureUser.email,
-            loginPassword: "snapshot-pass",
-            isAuthenticated: seedAuthenticated,
-            sessions: sessions,
-            thoughts: thoughts,
-            nextSessionOrdinal: 100,
-            nextThoughtOrdinal: 100
-        )
     }
 }
 

--- a/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
@@ -1,0 +1,597 @@
+import Foundation
+
+/// UI-test infrastructure extracted out of `APIClient` (issue #416).
+///
+/// When the app launches with `SP_UI_TEST_MODE` set, `APIClient` builds one of
+/// these actors and delegates every request to it instead of hitting the
+/// network. It owns the in-memory + `UserDefaults`-persisted fake backend
+/// (`UITestStore`) plus the launch config (`UITestConfig`).
+///
+/// The actor deliberately does NOT touch the `URLSession`, cookies, keychain
+/// token, or `URLCredentialStorage` — those are owned by `APIClient`. Instead,
+/// `logout()`/`deleteAccount()` return a flag telling the client whether to run
+/// its own `clearLocalSessionArtifacts()`, and `resetStore` lets the client
+/// clear those artifacts during init.
+actor UITestAPIStore {
+    private let config: UITestConfig
+    private var store: UITestStore
+    private var notificationPreferences: NotificationPreferencesDTO
+    private let defaultsKey: String
+
+    /// Whether launch requested a full reset. `APIClient` reads this
+    /// synchronously during init so it can also clear the session artifacts it
+    /// owns (auth token, cookies, URL credentials).
+    nonisolated let resetStore: Bool
+
+    private init(config: UITestConfig, store: UITestStore, defaultsKey: String) {
+        self.config = config
+        self.store = store
+        self.defaultsKey = defaultsKey
+        self.resetStore = config.resetStore
+        self.notificationPreferences = NotificationPreferencesDTO(
+            pushEnabled: false,
+            dailyReminderEnabled: false,
+            missADayEnabled: false,
+            friendRequestNotificationsEnabled: true,
+            suppressDuringSession: false,
+            dailyReminderTime: "09:00",
+            dailyReminderFrequency: .daily,
+            quietHoursStart: nil,
+            quietHoursEnd: nil,
+            tz: TimeZone.current.identifier
+        )
+    }
+
+    /// Builds the store from `SP_UI_TEST_*` env vars, or returns `nil` when the
+    /// app is not running in UI-test mode. Emits the same `[E2E-DIAG]` lines the
+    /// original `APIClient.init` did so CI xcresult logs are unchanged.
+    static func fromProcessInfo(defaultsKey: String = "StillPoint.UITest.Store") -> UITestAPIStore? {
+        guard let config = UITestConfig.fromProcessInfo() else {
+            APIClient.diagLog.notice("[E2E-DIAG] APIClient.init uiTestMode=NO")
+            return nil
+        }
+
+        let defaults = UserDefaults.standard
+        if config.resetStore {
+            // Wipe ALL persisted state, not just the UI-test store. State that
+            // bled across tests previously: Keychain auth tokens, cookies, URL
+            // credentials, AudioEngine sound prefs. Issue #266 surfaced this
+            // when the runner script started actually running tests after the
+            // silent-skip fix from issue #253.
+            // Note: the SwiftData store is wiped earlier in
+            // `StillPointApp.init()`, before `.modelContainer(...)` opens
+            // its SQLite files (issue #276). The session artifacts owned by
+            // `APIClient` are cleared by the client itself via `resetStore`.
+            defaults.removeObject(forKey: defaultsKey)
+            AudioEngine.resetPersistedPrefs()
+            // Flush the in-memory cache to cfprefsd so the immediately
+            // following read sees the cleared state. Issue #266 follow-up.
+            defaults.synchronize()
+        }
+
+        let resolvedStore: UITestStore
+        if config.snapshotSeed {
+            resolvedStore = UITestStore.makeSnapshot(seedAuthenticated: config.seedAuthenticated)
+            persist(store: resolvedStore, key: defaultsKey)
+        } else if let persistedData = defaults.data(forKey: defaultsKey),
+                  let persistedStore = try? JSONDecoder().decode(UITestStore.self, from: persistedData) {
+            resolvedStore = persistedStore
+        } else {
+            resolvedStore = UITestStore.makeDefault(seedAuthenticated: config.seedAuthenticated)
+            persist(store: resolvedStore, key: defaultsKey)
+        }
+
+        // Diagnostic for issue #266 / #276. Use os_log so the line lands
+        // in the xcresult bundle — `print()` from the app process is not
+        // captured by Xcode UI test runs, which is why the prior
+        // [E2E-DIAG] prints from PR #261 never showed up in CI logs.
+        APIClient.diagLog.notice("[E2E-DIAG] APIClient.init uiTestMode=YES seedAuth=\(config.seedAuthenticated, privacy: .public) resetStore=\(config.resetStore, privacy: .public) forceOffline=\(config.forceLaunchOffline, privacy: .public) forceTokenExpired=\(config.forceTokenExpired, privacy: .public) finalIsAuthenticated=\(resolvedStore.isAuthenticated, privacy: .public)")
+
+        return UITestAPIStore(config: config, store: resolvedStore, defaultsKey: defaultsKey)
+    }
+
+    // MARK: - Auth
+
+    func signup(email: String, username: String, password: String) -> UserDTO {
+        store.user = UserDTO(
+            id: store.user.id,
+            email: email,
+            username: username,
+            isPublic: store.user.isPublic,
+            currentDay: 1,
+            aphorismsEnabled: false
+        )
+        store.loginEmail = email
+        store.loginPassword = password
+        store.isAuthenticated = true
+        persist()
+        return store.user
+    }
+
+    func login(email: String, password: String) throws -> UserDTO {
+        guard email.lowercased() == store.loginEmail.lowercased(),
+              password == store.loginPassword else {
+            throw APIError(status: 401, message: "Invalid email or password")
+        }
+
+        store.isAuthenticated = true
+        persist()
+        return store.user
+    }
+
+    func signInWithApple() throws -> UserDTO {
+        throw APIError(status: 0, message: "Apple sign-in is not available in UI test mode")
+    }
+
+    func signInWithGoogle() throws -> UserDTO {
+        throw APIError(status: 0, message: "Google sign-in is not available in UI test mode")
+    }
+
+    func requestPasswordReset(email: String) throws -> String {
+        guard !email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw APIError(status: 400, message: "Email required")
+        }
+        return "If an account exists for that email, a reset link will arrive shortly."
+    }
+
+    /// Returns `true` when `APIClient` should also clear its local session artifacts.
+    func logout() -> Bool {
+        store.isAuthenticated = false
+        persist()
+        return true
+    }
+
+    /// Returns `true` when `APIClient` should also clear its local session artifacts.
+    func deleteAccount() -> Bool {
+        store.isAuthenticated = false
+        store.sessions = []
+        store.thoughts = []
+        persist()
+        return true
+    }
+
+    func me() throws -> UserDTO? {
+        if config.forceLaunchOffline {
+            throw APIError(status: 0, message: "No internet connection")
+        }
+
+        if config.forceTokenExpired {
+            if store.isAuthenticated {
+                store.isAuthenticated = false
+                persist()
+            }
+            throw APIError(
+                status: 401,
+                message: "Session expired. Please log in again.",
+                code: "TOKEN_EXPIRED"
+            )
+        }
+
+        return store.isAuthenticated ? store.user : nil
+    }
+
+    // MARK: - Device Tokens
+
+    func registerDeviceToken(_ request: DeviceTokenRegistrationRequest) -> DeviceTokenResponse.RegisteredDeviceToken {
+        DeviceTokenResponse.RegisteredDeviceToken(
+            id: "ui-device-token",
+            platform: request.platform,
+            apnsEnvironment: request.apnsEnvironment
+        )
+    }
+
+    // MARK: - Sessions
+
+    func getSessions() throws -> (sessions: [SessionDTO], stats: StatsDTO) {
+        try ensureAuthenticated()
+
+        if config.forceSessionsFailure {
+            throw APIError(status: 503, message: "Failed to load sessions. Check your connection.")
+        }
+
+        let sortedSessions = store.sessions.sorted { $0.sessionDate < $1.sessionDate }
+        return (sortedSessions, SessionStatistics.calculateStats(for: sortedSessions))
+    }
+
+    func createSession(_ data: CreateSessionRequest) throws -> SessionDTO {
+        try ensureAuthenticated()
+
+        let nextOrdinal = store.nextSessionOrdinal
+        let session = SessionDTO(
+            id: "ui-session-\(nextOrdinal)",
+            dayNumber: data.dayNumber,
+            sessionType: data.sessionType,
+            duration: data.duration,
+            bonusSeconds: data.bonusSeconds == 0 ? nil : data.bonusSeconds,
+            completed: data.completed,
+            actualTime: data.actualTime,
+            clearPercent: data.clearPercent,
+            thoughtCount: data.thoughtCount,
+            mindStateLog: data.mindStateLog,
+            sessionDate: data.sessionDate,
+            createdAt: nil,
+            buddySessionId: nil
+        )
+        store.nextSessionOrdinal += 1
+        store.sessions.append(session)
+
+        if data.completed && data.sessionType == .standard {
+            store.user = UserDTO(
+                id: store.user.id,
+                email: store.user.email,
+                username: store.user.username,
+                isPublic: store.user.isPublic,
+                currentDay: max(store.user.currentDay, data.dayNumber + 1),
+                aphorismsEnabled: store.user.aphorismsEnabled
+            )
+        }
+
+        persist()
+        return session
+    }
+
+    func getSession(sessionId: String) throws -> (session: SessionDTO, thoughts: [ThoughtDTO]) {
+        try ensureAuthenticated()
+
+        guard let session = store.sessions.first(where: { $0.id == sessionId }) else {
+            throw APIError(status: 404, message: "Session not found")
+        }
+
+        let thoughts = store.thoughts.filter { $0.sessionId == session.id }
+            .sorted { $0.timeInSession < $1.timeInSession }
+        return (session, thoughts)
+    }
+
+    // MARK: - Thoughts
+
+    func getThoughts() throws -> [ThoughtDTO] {
+        try ensureAuthenticated()
+        return store.thoughts
+            .sorted {
+                if $0.dayNumber == $1.dayNumber {
+                    return $0.timeInSession < $1.timeInSession
+                }
+                return $0.dayNumber > $1.dayNumber
+            }
+    }
+
+    func batchThoughts(_ data: BatchThoughtsRequest) throws -> [ThoughtDTO] {
+        try ensureAuthenticated()
+
+        let createdThoughts = data.thoughts.map { input -> ThoughtDTO in
+            let thought = ThoughtDTO(
+                id: "ui-thought-\(store.nextThoughtOrdinal)",
+                sessionId: data.sessionId,
+                dayNumber: data.dayNumber,
+                timeInSession: input.timeInSession,
+                text: input.text
+            )
+            store.nextThoughtOrdinal += 1
+            return thought
+        }
+        store.thoughts.append(contentsOf: createdThoughts)
+        persist()
+        return createdThoughts
+    }
+
+    // MARK: - Board
+
+    /// Board data in UI test mode: empty unless snapshot seed is enabled (marketing screenshots).
+    func getBoard() -> [BoardEntryDTO] {
+        guard config.snapshotSeed else { return [] }
+        guard store.isAuthenticated else { return [] }
+        let me = store.user.username
+        return [
+            BoardEntryDTO(username: "quietledger", currentDay: 24, streak: 18, avgClear: 84, totalSessions: 52),
+            BoardEntryDTO(username: me, currentDay: store.user.currentDay, streak: 6, avgClear: 77, totalSessions: 22),
+            BoardEntryDTO(username: "morningstill", currentDay: 11, streak: 9, avgClear: 71, totalSessions: 30),
+            BoardEntryDTO(username: "deepamber", currentDay: 9, streak: 4, avgClear: 68, totalSessions: 17),
+        ]
+    }
+
+    // MARK: - Settings
+
+    func updateSettings(isPublic: Bool?, username: String?, aphorismsEnabled: Bool?) throws -> UserDTO {
+        try ensureAuthenticated()
+
+        var nextUsername = store.user.username
+        var nextIsPublic = store.user.isPublic
+        var nextAphorismsEnabled = store.user.aphorismsEnabled
+
+        if let username {
+            let trimmed = username.trimmingCharacters(in: .whitespacesAndNewlines)
+            if config.forceUsernameConflict {
+                throw APIError(status: 409, message: "Username already taken")
+            }
+            guard UsernameValidation.isValid(trimmed) else {
+                throw APIError(status: 400, message: UsernameValidation.errorMessage)
+            }
+            nextUsername = trimmed
+        }
+
+        if let isPublic {
+            nextIsPublic = isPublic
+        }
+
+        if let aphorismsEnabled {
+            nextAphorismsEnabled = aphorismsEnabled
+        }
+
+        store.user = UserDTO(
+            id: store.user.id,
+            email: store.user.email,
+            username: nextUsername,
+            isPublic: nextIsPublic,
+            currentDay: store.user.currentDay,
+            aphorismsEnabled: nextAphorismsEnabled
+        )
+        persist()
+        return store.user
+    }
+
+    // MARK: - Notification preferences
+
+    func getNotificationPreferences() -> NotificationPreferencesDTO {
+        notificationPreferences
+    }
+
+    func updateNotificationPreferences(_ patch: NotificationPreferencesPatch) throws -> NotificationPreferencesDTO {
+        try ensureAuthenticated()
+
+        let current = notificationPreferences
+        var quietStart = current.quietHoursStart
+        var quietEnd = current.quietHoursEnd
+        if let quietHoursStart = patch.quietHoursStart {
+            switch quietHoursStart {
+            case .none: quietStart = nil
+            case .some(let value): quietStart = value
+            }
+        }
+        if let quietHoursEnd = patch.quietHoursEnd {
+            switch quietHoursEnd {
+            case .none: quietEnd = nil
+            case .some(let value): quietEnd = value
+            }
+        }
+
+        let next = NotificationPreferencesDTO(
+            pushEnabled: patch.pushEnabled ?? current.pushEnabled,
+            dailyReminderEnabled: patch.dailyReminderEnabled ?? current.dailyReminderEnabled,
+            missADayEnabled: patch.missADayEnabled ?? current.missADayEnabled,
+            friendRequestNotificationsEnabled: patch.friendRequestNotificationsEnabled ?? current.friendRequestNotificationsEnabled,
+            suppressDuringSession: patch.suppressDuringSession ?? current.suppressDuringSession,
+            dailyReminderTime: patch.dailyReminderTime ?? current.dailyReminderTime,
+            dailyReminderFrequency: patch.dailyReminderFrequency ?? current.dailyReminderFrequency,
+            quietHoursStart: quietStart,
+            quietHoursEnd: quietEnd,
+            tz: patch.tz ?? current.tz,
+            updatedAt: current.updatedAt
+        )
+
+        notificationPreferences = next
+        return next
+    }
+
+    // MARK: - Helpers
+
+    private func ensureAuthenticated() throws {
+        guard store.isAuthenticated else {
+            throw APIError(status: 401, message: "Please log in", code: "UNAUTHORIZED")
+        }
+    }
+
+    private func persist() {
+        Self.persist(store: store, key: defaultsKey)
+    }
+
+    private static func persist(store: UITestStore, key: String) {
+        guard let encoded = try? JSONEncoder().encode(store) else { return }
+        UserDefaults.standard.set(encoded, forKey: key)
+    }
+}
+
+// MARK: - Launch config
+
+private struct UITestConfig: Sendable {
+    let seedAuthenticated: Bool
+    let resetStore: Bool
+    let forceLaunchOffline: Bool
+    let forceTokenExpired: Bool
+    let forceSessionsFailure: Bool
+    let forceUsernameConflict: Bool
+    /// Deterministic marketing/scenario data for Fastlane snapshot runs (Issue #325).
+    let snapshotSeed: Bool
+
+    static func fromProcessInfo() -> UITestConfig? {
+        let env = ProcessInfo.processInfo.environment
+        guard truthy(env["SP_UI_TEST_MODE"]) else { return nil }
+        return UITestConfig(
+            seedAuthenticated: truthy(env["SP_UI_TEST_SEED_AUTH"]),
+            resetStore: truthy(env["SP_UI_TEST_RESET_STORE"]),
+            forceLaunchOffline: truthy(env["SP_UI_TEST_FORCE_LAUNCH_OFFLINE"]),
+            forceTokenExpired: truthy(env["SP_UI_TEST_FORCE_TOKEN_EXPIRED"]),
+            forceSessionsFailure: truthy(env["SP_UI_TEST_FORCE_SESSIONS_FAILURE"]),
+            forceUsernameConflict: truthy(env["SP_UI_TEST_FORCE_USERNAME_CONFLICT"]),
+            snapshotSeed: truthy(env["SP_UI_TEST_SNAPSHOT_SEED"])
+        )
+    }
+
+    private static func truthy(_ value: String?) -> Bool {
+        guard let value else { return false }
+        return ["1", "true", "yes", "on"].contains(value.lowercased())
+    }
+}
+
+// MARK: - Persisted store
+
+private struct UITestStore: Codable, Sendable {
+    var user: UserDTO
+    var loginEmail: String
+    var loginPassword: String
+    var isAuthenticated: Bool
+    var sessions: [SessionDTO]
+    var thoughts: [ThoughtDTO]
+    var nextSessionOrdinal: Int
+    var nextThoughtOrdinal: Int
+
+    static func makeDefault(seedAuthenticated: Bool) -> UITestStore {
+        let fixtureUser = UserDTO(
+            id: "ui-user-1",
+            email: "ios.fixture@stillpoint.test",
+            username: "ios_fixture",
+            isPublic: false,
+            currentDay: 1
+        )
+        return UITestStore(
+            user: fixtureUser,
+            loginEmail: fixtureUser.email,
+            loginPassword: "stillpoint-pass",
+            isAuthenticated: seedAuthenticated,
+            sessions: [],
+            thoughts: [],
+            nextSessionOrdinal: 1,
+            nextThoughtOrdinal: 1
+        )
+    }
+
+    /// Rich canned history, journal rows, and board-relevant profile for Fastlane screenshots.
+    static func makeSnapshot(seedAuthenticated: Bool) -> UITestStore {
+        let fixtureUser = UserDTO(
+            id: "snapshot-user-1",
+            email: "snapshot@stillpoint.test",
+            username: "still_snapshot",
+            isPublic: true,
+            currentDay: 9,
+            aphorismsEnabled: true
+        )
+
+        let sessions: [SessionDTO] = [
+            SessionDTO(
+                id: "snap-sess-1",
+                dayNumber: 4,
+                sessionType: .standard,
+                duration: 120,
+                bonusSeconds: 60,
+                completed: true,
+                actualTime: 125,
+                clearPercent: 74,
+                thoughtCount: 2,
+                mindStateLog: [],
+                sessionDate: "2026-01-05",
+                createdAt: "2026-01-05T08:30:00Z",
+                buddySessionId: nil
+            ),
+            SessionDTO(
+                id: "snap-sess-2",
+                dayNumber: 4,
+                sessionType: .standard,
+                duration: 120,
+                bonusSeconds: nil,
+                completed: true,
+                actualTime: 118,
+                clearPercent: 81,
+                thoughtCount: 1,
+                mindStateLog: [],
+                sessionDate: "2026-01-05",
+                createdAt: "2026-01-05T19:15:00Z",
+                buddySessionId: nil
+            ),
+            SessionDTO(
+                id: "snap-sess-3",
+                dayNumber: 5,
+                sessionType: .standard,
+                duration: 130,
+                bonusSeconds: 300,
+                completed: true,
+                actualTime: 400,
+                clearPercent: 69,
+                thoughtCount: 4,
+                mindStateLog: [],
+                sessionDate: "2026-01-06",
+                createdAt: "2026-01-06T07:00:00Z",
+                buddySessionId: nil
+            ),
+            SessionDTO(
+                id: "snap-sess-4",
+                dayNumber: 6,
+                sessionType: .standard,
+                duration: 140,
+                bonusSeconds: nil,
+                completed: true,
+                actualTime: 140,
+                clearPercent: 88,
+                thoughtCount: 0,
+                mindStateLog: [],
+                sessionDate: "2026-01-07",
+                createdAt: "2026-01-07T12:20:00Z",
+                buddySessionId: nil
+            ),
+            SessionDTO(
+                id: "snap-sess-5",
+                dayNumber: 7,
+                sessionType: .standard,
+                duration: 150,
+                bonusSeconds: nil,
+                completed: true,
+                actualTime: 150,
+                clearPercent: 72,
+                thoughtCount: 3,
+                mindStateLog: [],
+                sessionDate: "2026-01-08",
+                createdAt: "2026-01-08T06:45:00Z",
+                buddySessionId: nil
+            ),
+            SessionDTO(
+                id: "snap-sess-6",
+                dayNumber: 8,
+                sessionType: .standard,
+                duration: 160,
+                bonusSeconds: 120,
+                completed: true,
+                actualTime: 265,
+                clearPercent: 79,
+                thoughtCount: 2,
+                mindStateLog: [],
+                sessionDate: "2026-01-09",
+                createdAt: "2026-01-09T21:05:00Z",
+                buddySessionId: nil
+            ),
+            SessionDTO(
+                id: "snap-quick-1",
+                dayNumber: 8,
+                sessionType: .quick,
+                duration: StillPoint.quickDuration,
+                bonusSeconds: nil,
+                completed: true,
+                actualTime: StillPoint.quickDuration,
+                clearPercent: 62,
+                thoughtCount: 1,
+                mindStateLog: [],
+                sessionDate: "2026-01-09",
+                createdAt: "2026-01-09T08:10:00Z",
+                buddySessionId: nil
+            ),
+        ]
+
+        let thoughts: [ThoughtDTO] = [
+            ThoughtDTO(id: "snap-th-1", sessionId: "snap-sess-1", dayNumber: 4, timeInSession: 42, text: "Planning the week instead of watching the timer."),
+            ThoughtDTO(id: "snap-th-2", sessionId: "snap-sess-1", dayNumber: 4, timeInSession: 96, text: "Sound of traffic — came back to the breath."),
+            ThoughtDTO(id: "snap-th-3", sessionId: "snap-sess-3", dayNumber: 5, timeInSession: 55, text: "Should I adjust tomorrow's sit length?"),
+            ThoughtDTO(id: "snap-th-4", sessionId: "snap-sess-3", dayNumber: 5, timeInSession: 200, text: "Lost thread for a moment; noticed and returned."),
+            ThoughtDTO(id: "snap-th-5", sessionId: "snap-sess-5", dayNumber: 7, timeInSession: 22, text: "Flash of an old conversation."),
+            ThoughtDTO(id: "snap-th-6", sessionId: "snap-sess-6", dayNumber: 8, timeInSession: 140, text: "Room felt quieter toward the end."),
+            ThoughtDTO(id: "snap-th-7", sessionId: "snap-quick-1", dayNumber: 8, timeInSession: 12, text: "Quick reset between meetings."),
+        ]
+
+        return UITestStore(
+            user: fixtureUser,
+            loginEmail: fixtureUser.email,
+            loginPassword: "snapshot-pass",
+            isAuthenticated: seedAuthenticated,
+            sessions: sessions,
+            thoughts: thoughts,
+            nextSessionOrdinal: 100,
+            nextThoughtOrdinal: 100
+        )
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #416

## What & why

`APIClient` had ~317 lines of UI-test infrastructure interleaved with its real networking code: the `UITestConfig`/`UITestStore` types, `makeDefault`/`makeSnapshot` fixtures, 14 `uiTest*` request handlers, and 4 backing stored properties. This PR pulls all of it into a dedicated `UITestAPIStore` actor so `APIClient` reads as a clean network client with a single, obvious test seam.

## Changes

- **New `UITestAPIStore` actor** (`UITestAPIStore.swift`) owning the in-memory + `UserDefaults`-persisted fake backend, the launch `UITestConfig`, the notification-preferences fixture, and all request handlers. Built via `UITestAPIStore.fromProcessInfo()` using the same `SP_UI_TEST_*` env-var activation, and emits the identical `[E2E-DIAG]` diagnostic lines.
- **`APIClient` keeps one seam**: a `private let uiTestAPIStore: UITestAPIStore?`. Every request that had UI-test behavior now does `if let uiTestAPIStore { return … await uiTestAPIStore.<method>(…) }` before falling through to the network path. Because presence of the store *is* the UI-test signal, the handlers no longer need optional "continue" return values.
- **`clearLocalSessionArtifacts()` stays owned by `APIClient`** (it clears the keychain token, cookies, and URL credentials tied to the client's `URLSession`). Rather than injecting a callback into the store:
  - `logout()` / `deleteAccount()` on the store return a `Bool` flag telling the client to clear its session artifacts.
  - the store exposes `nonisolated let resetStore` so the client can clear those artifacts during `init` on a reset launch.
- Net: `APIClient.swift` shrinks by ~625 lines; behavior is unchanged.

## Test plan

⚠️ `swift test` for `StillPointShared` runs on **macOS** in CI (the package imports `os`, `AVFoundation`/`UIKit`, `SwiftUI`, `Security`, and `SwiftData`, and uses `URLSession` from `Foundation` — all Darwin-only). It cannot run on the Linux cloud-agent VM.

To verify the refactor's Swift correctness locally I installed Swift 6.1.2 (Linux) and ran a strict type-check of the two changed files plus their Foundation-only dependencies (`DTOs`, `Constants`, `UsernameValidation`, `HistoryJourney`, `MindStateEntry`, `SyncStatus`), with lightweight stubs standing in for the Apple-only collaborators (`AuthTokenStore`/Security, `AudioEngine`/AVFoundation, `os.Logger`):

- ✅ `swiftc -typecheck -swift-version 5 *.swift` → clean
- ✅ `swiftc -typecheck -swift-version 5 -warnings-as-errors *.swift` → clean (confirms no stray `try`/`await` misuse from the delegation rewrite)

This validates the risky parts of the change — actor isolation, `async`/`await` delegation signatures, and DTO usage. The full macOS `swift test` (required check) will run on this PR.

Also confirmed no other files reference the moved symbols: the app-target `uiTest*` matches are unrelated local fields (session-timer multiplier, app-blocking flags), not `APIClient` internals.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53930c4a-3f25-4e61-82ab-f074b5699d6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53930c4a-3f25-4e61-82ab-f074b5699d6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

