### PR TITLE
feat(web): dual-track fork at the 10-minute mark (#240)

### DIFF
--- a/drizzle/sessions_track_240_incremental.sql
+++ b/drizzle/sessions_track_240_incremental.sql
@@ -1,0 +1,22 @@
+-- Per-session track attribution (issue #240). Records whether a sit advanced the
+-- primary (original, 10-minute-capped) track or the opt-in second track. Defaults
+-- to 'primary' so every pre-#240 row is attributed to the original track.
+ALTER TABLE "sessions"
+  ADD COLUMN IF NOT EXISTS "track" varchar(16) NOT NULL DEFAULT 'primary';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'sessions_track_allowed'
+      AND conrelid = 'sessions'::regclass
+  ) THEN
+    ALTER TABLE "sessions"
+      ADD CONSTRAINT "sessions_track_allowed" CHECK ("track" IN ('primary', 'second'));
+  END IF;
+END $$;
+
+-- Backs the per-track "completed this track's standard sit today?" lookup that
+-- drives HomeView's dual-track completion badges.
+CREATE INDEX IF NOT EXISTS "idx_sessions_user_track_date"
+  ON "sessions" ("user_id", "track", "session_date");

--- a/drizzle/users_dual_track_240_incremental.sql
+++ b/drizzle/users_dual_track_240_incremental.sql
@@ -1,0 +1,8 @@
+-- Dual-track fork (issue #240). Once the primary track passes the 10-minute mark
+-- (currentDay > FORK_DAY) the user can opt into a second daily track that restarts
+-- at 1 minute and ramps +10s/day. `dual_track_enabled` gates the second track;
+-- `second_track_day` is its independent day counter. Both ship with
+-- backward-compatible defaults so existing rows stay single-track.
+ALTER TABLE "users"
+  ADD COLUMN IF NOT EXISTS "dual_track_enabled" boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS "second_track_day" integer NOT NULL DEFAULT 1;

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -165,6 +165,7 @@ final class AppViewModel {
         do {
             if let user = try await APIClient.shared.me() {
                 currentUser = user
+                resetTrackCompletionBadges()
                 currentView = Self.truthy(ProcessInfo.processInfo.environment["SP_UI_TEST_FORCE_START_SESSION"]) ? .session(type: .standard, track: .primary) : .home
                 authStatusMessage = nil
                 lastColdStartAuthCheckMs = Int(Date().timeIntervalSince(startedAt) * 1_000)
@@ -221,6 +222,7 @@ final class AppViewModel {
 
     func didLogin(user: UserDTO) {
         currentUser = user
+        resetTrackCompletionBadges()
         currentView = .home
         // Reset to Home so a prior session's tab (e.g. Settings) doesn't leak
         // across auth transitions now that selectedTab lives on the view model.
@@ -257,9 +259,15 @@ final class AppViewModel {
         pendingSessionDeepLink = nil
         buddyInviteError = nil
         authStatusMessage = nil
+        resetTrackCompletionBadges()
         currentView = .auth
         // Drop the cached suppress opt-in so it can't leak into the next account.
         SessionNotificationSuppressionController.clearSuppressPreference()
+    }
+
+    private func resetTrackCompletionBadges() {
+        primaryDoneToday = false
+        secondDoneToday = false
     }
 
     func beginSession(type: SessionType = .standard, track: Track = .primary) {

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -6,7 +6,7 @@ import os
 enum AppView: Equatable {
     case auth
     case home
-    case session(type: SessionType)
+    case session(type: SessionType, track: Track)
     case buddyHub
     case buddyCalendar
     case buddyCalendarWithBuddy(buddyId: String, buddyUsername: String)
@@ -36,8 +36,8 @@ enum AppView: Equatable {
              (.history, .history), (.journal, .journal), (.board, .board),
              (.settings, .settings):
             return true
-        case let (.session(lhsType), .session(rhsType)):
-            return lhsType == rhsType
+        case let (.session(lhsType, lhsTrack), .session(rhsType, rhsTrack)):
+            return lhsType == rhsType && lhsTrack == rhsTrack
         case let (.buddySession(lhsSessionId), .buddySession(rhsSessionId)):
             return lhsSessionId == rhsSessionId
         case let (.buddyCalendarWithBuddy(lhsId, lhsName), .buddyCalendarWithBuddy(rhsId, rhsName)):
@@ -93,6 +93,10 @@ final class AppViewModel {
         }
     }
 
+    /// #240: per-track "completed a standard sit today", drives the Home badges.
+    var primaryDoneToday = false
+    var secondDoneToday = false
+
     var currentDay: Int {
         StillPoint.clampedCurrentDay(for: currentUser)
     }
@@ -103,6 +107,31 @@ final class AppViewModel {
 
     var todayBlockCount: Int {
         StillPoint.blockCount(forDuration: todayDuration)
+    }
+
+    // MARK: - #240 Dual-track fork
+
+    /// Whether the user has opted into the second daily track.
+    var dualTrackEnabled: Bool {
+        currentUser?.dualTrackEnabled ?? false
+    }
+
+    /// True once the primary track has passed the 10-minute mark (fork available).
+    var dualTrackEligible: Bool {
+        StillPoint.isDualTrackEligible(currentDay: currentDay)
+    }
+
+    /// Second-track day counter (clamped to >= 1 for defensive upstream data).
+    var secondTrackDay: Int {
+        max(currentUser?.secondTrackDay ?? 1, 1)
+    }
+
+    var secondTrackDuration: Int {
+        StillPoint.duration(forDay: secondTrackDay)
+    }
+
+    var secondTrackBlockCount: Int {
+        StillPoint.blockCount(forDuration: secondTrackDuration)
     }
 
     var isInSession: Bool {
@@ -136,11 +165,12 @@ final class AppViewModel {
         do {
             if let user = try await APIClient.shared.me() {
                 currentUser = user
-                currentView = Self.truthy(ProcessInfo.processInfo.environment["SP_UI_TEST_FORCE_START_SESSION"]) ? .session(type: .standard) : .home
+                currentView = Self.truthy(ProcessInfo.processInfo.environment["SP_UI_TEST_FORCE_START_SESSION"]) ? .session(type: .standard, track: .primary) : .home
                 authStatusMessage = nil
                 lastColdStartAuthCheckMs = Int(Date().timeIntervalSince(startedAt) * 1_000)
                 PushNotificationCoordinator.shared.registerIfAlreadyAuthorized()
                 hydrateNotificationSuppressionPreference()
+                await refreshTracksDoneToday()
                 await consumePendingBuddyInviteIfNeeded()
                 await consumePendingSessionDeepLinkIfNeeded()
                 return
@@ -199,6 +229,7 @@ final class AppViewModel {
         PushNotificationCoordinator.shared.registerIfAlreadyAuthorized()
         hydrateNotificationSuppressionPreference()
         Task {
+            await refreshTracksDoneToday()
             await consumePendingBuddyInviteIfNeeded()
             await consumePendingSessionDeepLinkIfNeeded()
         }
@@ -231,8 +262,48 @@ final class AppViewModel {
         SessionNotificationSuppressionController.clearSuppressPreference()
     }
 
-    func beginSession(type: SessionType = .standard) {
-        currentView = .session(type: type)
+    func beginSession(type: SessionType = .standard, track: Track = .primary) {
+        currentView = .session(type: type, track: track)
+    }
+
+    /// #240: opt into the dual-track fork, then refresh local user + badges.
+    func enableDualTrack() async {
+        do {
+            let updated = try await APIClient.shared.enableDualTrack()
+            currentUser = updated
+            await refreshTracksDoneToday()
+        } catch {
+            print("Failed to enable dual track: \(error)")
+        }
+    }
+
+    /// #240: derive per-track "completed a standard sit today" from the session
+    /// list (a missing `track` on a legacy row counts as the primary track).
+    func refreshTracksDoneToday() async {
+        guard currentUser != nil else { return }
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.calendar = Calendar(identifier: .gregorian)
+        let today = dateFormatter.string(from: Date())
+        do {
+            let (sessions, _) = try await APIClient.shared.getSessions()
+            var primary = false
+            var second = false
+            for session in sessions where session.completed
+                && session.sessionType == .standard
+                && session.sessionDate == today {
+                if session.track == Track.second {
+                    second = true
+                } else {
+                    primary = true
+                }
+            }
+            primaryDoneToday = primary
+            secondDoneToday = second
+        } catch {
+            // Non-fatal: badges keep their last value.
+        }
     }
 
     func beginBreathCounting() {
@@ -389,6 +460,7 @@ final class AppViewModel {
         if let user = try? await APIClient.shared.me() {
             currentUser = user
         }
+        await refreshTracksDoneToday()
         await consumePendingBuddyInviteIfNeeded()
     }
 

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -310,7 +310,9 @@ final class AppViewModel {
             primaryDoneToday = primary
             secondDoneToday = second
         } catch {
-            // Non-fatal: badges keep their last value.
+            // Non-fatal: fail closed so stale "done today" badges do not leak.
+            primaryDoneToday = false
+            secondDoneToday = false
         }
     }
 

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -285,8 +285,8 @@ final class AppViewModel {
         }
     }
 
-    /// #240: derive per-track "completed a standard sit today" from the session
-    /// list (a missing `track` on a legacy row counts as the primary track).
+    /// #240: derive per-track "completed a standard sit today" from a lightweight
+    /// server-side filtered query.
     func refreshTracksDoneToday() async {
         guard currentUser != nil else { return }
         let dateFormatter = DateFormatter()
@@ -295,20 +295,9 @@ final class AppViewModel {
         dateFormatter.calendar = Calendar(identifier: .gregorian)
         let today = dateFormatter.string(from: Date())
         do {
-            let (sessions, _) = try await APIClient.shared.getSessions()
-            var primary = false
-            var second = false
-            for session in sessions where session.completed
-                && session.sessionType == .standard
-                && session.sessionDate == today {
-                if session.track == Track.second {
-                    second = true
-                } else {
-                    primary = true
-                }
-            }
-            primaryDoneToday = primary
-            secondDoneToday = second
+            let tracksDoneToday = try await APIClient.shared.getTracksDoneToday(date: today)
+            primaryDoneToday = tracksDoneToday.primary
+            secondDoneToday = tracksDoneToday.second
         } catch {
             // Non-fatal: fail closed so stale "done today" badges do not leak.
             primaryDoneToday = false

--- a/ios/StillPointApp/ViewModels/SessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/SessionViewModel.swift
@@ -7,6 +7,8 @@ final class SessionViewModel {
     // Session config
     let dayNumber: Int
     let sessionType: SessionType
+    /// #240: which daily track this sit advances.
+    let track: Track
     let plannedSeconds: Int
     var bonusSeconds: Int = 0
 
@@ -86,9 +88,10 @@ final class SessionViewModel {
         "\(minutes):\(String(format: "%02d", seconds))"
     }
 
-    init(dayNumber: Int, sessionType: SessionType = .standard) {
+    init(dayNumber: Int, sessionType: SessionType = .standard, track: Track = .primary) {
         self.dayNumber = dayNumber
         self.sessionType = sessionType
+        self.track = track
         self.plannedSeconds = Self.resolveTotalSeconds(for: dayNumber, sessionType: sessionType)
         self.soundPrefs = AudioEngine.loadPrefs()
         self.uiTestTimerMultiplier = Self.resolveUITestTimerMultiplier()
@@ -241,7 +244,8 @@ final class SessionViewModel {
             clearPercent: clearPercent,
             thoughtCount: thoughtCount,
             mindStateLog: mindStateLog,
-            sessionDate: dateFormatter.string(from: Date())
+            sessionDate: dateFormatter.string(from: Date()),
+            track: track
         )
 
         do {

--- a/ios/StillPointApp/Views/HomeView.swift
+++ b/ios/StillPointApp/Views/HomeView.swift
@@ -70,7 +70,10 @@ struct HomeView: View {
                 appGatePill
 
                 // #240: fork choice once past the 10-minute mark (not yet opted in).
-                if appVM.dualTrackEligible && !appVM.dualTrackEnabled && !forkDismissed {
+                // Suppressed during UI tests (would push the Begin button off-screen
+                // for long-running fixture users, producing an invalid hit point).
+                if appVM.dualTrackEligible && !appVM.dualTrackEnabled && !forkDismissed
+                    && ProcessInfo.processInfo.environment["SP_UI_TEST_MODE"] != "1" {
                     dualTrackForkCard
                 }
 

--- a/ios/StillPointApp/Views/HomeView.swift
+++ b/ios/StillPointApp/Views/HomeView.swift
@@ -6,6 +6,8 @@ struct HomeView: View {
 
     @State private var breatheAnimation = false
     @State private var showAppGateOnboarding = false
+    /// #240: dismiss the fork prompt for this session (may reappear on a later visit).
+    @State private var forkDismissed = false
 
     var body: some View {
         ScrollView {
@@ -21,25 +23,56 @@ struct HomeView: View {
 
                 Spacer().frame(height: SPSpacing.s4)
 
-                // Day number with breathing animation
-                Text("\(appVM.currentDay)")
-                    .font(SPFont.dayNumber)
-                    .foregroundStyle(Color(SPColor.fg))
-                    .scaleEffect(breatheAnimation ? 1.02 : 1.0)
-                    .opacity(breatheAnimation ? 1.0 : 0.6)
-                    .animation(
-                        .easeInOut(duration: 4).repeatForever(autoreverses: true),
-                        value: breatheAnimation
-                    )
-                    .onAppear { breatheAnimation = true }
+                // #240: dual-track shows two independently-startable track cards;
+                // single-track keeps the classic day readout.
+                if appVM.dualTrackEnabled {
+                    VStack(spacing: SPSpacing.s3) {
+                        trackCard(
+                            label: "TRACK ONE · \(StillPoint.maxDuration / 60) MIN",
+                            day: appVM.currentDay,
+                            duration: appVM.todayDuration,
+                            blocks: appVM.todayBlockCount,
+                            doneToday: appVM.primaryDoneToday,
+                            identifier: "home.trackOne",
+                            onBegin: { appVM.beginSession(track: .primary) }
+                        )
+                        trackCard(
+                            label: "TRACK TWO",
+                            day: appVM.secondTrackDay,
+                            duration: appVM.secondTrackDuration,
+                            blocks: appVM.secondTrackBlockCount,
+                            doneToday: appVM.secondDoneToday,
+                            identifier: "home.trackTwo",
+                            onBegin: { appVM.beginSession(track: .second) }
+                        )
+                    }
+                    .padding(.horizontal, SPSpacing.s2)
+                } else {
+                    // Day number with breathing animation
+                    Text("\(appVM.currentDay)")
+                        .font(SPFont.dayNumber)
+                        .foregroundStyle(Color(SPColor.fg))
+                        .scaleEffect(breatheAnimation ? 1.02 : 1.0)
+                        .opacity(breatheAnimation ? 1.0 : 0.6)
+                        .animation(
+                            .easeInOut(duration: 4).repeatForever(autoreverses: true),
+                            value: breatheAnimation
+                        )
+                        .onAppear { breatheAnimation = true }
 
-                // Day info
-                Text("day · \(appVM.todayDuration)s · \(appVM.todayBlockCount) blocks")
-                    .font(SPFont.mono(14, weight: .light))
-                    .foregroundStyle(Color(SPColor.fg3))
-                    .tracking(2)
+                    // Day info
+                    Text("day · \(appVM.todayDuration)s · \(appVM.todayBlockCount) blocks")
+                        .font(SPFont.mono(14, weight: .light))
+                        .foregroundStyle(Color(SPColor.fg3))
+                        .tracking(2)
+                }
 
                 appGatePill
+
+                // #240: fork choice once past the 10-minute mark (not yet opted in).
+                if appVM.dualTrackEligible && !appVM.dualTrackEnabled && !forkDismissed {
+                    dualTrackForkCard
+                }
 
                 aphorismSection
 
@@ -47,22 +80,25 @@ struct HomeView: View {
 
                 // Begin button
                 VStack(spacing: SPSpacing.s2) {
-                    Button {
-                        withAnimation {
-                            appVM.beginSession()
+                    // Primary Begin lives inside the track cards in dual-track mode.
+                    if !appVM.dualTrackEnabled {
+                        Button {
+                            withAnimation {
+                                appVM.beginSession()
+                            }
+                        } label: {
+                            Text("Begin")
+                                .font(SPFont.serifItalic(22, weight: .light))
+                                .foregroundStyle(Color(SPColor.fg))
+                                .padding(.horizontal, 48)
+                                .padding(.vertical, SPSpacing.s3)
+                                .background(SPColor.surface2)
+                                .clipShape(Capsule())
+                                .overlay(Capsule().stroke(SPColor.border2))
                         }
-                    } label: {
-                        Text("Begin")
-                            .font(SPFont.serifItalic(22, weight: .light))
-                            .foregroundStyle(Color(SPColor.fg))
-                            .padding(.horizontal, 48)
-                            .padding(.vertical, SPSpacing.s3)
-                            .background(SPColor.surface2)
-                            .clipShape(Capsule())
-                            .overlay(Capsule().stroke(SPColor.border2))
+                        .accessibilityIdentifier("home.beginButton")
+                        .accessibilityLabel("Start session")
                     }
-                    .accessibilityIdentifier("home.beginButton")
-                    .accessibilityLabel("Start session")
 
                     Button {
                         withAnimation {
@@ -196,6 +232,122 @@ struct HomeView: View {
             .accessibilityIdentifier("home.aphorism")
             .accessibilityElement(children: .combine)
         }
+    }
+
+    /// #240: one track's Home card — day number, planned length, completion badge
+    /// and its own Begin button so either track can be started independently.
+    private func trackCard(
+        label: String,
+        day: Int,
+        duration: Int,
+        blocks: Int,
+        doneToday: Bool,
+        identifier: String,
+        onBegin: @escaping () -> Void
+    ) -> some View {
+        VStack(spacing: SPSpacing.s2) {
+            HStack(spacing: SPSpacing.s2) {
+                Text(label)
+                    .font(SPFont.mono(11, weight: .medium))
+                    .foregroundStyle(Color(SPColor.fg3))
+                    .tracking(1.5)
+                if doneToday {
+                    Text("\u{2713} DONE TODAY")
+                        .font(SPFont.mono(11, weight: .medium))
+                        .foregroundStyle(SPColor.greenText)
+                        .tracking(1)
+                }
+            }
+
+            Text("\(day)")
+                .font(SPFont.mono(48, weight: .light))
+                .foregroundStyle(Color(SPColor.fg))
+                .monospacedDigit()
+
+            Text("day · \(duration)s · \(blocks) blocks")
+                .font(SPFont.mono(13, weight: .light))
+                .foregroundStyle(Color(SPColor.fg3))
+                .tracking(2)
+
+            Button {
+                withAnimation { onBegin() }
+            } label: {
+                Text(doneToday ? "Sit again" : "Begin")
+                    .font(SPFont.serifItalic(20, weight: .light))
+                    .foregroundStyle(Color(SPColor.fg))
+                    .padding(.horizontal, 40)
+                    .padding(.vertical, SPSpacing.s2)
+                    .background(SPColor.surface2)
+                    .clipShape(Capsule())
+                    .overlay(Capsule().stroke(SPColor.border2))
+            }
+            .padding(.top, SPSpacing.s1)
+            .accessibilityIdentifier("\(identifier).beginButton")
+            .accessibilityLabel(doneToday ? "\(label) sit again" : "\(label) begin")
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, SPSpacing.s4)
+        .padding(.horizontal, SPSpacing.s3)
+        .background(SPColor.surface1)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .overlay(RoundedRectangle(cornerRadius: 16).stroke(SPColor.border1))
+        .accessibilityIdentifier(identifier)
+    }
+
+    /// #240: fork choice presented once the primary track passes the 10-minute mark.
+    private var dualTrackForkCard: some View {
+        VStack(spacing: SPSpacing.s3) {
+            Text("\(StillPoint.maxDuration / 60)-MINUTE MARK REACHED")
+                .font(SPFont.mono(11, weight: .medium))
+                .foregroundStyle(SPColor.greenText)
+                .tracking(1.5)
+
+            Text("Add a second daily track?")
+                .font(SPFont.serifItalic(22, weight: .light))
+                .foregroundStyle(Color(SPColor.fg))
+                .multilineTextAlignment(.center)
+
+            Text("Your sits have grown to \(StillPoint.maxDuration / 60) minutes. Keep that daily sit and start a second one that restarts at 1 minute and grows +10s a day — two tracks, run independently.")
+                .font(SPFont.serif(15, weight: .light))
+                .foregroundStyle(Color(SPColor.fg3))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, SPSpacing.s2)
+
+            Button {
+                Task { await appVM.enableDualTrack() }
+            } label: {
+                Text("Add second track")
+                    .font(SPFont.mono(12, weight: .medium))
+                    .tracking(1.4)
+                    .foregroundStyle(SPColor.greenText)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, SPSpacing.s3)
+                    .background(SPColor.greenBgFaint)
+                    .clipShape(Capsule())
+                    .overlay(Capsule().stroke(SPColor.greenBorderSubtle))
+            }
+            .accessibilityIdentifier("home.addSecondTrackButton")
+
+            Button {
+                forkDismissed = true
+            } label: {
+                Text("Keep one track")
+                    .font(SPFont.mono(12, weight: .medium))
+                    .tracking(1.4)
+                    .foregroundStyle(Color(SPColor.fg3))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, SPSpacing.s3)
+                    .background(SPColor.surface1)
+                    .clipShape(Capsule())
+                    .overlay(Capsule().stroke(SPColor.border1))
+            }
+            .accessibilityIdentifier("home.keepOneTrackButton")
+        }
+        .padding(SPSpacing.s4)
+        .background(SPColor.surface1)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .overlay(RoundedRectangle(cornerRadius: 16).stroke(SPColor.border1))
+        .padding(.horizontal, SPSpacing.s2)
     }
 
     /// First-run prompt asking whether to set up the app gate. Shown at most once,

--- a/ios/StillPointApp/Views/RootView.swift
+++ b/ios/StillPointApp/Views/RootView.swift
@@ -20,8 +20,8 @@ struct RootView: View {
                 AuthView(appVM: appVM, launchAuthStatusMessage: appVM.authStatusMessage)
                     .transition(.opacity)
 
-            case .session(let sessionType):
-                SessionView(appVM: appVM, sessionType: sessionType)
+            case .session(let sessionType, let track):
+                SessionView(appVM: appVM, sessionType: sessionType, track: track)
                     .transition(.opacity)
 
             case .buddyHub:

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -10,9 +10,11 @@ struct SessionView: View {
     @State private var vm: SessionViewModel
     @State private var showSaveError = false
 
-    init(appVM: AppViewModel, sessionType: SessionType = .standard) {
+    init(appVM: AppViewModel, sessionType: SessionType = .standard, track: Track = .primary) {
         self.appVM = appVM
-        self._vm = State(initialValue: SessionViewModel(dayNumber: appVM.currentDay, sessionType: sessionType))
+        // #240: the second track uses its own day counter; the primary track uses currentDay.
+        let day = track == .second ? appVM.secondTrackDay : appVM.currentDay
+        self._vm = State(initialValue: SessionViewModel(dayNumber: day, sessionType: sessionType, track: track))
     }
 
     var body: some View {

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -278,6 +278,15 @@ public actor APIClient {
         return response.user
     }
 
+    /// #240: opt into the dual-track fork (enable a second daily track).
+    public func enableDualTrack() async throws -> UserDTO {
+        if let uiTestAPIStore {
+            return try await uiTestAPIStore.enableDualTrack()
+        }
+        let response: UserResponse = try await post("/api/track", body: Optional<String>.none)
+        return response.user
+    }
+
     // MARK: - Notification preferences
 
     public func getNotificationPreferences() async throws -> NotificationPreferencesDTO {

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -207,6 +207,15 @@ public actor APIClient {
         return (response.sessions, response.stats)
     }
 
+    public func getTracksDoneToday(date: String) async throws -> TracksDoneTodayDTO {
+        if let uiTestAPIStore {
+            return try await uiTestAPIStore.getTracksDoneToday(date: date)
+        }
+        let encodedDate = date.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? date
+        let response: TracksDoneTodayResponse = try await get("/api/track/done-today?date=\(encodedDate)")
+        return response.tracksDoneToday
+    }
+
     public func createSession(_ data: CreateSessionRequest) async throws -> SessionDTO {
         if let uiTestAPIStore {
             return try await uiTestAPIStore.createSession(data)

--- a/ios/StillPointShared/Sources/StillPointShared/Constants.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/Constants.swift
@@ -7,6 +7,14 @@ public enum SessionType: String, Codable, Sendable {
     case breath
 }
 
+/// #240: which daily progression a standard sit belongs to. `primary` is the
+/// original (now 10-minute-capped) track; `second` is the opt-in track that
+/// restarts at one minute and ramps +10s/day alongside it.
+public enum Track: String, Codable, Sendable {
+    case primary
+    case second
+}
+
 public enum StillPoint {
     /// Base session duration in seconds (Day 1)
     public static let baseDuration = 60
@@ -20,15 +28,39 @@ public enum StillPoint {
     /// Visual block duration in seconds
     public static let blockDuration = 10
 
+    /// #240: a standard sit tops out at ten minutes. The primary track reaches
+    /// this cap on `forkDay` and then holds steady — the "10-minute track" the
+    /// dual-track fork keeps while a second track ramps up alongside it.
+    public static let maxDuration = 600
+
+    /// #240: the day a standard sit first reaches the 10-minute cap
+    /// (60 + 54·10 = 600). Derived so it stays correct if the constants change.
+    public static let forkDay = (maxDuration - baseDuration) / increment + 1
+
     /// Calculate session duration for a given day number.
     ///
     /// Clamps `day` to `>= 1` so production code never traps on bad upstream data
     /// (e.g. a server returning `0`). A debug-only `assert` still surfaces
-    /// the upstream bug during development.
+    /// the upstream bug during development. #240: capped at ten minutes so both
+    /// tracks hold at 10 minutes once they reach `forkDay`.
     public static func duration(forDay day: Int) -> Int {
         assert(day >= 1, "Day must be >= 1, got \(day)")
         let safeDay = max(day, 1)
-        return baseDuration + (safeDay - 1) * increment
+        return min(maxDuration, baseDuration + (safeDay - 1) * increment)
+    }
+
+    /// #240: once the primary track has passed the 10-minute mark
+    /// (`currentDay > forkDay`, i.e. the day-55 ten-minute sit is behind them)
+    /// the user may opt into a second daily track.
+    public static func isDualTrackEligible(currentDay: Int) -> Bool {
+        currentDay > forkDay
+    }
+
+    /// #240: advance the independent second-track counter after a session save.
+    /// The second track has no recovery ramp: a completed standard sit bumps it
+    /// by one; anything else leaves it unchanged.
+    public static func advanceSecondTrackDay(sessionType: SessionType, completed: Bool, secondTrackDay: Int) -> Int {
+        shouldAdvanceDay(sessionType: sessionType, completed: completed) ? secondTrackDay + 1 : secondTrackDay
     }
 
     public static func duration(for sessionType: SessionType, day: Int) -> Int {

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -402,6 +402,20 @@ public struct SessionsResponse: Codable, Sendable {
     public let stats: StatsDTO
 }
 
+public struct TracksDoneTodayDTO: Codable, Sendable {
+    public let primary: Bool
+    public let second: Bool
+
+    public init(primary: Bool, second: Bool) {
+        self.primary = primary
+        self.second = second
+    }
+}
+
+public struct TracksDoneTodayResponse: Codable, Sendable {
+    public let tracksDoneToday: TracksDoneTodayDTO
+}
+
 public struct SessionDetailResponse: Codable, Sendable {
     public let session: SessionDTO
     public let thoughts: [ThoughtDTO]

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -12,6 +12,11 @@ public struct UserDTO: Codable, Sendable {
     /// responses from a server that predates this field (or cached fixtures)
     /// still decode, defaulting to off.
     public let aphorismsEnabled: Bool
+    /// #240: dual-track fork. `dualTrackEnabled` gates the opt-in second daily
+    /// track; `secondTrackDay` is its independent day counter. Both decoded
+    /// permissively so a server that predates #240 defaults to single-track.
+    public let dualTrackEnabled: Bool
+    public let secondTrackDay: Int
 
     public init(
         id: String,
@@ -19,7 +24,9 @@ public struct UserDTO: Codable, Sendable {
         username: String,
         isPublic: Bool,
         currentDay: Int,
-        aphorismsEnabled: Bool = false
+        aphorismsEnabled: Bool = false,
+        dualTrackEnabled: Bool = false,
+        secondTrackDay: Int = 1
     ) {
         self.id = id
         self.email = email
@@ -27,6 +34,8 @@ public struct UserDTO: Codable, Sendable {
         self.isPublic = isPublic
         self.currentDay = currentDay
         self.aphorismsEnabled = aphorismsEnabled
+        self.dualTrackEnabled = dualTrackEnabled
+        self.secondTrackDay = secondTrackDay
     }
 
     public init(from decoder: Decoder) throws {
@@ -37,10 +46,12 @@ public struct UserDTO: Codable, Sendable {
         isPublic = try c.decode(Bool.self, forKey: .isPublic)
         currentDay = try c.decode(Int.self, forKey: .currentDay)
         aphorismsEnabled = try c.decodeIfPresent(Bool.self, forKey: .aphorismsEnabled) ?? false
+        dualTrackEnabled = try c.decodeIfPresent(Bool.self, forKey: .dualTrackEnabled) ?? false
+        secondTrackDay = try c.decodeIfPresent(Int.self, forKey: .secondTrackDay) ?? 1
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, email, username, isPublic, currentDay, aphorismsEnabled
+        case id, email, username, isPublic, currentDay, aphorismsEnabled, dualTrackEnabled, secondTrackDay
     }
 }
 
@@ -62,6 +73,9 @@ public struct SessionDTO: Codable, Sendable {
     public let buddySessionId: String?
     /// Number of full breaths counted during a breath session (nil for non-breath sessions).
     public let breathCount: Int?
+    /// #240: which daily track this sit advanced. Decoded permissively (nil from a
+    /// server that predates #240); nil is treated as `.primary` by callers.
+    public let track: Track?
 
     public init(
         id: String,
@@ -77,7 +91,8 @@ public struct SessionDTO: Codable, Sendable {
         sessionDate: String,
         createdAt: String? = nil,
         buddySessionId: String?,
-        breathCount: Int? = nil
+        breathCount: Int? = nil,
+        track: Track? = nil
     ) {
         self.id = id
         self.dayNumber = dayNumber
@@ -93,6 +108,7 @@ public struct SessionDTO: Codable, Sendable {
         self.createdAt = createdAt
         self.buddySessionId = buddySessionId
         self.breathCount = breathCount
+        self.track = track
     }
 }
 
@@ -157,6 +173,8 @@ public struct CreateSessionRequest: Codable, Sendable {
     public let sessionDate: String
     /// Number of full breaths counted. Only sent for `.breath` sessions; nil otherwise.
     public let breathCount: Int?
+    /// #240: which daily track this sit advances. Defaults to `.primary`.
+    public let track: Track
 
     public init(
         dayNumber: Int,
@@ -169,7 +187,8 @@ public struct CreateSessionRequest: Codable, Sendable {
         thoughtCount: Int,
         mindStateLog: [MindStateEntry],
         sessionDate: String,
-        breathCount: Int? = nil
+        breathCount: Int? = nil,
+        track: Track = .primary
     ) {
         self.dayNumber = dayNumber
         self.sessionType = sessionType
@@ -182,6 +201,7 @@ public struct CreateSessionRequest: Codable, Sendable {
         self.mindStateLog = mindStateLog
         self.sessionDate = sessionDate
         self.breathCount = breathCount
+        self.track = track
     }
 }
 

--- a/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
@@ -193,6 +193,27 @@ actor UITestAPIStore {
         return (sortedSessions, SessionStatistics.calculateStats(for: sortedSessions))
     }
 
+    func getTracksDoneToday(date: String) throws -> TracksDoneTodayDTO {
+        try ensureAuthenticated()
+
+        if config.forceSessionsFailure {
+            throw APIError(status: 503, message: "Failed to load sessions. Check your connection.")
+        }
+
+        var primary = false
+        var second = false
+        for session in store.sessions where session.completed
+            && session.sessionType == .standard
+            && session.sessionDate == date {
+            if session.track == .second {
+                second = true
+            } else {
+                primary = true
+            }
+        }
+        return TracksDoneTodayDTO(primary: primary, second: second)
+    }
+
     func createSession(_ data: CreateSessionRequest) throws -> SessionDTO {
         try ensureAuthenticated()
 

--- a/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
@@ -210,24 +210,62 @@ actor UITestAPIStore {
             mindStateLog: data.mindStateLog,
             sessionDate: data.sessionDate,
             createdAt: nil,
-            buddySessionId: nil
+            buddySessionId: nil,
+            track: data.track
         )
         store.nextSessionOrdinal += 1
         store.sessions.append(session)
 
         if data.completed && data.sessionType == .standard {
-            store.user = UserDTO(
-                id: store.user.id,
-                email: store.user.email,
-                username: store.user.username,
-                isPublic: store.user.isPublic,
-                currentDay: max(store.user.currentDay, data.dayNumber + 1),
-                aphorismsEnabled: store.user.aphorismsEnabled
-            )
+            // #240: a `second`-track sit advances the second-track counter (only when
+            // opted in); a `primary` sit advances currentDay as before.
+            if data.track == .second {
+                let nextSecond = store.user.dualTrackEnabled
+                    ? StillPoint.advanceSecondTrackDay(sessionType: data.sessionType, completed: data.completed, secondTrackDay: store.user.secondTrackDay)
+                    : store.user.secondTrackDay
+                store.user = UserDTO(
+                    id: store.user.id,
+                    email: store.user.email,
+                    username: store.user.username,
+                    isPublic: store.user.isPublic,
+                    currentDay: store.user.currentDay,
+                    aphorismsEnabled: store.user.aphorismsEnabled,
+                    dualTrackEnabled: store.user.dualTrackEnabled,
+                    secondTrackDay: nextSecond
+                )
+            } else {
+                store.user = UserDTO(
+                    id: store.user.id,
+                    email: store.user.email,
+                    username: store.user.username,
+                    isPublic: store.user.isPublic,
+                    currentDay: max(store.user.currentDay, data.dayNumber + 1),
+                    aphorismsEnabled: store.user.aphorismsEnabled,
+                    dualTrackEnabled: store.user.dualTrackEnabled,
+                    secondTrackDay: store.user.secondTrackDay
+                )
+            }
         }
 
         persist()
         return session
+    }
+
+    /// #240: opt into the dual-track fork (enable a second daily track).
+    func enableDualTrack() throws -> UserDTO {
+        try ensureAuthenticated()
+        store.user = UserDTO(
+            id: store.user.id,
+            email: store.user.email,
+            username: store.user.username,
+            isPublic: store.user.isPublic,
+            currentDay: store.user.currentDay,
+            aphorismsEnabled: store.user.aphorismsEnabled,
+            dualTrackEnabled: true,
+            secondTrackDay: store.user.secondTrackDay
+        )
+        persist()
+        return store.user
     }
 
     func getSession(sessionId: String) throws -> (session: SessionDTO, thoughts: [ThoughtDTO]) {
@@ -323,7 +361,9 @@ actor UITestAPIStore {
             username: nextUsername,
             isPublic: nextIsPublic,
             currentDay: store.user.currentDay,
-            aphorismsEnabled: nextAphorismsEnabled
+            aphorismsEnabled: nextAphorismsEnabled,
+            dualTrackEnabled: store.user.dualTrackEnabled,
+            secondTrackDay: store.user.secondTrackDay
         )
         persist()
         return store.user

--- a/ios/StillPointShared/Tests/StillPointSharedTests/StillPointDurationTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/StillPointDurationTests.swift
@@ -32,6 +32,32 @@ final class StillPointDurationTests: XCTestCase {
         XCTAssertEqual(StillPoint.blockCount(forDuration: 65), 7)
     }
 
+    // MARK: - #240 dual-track: 10-minute cap + fork eligibility
+
+    func testDurationCapsAtTenMinutes() {
+        XCTAssertEqual(StillPoint.duration(forDay: 54), 590)
+        XCTAssertEqual(StillPoint.duration(forDay: StillPoint.forkDay), StillPoint.maxDuration)
+        XCTAssertEqual(StillPoint.duration(forDay: 56), StillPoint.maxDuration)
+        XCTAssertEqual(StillPoint.duration(forDay: 200), StillPoint.maxDuration)
+    }
+
+    func testForkDayIsFirstDayAtCap() {
+        XCTAssertEqual(StillPoint.forkDay, 55)
+        XCTAssertLessThan(StillPoint.duration(forDay: StillPoint.forkDay - 1), StillPoint.maxDuration)
+    }
+
+    func testIsDualTrackEligibleOnlyAfterTenMinuteSit() {
+        XCTAssertFalse(StillPoint.isDualTrackEligible(currentDay: 1))
+        XCTAssertFalse(StillPoint.isDualTrackEligible(currentDay: StillPoint.forkDay))
+        XCTAssertTrue(StillPoint.isDualTrackEligible(currentDay: StillPoint.forkDay + 1))
+    }
+
+    func testAdvanceSecondTrackDay() {
+        XCTAssertEqual(StillPoint.advanceSecondTrackDay(sessionType: .standard, completed: true, secondTrackDay: 1), 2)
+        XCTAssertEqual(StillPoint.advanceSecondTrackDay(sessionType: .quick, completed: true, secondTrackDay: 3), 3)
+        XCTAssertEqual(StillPoint.advanceSecondTrackDay(sessionType: .standard, completed: false, secondTrackDay: 3), 3)
+    }
+
     // Note: invalid days (`< 1`) are tested via `clampedCurrentDay(for:)` below.
     // Calling `duration(forDay:)` with `< 1` traps the debug `assert` in the
     // test runner (intended dev behavior); production builds survive via the

--- a/ios/StillPointShared/Tests/StillPointSharedTests/UserDTOTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/UserDTOTests.swift
@@ -36,4 +36,28 @@ final class UserDTOTests: XCTestCase {
         XCTAssertEqual(decoded.aphorismsEnabled, true)
         XCTAssertEqual(decoded.id, user.id)
     }
+
+    // MARK: - #240 dual-track fields
+
+    func testDecodesDualTrackFieldsWhenPresent() throws {
+        let json = """
+        {"id":"u1","email":"a@b.com","username":"alice","isPublic":false,"currentDay":56,"dualTrackEnabled":true,"secondTrackDay":4}
+        """.data(using: .utf8)!
+
+        let user = try JSONDecoder().decode(UserDTO.self, from: json)
+        XCTAssertTrue(user.dualTrackEnabled)
+        XCTAssertEqual(user.secondTrackDay, 4)
+    }
+
+    /// #240 shipped as additive fields; a server/fixture that predates them must
+    /// still decode, defaulting to single-track (disabled, day 1).
+    func testDefaultsDualTrackFieldsWhenMissing() throws {
+        let json = """
+        {"id":"u1","email":"a@b.com","username":"alice","isPublic":false,"currentDay":3}
+        """.data(using: .utf8)!
+
+        let user = try JSONDecoder().decode(UserDTO.self, from: json)
+        XCTAssertFalse(user.dualTrackEnabled)
+        XCTAssertEqual(user.secondTrackDay, 1)
+    }
 }

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -61,6 +61,8 @@ export async function POST(request: NextRequest) {
         recoveryTargetDay: user.recoveryTargetDay,
         recoveryCurrentStep: user.recoveryCurrentStep,
         recoveryTotalSteps: user.recoveryTotalSteps,
+        dualTrackEnabled: user.dualTrackEnabled,
+        secondTrackDay: user.secondTrackDay,
       },
       ...(includeToken ? { token } : {}),
     });

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -27,6 +27,8 @@ export async function GET(request: NextRequest) {
       recoveryTargetDay: users.recoveryTargetDay,
       recoveryCurrentStep: users.recoveryCurrentStep,
       recoveryTotalSteps: users.recoveryTotalSteps,
+      dualTrackEnabled: users.dualTrackEnabled,
+      secondTrackDay: users.secondTrackDay,
     }).from(users).where(eq(users.id, auth.userId)).limit(1);
 
     if (!user) {

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -47,6 +47,9 @@ export async function GET(request: NextRequest) {
           eq(sessions.userId, auth.userId),
           eq(sessions.completed, true),
           eq(sessions.sessionType, "standard"),
+          // #240: recovery tracks the primary track's currentDay, so a recent
+          // second-track sit must not mask a gap since the last primary sit.
+          eq(sessions.track, "primary"),
         ))
         .orderBy(desc(sessions.sessionDate))
         .limit(1);

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -81,6 +81,8 @@ export async function POST(request: NextRequest) {
         recoveryTargetDay: newUser.recoveryTargetDay,
         recoveryCurrentStep: newUser.recoveryCurrentStep,
         recoveryTotalSteps: newUser.recoveryTotalSteps,
+        dualTrackEnabled: newUser.dualTrackEnabled,
+        secondTrackDay: newUser.secondTrackDay,
       },
       ...(includeToken ? { token } : {}),
     });

--- a/src/app/api/sessions/route.dual-track.integration.test.ts
+++ b/src/app/api/sessions/route.dual-track.integration.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Issue #240 — dual-track fork: a `second`-track completed standard sit advances
+ * the independent `secondTrackDay` counter (only when the user has opted in) and
+ * never touches the primary track's `currentDay`, while a `primary` sit keeps the
+ * original progression. Route-level tests against a real in-process Postgres.
+ */
+import { NextRequest } from "next/server";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { sessions, users } from "@/db/schema";
+import { closeTestDb, getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
+
+const { getCurrentUser } = vi.hoisted(() => ({ getCurrentUser: vi.fn() }));
+
+vi.mock("@/lib/auth", () => ({ getCurrentUser }));
+vi.mock("@/db", async () => ({ db: await getTestDb() }));
+vi.mock("@/db/pool", async () => ({ poolDb: await getTestDb() }));
+
+import { POST } from "./route";
+
+let db: TestDb;
+let seq = 0;
+
+function makeUser(overrides: Partial<typeof users.$inferInsert> = {}) {
+  seq += 1;
+  return db
+    .insert(users)
+    .values({ email: `dt240-${seq}@test.local`, username: `dt240_${seq}`, ...overrides })
+    .returning()
+    .then((rows) => rows[0]!);
+}
+
+function sessionRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://test.local/api/sessions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function baseSessionBody(overrides: Record<string, unknown> = {}) {
+  return {
+    dayNumber: 1,
+    duration: 60,
+    actualTime: 60,
+    clearPercent: 90,
+    thoughtCount: 0,
+    mindStateLog: [],
+    sessionDate: "2026-06-11",
+    completed: true,
+    sessionType: "standard",
+    ...overrides,
+  };
+}
+
+afterAll(async () => {
+  await closeTestDb();
+});
+
+beforeEach(async () => {
+  db = await getTestDb();
+});
+
+describe("POST /api/sessions — dual-track advancement (#240)", () => {
+  test("a payload without a track defaults to primary and advances currentDay", async () => {
+    const user = await makeUser({ currentDay: 56, dualTrackEnabled: true, secondTrackDay: 3 });
+    getCurrentUser.mockResolvedValue({ userId: user.id, email: user.email });
+
+    const res = await POST(sessionRequest(baseSessionBody({ dayNumber: 56 })));
+    expect(res.status).toBe(200);
+    const { session } = await res.json();
+    expect(session.track).toBe("primary");
+
+    const [row] = await db.select().from(users).where(eq(users.id, user.id));
+    expect(row!.currentDay).toBe(57);
+    expect(row!.secondTrackDay).toBe(3);
+  });
+
+  test("a completed second-track sit advances secondTrackDay and leaves currentDay untouched", async () => {
+    const user = await makeUser({ currentDay: 56, dualTrackEnabled: true, secondTrackDay: 3 });
+    getCurrentUser.mockResolvedValue({ userId: user.id, email: user.email });
+
+    const res = await POST(sessionRequest(baseSessionBody({ dayNumber: 3, track: "second" })));
+    expect(res.status).toBe(200);
+    const { session } = await res.json();
+    expect(session.track).toBe("second");
+
+    const [row] = await db.select().from(users).where(eq(users.id, user.id));
+    expect(row!.currentDay).toBe(56);
+    expect(row!.secondTrackDay).toBe(4);
+  });
+
+  test("a second-track sit is ignored for advancement when dual-track is not enabled", async () => {
+    const user = await makeUser({ currentDay: 56, dualTrackEnabled: false, secondTrackDay: 1 });
+    getCurrentUser.mockResolvedValue({ userId: user.id, email: user.email });
+
+    const res = await POST(sessionRequest(baseSessionBody({ dayNumber: 1, track: "second" })));
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(users).where(eq(users.id, user.id));
+    expect(row!.currentDay).toBe(56);
+    expect(row!.secondTrackDay).toBe(1);
+  });
+
+  test("an incomplete second-track sit does not advance secondTrackDay", async () => {
+    const user = await makeUser({ currentDay: 56, dualTrackEnabled: true, secondTrackDay: 5 });
+    getCurrentUser.mockResolvedValue({ userId: user.id, email: user.email });
+
+    const res = await POST(
+      sessionRequest(baseSessionBody({ dayNumber: 5, track: "second", completed: false })),
+    );
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(users).where(eq(users.id, user.id));
+    expect(row!.secondTrackDay).toBe(5);
+  });
+
+  test("a quick second-track sit never advances either counter", async () => {
+    const user = await makeUser({ currentDay: 56, dualTrackEnabled: true, secondTrackDay: 5 });
+    getCurrentUser.mockResolvedValue({ userId: user.id, email: user.email });
+
+    const res = await POST(
+      sessionRequest(baseSessionBody({ dayNumber: 5, track: "second", sessionType: "quick", duration: 60 })),
+    );
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(users).where(eq(users.id, user.id));
+    expect(row!.currentDay).toBe(56);
+    expect(row!.secondTrackDay).toBe(5);
+  });
+
+  test("an invalid track value is rejected with 400", async () => {
+    const user = await makeUser({ currentDay: 56, dualTrackEnabled: true });
+    getCurrentUser.mockResolvedValue({ userId: user.id, email: user.email });
+
+    const res = await POST(sessionRequest(baseSessionBody({ track: "bogus" })));
+    expect(res.status).toBe(400);
+
+    const rows = await db.select().from(sessions).where(eq(sessions.userId, user.id));
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -3,8 +3,8 @@ import { db } from "@/db";
 import { poolDb } from "@/db/pool";
 import { sessions, users } from "@/db/schema";
 import { getCurrentUser } from "@/lib/auth";
-import { calculateSessionStats, parseCompleted, parseOptionalSessionType, shouldAdvanceDay } from "@/lib/constants";
-import { advanceProgression } from "@/lib/duration";
+import { calculateSessionStats, parseCompleted, parseOptionalSessionType, parseOptionalTrack, shouldAdvanceDay } from "@/lib/constants";
+import { advanceProgression, advanceSecondTrackDay } from "@/lib/duration";
 import { eq, desc } from "drizzle-orm";
 
 export async function GET() {
@@ -44,6 +44,8 @@ export async function POST(request: NextRequest) {
     const { dayNumber, duration, actualTime, clearPercent, thoughtCount, mindStateLog, sessionDate } = body;
     const completed = parseCompleted(body.completed);
     const sessionType = parseOptionalSessionType(body.sessionType);
+    // #240: which daily track this sit belongs to. Absent/legacy payloads → primary.
+    const track = parseOptionalTrack(body.track);
     // #374: taps-per-breath count. Only persisted for breath sessions (so a stray
     // breathCount on a standard/quick payload can't violate the data contract), and
     // clamped to the Postgres integer range so an out-of-range value can't turn into
@@ -68,6 +70,9 @@ export async function POST(request: NextRequest) {
     if (!sessionType) {
       return NextResponse.json({ error: "Invalid session type" }, { status: 400 });
     }
+    if (!track) {
+      return NextResponse.json({ error: "Invalid track" }, { status: 400 });
+    }
 
     // Quick sessions are extra practice and do not advance the daily progression.
     // Wrap the insert + any progression update in a single transaction and lock the
@@ -78,6 +83,7 @@ export async function POST(request: NextRequest) {
         userId: auth.userId,
         dayNumber,
         sessionType,
+        track,
         duration,
         bonusSeconds,
         completed,
@@ -99,24 +105,42 @@ export async function POST(request: NextRequest) {
             recoveryTargetDay: users.recoveryTargetDay,
             recoveryCurrentStep: users.recoveryCurrentStep,
             recoveryTotalSteps: users.recoveryTotalSteps,
+            dualTrackEnabled: users.dualTrackEnabled,
+            secondTrackDay: users.secondTrackDay,
           })
           .from(users)
           .where(eq(users.id, auth.userId))
           .limit(1);
 
         if (current) {
-          // #238: while recovering, a completed sit steps the ramp forward instead of
-          // bumping `currentDay` — see advanceProgression for the full rule.
-          const next = advanceProgression(sessionType, completed, current);
-          await tx.update(users)
-            .set({
-              currentDay: next.currentDay,
-              recoveryTargetDay: next.recoveryTargetDay,
-              recoveryCurrentStep: next.recoveryCurrentStep,
-              recoveryTotalSteps: next.recoveryTotalSteps,
-              updatedAt: new Date(),
-            })
-            .where(eq(users.id, auth.userId));
+          if (track === "second") {
+            // #240: the second track advances its own counter, and only when the
+            // user has actually opted into dual-track. It has no recovery ramp and
+            // never touches `currentDay` (the primary track), so the two progress
+            // independently. A `second` payload from a non-dual user is ignored
+            // defensively rather than trusted.
+            if (current.dualTrackEnabled) {
+              await tx.update(users)
+                .set({
+                  secondTrackDay: advanceSecondTrackDay(sessionType, completed, current.secondTrackDay),
+                  updatedAt: new Date(),
+                })
+                .where(eq(users.id, auth.userId));
+            }
+          } else {
+            // #238: while recovering, a completed primary sit steps the ramp forward
+            // instead of bumping `currentDay` — see advanceProgression for the full rule.
+            const next = advanceProgression(sessionType, completed, current);
+            await tx.update(users)
+              .set({
+                currentDay: next.currentDay,
+                recoveryTargetDay: next.recoveryTargetDay,
+                recoveryCurrentStep: next.recoveryCurrentStep,
+                recoveryTotalSteps: next.recoveryTotalSteps,
+                updatedAt: new Date(),
+              })
+              .where(eq(users.id, auth.userId));
+          }
         }
       }
 

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -15,6 +15,8 @@ const RETURN_FIELDS = {
   isPublic: users.isPublic,
   currentDay: users.currentDay,
   aphorismsEnabled: users.aphorismsEnabled,
+  dualTrackEnabled: users.dualTrackEnabled,
+  secondTrackDay: users.secondTrackDay,
 };
 
 export async function PATCH(request: NextRequest) {

--- a/src/app/api/track/done-today/route.integration.test.ts
+++ b/src/app/api/track/done-today/route.integration.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Issue #240 — lightweight per-track completion badges. This route should avoid
+ * downloading full session history by filtering to completed standard sits for
+ * one authenticated user and one client-local calendar date.
+ */
+import { NextRequest } from "next/server";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { sessions, users } from "@/db/schema";
+import { closeTestDb, getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
+
+const { getCurrentUser } = vi.hoisted(() => ({ getCurrentUser: vi.fn() }));
+
+vi.mock("@/lib/auth", () => ({ getCurrentUser }));
+vi.mock("@/db", async () => ({ db: await getTestDb() }));
+
+import { GET } from "./route";
+
+let db: TestDb;
+let seq = 0;
+
+function makeUser(overrides: Partial<typeof users.$inferInsert> = {}) {
+  seq += 1;
+  return db
+    .insert(users)
+    .values({ email: `track-done-${seq}@test.local`, username: `track_done_${seq}`, ...overrides })
+    .returning()
+    .then((rows) => rows[0]!);
+}
+
+function doneTodayRequest(date = "2026-06-11") {
+  return new NextRequest(`http://test.local/api/track/done-today?date=${date}`);
+}
+
+async function insertSession(userId: string, overrides: Partial<typeof sessions.$inferInsert> = {}) {
+  await db.insert(sessions).values({
+    userId,
+    dayNumber: 1,
+    sessionType: "standard",
+    track: "primary",
+    duration: 60,
+    completed: true,
+    actualTime: 60,
+    clearPercent: 90,
+    thoughtCount: 0,
+    mindStateLog: [],
+    sessionDate: "2026-06-11",
+    ...overrides,
+  });
+}
+
+afterAll(async () => {
+  await closeTestDb();
+});
+
+beforeEach(async () => {
+  db = await getTestDb();
+});
+
+describe("GET /api/track/done-today", () => {
+  test("returns per-track completion using only matching completed standard sessions", async () => {
+    const user = await makeUser();
+    const other = await makeUser();
+    getCurrentUser.mockResolvedValue({ userId: user.id, email: user.email });
+
+    await insertSession(user.id, { track: "primary" });
+    await insertSession(user.id, { track: "second", completed: false });
+    await insertSession(user.id, { track: "second", sessionType: "quick" });
+    await insertSession(user.id, { track: "second", sessionDate: "2026-06-10" });
+    await insertSession(other.id, { track: "second" });
+
+    const res = await GET(doneTodayRequest());
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      tracksDoneToday: { primary: true, second: false },
+    });
+  });
+
+  test("counts second-track completion independently", async () => {
+    const user = await makeUser();
+    getCurrentUser.mockResolvedValue({ userId: user.id, email: user.email });
+    await insertSession(user.id, { track: "second" });
+
+    const res = await GET(doneTodayRequest());
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      tracksDoneToday: { primary: false, second: true },
+    });
+  });
+
+  test("rejects invalid calendar dates", async () => {
+    const user = await makeUser();
+    getCurrentUser.mockResolvedValue({ userId: user.id, email: user.email });
+
+    const res = await GET(doneTodayRequest("not-a-date"));
+    expect(res.status).toBe(400);
+  });
+
+  test("requires the client-local calendar date", async () => {
+    const user = await makeUser();
+    getCurrentUser.mockResolvedValue({ userId: user.id, email: user.email });
+
+    const res = await GET(new NextRequest("http://test.local/api/track/done-today"));
+    expect(res.status).toBe(400);
+  });
+
+  test("401 when unauthenticated", async () => {
+    getCurrentUser.mockResolvedValue(null);
+    const res = await GET(doneTodayRequest());
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/api/track/done-today/route.ts
+++ b/src/app/api/track/done-today/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "@/db";
+import { sessions } from "@/db/schema";
+import { getCurrentUser } from "@/lib/auth";
+import { isValidSessionCalendarDate } from "@/lib/sessionCalendar";
+
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const date = request.nextUrl.searchParams.get("date");
+    if (!date || !isValidSessionCalendarDate(date)) {
+      return NextResponse.json({ error: "Invalid date" }, { status: 400 });
+    }
+
+    const completedTracks = await db
+      .select({ track: sessions.track })
+      .from(sessions)
+      .where(and(
+        eq(sessions.userId, auth.userId),
+        eq(sessions.sessionDate, date),
+        eq(sessions.completed, true),
+        eq(sessions.sessionType, "standard"),
+        inArray(sessions.track, ["primary", "second"]),
+      ));
+
+    return NextResponse.json({
+      tracksDoneToday: {
+        primary: completedTracks.some((session) => session.track === "primary"),
+        second: completedTracks.some((session) => session.track === "second"),
+      },
+    });
+  } catch (error) {
+    console.error("Get track completion error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/track/route.integration.test.ts
+++ b/src/app/api/track/route.integration.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Issue #240 — dual-track opt-in route. Enabling a second daily track is only
+ * allowed once the primary track has passed the 10-minute mark
+ * (`currentDay > FORK_DAY`); the flag flip is idempotent. Route-level tests
+ * against a real in-process Postgres.
+ */
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { users } from "@/db/schema";
+import { FORK_DAY } from "@/lib/constants";
+import { closeTestDb, getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
+
+const { getCurrentUser } = vi.hoisted(() => ({ getCurrentUser: vi.fn() }));
+
+vi.mock("@/lib/auth", () => ({ getCurrentUser }));
+vi.mock("@/db", async () => ({ db: await getTestDb() }));
+
+import { POST } from "./route";
+
+let db: TestDb;
+let seq = 0;
+
+function makeUser(overrides: Partial<typeof users.$inferInsert> = {}) {
+  seq += 1;
+  return db
+    .insert(users)
+    .values({ email: `track240-${seq}@test.local`, username: `track240_${seq}`, ...overrides })
+    .returning()
+    .then((rows) => rows[0]!);
+}
+
+afterAll(async () => {
+  await closeTestDb();
+});
+
+beforeEach(async () => {
+  db = await getTestDb();
+});
+
+describe("POST /api/track — enable dual track (#240)", () => {
+  test("enables the second track once past the 10-minute mark", async () => {
+    const user = await makeUser({ currentDay: FORK_DAY + 1, dualTrackEnabled: false });
+    getCurrentUser.mockResolvedValue({ userId: user.id, email: user.email });
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const { user: returned } = await res.json();
+    expect(returned.dualTrackEnabled).toBe(true);
+    expect(returned.secondTrackDay).toBe(1);
+
+    const [row] = await db.select().from(users).where(eq(users.id, user.id));
+    expect(row!.dualTrackEnabled).toBe(true);
+  });
+
+  test("rejects enabling before the 10-minute mark", async () => {
+    const user = await makeUser({ currentDay: FORK_DAY, dualTrackEnabled: false });
+    getCurrentUser.mockResolvedValue({ userId: user.id, email: user.email });
+
+    const res = await POST();
+    expect(res.status).toBe(409);
+
+    const [row] = await db.select().from(users).where(eq(users.id, user.id));
+    expect(row!.dualTrackEnabled).toBe(false);
+  });
+
+  test("is idempotent for an already-enabled account", async () => {
+    const user = await makeUser({ currentDay: FORK_DAY + 5, dualTrackEnabled: true, secondTrackDay: 4 });
+    getCurrentUser.mockResolvedValue({ userId: user.id, email: user.email });
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const { user: returned } = await res.json();
+    expect(returned.dualTrackEnabled).toBe(true);
+    expect(returned.secondTrackDay).toBe(4);
+  });
+
+  test("401 when unauthenticated", async () => {
+    getCurrentUser.mockResolvedValue(null);
+    const res = await POST();
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -57,6 +57,10 @@ export async function POST() {
       .where(eq(users.id, auth.userId))
       .returning(RETURN_FIELDS);
 
+    if (!updated) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
     return NextResponse.json({ user: updated });
   } catch (error) {
     console.error("Enable dual track error:", error);

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db";
+import { users } from "@/db/schema";
+import { getCurrentUser } from "@/lib/auth";
+import { isDualTrackEligible } from "@/lib/duration";
+import { eq } from "drizzle-orm";
+
+const RETURN_FIELDS = {
+  id: users.id,
+  email: users.email,
+  username: users.username,
+  isPublic: users.isPublic,
+  currentDay: users.currentDay,
+  aphorismsEnabled: users.aphorismsEnabled,
+  recoveryTargetDay: users.recoveryTargetDay,
+  recoveryCurrentStep: users.recoveryCurrentStep,
+  recoveryTotalSteps: users.recoveryTotalSteps,
+  dualTrackEnabled: users.dualTrackEnabled,
+  secondTrackDay: users.secondTrackDay,
+};
+
+/**
+ * Opt into the dual-track fork (#240). One-way: enabling a second daily track is
+ * only allowed once the primary track has passed the 10-minute mark
+ * (`currentDay > FORK_DAY`). Idempotent — enabling an already-enabled account just
+ * returns the current state. The second track's day counter (`secondTrackDay`) is
+ * left at its default so it starts at 1 minute the first time it is run.
+ */
+export async function POST() {
+  try {
+    const auth = await getCurrentUser();
+    if (!auth) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const [current] = await db
+      .select({ currentDay: users.currentDay, dualTrackEnabled: users.dualTrackEnabled })
+      .from(users)
+      .where(eq(users.id, auth.userId))
+      .limit(1);
+
+    if (!current) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    // Guard server-side so a client can't flip the flag before reaching the fork.
+    if (!current.dualTrackEnabled && !isDualTrackEligible(current.currentDay)) {
+      return NextResponse.json(
+        { error: "Reach the 10-minute mark before adding a second track." },
+        { status: 409 },
+      );
+    }
+
+    const [updated] = await db
+      .update(users)
+      .set({ dualTrackEnabled: true, updatedAt: new Date() })
+      .where(eq(users.id, auth.userId))
+      .returning(RETURN_FIELDS);
+
+    return NextResponse.json({ user: updated });
+  } catch (error) {
+    console.error("Enable dual track error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -306,6 +306,10 @@ export default function StillPoint() {
     const sessionParam = new URLSearchParams(window.location.search).get("session");
     if (sessionParam !== "quick" && sessionParam !== "standard") return;
     setActiveSessionType(sessionParam);
+    // #240: this deep-link path bypasses handleBegin, which normally sets the
+    // track explicitly — without this, a stale `second` track from an earlier
+    // interaction would incorrectly attribute this auto-started sit.
+    setActiveTrack("primary");
     setOverlay("session");
     router.replace(rawTab && isTab(rawTab) ? pathForTab(rawTab) : pathForTab(DEFAULT_TAB));
   }, [user, authChecked, rawTab, router]);
@@ -410,6 +414,12 @@ export default function StillPoint() {
     setBuddyCalendarMessage(null);
     setOverlay(null);
     setUser(null);
+    // #240: per-track completion badges and the fork-dismissal flag are
+    // account-scoped local state, not tied to the user object itself — clear
+    // them on logout so the next account's Home screen doesn't briefly show
+    // this account's "done today" badges or suppressed fork prompt.
+    setTracksDoneToday({ primary: false, second: false });
+    setForkDismissed(false);
   };
 
   const handleBegin = (sessionType: SessionType = "standard", track: Track = "primary") => {

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -17,8 +17,8 @@ import { BuddySessionHub } from "@/components/BuddySessionHub";
 import { BuddySessionRoom, type BuddyPersonalRecordPayload } from "@/components/BuddySessionRoom";
 import { useIsMobile } from "@/lib/useIsMobile";
 import { api, ApiError } from "@/lib/api";
-import type { SessionType } from "@/lib/constants";
-import { advanceProgression, sessionDurationForUser, type RecoveryFields } from "@/lib/duration";
+import type { SessionType, Track } from "@/lib/constants";
+import { advanceProgression, advanceSecondTrackDay, isDualTrackEligible, sessionDurationForUser, type RecoveryFields } from "@/lib/duration";
 import { todayLocalIsoDate } from "@/lib/sessionCalendar";
 
 /** Normalizes `User`'s optional recovery fields (absent on some legacy responses)
@@ -31,6 +31,12 @@ function recoveryFieldsOf(user: Pick<User, "recoveryTargetDay" | "recoveryCurren
   };
 }
 
+const NO_RECOVERY: RecoveryFields = {
+  recoveryTargetDay: null,
+  recoveryCurrentStep: null,
+  recoveryTotalSteps: null,
+};
+
 /**
  * Planned duration of the *next* standard sit, previewed client-side from the
  * pre-save user state using the same `advanceProgression` / `sessionDurationForUser`
@@ -41,9 +47,16 @@ function recoveryFieldsOf(user: Pick<User, "recoveryTargetDay" | "recoveryCurren
 function previewNextStandardDuration(
   sessionType: SessionType,
   completed: boolean,
+  track: Track,
   user: User | null,
 ): number {
   if (!user) return 60;
+  // #240: the second track has its own counter and no recovery ramp, so preview
+  // its next length independently from the primary track's progression.
+  if (track === "second") {
+    const nextSecond = advanceSecondTrackDay(sessionType, completed, user.secondTrackDay ?? 1);
+    return sessionDurationForUser("standard", nextSecond, NO_RECOVERY);
+  }
   const next = advanceProgression(sessionType, completed, {
     currentDay: user.currentDay,
     ...recoveryFieldsOf(user),
@@ -171,6 +184,8 @@ type CompletionData = {
   sessionId: string | null;
   dayNumber: number;
   sessionType: SessionType;
+  /** #240: which daily track this completed sit belonged to. */
+  track: Track;
   duration: number;
   bonusSeconds: number;
   clearPercent: number;
@@ -203,6 +218,14 @@ export default function StillPoint() {
   const [authRetryKey, setAuthRetryKey] = useState(0);
   const [completionData, setCompletionData] = useState<CompletionData | null>(null);
   const [activeSessionType, setActiveSessionType] = useState<SessionType>("standard");
+  // #240: which track the in-progress standard sit belongs to, per-track completion
+  // status for today, and whether the fork prompt was dismissed this session.
+  const [activeTrack, setActiveTrack] = useState<Track>("primary");
+  const [tracksDoneToday, setTracksDoneToday] = useState<{ primary: boolean; second: boolean }>({
+    primary: false,
+    second: false,
+  });
+  const [forkDismissed, setForkDismissed] = useState(false);
   const [buddySessionId, setBuddySessionId] = useState<string | null>(null);
   const [buddyInviteError, setBuddyInviteError] = useState<string | null>(null);
   const [buddyCalendarMessage, setBuddyCalendarMessage] = useState<string | null>(null);
@@ -389,10 +412,44 @@ export default function StillPoint() {
     setUser(null);
   };
 
-  const handleBegin = (sessionType: SessionType = "standard") => {
+  const handleBegin = (sessionType: SessionType = "standard", track: Track = "primary") => {
     setActiveSessionType(sessionType);
+    setActiveTrack(track);
     setOverlay("session");
   };
+
+  // #240: derive per-track "completed a standard sit today" from the session list,
+  // to drive HomeView's completion badges. A missing `track` (pre-#240 row) counts
+  // as the primary track.
+  const refreshTodayTracks = useCallback(async () => {
+    try {
+      const { sessions } = await api.getSessions();
+      const today = todayLocalIsoDate();
+      let primary = false;
+      let second = false;
+      for (const s of sessions) {
+        if (s.completed && s.sessionType === "standard" && s.sessionDate === today) {
+          if (s.track === "second") second = true;
+          else primary = true;
+        }
+      }
+      setTracksDoneToday({ primary, second });
+    } catch {
+      /* non-fatal: badges just stay in their last state */
+    }
+  }, []);
+
+  const handleEnableDualTrack = useCallback(async () => {
+    const { user: updated } = await api.enableDualTrack();
+    setUser(updated);
+    void refreshTodayTracks();
+  }, [refreshTodayTracks]);
+
+  // #240: load per-track completion badges once a user is present.
+  useEffect(() => {
+    if (!user || !authChecked) return;
+    void refreshTodayTracks();
+  }, [user?.id, authChecked, refreshTodayTracks]);
 
   const handleBuddyExit = useCallback(() => {
     setBuddySessionId(null);
@@ -409,23 +466,27 @@ export default function StillPoint() {
       sessionId: data.sessionId,
       dayNumber: data.dayNumber,
       sessionType: "standard",
+      // Buddy sits always count toward the primary track (#240).
+      track: "primary",
       duration: data.duration,
       bonusSeconds: 0,
       clearPercent: data.clearPercent,
       thoughtCount: data.thoughtCount,
       thoughts: data.thoughts,
-      nextDuration: previewNextStandardDuration("standard", true, user),
+      nextDuration: previewNextStandardDuration("standard", true, "primary", user),
     });
     setOverlay("complete");
     void api
       .me()
       .then(({ user: u }) => setUser(u))
       .catch(() => {});
-  }, [user]);
+    void refreshTodayTracks();
+  }, [user, refreshTodayTracks]);
 
   const handleSessionComplete = useCallback(async (data: {
     dayNumber: number;
     sessionType: SessionType;
+    track: Track;
     duration: number;
     bonusSeconds: number;
     completed: boolean;
@@ -445,6 +506,7 @@ export default function StillPoint() {
         body: JSON.stringify({
           dayNumber: data.dayNumber,
           sessionType: data.sessionType,
+          track: data.track,
           duration: data.duration,
           bonusSeconds: data.bonusSeconds,
           completed: data.completed,
@@ -484,6 +546,8 @@ export default function StillPoint() {
             .me()
             .then(({ user: u }) => setUser(u))
             .catch(() => {});
+          // #240: refresh per-track completion badges for today.
+          void refreshTodayTracks();
         }
       }
     } catch (error) {
@@ -494,19 +558,21 @@ export default function StillPoint() {
       sessionId: savedSessionId,
       dayNumber: data.dayNumber,
       sessionType: data.sessionType,
+      track: data.track,
       duration: data.duration,
       bonusSeconds: data.bonusSeconds,
       clearPercent: data.clearPercent,
       thoughtCount: data.thoughtCount,
       thoughts: data.thoughts,
-      nextDuration: previewNextStandardDuration(data.sessionType, data.completed, user),
+      nextDuration: previewNextStandardDuration(data.sessionType, data.completed, data.track, user),
     });
     setOverlay("complete");
-  }, [user]);
+  }, [user, refreshTodayTracks]);
 
   const handleSessionAbandon = useCallback(async (data: {
     dayNumber: number;
     sessionType: SessionType;
+    track: Track;
     duration: number;
     bonusSeconds: number;
     completed: boolean;
@@ -524,6 +590,7 @@ export default function StillPoint() {
         body: JSON.stringify({
           dayNumber: data.dayNumber,
           sessionType: data.sessionType,
+          track: data.track,
           duration: data.duration,
           bonusSeconds: data.bonusSeconds,
           completed: false,
@@ -817,9 +884,11 @@ export default function StillPoint() {
       {/* Transient overlays take precedence over the active tab. */}
       {overlay === "session" && (
         <SessionView
-          currentDay={user.currentDay}
-          recovery={userRecovery}
+          // #240: the second track uses its own day counter and has no recovery ramp.
+          currentDay={activeTrack === "second" ? (user.secondTrackDay ?? 1) : user.currentDay}
+          recovery={activeTrack === "second" ? NO_RECOVERY : userRecovery}
           sessionType={activeSessionType}
+          track={activeTrack}
           onComplete={handleSessionComplete}
           onAbandon={handleSessionAbandon}
         />
@@ -874,7 +943,15 @@ export default function StillPoint() {
           currentDay={user.currentDay}
           aphorismsEnabled={user.aphorismsEnabled}
           recovery={userRecovery}
-          onBegin={() => handleBegin("standard")}
+          dualTrackEnabled={user.dualTrackEnabled ?? false}
+          secondTrackDay={user.secondTrackDay ?? 1}
+          dualTrackEligible={isDualTrackEligible(user.currentDay) && !forkDismissed}
+          primaryDoneToday={tracksDoneToday.primary}
+          secondDoneToday={tracksDoneToday.second}
+          onBegin={() => handleBegin("standard", "primary")}
+          onBeginSecond={() => handleBegin("standard", "second")}
+          onEnableDualTrack={handleEnableDualTrack}
+          onDismissFork={() => setForkDismissed(true)}
           onQuickBegin={() => handleBegin("quick")}
           onBreath={() => setOverlay("breath")}
           onBuddy={() => {

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -445,7 +445,9 @@ export default function StillPoint() {
       }
       setTracksDoneToday({ primary, second });
     } catch {
-      /* non-fatal: badges just stay in their last state */
+      // Fail closed so a failed refresh can't leave a stale "done today"
+      // badge on screen (e.g. after switching accounts).
+      setTracksDoneToday({ primary: false, second: false });
     }
   }, []);
 

--- a/src/components/DualTrackFork.tsx
+++ b/src/components/DualTrackFork.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useState } from "react";
+import { MAX_DURATION, BASE_DURATION } from "@/lib/constants";
+import { ApiError } from "@/lib/api";
+
+type DualTrackForkProps = {
+  /** Opt into the second daily track. Resolves once the server has enabled it. */
+  onEnable: () => Promise<void>;
+  /** Dismiss the fork for now (stay single-track); may reappear on a later visit. */
+  onDismiss: () => void;
+};
+
+const MAX_MINUTES = Math.round(MAX_DURATION / 60);
+const BASE_MINUTES = Math.round(BASE_DURATION / 60);
+
+/**
+ * Dual-track fork choice (#240). Presented on Home once the primary track passes
+ * the 10-minute mark. Follows the BuddySessionHub two-path layout: one framed
+ * card per path, a primary "add a second track" action and a quieter "keep one
+ * track" dismissal, so the choice reads as two clear options rather than a
+ * yes/no prompt.
+ */
+export function DualTrackFork({ onEnable, onDismiss }: DualTrackForkProps) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleEnable() {
+    if (busy) return;
+    setError(null);
+    setBusy(true);
+    try {
+      await onEnable();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "Could not add a second track. Please retry.");
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "var(--s3)",
+        width: "100%",
+        maxWidth: "min(440px, calc(100vw - 40px))",
+        margin: "0 auto",
+        border: "1px solid var(--border-2)",
+        borderRadius: "16px",
+        padding: "var(--s4)",
+        background: "var(--surface-1)",
+        boxSizing: "border-box",
+        animation: "fadeIn 0.6s ease",
+      }}
+    >
+      <div style={{ textAlign: "center" }}>
+        <div
+          style={{
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+            fontSize: "11px",
+            color: "var(--accent-green-text)",
+            letterSpacing: "0.15em",
+            textTransform: "uppercase",
+            marginBottom: "var(--s2)",
+          }}
+        >
+          {MAX_MINUTES}-minute mark reached
+        </div>
+        <h2
+          style={{
+            fontSize: "22px",
+            fontWeight: 300,
+            fontStyle: "italic",
+            margin: 0,
+            color: "var(--fg)",
+            fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+          }}
+        >
+          Add a second daily track?
+        </h2>
+        <p
+          style={{
+            fontSize: "14px",
+            color: "var(--fg-2)",
+            lineHeight: 1.5,
+            margin: "var(--s2) 0 0",
+          }}
+        >
+          Your sits have grown to {MAX_MINUTES} minutes. Keep that daily sit and start a second
+          one that restarts at {BASE_MINUTES} minute and grows +10s a day — two tracks, run
+          independently.
+        </p>
+      </div>
+
+      {error && (
+        <p
+          role="alert"
+          style={{
+            margin: 0,
+            fontSize: "13px",
+            color: "var(--fg)",
+            textAlign: "center",
+            border: "1px solid var(--border-2)",
+            padding: "10px 14px",
+            borderRadius: "8px",
+            width: "100%",
+            boxSizing: "border-box",
+          }}
+        >
+          {error}
+        </p>
+      )}
+
+      {/* Path 1: add the second track (primary action). */}
+      <div
+        style={{
+          width: "100%",
+          border: "1px solid var(--accent-green-border)",
+          borderRadius: "12px",
+          padding: "var(--s3)",
+          background: "var(--accent-green-bg-subtle)",
+          boxSizing: "border-box",
+          display: "grid",
+          gap: "var(--s2)",
+        }}
+      >
+        <div
+          style={{
+            fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+            fontSize: "16px",
+            fontStyle: "italic",
+            color: "var(--fg)",
+          }}
+        >
+          Two tracks
+        </div>
+        <p style={{ margin: 0, fontSize: "13px", color: "var(--fg-2)", lineHeight: 1.45 }}>
+          Keep your {MAX_MINUTES}-minute sit and add a fresh {BASE_MINUTES}-minute track that ramps
+          back up alongside it.
+        </p>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={handleEnable}
+          style={{
+            marginTop: "var(--s1)",
+            background: "transparent",
+            border: "1px solid var(--accent-green-border)",
+            color: "var(--accent-green-text)",
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+            fontSize: "11px",
+            letterSpacing: "0.12em",
+            textTransform: "uppercase",
+            padding: "12px 24px",
+            borderRadius: "40px",
+            cursor: busy ? "wait" : "pointer",
+            width: "100%",
+          }}
+        >
+          {busy ? "Adding…" : "Add second track"}
+        </button>
+      </div>
+
+      {/* Path 2: keep a single track (dismiss). */}
+      <div
+        style={{
+          width: "100%",
+          border: "1px solid var(--border-2)",
+          borderRadius: "12px",
+          padding: "var(--s3)",
+          boxSizing: "border-box",
+          display: "grid",
+          gap: "var(--s2)",
+        }}
+      >
+        <div
+          style={{
+            fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+            fontSize: "16px",
+            fontStyle: "italic",
+            color: "var(--fg)",
+          }}
+        >
+          One track
+        </div>
+        <p style={{ margin: 0, fontSize: "13px", color: "var(--fg-2)", lineHeight: 1.45 }}>
+          Stay with a single {MAX_MINUTES}-minute daily sit. You can add a second track later.
+        </p>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onDismiss}
+          style={{
+            marginTop: "var(--s1)",
+            background: "transparent",
+            border: "1px solid var(--border-2)",
+            color: "var(--fg-2)",
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+            fontSize: "11px",
+            letterSpacing: "0.12em",
+            textTransform: "uppercase",
+            padding: "12px 24px",
+            borderRadius: "40px",
+            cursor: busy ? "not-allowed" : "pointer",
+            width: "100%",
+          }}
+        >
+          Keep one track
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { BLOCK_DURATION, QUICK_DURATION } from "@/lib/constants";
-import { activeRecovery, sessionDurationForUser, type RecoveryFields } from "@/lib/duration";
+import { BLOCK_DURATION, MAX_DURATION, QUICK_DURATION } from "@/lib/constants";
+import { activeRecovery, sessionDurationForUser, type ActiveRecovery, type RecoveryFields } from "@/lib/duration";
 import { Pathway } from "@/components/Pathway";
+import { DualTrackFork } from "@/components/DualTrackFork";
 import { aphorismForDay } from "@/lib/aphorisms";
 
 type HomeViewProps = {
@@ -10,7 +11,21 @@ type HomeViewProps = {
   /** #88: opt-in pre-session inspiration quote. */
   aphorismsEnabled?: boolean;
   recovery?: RecoveryFields;
+  /** #240: dual-track fork state. */
+  dualTrackEnabled?: boolean;
+  secondTrackDay?: number;
+  /** True once the primary track has passed the 10-minute mark (fork available). */
+  dualTrackEligible?: boolean;
+  /** Per-track "completed a standard sit today" — drives the completion badges. */
+  primaryDoneToday?: boolean;
+  secondDoneToday?: boolean;
   onBegin: () => void;
+  /** #240: start the second track's sit (only used when dual-track is enabled). */
+  onBeginSecond?: () => void;
+  /** #240: opt into the second track from the fork card. */
+  onEnableDualTrack?: () => Promise<void>;
+  /** #240: dismiss the fork card for now (stay single-track). */
+  onDismissFork?: () => void;
   onQuickBegin: () => void;
   onBreath?: () => void;
   onBuddy?: () => void;
@@ -22,11 +37,148 @@ const NO_RECOVERY: RecoveryFields = {
   recoveryTotalSteps: null,
 };
 
-export function HomeView({ currentDay, aphorismsEnabled, recovery = NO_RECOVERY, onBegin, onQuickBegin, onBreath, onBuddy }: HomeViewProps) {
+const MAX_MINUTES = Math.round(MAX_DURATION / 60);
+
+/** One track's Home card (#240): day number, planned length, completion badge and
+ *  its own Begin button so either track can be started independently. */
+function TrackCard({
+  label,
+  day,
+  duration,
+  doneToday,
+  recovery,
+  onBegin,
+}: {
+  label: string;
+  day: number;
+  duration: number;
+  doneToday: boolean;
+  recovery: ActiveRecovery | null;
+  onBegin: () => void;
+}) {
+  const blocks = Math.ceil(duration / BLOCK_DURATION);
+  return (
+    <div
+      style={{
+        width: "100%",
+        border: "1px solid var(--border-2)",
+        borderRadius: "16px",
+        padding: "var(--s4) var(--s3)",
+        background: "var(--surface-1)",
+        boxSizing: "border-box",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "var(--s2)",
+        textAlign: "center",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--s2)",
+          fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+          fontSize: "11px",
+          color: "var(--fg-3)",
+          letterSpacing: "0.15em",
+          textTransform: "uppercase",
+        }}
+      >
+        <span>{label}</span>
+        {doneToday && (
+          <span
+            style={{ color: "var(--accent-green-text)" }}
+            aria-label="completed today"
+          >
+            &#10003; done today
+          </span>
+        )}
+      </div>
+
+      <div
+        style={{
+          fontSize: "min(72px, 16vw)",
+          fontWeight: 200,
+          fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+          lineHeight: 1,
+          color: "var(--fg-4)",
+        }}
+      >
+        {day}
+      </div>
+      <div
+        style={{
+          fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+          fontSize: "12px",
+          color: "var(--fg-2)",
+          letterSpacing: "0.15em",
+          textTransform: "uppercase",
+        }}
+      >
+        day &middot; {duration}s &middot; {blocks} blocks
+      </div>
+      {recovery && (
+        <div
+          style={{
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+            fontSize: "10px",
+            color: "var(--accent-amber-text)",
+            letterSpacing: "0.1em",
+            textTransform: "uppercase",
+          }}
+        >
+          recovery {recovery.recoveryCurrentStep}/{recovery.recoveryTotalSteps} &middot; ramping back to day {recovery.recoveryTargetDay}
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={onBegin}
+        style={{
+          marginTop: "var(--s2)",
+          background: "var(--surface-2)",
+          border: "1px solid var(--border-2)",
+          color: "var(--fg)",
+          fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+          fontSize: "16px",
+          fontStyle: "italic",
+          padding: "12px 40px",
+          borderRadius: "40px",
+          cursor: "pointer",
+          transition: "all 0.3s",
+          letterSpacing: "0.04em",
+        }}
+      >
+        {doneToday ? "Sit again" : "Begin"}
+      </button>
+    </div>
+  );
+}
+
+export function HomeView({
+  currentDay,
+  aphorismsEnabled,
+  recovery = NO_RECOVERY,
+  dualTrackEnabled = false,
+  secondTrackDay = 1,
+  dualTrackEligible = false,
+  primaryDoneToday = false,
+  secondDoneToday = false,
+  onBegin,
+  onBeginSecond,
+  onEnableDualTrack,
+  onDismissFork,
+  onQuickBegin,
+  onBreath,
+  onBuddy,
+}: HomeViewProps) {
   const todayDuration = sessionDurationForUser("standard", currentDay, recovery);
   const totalBlocks = Math.ceil(todayDuration / BLOCK_DURATION);
   const inRecovery = activeRecovery(recovery);
   const aphorism = aphorismsEnabled ? aphorismForDay(currentDay) : null;
+  const secondDuration = sessionDurationForUser("standard", secondTrackDay, NO_RECOVERY);
+  const showFork = !dualTrackEnabled && dualTrackEligible && !!onEnableDualTrack;
 
   return (
     <div style={{
@@ -54,36 +206,69 @@ export function HomeView({ currentDay, aphorismsEnabled, recovery = NO_RECOVERY,
         </p>
       </div>
 
-      {/* Block B: Session data */}
-      <div style={{
-        textAlign: "center", animation: "breathe 4s ease-in-out infinite",
-        display: "flex", flexDirection: "column", alignItems: "center",
-        gap: "var(--s1)",
-      }}>
+      {/* Block B: Session data. Single-track shows the classic day readout; the
+          dual-track view (#240) swaps in two independently-startable track cards. */}
+      {dualTrackEnabled ? (
         <div style={{
-          fontSize: "min(120px, 20vw)", fontWeight: 200,
-          fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-          lineHeight: 1, color: "var(--fg-4)",
+          display: "flex", flexDirection: "column", alignItems: "center",
+          gap: "var(--s3)", width: "100%", maxWidth: "min(440px, calc(100vw - 40px))",
         }}>
-          {currentDay}
+          <TrackCard
+            label={`Track One \u00B7 ${MAX_MINUTES} min`}
+            day={currentDay}
+            duration={todayDuration}
+            doneToday={primaryDoneToday}
+            recovery={inRecovery}
+            onBegin={onBegin}
+          />
+          <TrackCard
+            label="Track Two"
+            day={secondTrackDay}
+            duration={secondDuration}
+            doneToday={secondDoneToday}
+            recovery={null}
+            onBegin={onBeginSecond ?? onBegin}
+          />
         </div>
+      ) : (
         <div style={{
-          fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-          fontSize: "12px", color: "var(--fg-2)",
-          letterSpacing: "0.15em", textTransform: "uppercase",
+          textAlign: "center", animation: "breathe 4s ease-in-out infinite",
+          display: "flex", flexDirection: "column", alignItems: "center",
+          gap: "var(--s1)",
         }}>
-          day &middot; {todayDuration}s &middot; {totalBlocks} blocks
-        </div>
-        {inRecovery && (
+          <div style={{
+            fontSize: "min(120px, 20vw)", fontWeight: 200,
+            fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+            lineHeight: 1, color: "var(--fg-4)",
+          }}>
+            {currentDay}
+          </div>
           <div style={{
             fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
-            fontSize: "10px", color: "var(--accent-amber-text)",
-            letterSpacing: "0.1em", textTransform: "uppercase",
+            fontSize: "12px", color: "var(--fg-2)",
+            letterSpacing: "0.15em", textTransform: "uppercase",
           }}>
-            recovery {inRecovery.recoveryCurrentStep}/{inRecovery.recoveryTotalSteps} &middot; ramping back to day {inRecovery.recoveryTargetDay}
+            day &middot; {todayDuration}s &middot; {totalBlocks} blocks
           </div>
-        )}
-      </div>
+          {inRecovery && (
+            <div style={{
+              fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
+              fontSize: "10px", color: "var(--accent-amber-text)",
+              letterSpacing: "0.1em", textTransform: "uppercase",
+            }}>
+              recovery {inRecovery.recoveryCurrentStep}/{inRecovery.recoveryTotalSteps} &middot; ramping back to day {inRecovery.recoveryTargetDay}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Fork choice (#240): once past the 10-minute mark, offer a second track. */}
+      {showFork && (
+        <DualTrackFork
+          onEnable={onEnableDualTrack!}
+          onDismiss={onDismissFork ?? (() => {})}
+        />
+      )}
 
       {/* Block B2: Lesson pathway (#336) */}
       <Pathway currentDay={currentDay} />
@@ -113,39 +298,42 @@ export function HomeView({ currentDay, aphorismsEnabled, recovery = NO_RECOVERY,
         </div>
       )}
 
-      {/* Block C: CTA */}
-      <button
-        type="button"
-        onClick={onBegin}
-        style={{
-          background: "var(--surface-1)",
-          border: "1px solid var(--border-2)",
-          color: "var(--fg)",
-          fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
-          fontSize: "17px", fontStyle: "italic",
-          padding: "16px 52px", borderRadius: "40px",
-          cursor: "pointer", transition: "all 0.3s", letterSpacing: "0.04em",
-        }}
-        onMouseEnter={e => {
-          e.currentTarget.style.borderColor = "var(--border-3)";
-          e.currentTarget.style.background = "var(--surface-2)";
-        }}
-        onMouseLeave={e => {
-          e.currentTarget.style.borderColor = "var(--border-2)";
-          e.currentTarget.style.background = "var(--surface-1)";
-        }}
-        onFocus={e => {
-          if (e.currentTarget.matches(":focus-visible")) {
-            e.currentTarget.style.outline = "2px solid var(--border-3)";
-            e.currentTarget.style.outlineOffset = "3px";
-          }
-        }}
-        onBlur={e => {
-          e.currentTarget.style.outline = "none";
-        }}
-      >
-        Begin
-      </button>
+      {/* Block C: CTA. The primary Begin lives inside the per-track cards in the
+          dual-track view, so the standalone button only shows for a single track. */}
+      {!dualTrackEnabled && (
+        <button
+          type="button"
+          onClick={onBegin}
+          style={{
+            background: "var(--surface-1)",
+            border: "1px solid var(--border-2)",
+            color: "var(--fg)",
+            fontFamily: "var(--font-newsreader), 'Newsreader', Georgia, serif",
+            fontSize: "17px", fontStyle: "italic",
+            padding: "16px 52px", borderRadius: "40px",
+            cursor: "pointer", transition: "all 0.3s", letterSpacing: "0.04em",
+          }}
+          onMouseEnter={e => {
+            e.currentTarget.style.borderColor = "var(--border-3)";
+            e.currentTarget.style.background = "var(--surface-2)";
+          }}
+          onMouseLeave={e => {
+            e.currentTarget.style.borderColor = "var(--border-2)";
+            e.currentTarget.style.background = "var(--surface-1)";
+          }}
+          onFocus={e => {
+            if (e.currentTarget.matches(":focus-visible")) {
+              e.currentTarget.style.outline = "2px solid var(--border-3)";
+              e.currentTarget.style.outlineOffset = "3px";
+            }
+          }}
+          onBlur={e => {
+            e.currentTarget.style.outline = "none";
+          }}
+        >
+          Begin
+        </button>
+      )}
 
       <button
         type="button"

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useCallback, useEffect, type CSSProperties } from "react";
-import { type SessionType } from "@/lib/constants";
+import { type SessionType, type Track } from "@/lib/constants";
 import { sessionDurationForUser, type RecoveryFields } from "@/lib/duration";
 import { BlockTimer } from "./BlockTimer";
 import { ThoughtCapture } from "./ThoughtCapture";
@@ -25,9 +25,12 @@ type SessionViewProps = {
   currentDay: number;
   recovery?: RecoveryFields;
   sessionType?: SessionType;
+  /** #240: which daily track this sit belongs to; echoed back in the payloads. */
+  track?: Track;
   onComplete: (data: {
     dayNumber: number;
     sessionType: SessionType;
+    track: Track;
     duration: number;
     bonusSeconds: number;
     completed: boolean;
@@ -40,6 +43,7 @@ type SessionViewProps = {
   onAbandon: (data: {
     dayNumber: number;
     sessionType: SessionType;
+    track: Track;
     duration: number;
     bonusSeconds: number;
     completed: boolean;
@@ -55,7 +59,7 @@ const mono: CSSProperties = {
   fontFamily: "var(--font-jetbrains), 'JetBrains Mono', monospace",
 };
 
-export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = "standard", onComplete, onAbandon }: SessionViewProps) {
+export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = "standard", track = "primary", onComplete, onAbandon }: SessionViewProps) {
   const isMobile = useIsMobile();
   const plannedSeconds = sessionDurationForUser(sessionType, currentDay, recovery);
   const [bonusSeconds, setBonusSeconds] = useState(0);
@@ -189,6 +193,7 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
     onComplete({
       dayNumber: currentDay,
       sessionType,
+      track,
       duration: plannedSeconds,
       bonusSeconds,
       completed: true,
@@ -198,7 +203,7 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
       mindStateLog: resolvedLog,
       thoughts: sessionThoughtsRef.current,
     });
-  }, [currentDay, sessionType, plannedSeconds, bonusSeconds, totalSeconds, onComplete, snapshotForComplete]);
+  }, [currentDay, sessionType, track, plannedSeconds, bonusSeconds, totalSeconds, onComplete, snapshotForComplete]);
 
   const handlePointerDistractionDown = () => {
     if (!isActive || mindStateRef.current !== "clear" || showPostDistractionCapture) return;
@@ -248,6 +253,7 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
     onComplete({
       dayNumber: currentDay,
       sessionType,
+      track,
       duration: plannedSeconds,
       bonusSeconds,
       completed: false,
@@ -269,6 +275,7 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
     onAbandon({
       dayNumber: currentDay,
       sessionType,
+      track,
       duration: plannedSeconds,
       bonusSeconds,
       completed: false,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -40,6 +40,13 @@ export const users = pgTable("users", {
   recoveryTargetDay: integer("recovery_target_day"),
   recoveryCurrentStep: integer("recovery_current_step"),
   recoveryTotalSteps: integer("recovery_total_steps"),
+  /** #240: dual-track fork. Once the primary track passes the 10-minute mark the
+   *  user can opt into a second daily track that restarts at 1 minute and ramps
+   *  +10s/day. `dualTrackEnabled` gates the second track; `secondTrackDay` is its
+   *  independent day counter (starts at 1, capped at 10 min via `durationForDay`).
+   *  Both are backward-compatible defaults so existing rows stay single-track. */
+  dualTrackEnabled: boolean("dual_track_enabled").default(false).notNull(),
+  secondTrackDay: integer("second_track_day").default(1).notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 }, (table) => ({
@@ -345,6 +352,10 @@ export const sessions = pgTable("sessions", {
   buddySessionId: uuid("buddy_session_id").references(() => buddySessions.id, { onDelete: "set null" }),
   dayNumber: integer("day_number").notNull(),
   sessionType: varchar("session_type", { length: 20 }).notNull().default("standard"),
+  /** #240: which daily progression this sit advanced — `primary` (original,
+   *  10-minute-capped) or `second` (opt-in dual track). Defaults to `primary` so
+   *  every pre-#240 row is attributed to the original track. */
+  track: varchar("track", { length: 16 }).notNull().default("primary"),
   duration: integer("duration").notNull(),
   /** Seconds added via in-session +1/+5 extensions beyond `duration` (#90). */
   bonusSeconds: integer("bonus_seconds").notNull().default(0),
@@ -367,6 +378,17 @@ export const sessions = pgTable("sessions", {
   sessionTypeCheck: check(
     "sessions_session_type_allowed",
     sql`${table.sessionType} in ('standard', 'quick', 'breath')`,
+  ),
+  trackCheck: check(
+    "sessions_track_allowed",
+    sql`${table.track} in ('primary', 'second')`,
+  ),
+  /** #240: backs "did this user complete each track's standard sit today?" —
+   *  the per-track completion badges HomeView shows for the dual-track view. */
+  userTrackDateIdx: index("idx_sessions_user_track_date").on(
+    table.userId,
+    table.track,
+    table.sessionDate,
   ),
   /** At most one personal session row per user per shared buddy sit. */
   userBuddyUnique: uniqueIndex("sessions_user_buddy_session_unique").on(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -33,6 +33,11 @@ export type User = {
   recoveryTargetDay?: number | null;
   recoveryCurrentStep?: number | null;
   recoveryTotalSteps?: number | null;
+  /** #240: dual-track fork. `dualTrackEnabled` gates the opt-in second daily track;
+   *  `secondTrackDay` is its independent day counter. Optional so responses from a
+   *  server that predates #240 still type-check (treated as single-track). */
+  dualTrackEnabled?: boolean;
+  secondTrackDay?: number;
 };
 
 export type Session = {
@@ -42,6 +47,8 @@ export type Session = {
   /** Seconds added via +1/+5 extensions beyond planned duration (#90). */
   bonusSeconds?: number;
   sessionType: "standard" | "quick" | "breath";
+  /** #240: which daily track this sit advanced ("primary" | "second"). */
+  track?: "primary" | "second";
   completed: boolean;
   actualTime: number | null;
   clearPercent: number;
@@ -196,6 +203,8 @@ export const api = {
     duration: number;
     bonusSeconds?: number;
     sessionType?: "standard" | "quick" | "breath";
+    /** #240: which daily track this sit advanced. Defaults to "primary" server-side. */
+    track?: "primary" | "second";
     completed: boolean;
     actualTime: number;
     clearPercent: number;
@@ -204,6 +213,10 @@ export const api = {
     sessionDate: string;
   }) =>
     request<{ session: Session }>("/api/sessions", { method: "POST", body: JSON.stringify(data) }),
+
+  /** #240: opt into the dual-track fork (enable a second daily track). */
+  enableDualTrack: () =>
+    request<{ user: User }>("/api/track", { method: "POST" }),
 
   getSession: (dayNumber: number) =>
     request<{ session: Session; thoughts: Thought[] }>(`/api/sessions/${dayNumber}`),

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -4,8 +4,33 @@ export const BASE_DURATION = 60;
 export const QUICK_DURATION = 60;
 export const INCREMENT = 10;
 export const BLOCK_DURATION = 10;
+/** #240: a standard sit tops out at ten minutes. The primary track reaches this
+ *  cap on `FORK_DAY` and then holds steady — the "10-minute track" the dual-track
+ *  fork keeps while a second track ramps up alongside it. */
+export const MAX_DURATION = 600;
+/** #240: the day a standard sit first reaches the 10-minute cap (60 + 54·10 = 600).
+ *  Derived so it stays correct if the base/increment/cap ever change. */
+export const FORK_DAY = (MAX_DURATION - BASE_DURATION) / INCREMENT + 1;
 const SESSION_TYPES = ["standard", "quick", "breath"] as const;
 export type SessionType = (typeof SESSION_TYPES)[number];
+
+/** #240: which daily progression a standard sit belongs to. `primary` is the
+ *  original (now 10-minute-capped) track; `second` is the opt-in track that
+ *  restarts at one minute and ramps +10s/day alongside it. */
+const TRACKS = ["primary", "second"] as const;
+export type Track = (typeof TRACKS)[number];
+
+export function isTrack(value: unknown): value is Track {
+  return typeof value === "string" && TRACKS.includes(value as Track);
+}
+
+/** Missing/absent track defaults to `primary` so pre-#240 clients (and rows) keep working. */
+export function parseOptionalTrack(value: unknown): Track | null {
+  if (value === undefined || value === null) {
+    return "primary";
+  }
+  return isTrack(value) ? value : null;
+}
 
 export type SessionStatsInput = {
   sessionType?: string;
@@ -40,7 +65,9 @@ export function parseCompleted(value: unknown): boolean | null {
 }
 
 export function durationForDay(dayNumber: number): number {
-  return BASE_DURATION + (Math.max(dayNumber, 1) - 1) * INCREMENT;
+  // #240: cap at ten minutes. Both tracks share this function, so each one holds
+  // at 10 minutes once it reaches FORK_DAY instead of growing without bound.
+  return Math.min(MAX_DURATION, BASE_DURATION + (Math.max(dayNumber, 1) - 1) * INCREMENT);
 }
 
 export function durationForSession(sessionType: SessionType, dayNumber: number): number {

--- a/src/lib/duration.test.ts
+++ b/src/lib/duration.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "vitest";
-import { durationForDay } from "./constants";
+import { FORK_DAY, MAX_DURATION, durationForDay } from "./constants";
 import {
   activeRecovery,
   advanceProgression,
+  advanceSecondTrackDay,
   detectMissedDayGap,
+  isDualTrackEligible,
   recoveryStepDuration,
   recoveryTotalStepsFor,
   sessionDurationForUser,
@@ -11,6 +13,47 @@ import {
 } from "./duration";
 
 const NO_RECOVERY = { recoveryTargetDay: null, recoveryCurrentStep: null, recoveryTotalSteps: null };
+
+describe("durationForDay 10-minute cap (#240)", () => {
+  test("grows 10s/day up to the cap, then holds at 10 minutes", () => {
+    expect(durationForDay(54)).toBe(590);
+    expect(durationForDay(FORK_DAY)).toBe(MAX_DURATION); // day 55 = 600s
+    expect(durationForDay(56)).toBe(MAX_DURATION);
+    expect(durationForDay(200)).toBe(MAX_DURATION);
+  });
+
+  test("FORK_DAY is the first day that reaches the cap", () => {
+    expect(FORK_DAY).toBe(55);
+    expect(durationForDay(FORK_DAY - 1)).toBeLessThan(MAX_DURATION);
+  });
+});
+
+describe("isDualTrackEligible (#240)", () => {
+  test("only eligible after passing the 10-minute (day-55) sit", () => {
+    expect(isDualTrackEligible(1)).toBe(false);
+    expect(isDualTrackEligible(FORK_DAY)).toBe(false); // on day 55, the 10-min sit isn't done yet
+    expect(isDualTrackEligible(FORK_DAY + 1)).toBe(true); // day 56 = after the 10-min sit
+    expect(isDualTrackEligible(120)).toBe(true);
+  });
+});
+
+describe("advanceSecondTrackDay (#240)", () => {
+  test("a completed standard sit bumps the second-track counter by one", () => {
+    expect(advanceSecondTrackDay("standard", true, 1)).toBe(2);
+    expect(advanceSecondTrackDay("standard", true, 12)).toBe(13);
+  });
+
+  test("quick and incomplete sits never advance the second track", () => {
+    expect(advanceSecondTrackDay("quick", true, 3)).toBe(3);
+    expect(advanceSecondTrackDay("standard", false, 3)).toBe(3);
+    expect(advanceSecondTrackDay("breath", true, 3)).toBe(3);
+  });
+
+  test("second-track duration caps at 10 minutes like the primary track", () => {
+    expect(sessionDurationForUser("standard", 1, NO_RECOVERY)).toBe(60);
+    expect(sessionDurationForUser("standard", FORK_DAY + 10, NO_RECOVERY)).toBe(MAX_DURATION);
+  });
+});
 
 describe("recoveryTotalStepsFor", () => {
   test("day 1 (nothing lost) needs zero steps", () => {

--- a/src/lib/duration.ts
+++ b/src/lib/duration.ts
@@ -10,7 +10,7 @@
  * recovery step completes and the recovery columns clear, the very next session
  * naturally lands back on `durationForDay(currentDay)` — the prior level.
  */
-import { BASE_DURATION, QUICK_DURATION, durationForDay, shouldAdvanceDay, type SessionType } from "./constants";
+import { BASE_DURATION, FORK_DAY, QUICK_DURATION, durationForDay, shouldAdvanceDay, type SessionType } from "./constants";
 import { daysBetweenIsoDatesInclusive } from "./sessionCalendar";
 
 /** Recovery ramps back to the prior duration level over at most this many sessions. */
@@ -147,4 +147,29 @@ export function advanceProgression(
   }
 
   return { ...state, currentDay: state.currentDay + 1 };
+}
+
+/**
+ * Dual-track fork (#240): once the primary track has passed the 10-minute mark
+ * (`currentDay > FORK_DAY`, i.e. the day-55 ten-minute sit is behind them) the
+ * user may opt into a second daily track. Eligibility is derived from the
+ * primary counter alone so it does not need its own persisted flag.
+ */
+export function isDualTrackEligible(currentDay: number): boolean {
+  return currentDay > FORK_DAY;
+}
+
+/**
+ * Advance the independent second-track counter (#240) after a session save. The
+ * second track has no recovery ramp: a completed standard sit bumps it by one
+ * (its duration is `durationForDay(secondTrackDay)`, which caps at 10 minutes
+ * just like the primary track); anything else leaves it unchanged. Mirrors the
+ * non-recovery branch of `advanceProgression` so both tracks step in lockstep.
+ */
+export function advanceSecondTrackDay(
+  sessionType: SessionType,
+  completed: boolean,
+  secondTrackDay: number,
+): number {
+  return shouldAdvanceDay(sessionType, completed) ? secondTrackDay + 1 : secondTrackDay;
 }


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #240.

Builds on #238's shared duration/progression core — extends it rather than forking the progression code.

## What

Once a user's standard sit reaches ten minutes (day 55), the primary track holds steady at 10 minutes and the user is offered a **fork**: opt into a **second daily track** that restarts at 1 minute and ramps +10s/day alongside the 10-minute track. Both tracks are startable independently and show per-track completion status.

## Walkthrough

[dual_track_fork_flow.mp4](https://cursor.com/agents/bc-6e1a7d1f-1543-4a92-863c-5a2ffefbc1da/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdual_track_fork_flow.mp4)
Fork prompt → "Add second track" → two independent track cards → complete Track Two (day 1→2) → "done today" badge, Track One untouched.

[Fork prompt at the 10-minute mark](https://cursor.com/agents/bc-6e1a7d1f-1543-4a92-863c-5a2ffefbc1da/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdual_track_fork_prompt.webp)
[Two track cards after opting in](https://cursor.com/agents/bc-6e1a7d1f-1543-4a92-863c-5a2ffefbc1da/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdual_track_two_cards.webp)
[Track Two done-today badge, Track One still Begin](https://cursor.com/agents/bc-6e1a7d1f-1543-4a92-863c-5a2ffefbc1da/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdual_track_done_badge.webp)

## Changes

- **`constants.ts`**: `MAX_DURATION` (600s) cap + derived `FORK_DAY` (55) + `Track` type; `durationForDay` caps at 10 minutes so both tracks top out there.
- **`duration.ts`**: `isDualTrackEligible(currentDay)` (eligible once `currentDay > FORK_DAY`) and `advanceSecondTrackDay(...)`; the second track has no recovery ramp.
- **Schema + migrations** (backward-compatible defaults): `users.dual_track_enabled`, `users.second_track_day`, `sessions.track` (check + index). Two incremental migrations.
- **API**: `me`/`login`/`signup`/`settings` return the dual-track fields; `POST /api/sessions` advances the correct counter per `track`; new `POST /api/track` one-way opt-in with a server-side eligibility guard.
- **UI**: `DualTrackFork` (BuddySessionHub two-path layout); `HomeView` renders both track cards with day/length/blocks, a "done today" badge, and independent Begin buttons; `SessionView`/page thread `track` through completion/abandon.
- **iOS parity**: shared `UserDTO`/`Constants`/`DTOs`/`APIClient` + `HomeView` dual-track cards & fork, `AppViewModel`/`SessionView` wiring, and shared unit tests.

## Testing

- ✅ `npm run typecheck`
- ✅ `npm run test:unit` (410 passing; +16 new)
- ✅ Manual: verified the full flow end-to-end in the browser against a local Postgres (curl-verified counters: second-track sit advances `second_track_day` only; primary sit advances `current_day` only) — see walkthrough.
- iOS: `xcodebuild` cannot run in this environment; iOS changes are validated by CI compile and the required `StillPointShared` swift-test check (new duration/UserDTO tests added).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e1a7d1f-1543-4a92-863c-5a2ffefbc1da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e1a7d1f-1543-4a92-863c-5a2ffefbc1da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Add an opt-in second daily track after the 10-minute mark**

### What Changed
- Standard sits now stop increasing after 10 minutes, and users can unlock a second daily track once they pass that point
- Sessions now remember which track they belong to, so each track advances on its own and the primary track is left unchanged when the second track is used
- Home screens show separate cards, progress, and "done today" badges for each track, with a choice to add the second track or keep one track
- Login, signup, settings, and session responses now include the new dual-track fields so the app can stay in sync across web and iOS

### Impact
`✅ Start a second daily sit after reaching 10 minutes`
`✅ Keep primary and second-track progress separate`
`✅ Clearer daily progress for dual-track users`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
