### PR TITLE
Web-iOS shared-algorithm parity test harness (#421)

### DIFF
--- a/ios/StillPointShared/Sources/StillPointShared/HistoryJourney.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/HistoryJourney.swift
@@ -138,8 +138,9 @@ public enum HistoryJourneyListRow: Sendable {
 
 public enum HistoryJourney {
     /// Gaps of this many consecutive missed days or more collapse into one `.missedRange`
-    /// row; shorter gaps keep per-day `.missed` rows (#379). The web journey still emits
-    /// per-day rows — see the issue for the parity follow-up.
+    /// row; shorter gaps keep per-day `.missed` rows (#379). The web journey mirrors this
+    /// exactly — same threshold and the matching `missedRange` row kind (#421). Shared
+    /// golden fixtures (`shared/test-fixtures/historyJourney.json`) lock both in lockstep.
     public static let collapseGapThresholdDays = 3
 
     /// Builds journey rows from all sessions (standard and quick), sorted by

--- a/ios/StillPointShared/Tests/StillPointSharedTests/AphorismsTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/AphorismsTests.swift
@@ -30,4 +30,16 @@ final class AphorismsTests: XCTestCase {
             XCTAssertTrue(Aphorisms.all.contains(Aphorisms.forDay(day)))
         }
     }
+
+    // MARK: - Shared cross-platform fixtures (#421)
+
+    // The same day->index golden set is asserted by web aphorismForDay.
+    func testSharedAphorismsFixtures() throws {
+        let fixture = try SharedFixtures.load("aphorisms.json", as: AphorismsFixture.self)
+        XCTAssertEqual(Aphorisms.all.count, fixture.expectedCount)
+
+        for testCase in fixture.cases {
+            XCTAssertEqual(Aphorisms.forDay(testCase.day), Aphorisms.all[testCase.expectedIndex], "day \(testCase.day)")
+        }
+    }
 }

--- a/ios/StillPointShared/Tests/StillPointSharedTests/BreathCountingLogicTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/BreathCountingLogicTests.swift
@@ -115,4 +115,24 @@ final class BreathCountingLogicTests: XCTestCase {
         // Negative input is treated as 0
         XCTAssertEqual(BreathCounting.elapsedDisplay(-5), "0:00")
     }
+
+    // MARK: - Shared cross-platform fixtures (#421)
+
+    // The same golden set is asserted by web breathCountForTaps / phaseForTaps /
+    // elapsedDisplay. Only non-negative taps are shared (web clamps negatives, iOS
+    // does not), so those stay in the per-suite tests above.
+    func testSharedBreathCountingFixtures() throws {
+        let fixture = try SharedFixtures.load("breathCounting.json", as: BreathCountingFixture.self)
+
+        for testCase in fixture.breathCount {
+            XCTAssertEqual(BreathCounting.breathCount(forTaps: testCase.taps), testCase.expected, "breathCount(\(testCase.taps))")
+        }
+        for testCase in fixture.phase {
+            let expected: BreathPhase = testCase.expected == "inhale" ? .inhale : .exhale
+            XCTAssertEqual(BreathCounting.phase(forTaps: testCase.taps), expected, "phase(\(testCase.taps))")
+        }
+        for testCase in fixture.elapsedDisplay {
+            XCTAssertEqual(BreathCounting.elapsedDisplay(testCase.seconds), testCase.expected, "elapsedDisplay(\(testCase.seconds))")
+        }
+    }
 }

--- a/ios/StillPointShared/Tests/StillPointSharedTests/BuddyCalendarColorsTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/BuddyCalendarColorsTests.swift
@@ -25,4 +25,20 @@ final class BuddyCalendarColorsTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(index, 0)
         XCTAssertLessThan(index, BUDDY_CALENDAR_PALETTE.count)
     }
+
+    // MARK: - Shared cross-platform fixtures (#421)
+
+    // The same user-id -> palette index/hex golden set is asserted by web
+    // buddyColorFromUserId (which returns the hex). Pins exact indices so any
+    // hash/palette drift breaks CI on either platform.
+    func testSharedBuddyCalendarColorsFixtures() throws {
+        let fixture = try SharedFixtures.load("buddyCalendarColors.json", as: BuddyCalendarColorsFixture.self)
+        XCTAssertEqual(BUDDY_CALENDAR_PALETTE.count, fixture.paletteLength)
+        XCTAssertEqual(BUDDY_CALENDAR_PALETTE, fixture.palette)
+
+        for testCase in fixture.cases {
+            XCTAssertEqual(buddyColorIndexFromUserId(testCase.userId), testCase.expectedIndex, testCase.userId)
+            XCTAssertEqual(BUDDY_CALENDAR_PALETTE[testCase.expectedIndex], testCase.expectedHex, testCase.userId)
+        }
+    }
 }

--- a/ios/StillPointShared/Tests/StillPointSharedTests/HistoryJourneyTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/HistoryJourneyTests.swift
@@ -228,4 +228,59 @@ final class HistoryJourneyTests: XCTestCase {
         XCTAssertEqual(mixed.streak, 1, "quick sit on a later day must not extend the streak")
         XCTAssertEqual(mixed.avgThoughtsPerSession, 10, "average must count standard sessions only")
     }
+
+    // MARK: - Shared cross-platform fixtures (#421)
+
+    // The same golden set is asserted by web buildHistoryJourneyRows; drift between
+    // the two implementations breaks CI on at least one platform.
+    func testSharedHistoryJourneyFixtures() throws {
+        let fixture = try SharedFixtures.load("historyJourney.json", as: HistoryJourneyFixture.self)
+        XCTAssertEqual(HistoryJourney.collapseGapThresholdDays, fixture.collapseGapThresholdDays)
+
+        for testCase in fixture.cases {
+            let rows = HistoryJourney.buildRows(
+                fromSessions: testCase.sessions.map { $0.toSessionDTO() },
+                todayIsoDate: testCase.todayIsoDate
+            )
+            XCTAssertEqual(rows.count, testCase.expectedRows.count, "\(testCase.name): row count")
+
+            for (row, expected) in zip(rows, testCase.expectedRows) {
+                switch row {
+                case .missed(let date):
+                    XCTAssertEqual(expected.kind, "missed", testCase.name)
+                    XCTAssertEqual(date, try XCTUnwrap(expected.date), testCase.name)
+                case .missedRange(let startDate, let endDate, let dayCount):
+                    XCTAssertEqual(expected.kind, "missedRange", testCase.name)
+                    XCTAssertEqual(startDate, try XCTUnwrap(expected.startDate), testCase.name)
+                    XCTAssertEqual(endDate, try XCTUnwrap(expected.endDate), testCase.name)
+                    XCTAssertEqual(dayCount, try XCTUnwrap(expected.dayCount), testCase.name)
+                case .session(let session, let sessionIndexInDay):
+                    XCTAssertEqual(expected.kind, "session", testCase.name)
+                    XCTAssertEqual(session.id, try XCTUnwrap(expected.id), testCase.name)
+                    XCTAssertEqual(sessionIndexInDay, try XCTUnwrap(expected.sessionIndexInDay), testCase.name)
+                }
+            }
+        }
+    }
+
+    // Web rounds averages to one decimal while iOS returns raw doubles, so the
+    // shared fixtures keep them on clean values and assert with a small tolerance.
+    func testSharedSessionStatsFixtures() throws {
+        let fixture = try SharedFixtures.load("sessionStats.json", as: SessionStatsFixture.self)
+
+        for testCase in fixture.cases {
+            let stats = SessionStatistics.calculateStats(for: testCase.sessions.map { $0.toSessionDTO() })
+            XCTAssertEqual(stats.streak, testCase.expected.streak, "\(testCase.name): streak")
+            XCTAssertEqual(stats.avgClearPercent, testCase.expected.avgClearPercent, "\(testCase.name): avgClearPercent")
+            XCTAssertEqual(
+                stats.avgThoughtsPerSession, testCase.expected.avgThoughtsPerSession,
+                accuracy: 0.05, "\(testCase.name): avgThoughtsPerSession"
+            )
+            XCTAssertEqual(
+                stats.avgThoughtsPerMinute, testCase.expected.avgThoughtsPerMinute,
+                accuracy: 0.05, "\(testCase.name): avgThoughtsPerMinute"
+            )
+            XCTAssertEqual(stats.bonusMinutesTotal ?? 0, testCase.expected.bonusMinutesTotal, "\(testCase.name): bonusMinutesTotal")
+        }
+    }
 }

--- a/ios/StillPointShared/Tests/StillPointSharedTests/SessionLogicClearPercentTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/SessionLogicClearPercentTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import StillPointShared
+
+final class SessionLogicClearPercentTests: XCTestCase {
+    // Cross-platform parity: the same clear-percent golden set is asserted by web
+    // computeClearPercentFromLog (#421). Cases avoid .5 boundaries so JS Math.round
+    // and Swift rounded() agree.
+    func testSharedClearPercentFixtures() throws {
+        let fixture = try SharedFixtures.load("clearPercent.json", as: ClearPercentFixture.self)
+
+        for testCase in fixture.cases {
+            let log = testCase.log.map { MindStateEntry(time: $0.time, state: $0.state) }
+            let actual = SessionLogic.calculateClearPercent(
+                mindStateLog: log,
+                totalElapsed: testCase.endTime
+            )
+            XCTAssertEqual(actual, testCase.expected, testCase.name)
+        }
+    }
+}

--- a/ios/StillPointShared/Tests/StillPointSharedTests/SharedFixtures.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/SharedFixtures.swift
@@ -142,7 +142,7 @@ extension HistoryJourneyFixture.Session {
         SessionDTO(
             id: id,
             dayNumber: 1,
-            sessionType: SessionType(rawValue: sessionType) ?? .standard,
+            sessionType: SessionType(rawValue: sessionType)!,
             duration: 60,
             completed: true,
             actualTime: 60,
@@ -161,7 +161,7 @@ extension SessionStatsFixture.Session {
         SessionDTO(
             id: id,
             dayNumber: dayNumber,
-            sessionType: SessionType(rawValue: sessionType) ?? .standard,
+            sessionType: SessionType(rawValue: sessionType)!,
             duration: duration,
             bonusSeconds: bonusSeconds,
             completed: completed,

--- a/ios/StillPointShared/Tests/StillPointSharedTests/SharedFixtures.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/SharedFixtures.swift
@@ -1,0 +1,177 @@
+import Foundation
+import XCTest
+@testable import StillPointShared
+
+/// Loads the cross-platform golden fixtures in `shared/test-fixtures/` (#421).
+/// The same JSON files back the web `vitest` suites via
+/// `src/lib/testing/sharedFixtures.ts`, so web + iOS assert against one source of
+/// truth and any drift between the duplicated algorithms breaks CI.
+///
+/// `swift test` compiles from the checked-out source tree, so the fixtures are
+/// resolved from this file's `#filePath` (valid locally and in CI).
+enum SharedFixtures {
+    /// `.../ios/StillPointShared/Tests/StillPointSharedTests/SharedFixtures.swift`
+    /// → repo root is five path components up.
+    static let directoryURL: URL = {
+        var url = URL(fileURLWithPath: #filePath)
+        for _ in 0..<5 { url.deleteLastPathComponent() }
+        return url.appendingPathComponent("shared/test-fixtures", isDirectory: true)
+    }()
+
+    static func load<T: Decodable>(_ fileName: String, as type: T.Type) throws -> T {
+        let fileURL = directoryURL.appendingPathComponent(fileName)
+        let data = try Data(contentsOf: fileURL)
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+}
+
+// MARK: - Fixture shapes (mirror shared/test-fixtures/*.json)
+
+struct ClearPercentFixture: Decodable {
+    struct LogEntry: Decodable {
+        let time: Double
+        let state: String
+    }
+    struct Case: Decodable {
+        let name: String
+        let log: [LogEntry]
+        let endTime: Double
+        let expected: Int
+    }
+    let cases: [Case]
+}
+
+struct HistoryJourneyFixture: Decodable {
+    struct Session: Decodable {
+        let id: String
+        let sessionType: String
+        let sessionDate: String
+        let createdAt: String
+    }
+    /// Flat, discriminated row (`kind`) so heterogeneous rows decode with plain Codable.
+    struct ExpectedRow: Decodable {
+        let kind: String
+        let date: String?
+        let startDate: String?
+        let endDate: String?
+        let dayCount: Int?
+        let id: String?
+        let sessionIndexInDay: Int?
+    }
+    struct Case: Decodable {
+        let name: String
+        let todayIsoDate: String?
+        let sessions: [Session]
+        let expectedRows: [ExpectedRow]
+    }
+    let collapseGapThresholdDays: Int
+    let cases: [Case]
+}
+
+struct SessionStatsFixture: Decodable {
+    struct Session: Decodable {
+        let id: String
+        let sessionType: String
+        let dayNumber: Int
+        let duration: Int
+        let bonusSeconds: Int
+        let actualTime: Int
+        let completed: Bool
+        let clearPercent: Int
+        let thoughtCount: Int
+        let sessionDate: String
+    }
+    struct Expected: Decodable {
+        let streak: Int
+        let avgClearPercent: Int
+        let avgThoughtsPerSession: Double
+        let avgThoughtsPerMinute: Double
+        let bonusSecondsTotal: Int
+        let bonusMinutesTotal: Int
+    }
+    struct Case: Decodable {
+        let name: String
+        let sessions: [Session]
+        let expected: Expected
+    }
+    let cases: [Case]
+}
+
+struct BreathCountingFixture: Decodable {
+    struct CountCase: Decodable {
+        let taps: Int
+        let expected: Int
+    }
+    struct PhaseCase: Decodable {
+        let taps: Int
+        let expected: String
+    }
+    struct DisplayCase: Decodable {
+        let seconds: Int
+        let expected: String
+    }
+    let breathCount: [CountCase]
+    let phase: [PhaseCase]
+    let elapsedDisplay: [DisplayCase]
+}
+
+struct AphorismsFixture: Decodable {
+    struct Case: Decodable {
+        let day: Int
+        let expectedIndex: Int
+    }
+    let expectedCount: Int
+    let cases: [Case]
+}
+
+struct BuddyCalendarColorsFixture: Decodable {
+    struct Case: Decodable {
+        let userId: String
+        let expectedIndex: Int
+        let expectedHex: String
+    }
+    let paletteLength: Int
+    let palette: [String]
+    let cases: [Case]
+}
+
+// MARK: - Fixture -> SessionDTO helpers
+
+extension HistoryJourneyFixture.Session {
+    func toSessionDTO() -> SessionDTO {
+        SessionDTO(
+            id: id,
+            dayNumber: 1,
+            sessionType: SessionType(rawValue: sessionType) ?? .standard,
+            duration: 60,
+            completed: true,
+            actualTime: 60,
+            clearPercent: 50,
+            thoughtCount: 0,
+            mindStateLog: nil,
+            sessionDate: sessionDate,
+            createdAt: createdAt,
+            buddySessionId: nil
+        )
+    }
+}
+
+extension SessionStatsFixture.Session {
+    func toSessionDTO() -> SessionDTO {
+        SessionDTO(
+            id: id,
+            dayNumber: dayNumber,
+            sessionType: SessionType(rawValue: sessionType) ?? .standard,
+            duration: duration,
+            bonusSeconds: bonusSeconds,
+            completed: completed,
+            actualTime: actualTime,
+            clearPercent: clearPercent,
+            thoughtCount: thoughtCount,
+            mindStateLog: nil,
+            sessionDate: sessionDate,
+            createdAt: nil,
+            buddySessionId: nil
+        )
+    }
+}

--- a/shared/test-fixtures/README.md
+++ b/shared/test-fixtures/README.md
@@ -1,0 +1,53 @@
+# Shared cross-platform test fixtures (#421)
+
+Golden-set JSON fixtures for the algorithms that are duplicated between the web
+app (`src/lib/**`, TypeScript) and the iOS app (`ios/StillPointShared`, Swift).
+Both test suites load the **same** files, so any drift between the two
+implementations breaks CI on at least one platform.
+
+## Fixtures
+
+| File | Web impl (vitest) | iOS impl (XCTest) |
+| --- | --- | --- |
+| `clearPercent.json` | `computeClearPercentFromLog` (`src/lib/mindStateSession.ts`) | `SessionLogic.calculateClearPercent` (`SessionLogic.swift`) |
+| `historyJourney.json` | `buildHistoryJourneyRows` (`src/lib/historyJourney.ts`) | `HistoryJourney.buildRows` (`HistoryJourney.swift`) |
+| `sessionStats.json` | `calculateSessionStats` (`src/lib/constants.ts`) | `SessionStatistics.calculateStats` (`HistoryJourney.swift`) |
+| `breathCounting.json` | `breathCountForTaps` / `phaseForTaps` / `elapsedDisplay` (`src/lib/breathCounting.ts`) | `BreathCounting.breathCount` / `phase` / `elapsedDisplay` (`BreathCountingLogic.swift`) |
+| `aphorisms.json` | `aphorismForDay` (`src/lib/aphorisms.ts`) | `Aphorisms.forDay` (`Aphorisms.swift`) |
+| `buddyCalendarColors.json` | `buddyColorFromUserId` (`src/lib/buddyCalendarColors.ts`) | `buddyColorIndexFromUserId` (`BuddyCalendarColors.swift`) |
+
+## How each suite loads them
+
+- **Web / vitest** — `loadFixture(name)` in `src/lib/testing/sharedFixtures.ts`
+  reads the JSON from this directory (resolved relative to the repo root). The
+  parity suites live next to each source file (e.g. `historyJourney.test.ts`).
+- **iOS / XCTest** — `SharedFixtures.load(_:)` in
+  `ios/StillPointShared/Tests/StillPointSharedTests/SharedFixtures.swift`
+  resolves this directory from the test file's `#filePath` and decodes each
+  fixture with `Codable`. `swift test` compiles from the checked-out source
+  tree, so the path is valid both locally and in CI.
+
+## Cross-platform value conventions
+
+These fixtures only contain inputs where **both** implementations produce
+identical golden values. To keep them in agreement:
+
+- **clearPercent** — cases avoid exact `.5` percentages (JS `Math.round`
+  rounds half up; Swift `rounded()` rounds half away from zero) and always use
+  a non-empty log with `endTime > 0` so both share the empty/zero-elapsed guard.
+- **sessionStats** — every session sets `actualTime = duration + bonusSeconds`
+  so the thoughts-per-minute denominators match (web divides by
+  `duration + bonusSeconds`, iOS by `actualTime`). Averages are kept on clean
+  values because web rounds to one decimal while iOS returns a raw `Double`
+  (the iOS suite asserts these with a small tolerance). Web exposes
+  `bonusSecondsTotal`; iOS exposes `bonusMinutesTotal` — both are provided.
+- **historyJourney** — each session has a distinct `createdAt`, which web feeds
+  as its `sortKey`, so ordering is identical to iOS (`sessionDate`, then
+  `createdAt`, then `id`) without relying on the id tiebreaker.
+- **breathCounting** — only non-negative `taps` are included; web clamps
+  negatives to 0 while iOS does not, so negative inputs are platform-specific
+  and tested per-suite. Wall-clock `elapsedSeconds` is omitted because its
+  input is a platform-specific timestamp/`Date` rather than a portable scalar.
+
+When adding a case, prefer inputs whose expected values are exact on both
+platforms; otherwise document the tolerance in the loading suite.

--- a/shared/test-fixtures/README.md
+++ b/shared/test-fixtures/README.md
@@ -41,6 +41,11 @@ identical golden values. To keep them in agreement:
   values because web rounds to one decimal while iOS returns a raw `Double`
   (the iOS suite asserts these with a small tolerance). Web exposes
   `bonusSecondsTotal`; iOS exposes `bonusMinutesTotal` — both are provided.
+  Note the inclusion-rule asymmetry: `avgClearPercent` is computed from
+  **completed standard sessions only**, while `avgThoughtsPerSession` and
+  `avgThoughtsPerMinute` average across **all standard sessions** (completed or
+  not) using a per-session-rate average. When adding cases, make sure the
+  fixture's expected values respect this difference.
 - **historyJourney** — each session has a distinct `createdAt`, which web feeds
   as its `sortKey`, so ordering is identical to iOS (`sessionDate`, then
   `createdAt`, then `id`) without relying on the id tiebreaker.

--- a/shared/test-fixtures/aphorisms.json
+++ b/shared/test-fixtures/aphorisms.json
@@ -1,0 +1,14 @@
+{
+  "algorithm": "aphorisms",
+  "description": "Deterministic day-driven aphorism rotation. Web aphorismForDay(day) and iOS Aphorisms.forDay(day) both clamp day to >= 1 and return item (safeDay - 1) % count. Golden cases pin the resolved index for a given day so drift in the clamp/rotation math breaks CI. `expectedCount` locks the shared list length.",
+  "expectedCount": 11,
+  "cases": [
+    { "day": 1, "expectedIndex": 0 },
+    { "day": 2, "expectedIndex": 1 },
+    { "day": 11, "expectedIndex": 10 },
+    { "day": 12, "expectedIndex": 0 },
+    { "day": 23, "expectedIndex": 0 },
+    { "day": 0, "expectedIndex": 0 },
+    { "day": -5, "expectedIndex": 0 }
+  ]
+}

--- a/shared/test-fixtures/breathCounting.json
+++ b/shared/test-fixtures/breathCounting.json
@@ -1,0 +1,26 @@
+{
+  "algorithm": "breathCounting",
+  "description": "Pure breath-counting helpers shared by web (breathCountForTaps/phaseForTaps/elapsedDisplay) and iOS (BreathCounting.breathCount/phase/elapsedDisplay). taps clamp negatives to 0; phase is the next expected action (even taps => inhale, odd => exhale); elapsedDisplay formats whole seconds as M:SS. Wall-clock elapsedSeconds is intentionally omitted — its input is a platform-specific timestamp/Date, not a portable scalar.",
+  "breathCount": [
+    { "taps": 0, "expected": 0 },
+    { "taps": 1, "expected": 0 },
+    { "taps": 2, "expected": 1 },
+    { "taps": 5, "expected": 2 },
+    { "taps": 10, "expected": 5 }
+  ],
+  "phase": [
+    { "taps": 0, "expected": "inhale" },
+    { "taps": 1, "expected": "exhale" },
+    { "taps": 2, "expected": "inhale" },
+    { "taps": 3, "expected": "exhale" },
+    { "taps": 8, "expected": "inhale" },
+    { "taps": 9, "expected": "exhale" }
+  ],
+  "elapsedDisplay": [
+    { "seconds": 0, "expected": "0:00" },
+    { "seconds": 9, "expected": "0:09" },
+    { "seconds": 65, "expected": "1:05" },
+    { "seconds": 600, "expected": "10:00" },
+    { "seconds": 3600, "expected": "60:00" }
+  ]
+}

--- a/shared/test-fixtures/buddyCalendarColors.json
+++ b/shared/test-fixtures/buddyCalendarColors.json
@@ -1,0 +1,23 @@
+{
+  "algorithm": "buddyCalendarColors",
+  "description": "Deterministic buddy accent color from a user id. Web buddyColorFromUserId(userId) returns the hex string; iOS buddyColorIndexFromUserId(userId) returns the palette index. Both hash with `h = h * 31 + codeUnit` over the id and mod the 8-color palette. Golden indices are pinned so any hash/palette drift breaks CI on either platform.",
+  "paletteLength": 8,
+  "palette": [
+    "#5B8C7A",
+    "#7A6B8C",
+    "#8C7A5B",
+    "#5B6F8C",
+    "#8C5B6B",
+    "#6B8C5B",
+    "#8C6B5B",
+    "#5B8C8C"
+  ],
+  "cases": [
+    { "userId": "00000000-0000-4000-8000-000000000001", "expectedIndex": 5, "expectedHex": "#6B8C5B" },
+    { "userId": "00000000-0000-4000-8000-000000000002", "expectedIndex": 6, "expectedHex": "#8C6B5B" },
+    { "userId": "00000000-0000-4000-8000-000000000003", "expectedIndex": 7, "expectedHex": "#5B8C8C" },
+    { "userId": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "expectedIndex": 4, "expectedHex": "#8C5B6B" },
+    { "userId": "11111111-2222-4333-8444-555555555555", "expectedIndex": 3, "expectedHex": "#5B6F8C" },
+    { "userId": "stillpoint", "expectedIndex": 0, "expectedHex": "#5B8C7A" }
+  ]
+}

--- a/shared/test-fixtures/clearPercent.json
+++ b/shared/test-fixtures/clearPercent.json
@@ -1,0 +1,74 @@
+{
+  "algorithm": "calculateClearPercent",
+  "description": "Percentage of [0, endTime] spent in an aware state (`clear` or `hyperfocus`). Web computeClearPercentFromLog(log, endTime) and iOS SessionLogic.calculateClearPercent(mindStateLog:totalElapsed:) both treat time before the first entry as clear and credit each segment to the state that began it, then round to a whole percent. Cases avoid exact .5 boundaries so JS Math.round and Swift rounded() agree, and keep endTime > 0 with a non-empty log so both share the same empty/zero guard.",
+  "cases": [
+    {
+      "name": "empty log is fully clear",
+      "log": [],
+      "endTime": 300,
+      "expected": 100
+    },
+    {
+      "name": "clear for the whole session",
+      "log": [{ "time": 0, "state": "clear" }],
+      "endTime": 300,
+      "expected": 100
+    },
+    {
+      "name": "thinking for the whole session",
+      "log": [{ "time": 0, "state": "thinking" }],
+      "endTime": 200,
+      "expected": 0
+    },
+    {
+      "name": "thinking exactly half the time",
+      "log": [{ "time": 0, "state": "clear" }, { "time": 150, "state": "thinking" }],
+      "endTime": 300,
+      "expected": 50
+    },
+    {
+      "name": "hyperfocus counts as aware",
+      "log": [{ "time": 0, "state": "hyperfocus" }],
+      "endTime": 100,
+      "expected": 100
+    },
+    {
+      "name": "clear, thinking, then clear again",
+      "log": [
+        { "time": 0, "state": "clear" },
+        { "time": 60, "state": "thinking" },
+        { "time": 120, "state": "clear" }
+      ],
+      "endTime": 240,
+      "expected": 75
+    },
+    {
+      "name": "time before the first entry is treated as clear",
+      "log": [{ "time": 50, "state": "thinking" }],
+      "endTime": 100,
+      "expected": 50
+    },
+    {
+      "name": "rounds down (100 of 300 clear)",
+      "log": [{ "time": 0, "state": "clear" }, { "time": 100, "state": "thinking" }],
+      "endTime": 300,
+      "expected": 33
+    },
+    {
+      "name": "rounds up (200 of 300 clear)",
+      "log": [{ "time": 0, "state": "clear" }, { "time": 200, "state": "thinking" }],
+      "endTime": 300,
+      "expected": 67
+    },
+    {
+      "name": "hyperfocus and clear mixed with thinking",
+      "log": [
+        { "time": 0, "state": "hyperfocus" },
+        { "time": 90, "state": "thinking" },
+        { "time": 180, "state": "clear" }
+      ],
+      "endTime": 360,
+      "expected": 75
+    }
+  ]
+}

--- a/shared/test-fixtures/historyJourney.json
+++ b/shared/test-fixtures/historyJourney.json
@@ -1,0 +1,171 @@
+{
+  "algorithm": "buildHistoryJourney",
+  "description": "History-journey row builder shared by web buildHistoryJourneyRows(sessions, todayDate?) and iOS HistoryJourney.buildRows(fromSessions:todayIsoDate:). Sessions are sorted by sessionDate then createdAt (web feeds createdAt as its sortKey; every fixture session has a distinct createdAt so the id tiebreaker never applies). Missed days strictly between sessions are emitted per-day (`missed`) below the collapse threshold and as a single `missedRange` at/above it. session rows are identified by `id` plus per-type `sessionIndexInDay`. Optional `todayIsoDate` adds the trailing gap to today (today is never itself missed).",
+  "collapseGapThresholdDays": 3,
+  "cases": [
+    {
+      "name": "sequential sessions on the same calendar day get incrementing indices",
+      "todayIsoDate": null,
+      "sessions": [
+        { "id": "a", "sessionType": "standard", "sessionDate": "2026-04-28", "createdAt": "2026-04-28T08:00:00.000Z" },
+        { "id": "b", "sessionType": "standard", "sessionDate": "2026-04-28", "createdAt": "2026-04-28T09:00:00.000Z" },
+        { "id": "c", "sessionType": "standard", "sessionDate": "2026-04-28", "createdAt": "2026-04-28T10:00:00.000Z" }
+      ],
+      "expectedRows": [
+        { "kind": "session", "id": "a", "sessionIndexInDay": 1 },
+        { "kind": "session", "id": "b", "sessionIndexInDay": 2 },
+        { "kind": "session", "id": "c", "sessionIndexInDay": 3 }
+      ]
+    },
+    {
+      "name": "same-day sessions are ordered by createdAt",
+      "todayIsoDate": null,
+      "sessions": [
+        { "id": "later-id", "sessionType": "standard", "sessionDate": "2026-04-28", "createdAt": "2026-04-28T12:00:00.000Z" },
+        { "id": "earlier-id", "sessionType": "standard", "sessionDate": "2026-04-28", "createdAt": "2026-04-28T10:00:00.000Z" }
+      ],
+      "expectedRows": [
+        { "kind": "session", "id": "earlier-id", "sessionIndexInDay": 1 },
+        { "kind": "session", "id": "later-id", "sessionIndexInDay": 2 }
+      ]
+    },
+    {
+      "name": "a quick-only sit still produces a session row",
+      "todayIsoDate": null,
+      "sessions": [
+        { "id": "q1", "sessionType": "quick", "sessionDate": "2026-06-10", "createdAt": "2026-06-10T08:00:00.000Z" }
+      ],
+      "expectedRows": [
+        { "kind": "session", "id": "q1", "sessionIndexInDay": 1 }
+      ]
+    },
+    {
+      "name": "quick and standard mix uses per-type day indices",
+      "todayIsoDate": null,
+      "sessions": [
+        { "id": "s1", "sessionType": "standard", "sessionDate": "2026-06-10", "createdAt": "2026-06-10T08:00:00.000Z" },
+        { "id": "q1", "sessionType": "quick", "sessionDate": "2026-06-10", "createdAt": "2026-06-10T09:00:00.000Z" },
+        { "id": "s2", "sessionType": "standard", "sessionDate": "2026-06-10", "createdAt": "2026-06-10T10:00:00.000Z" }
+      ],
+      "expectedRows": [
+        { "kind": "session", "id": "s1", "sessionIndexInDay": 1 },
+        { "kind": "session", "id": "q1", "sessionIndexInDay": 1 },
+        { "kind": "session", "id": "s2", "sessionIndexInDay": 2 }
+      ]
+    },
+    {
+      "name": "two missed days stay as per-day missed rows",
+      "todayIsoDate": null,
+      "sessions": [
+        { "id": "a", "sessionType": "standard", "sessionDate": "2026-06-01", "createdAt": "2026-06-01T08:00:00.000Z" },
+        { "id": "b", "sessionType": "standard", "sessionDate": "2026-06-04", "createdAt": "2026-06-04T08:00:00.000Z" }
+      ],
+      "expectedRows": [
+        { "kind": "session", "id": "a", "sessionIndexInDay": 1 },
+        { "kind": "missed", "date": "2026-06-02" },
+        { "kind": "missed", "date": "2026-06-03" },
+        { "kind": "session", "id": "b", "sessionIndexInDay": 1 }
+      ]
+    },
+    {
+      "name": "three missed days collapse to a single range (threshold boundary)",
+      "todayIsoDate": null,
+      "sessions": [
+        { "id": "a", "sessionType": "standard", "sessionDate": "2026-06-01", "createdAt": "2026-06-01T08:00:00.000Z" },
+        { "id": "b", "sessionType": "standard", "sessionDate": "2026-06-05", "createdAt": "2026-06-05T08:00:00.000Z" }
+      ],
+      "expectedRows": [
+        { "kind": "session", "id": "a", "sessionIndexInDay": 1 },
+        { "kind": "missedRange", "startDate": "2026-06-02", "endDate": "2026-06-04", "dayCount": 3 },
+        { "kind": "session", "id": "b", "sessionIndexInDay": 1 }
+      ]
+    },
+    {
+      "name": "a 30-day gap collapses and keeps the prior session reachable",
+      "todayIsoDate": null,
+      "sessions": [
+        { "id": "a", "sessionType": "standard", "sessionDate": "2026-04-01", "createdAt": "2026-04-01T08:00:00.000Z" },
+        { "id": "b", "sessionType": "standard", "sessionDate": "2026-05-01", "createdAt": "2026-05-01T08:00:00.000Z" }
+      ],
+      "expectedRows": [
+        { "kind": "session", "id": "a", "sessionIndexInDay": 1 },
+        { "kind": "missedRange", "startDate": "2026-04-02", "endDate": "2026-04-30", "dayCount": 29 },
+        { "kind": "session", "id": "b", "sessionIndexInDay": 1 }
+      ]
+    },
+    {
+      "name": "a gap spanning a standard then quick session still collapses",
+      "todayIsoDate": null,
+      "sessions": [
+        { "id": "s1", "sessionType": "standard", "sessionDate": "2026-04-01", "createdAt": "2026-04-01T08:00:00.000Z" },
+        { "id": "q1", "sessionType": "quick", "sessionDate": "2026-05-06", "createdAt": "2026-05-06T08:00:00.000Z" }
+      ],
+      "expectedRows": [
+        { "kind": "session", "id": "s1", "sessionIndexInDay": 1 },
+        { "kind": "missedRange", "startDate": "2026-04-02", "endDate": "2026-05-05", "dayCount": 34 },
+        { "kind": "session", "id": "q1", "sessionIndexInDay": 1 }
+      ]
+    },
+    {
+      "name": "a long gap between the last session and today collapses",
+      "todayIsoDate": "2026-06-11",
+      "sessions": [
+        { "id": "a", "sessionType": "standard", "sessionDate": "2026-05-01", "createdAt": "2026-05-01T08:00:00.000Z" }
+      ],
+      "expectedRows": [
+        { "kind": "session", "id": "a", "sessionIndexInDay": 1 },
+        { "kind": "missedRange", "startDate": "2026-05-02", "endDate": "2026-06-10", "dayCount": 40 }
+      ]
+    },
+    {
+      "name": "a short trailing gap emits per-day missed rows",
+      "todayIsoDate": "2026-06-11",
+      "sessions": [
+        { "id": "a", "sessionType": "standard", "sessionDate": "2026-06-09", "createdAt": "2026-06-09T08:00:00.000Z" }
+      ],
+      "expectedRows": [
+        { "kind": "session", "id": "a", "sessionIndexInDay": 1 },
+        { "kind": "missed", "date": "2026-06-10" }
+      ]
+    },
+    {
+      "name": "no trailing gap when the last session is today",
+      "todayIsoDate": "2026-06-11",
+      "sessions": [
+        { "id": "a", "sessionType": "standard", "sessionDate": "2026-06-11", "createdAt": "2026-06-11T08:00:00.000Z" }
+      ],
+      "expectedRows": [
+        { "kind": "session", "id": "a", "sessionIndexInDay": 1 }
+      ]
+    },
+    {
+      "name": "no trailing gap when the last session was yesterday",
+      "todayIsoDate": "2026-06-11",
+      "sessions": [
+        { "id": "a", "sessionType": "standard", "sessionDate": "2026-06-10", "createdAt": "2026-06-10T08:00:00.000Z" }
+      ],
+      "expectedRows": [
+        { "kind": "session", "id": "a", "sessionIndexInDay": 1 }
+      ]
+    },
+    {
+      "name": "no sessions produce no rows",
+      "todayIsoDate": "2026-06-11",
+      "sessions": [],
+      "expectedRows": []
+    },
+    {
+      "name": "a multi-year gap collapses to one range with no per-day rows",
+      "todayIsoDate": null,
+      "sessions": [
+        { "id": "a", "sessionType": "standard", "sessionDate": "2020-01-01", "createdAt": "2020-01-01T08:00:00.000Z" },
+        { "id": "b", "sessionType": "standard", "sessionDate": "2030-01-01", "createdAt": "2030-01-01T08:00:00.000Z" }
+      ],
+      "expectedRows": [
+        { "kind": "session", "id": "a", "sessionIndexInDay": 1 },
+        { "kind": "missedRange", "startDate": "2020-01-02", "endDate": "2029-12-31", "dayCount": 3652 },
+        { "kind": "session", "id": "b", "sessionIndexInDay": 1 }
+      ]
+    }
+  ]
+}

--- a/shared/test-fixtures/sessionStats.json
+++ b/shared/test-fixtures/sessionStats.json
@@ -1,0 +1,46 @@
+{
+  "algorithm": "sessionStats",
+  "description": "Aggregate progression stats over standard sessions only (quick/breath excluded). Web calculateSessionStats(SessionStatsInput[]) and iOS SessionStatistics.calculateStats([SessionDTO]) share streak, avgClearPercent, avgThoughtsPerSession and avgThoughtsPerMinute. Web returns bonusSecondsTotal; iOS returns bonusMinutesTotal (= bonusSecondsTotal / 60), so both golden values are provided. Every session sets actualTime = duration + bonusSeconds so the thoughts/min denominators match across platforms; cases keep averages on clean values so JS rounding and Swift's raw doubles agree within a small tolerance.",
+  "cases": [
+    {
+      "name": "two standard sits on the same calendar day are one streak day",
+      "sessions": [
+        { "id": "s1", "sessionType": "standard", "dayNumber": 1, "duration": 60, "bonusSeconds": 0, "actualTime": 60, "completed": true, "clearPercent": 80, "thoughtCount": 2, "sessionDate": "2026-04-28" },
+        { "id": "s2", "sessionType": "standard", "dayNumber": 1, "duration": 60, "bonusSeconds": 0, "actualTime": 60, "completed": true, "clearPercent": 80, "thoughtCount": 2, "sessionDate": "2026-04-28" }
+      ],
+      "expected": { "streak": 1, "avgClearPercent": 80, "avgThoughtsPerSession": 2, "avgThoughtsPerMinute": 2, "bonusSecondsTotal": 0, "bonusMinutesTotal": 0 }
+    },
+    {
+      "name": "quick sits are excluded from every stat",
+      "sessions": [
+        { "id": "s1", "sessionType": "standard", "dayNumber": 1, "duration": 60, "bonusSeconds": 0, "actualTime": 60, "completed": true, "clearPercent": 90, "thoughtCount": 10, "sessionDate": "2026-06-10" },
+        { "id": "q1", "sessionType": "quick", "dayNumber": 1, "duration": 60, "bonusSeconds": 0, "actualTime": 60, "completed": true, "clearPercent": 10, "thoughtCount": 5, "sessionDate": "2026-06-11" }
+      ],
+      "expected": { "streak": 1, "avgClearPercent": 90, "avgThoughtsPerSession": 10, "avgThoughtsPerMinute": 10, "bonusSecondsTotal": 0, "bonusMinutesTotal": 0 }
+    },
+    {
+      "name": "calendar-day streak breaks across a missed day",
+      "sessions": [
+        { "id": "s1", "sessionType": "standard", "dayNumber": 3, "duration": 60, "bonusSeconds": 0, "actualTime": 60, "completed": true, "clearPercent": 90, "thoughtCount": 0, "sessionDate": "2026-04-30" },
+        { "id": "s2", "sessionType": "standard", "dayNumber": 2, "duration": 60, "bonusSeconds": 0, "actualTime": 60, "completed": true, "clearPercent": 100, "thoughtCount": 0, "sessionDate": "2026-04-28" }
+      ],
+      "expected": { "streak": 1, "avgClearPercent": 95, "avgThoughtsPerSession": 0, "avgThoughtsPerMinute": 0, "bonusSecondsTotal": 0, "bonusMinutesTotal": 0 }
+    },
+    {
+      "name": "day-number fallback streak with bonus seconds",
+      "sessions": [
+        { "id": "s1", "sessionType": "standard", "dayNumber": 1, "duration": 300, "bonusSeconds": 120, "actualTime": 420, "completed": true, "clearPercent": 80, "thoughtCount": 6, "sessionDate": "" }
+      ],
+      "expected": { "streak": 1, "avgClearPercent": 80, "avgThoughtsPerSession": 6, "avgThoughtsPerMinute": 0.9, "bonusSecondsTotal": 120, "bonusMinutesTotal": 2 }
+    },
+    {
+      "name": "streak stops when the latest day has no completed standard sit",
+      "sessions": [
+        { "id": "s3", "sessionType": "standard", "dayNumber": 3, "duration": 80, "bonusSeconds": 0, "actualTime": 80, "completed": false, "clearPercent": 20, "thoughtCount": 0, "sessionDate": "" },
+        { "id": "s2", "sessionType": "standard", "dayNumber": 2, "duration": 70, "bonusSeconds": 0, "actualTime": 70, "completed": true, "clearPercent": 100, "thoughtCount": 0, "sessionDate": "" },
+        { "id": "s1", "sessionType": "standard", "dayNumber": 1, "duration": 60, "bonusSeconds": 0, "actualTime": 60, "completed": true, "clearPercent": 80, "thoughtCount": 3, "sessionDate": "" }
+      ],
+      "expected": { "streak": 0, "avgClearPercent": 90, "avgThoughtsPerSession": 1, "avgThoughtsPerMinute": 1, "bonusSecondsTotal": 0, "bonusMinutesTotal": 0 }
+    }
+  ]
+}

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -143,7 +143,7 @@ export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: Hi
             missed: true,
           };
         }
-        if (row.kind === "collapsedGap") {
+        if (row.kind === "missedRange") {
           return {
             day: null,
             duration: 0,

--- a/src/lib/aphorisms.test.ts
+++ b/src/lib/aphorisms.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { APHORISMS, aphorismForDay } from "./aphorisms";
+import { loadSharedFixture, type AphorismsFixture } from "./testing/sharedFixtures";
 
 describe("APHORISMS", () => {
   test("every entry has non-empty text and author", () => {
@@ -32,5 +33,19 @@ describe("aphorismForDay", () => {
     for (let day = 1; day <= APHORISMS.length * 2; day++) {
       expect(APHORISMS).toContainEqual(aphorismForDay(day));
     }
+  });
+});
+
+// Cross-platform parity: the same day->index golden set is asserted by iOS
+// Aphorisms.forDay (#421). `expectedCount` locks the shared list length.
+describe("aphorismForDay — shared fixtures", () => {
+  const fixture = loadSharedFixture<AphorismsFixture>("aphorisms.json");
+
+  test("list length matches the shared fixture", () => {
+    expect(APHORISMS.length).toBe(fixture.expectedCount);
+  });
+
+  test.each(fixture.cases)("day $day resolves to index $expectedIndex", ({ day, expectedIndex }) => {
+    expect(aphorismForDay(day)).toEqual(APHORISMS[expectedIndex]);
   });
 });

--- a/src/lib/breathCounting.test.ts
+++ b/src/lib/breathCounting.test.ts
@@ -5,6 +5,7 @@ import {
   elapsedSeconds,
   phaseForTaps,
 } from "./breathCounting";
+import { loadSharedFixture, type BreathCountingFixture } from "./testing/sharedFixtures";
 
 // Ports ios/StillPointShared/Tests/StillPointSharedTests/BreathCountingLogicTests.swift
 // so the web breath-counting semantics stay locked to iOS (#374 → #376).
@@ -106,5 +107,24 @@ describe("elapsedDisplay", () => {
 
   it("treats negative input as 0", () => {
     expect(elapsedDisplay(-5)).toBe("0:00");
+  });
+});
+
+// Cross-platform parity: the same breath-counting golden set is asserted by iOS
+// BreathCounting (#421). Only non-negative taps are shared (web clamps negatives,
+// iOS does not).
+describe("breath counting — shared fixtures", () => {
+  const fixture = loadSharedFixture<BreathCountingFixture>("breathCounting.json");
+
+  it.each(fixture.breathCount)("breathCountForTaps($taps) === $expected", ({ taps, expected }) => {
+    expect(breathCountForTaps(taps)).toBe(expected);
+  });
+
+  it.each(fixture.phase)("phaseForTaps($taps) === $expected", ({ taps, expected }) => {
+    expect(phaseForTaps(taps)).toBe(expected);
+  });
+
+  it.each(fixture.elapsedDisplay)("elapsedDisplay($seconds) === $expected", ({ seconds, expected }) => {
+    expect(elapsedDisplay(seconds)).toBe(expected);
   });
 });

--- a/src/lib/buddyCalendar.test.ts
+++ b/src/lib/buddyCalendar.test.ts
@@ -6,6 +6,7 @@ import {
   parseBuddyCalendarRange,
 } from "./buddyCalendarRange";
 import { addDaysToIsoDate } from "./sessionCalendar";
+import { loadSharedFixture, type BuddyCalendarColorsFixture } from "./testing/sharedFixtures";
 
 describe("buddyColorFromUserId", () => {
   test("returns stable color for the same id", () => {
@@ -17,6 +18,21 @@ describe("buddyColorFromUserId", () => {
     const a = "00000000-0000-4000-8000-000000000001";
     const b = "00000000-0000-4000-8000-000000000002";
     expect(buddyColorFromUserId(a)).not.toBe(buddyColorFromUserId(b));
+  });
+});
+
+// Cross-platform parity: the same user-id -> palette index/hex golden set is
+// asserted by iOS buddyColorIndexFromUserId (#421). Web only exposes the hex.
+describe("buddyColorFromUserId — shared fixtures", () => {
+  const fixture = loadSharedFixture<BuddyCalendarColorsFixture>("buddyCalendarColors.json");
+
+  test("palette matches the shared fixture", () => {
+    expect(fixture.palette).toHaveLength(fixture.paletteLength);
+  });
+
+  test.each(fixture.cases)("$userId -> $expectedHex", ({ userId, expectedIndex, expectedHex }) => {
+    expect(fixture.palette[expectedIndex]).toBe(expectedHex);
+    expect(buddyColorFromUserId(userId)).toBe(expectedHex);
   });
 });
 

--- a/src/lib/historyJourney.test.ts
+++ b/src/lib/historyJourney.test.ts
@@ -4,6 +4,7 @@ import {
   sortSessionsForHistory,
   COLLAPSE_GAP_THRESHOLD_DAYS,
 } from "./historyJourney";
+import { loadSharedFixture, type HistoryJourneyFixture } from "./testing/sharedFixtures";
 
 describe("buildHistoryJourneyRows", () => {
   test("labels sequential sessions on the same calendar day", () => {
@@ -23,7 +24,7 @@ describe("buildHistoryJourneyRows", () => {
     expect(
       rows.map(r => {
         if (r.kind === "missed") return `missed:${r.date}`;
-        if (r.kind === "collapsedGap") return `gap:${r.startDate}:${r.dayCount}`;
+        if (r.kind === "missedRange") return `gap:${r.startDate}:${r.dayCount}`;
         return `session:${r.date}:${r.sessionIndexInDay}`;
       }),
     ).toEqual([
@@ -83,7 +84,7 @@ describe("buildHistoryJourneyRows", () => {
       { sessionDate: "2026-06-05", sortKey: "b", data: { id: "b" } },
     ]);
     expect(rows).toHaveLength(3);
-    expect(rows[1]).toEqual({ kind: "collapsedGap", startDate: "2026-06-02", endDate: "2026-06-04", dayCount: 3 });
+    expect(rows[1]).toEqual({ kind: "missedRange", startDate: "2026-06-02", endDate: "2026-06-04", dayCount: 3 });
     expect(COLLAPSE_GAP_THRESHOLD_DAYS).toBe(3);
   });
 
@@ -94,7 +95,7 @@ describe("buildHistoryJourneyRows", () => {
     ]);
     expect(rows).toHaveLength(3);
     expect(rows[0]).toMatchObject({ kind: "session", data: { id: "a" } });
-    expect(rows[1]).toEqual({ kind: "collapsedGap", startDate: "2026-04-02", endDate: "2026-04-30", dayCount: 29 });
+    expect(rows[1]).toEqual({ kind: "missedRange", startDate: "2026-04-02", endDate: "2026-04-30", dayCount: 29 });
     expect(rows[2]).toMatchObject({ kind: "session", data: { id: "b" } });
   });
 
@@ -104,7 +105,7 @@ describe("buildHistoryJourneyRows", () => {
       { sessionDate: "2026-05-06", sessionType: "quick", sortKey: "b", data: { id: "q1" } },
     ]);
     expect(rows).toHaveLength(3);
-    expect(rows[1]).toEqual({ kind: "collapsedGap", startDate: "2026-04-02", endDate: "2026-05-05", dayCount: 34 });
+    expect(rows[1]).toEqual({ kind: "missedRange", startDate: "2026-04-02", endDate: "2026-05-05", dayCount: 34 });
     expect(rows[2]).toMatchObject({ kind: "session", data: { id: "q1" } });
   });
 
@@ -117,7 +118,7 @@ describe("buildHistoryJourneyRows", () => {
     );
     expect(rows).toHaveLength(2);
     // today itself is never emitted as missed.
-    expect(rows[1]).toEqual({ kind: "collapsedGap", startDate: "2026-05-02", endDate: "2026-06-10", dayCount: 40 });
+    expect(rows[1]).toEqual({ kind: "missedRange", startDate: "2026-05-02", endDate: "2026-06-10", dayCount: 40 });
   });
 
   test("a short trailing gap emits per-day missed rows", () => {
@@ -157,6 +158,38 @@ describe("buildHistoryJourneyRows", () => {
     ]);
     expect(rows).toHaveLength(3);
     expect(rows.filter(r => r.kind === "missed")).toHaveLength(0);
-    expect(rows[1]).toMatchObject({ kind: "collapsedGap", startDate: "2020-01-02", endDate: "2029-12-31" });
+    expect(rows[1]).toMatchObject({ kind: "missedRange", startDate: "2020-01-02", endDate: "2029-12-31" });
+  });
+});
+
+// Cross-platform parity: the same journey golden set is asserted by iOS
+// HistoryJourney.buildRows (#421). session rows are matched by id + per-type index.
+describe("buildHistoryJourneyRows — shared fixtures", () => {
+  const fixture = loadSharedFixture<HistoryJourneyFixture>("historyJourney.json");
+
+  test("threshold matches the shared fixture", () => {
+    expect(COLLAPSE_GAP_THRESHOLD_DAYS).toBe(fixture.collapseGapThresholdDays);
+  });
+
+  test.each(fixture.cases)("$name", ({ sessions, todayIsoDate, expectedRows }) => {
+    const rows = buildHistoryJourneyRows(
+      sessions.map(s => ({
+        sessionDate: s.sessionDate,
+        sessionType: s.sessionType,
+        sortKey: s.createdAt,
+        data: { id: s.id },
+      })),
+      todayIsoDate ?? undefined,
+    );
+
+    const actual = rows.map(r => {
+      if (r.kind === "missed") return { kind: r.kind, date: r.date };
+      if (r.kind === "missedRange") {
+        return { kind: r.kind, startDate: r.startDate, endDate: r.endDate, dayCount: r.dayCount };
+      }
+      return { kind: r.kind, id: (r.data as { id: string }).id, sessionIndexInDay: r.sessionIndexInDay };
+    });
+
+    expect(actual).toEqual(expectedRows);
   });
 });

--- a/src/lib/historyJourney.ts
+++ b/src/lib/historyJourney.ts
@@ -2,7 +2,7 @@ import { addDaysToIsoDate, daysBetweenIsoDatesInclusive } from "./sessionCalenda
 
 /**
  * Gaps of this many consecutive missed days or more collapse into a single
- * `collapsedGap` row; shorter gaps keep per-day `missed` rows (#379/#381).
+ * `missedRange` row; shorter gaps keep per-day `missed` rows (#379/#381/#421).
  * Mirrors iOS `HistoryJourney.collapseGapThresholdDays`.
  */
 export const COLLAPSE_GAP_THRESHOLD_DAYS = 3;
@@ -16,9 +16,13 @@ export type HistoryJourneySession<T> = {
   data: T;
 };
 
+/**
+ * Row kinds mirror iOS `HistoryJourneyListRow` for cross-platform parity (#421):
+ * `missed` (single day), `missedRange` (collapsed run), and `session`.
+ */
 export type HistoryJourneyRow<T> =
   | { kind: "missed"; date: string }
-  | { kind: "collapsedGap"; startDate: string; endDate: string; dayCount: number }
+  | { kind: "missedRange"; startDate: string; endDate: string; dayCount: number }
   | { kind: "session"; date: string; sessionIndexInDay: number; data: T };
 
 /**
@@ -34,7 +38,7 @@ export function sortSessionsForHistory<T>(sessions: HistoryJourneySession<T>[]):
 
 /**
  * Emits rows for the missed days strictly between `fromIso` and `toIso`: per-day
- * `missed` rows for short gaps, a single `collapsedGap` at/above the collapse
+ * `missed` rows for short gaps, a single `missedRange` at/above the collapse
  * threshold. Mirrors iOS `HistoryJourney.appendGapRows`.
  */
 function appendGapRows<T>(fromIso: string, toIso: string, rows: HistoryJourneyRow<T>[]): void {
@@ -43,7 +47,7 @@ function appendGapRows<T>(fromIso: string, toIso: string, rows: HistoryJourneyRo
   if (missedCount <= 0) return;
   if (missedCount >= COLLAPSE_GAP_THRESHOLD_DAYS) {
     rows.push({
-      kind: "collapsedGap",
+      kind: "missedRange",
       startDate: addDaysToIsoDate(fromIso, 1),
       endDate: addDaysToIsoDate(fromIso, missedCount),
       dayCount: missedCount,

--- a/src/lib/mindStateSession.test.ts
+++ b/src/lib/mindStateSession.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "vitest";
+import { computeClearPercentFromLog } from "./mindStateSession";
+import { loadSharedFixture, type ClearPercentFixture } from "./testing/sharedFixtures";
+
+// Cross-platform parity: validates the web clear-percent against the shared golden
+// set that iOS SessionLogic.calculateClearPercent also asserts (#421). Drift between
+// the two duplicated implementations breaks CI on at least one platform.
+describe("computeClearPercentFromLog — shared fixtures", () => {
+  const fixture = loadSharedFixture<ClearPercentFixture>("clearPercent.json");
+
+  test.each(fixture.cases)("$name", ({ log, endTime, expected }) => {
+    expect(computeClearPercentFromLog(log, endTime)).toBe(expected);
+  });
+});

--- a/src/lib/sessionProgression.test.ts
+++ b/src/lib/sessionProgression.test.ts
@@ -5,6 +5,7 @@ import {
   shouldAdvanceDay,
   type SessionStatsInput,
 } from "./constants";
+import { loadSharedFixture, type SessionStatsFixture } from "./testing/sharedFixtures";
 
 describe("session progression rules", () => {
   test("only advances the day counter for completed standard sessions", () => {
@@ -208,5 +209,33 @@ describe("session progression rules", () => {
     expect(stats.streak).toBe(1);
     expect(stats.bonusSecondsTotal).toBe(120);
     expect(stats.avgThoughtsPerMinute).toBe(0.9);
+  });
+});
+
+// Cross-platform parity: the same stats golden set is asserted by iOS
+// SessionStatistics.calculateStats (#421). Web exposes bonusSecondsTotal; the
+// fixture also carries bonusMinutesTotal for the iOS side.
+describe("calculateSessionStats — shared fixtures", () => {
+  const fixture = loadSharedFixture<SessionStatsFixture>("sessionStats.json");
+
+  test.each(fixture.cases)("$name", ({ sessions, expected }) => {
+    const input: SessionStatsInput[] = sessions.map(s => ({
+      sessionType: s.sessionType,
+      dayNumber: s.dayNumber,
+      duration: s.duration,
+      bonusSeconds: s.bonusSeconds,
+      completed: s.completed,
+      clearPercent: s.clearPercent,
+      thoughtCount: s.thoughtCount,
+      sessionDate: s.sessionDate,
+    }));
+
+    expect(calculateSessionStats(input)).toEqual({
+      streak: expected.streak,
+      avgClearPercent: expected.avgClearPercent,
+      avgThoughtsPerSession: expected.avgThoughtsPerSession,
+      avgThoughtsPerMinute: expected.avgThoughtsPerMinute,
+      bonusSecondsTotal: expected.bonusSecondsTotal,
+    });
   });
 });

--- a/src/lib/testing/sharedFixtures.ts
+++ b/src/lib/testing/sharedFixtures.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Loader for the cross-platform golden fixtures in `shared/test-fixtures/`
+ * (#421). The same JSON files are consumed by the iOS `swift test` suite via
+ * `SharedFixtures.swift`, so web + iOS assert against one source of truth and
+ * any drift between the duplicated algorithms breaks CI.
+ */
+const FIXTURES_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+  "shared",
+  "test-fixtures",
+);
+
+export function loadSharedFixture<T>(fileName: string): T {
+  const raw = readFileSync(join(FIXTURES_DIR, fileName), "utf8");
+  return JSON.parse(raw) as T;
+}
+
+// MARK: - Fixture shapes (mirror shared/test-fixtures/*.json)
+
+export type ClearPercentFixture = {
+  cases: Array<{
+    name: string;
+    log: Array<{ time: number; state: string }>;
+    endTime: number;
+    expected: number;
+  }>;
+};
+
+export type HistoryJourneyFixture = {
+  collapseGapThresholdDays: number;
+  cases: Array<{
+    name: string;
+    todayIsoDate: string | null;
+    sessions: Array<{
+      id: string;
+      sessionType: string;
+      sessionDate: string;
+      createdAt: string;
+    }>;
+    expectedRows: Array<
+      | { kind: "missed"; date: string }
+      | { kind: "missedRange"; startDate: string; endDate: string; dayCount: number }
+      | { kind: "session"; id: string; sessionIndexInDay: number }
+    >;
+  }>;
+};
+
+export type SessionStatsFixture = {
+  cases: Array<{
+    name: string;
+    sessions: Array<{
+      id: string;
+      sessionType: string;
+      dayNumber: number;
+      duration: number;
+      bonusSeconds: number;
+      actualTime: number;
+      completed: boolean;
+      clearPercent: number;
+      thoughtCount: number;
+      sessionDate: string;
+    }>;
+    expected: {
+      streak: number;
+      avgClearPercent: number;
+      avgThoughtsPerSession: number;
+      avgThoughtsPerMinute: number;
+      bonusSecondsTotal: number;
+      bonusMinutesTotal: number;
+    };
+  }>;
+};
+
+export type BreathCountingFixture = {
+  breathCount: Array<{ taps: number; expected: number }>;
+  phase: Array<{ taps: number; expected: "inhale" | "exhale" }>;
+  elapsedDisplay: Array<{ seconds: number; expected: string }>;
+};
+
+export type AphorismsFixture = {
+  expectedCount: number;
+  cases: Array<{ day: number; expectedIndex: number }>;
+};
+
+export type BuddyCalendarColorsFixture = {
+  paletteLength: number;
+  palette: string[];
+  cases: Array<{ userId: string; expectedIndex: number; expectedHex: string }>;
+};


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #421

## What

Introduces a cross-platform golden-fixture harness so the six algorithms duplicated between the web app (`src/lib`, TypeScript) and iOS (`StillPointShared`, Swift) can't silently drift, and aligns the web history-journey row shape to iOS.

### 1. Web → iOS history-journey alignment (intended direction)
- Renamed the web `HistoryJourneyRow` `collapsedGap` kind to **`missedRange`** so the row discriminant matches iOS `HistoryJourneyListRow.missedRange` exactly. The ≥3-day collapse threshold and date math were already identical; this closes the last naming gap.
- Updated the `HistoryView` consumer and refreshed the stale iOS comment that claimed web still emitted per-day rows.

### 2. Shared golden fixtures (`shared/test-fixtures/`)
JSON golden-sets loadable by **both vitest and XCTest**, one per duplicated algorithm:

| Fixture | Web | iOS |
| --- | --- | --- |
| `clearPercent.json` | `computeClearPercentFromLog` | `SessionLogic.calculateClearPercent` |
| `historyJourney.json` | `buildHistoryJourneyRows` | `HistoryJourney.buildRows` |
| `sessionStats.json` | `calculateSessionStats` | `SessionStatistics.calculateStats` |
| `breathCounting.json` | `breathCountForTaps`/`phaseForTaps`/`elapsedDisplay` | `BreathCounting.*` |
| `aphorisms.json` | `aphorismForDay` | `Aphorisms.forDay` |
| `buddyCalendarColors.json` | `buddyColorFromUserId` | `buddyColorIndexFromUserId` |

- Both `calculateClearPercent` implementations are kept as-is but now guarded by the shared clear-percent fixtures (previously untested on both sides).
- Loaders: web `src/lib/testing/sharedFixtures.ts` (reads relative to repo root); iOS `SharedFixtures.swift` (resolves the dir via `#filePath`, valid for `swift test` locally and in CI).
- Extended the existing vitest + XCTest suites (plus new `mindStateSession.test.ts` and `SessionLogicClearPercentTests.swift`) to assert against the fixtures, so future drift breaks CI on at least one platform.
- `README.md` documents the schema and the cross-platform value conventions (JS rounding vs Swift raw doubles, thoughts/min denominators, session ordering, negative-tap clamp) that keep the golden values identical on both platforms.

## Test plan

- ✅ `npm run test:unit` — 455 passed (50 files), including the new fixture-driven web parity suites.
- ✅ `npm run typecheck` — `tsc --noEmit` clean.
- ✅ iOS `swift test` — the `StillPointShared` package links Apple-only frameworks (SwiftData/SwiftUI/UIKit), so its required `swift test` check runs on `macos-26` in CI (`.github/workflows/ios-shared-tests.yml`), not on the Linux agent VM. To still get runtime evidence here, the pure-logic sources plus the actual new test files were compiled and run with Swift 6.0.3 on Linux against the same `shared/test-fixtures/` JSON: **50 tests, 0 failures**, including all six `testShared*Fixtures` cases (clear percent, history journey, session stats, breath counting, aphorisms, buddy colors).

Because both suites read the identical JSON, the web run and the Swift run each independently confirm the golden values, locking the two implementations together.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77935c49-4020-40f8-8684-9eb0077d8255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77935c49-4020-40f8-8684-9eb0077d8255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized how collapsed missing-day ranges are shown in history, keeping the displayed date span and count consistent.
  * Improved history display handling so collapsed gaps render correctly.

* **Tests**
  * Added broader coverage for history, session stats, breath counting, aphorisms, clear-percent, and buddy color behavior.
  * Added shared fixture-based checks to keep iOS and web results aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Keep web and iOS behavior in sync with shared parity checks**

### What Changed
- Renamed the history gap row from `collapsedGap` to `missedRange` so the web app matches iOS row names.
- Added shared fixture-based tests for aphorisms, breath counting, history rows, session stats, buddy colors, and clear-percent calculations on both web and iOS.
- Added shared fixture files and loading helpers so both platforms validate the same expected results in CI.
- Updated history, session, and fixture documentation to describe the shared rules and matching outcomes.

### Impact
`✅ Fewer web/iOS behavior mismatches`
`✅ Earlier detection of algorithm drift`
`✅ Clearer history gap row names`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
