### PR TITLE
Design-token single source of truth CI lint (#420)

### DIFF
--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -26,5 +26,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify design token parity (iOS ↔ web)
+        run: npm run e2e:policy:design-tokens
+
       - name: Verify repeatable clean builds
         run: npm run build:verify -- 3

--- a/ios/StillPointApp/Theme/DesignTokens.swift
+++ b/ios/StillPointApp/Theme/DesignTokens.swift
@@ -41,10 +41,10 @@ public enum SPColor {
     static let amberBg = amber.opacity(0.15)
     static let amberBgFaint = amber.opacity(0.06)
 
-    // Red / Danger
-    static let danger = Color.red.opacity(0.7)
-    static let dangerMuted = Color.red.opacity(0.5)
-    static let dangerBorderSubtle = Color.red.opacity(0.15)
+    // Red / Danger (Tailwind red-500 #ef4444)
+    static let danger = Color(red: 239/255, green: 68/255, blue: 68/255).opacity(0.7)
+    static let dangerMuted = Color(red: 239/255, green: 68/255, blue: 68/255).opacity(0.5)
+    static let dangerBorderSubtle = Color(red: 239/255, green: 68/255, blue: 68/255).opacity(0.15)
 
     // Overlay
     static let overlayText = Color.black.opacity(0.5)

--- a/ios/StillPointAppUITests/Snapshots/SnapshotTests.swift
+++ b/ios/StillPointAppUITests/Snapshots/SnapshotTests.swift
@@ -216,14 +216,24 @@ final class SnapshotTests: XCTestCase {
         XCTAssertTrue(root.waitForExistence(timeout: launchTimeout), message)
     }
 
-    private func terminateAppReliably(_ app: XCUIApplication, attempts: Int = 4) {
+    private func terminateAppReliably(_ app: XCUIApplication, attempts: Int = 6) {
+        if app.state == .notRunning { return }
+
         for _ in 1 ... attempts {
-            app.terminate()
-            let deadline = Date().addingTimeInterval(15)
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+            if app.state == .notRunning { return }
+
+            _ = app.terminate()
+
+            let deadline = Date().addingTimeInterval(20)
             while Date() < deadline {
                 if app.state == .notRunning { return }
-                RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+                RunLoop.current.run(until: Date().addingTimeInterval(0.25))
             }
+
+            XCUIDevice.shared.press(.home)
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+            if app.state == .notRunning { return }
         }
         XCTFail("App did not terminate")
     }

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -86,6 +86,8 @@ final class StillPointAppUITests: XCTestCase {
             app.otherElements["root.currentView.session"].waitForExistence(timeout: 20),
             "Session screen did not appear after Begin tap"
         )
+        // Let session chrome/timer settle before terminate (macos-26 launchd race).
+        _ = app.staticTexts["session.timerLabel"].waitForExistence(timeout: 8)
         app.launchEnvironment["SP_UI_TEST_SEED_AUTH"] = "1"
         terminateAppReliably(app)
         app.launch()
@@ -565,17 +567,25 @@ final class StillPointAppUITests: XCTestCase {
         return nil
     }
 
-    /// Retries `terminate()` since XCTest occasionally reports "Failed to terminate … :0" on loaded CI simulators.
-    private func terminateAppReliably(_ app: XCUIApplication, attempts: Int = 4) {
+    /// Retries termination since XCTest occasionally reports "Failed to terminate … :0" on loaded CI simulators.
+    private func terminateAppReliably(_ app: XCUIApplication, attempts: Int = 6) {
+        if app.state == .notRunning { return }
+
         for _ in 1...attempts {
-            app.terminate()
-            let deadline = Date().addingTimeInterval(15)
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+            if app.state == .notRunning { return }
+
+            _ = app.terminate()
+
+            let deadline = Date().addingTimeInterval(20)
             while Date() < deadline {
-                if app.state == .notRunning {
-                    return
-                }
-                RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+                if app.state == .notRunning { return }
+                RunLoop.current.run(until: Date().addingTimeInterval(0.25))
             }
+
+            XCUIDevice.shared.press(.home)
+            RunLoop.current.run(until: Date().addingTimeInterval(0.5))
+            if app.state == .notRunning { return }
         }
         XCTFail("App did not reach notRunning after \(attempts) terminate attempts")
     }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "e2e:guard": "node scripts/e2e/assert-non-prod.mjs",
     "e2e:policy:no-sleep": "node scripts/e2e/check-no-naked-sleep.mjs",
     "e2e:policy:secrets": "node scripts/e2e/check-test-secrets.mjs",
+    "e2e:policy:design-tokens": "node scripts/e2e/check-design-tokens.mjs",
     "e2e:policy": "E2E_BASE_URL=${E2E_BASE_URL:-http://127.0.0.1:3000} npm run e2e:policy:no-sleep && npm run e2e:policy:secrets && E2E_BASE_URL=${E2E_BASE_URL:-http://127.0.0.1:3000} npm run e2e:guard",
     "e2e:setup-web-user": "tsx scripts/e2e/setup-web-user.ts",
     "ios:app-store:dry-run": "node scripts/ios-app-store-dry-run.mjs",

--- a/scripts/e2e/check-design-tokens.mjs
+++ b/scripts/e2e/check-design-tokens.mjs
@@ -1,0 +1,341 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ROOT = process.cwd();
+const GLOBALS_CSS = resolve(ROOT, "src/app/globals.css");
+const DESIGN_TOKENS = resolve(ROOT, "ios/StillPointApp/Theme/DesignTokens.swift");
+
+/** @typedef {{ r: number, g: number, b: number, a: number }} Rgba */
+
+/** Shared color tokens: Swift SPColor name -> CSS custom property. */
+const SHARED_COLOR_MAP = {
+  bg: { css: "--bg-rgb", format: "rgb-triple" },
+  fg: { css: "--fg" },
+  fg2: { css: "--fg-2" },
+  fg3: { css: "--fg-3" },
+  fg4: { css: "--fg-4" },
+  border1: { css: "--border-1" },
+  border2: { css: "--border-2" },
+  border3: { css: "--border-3" },
+  surface1: { css: "--surface-1" },
+  surface2: { css: "--surface-2" },
+  surface3: { css: "--surface-3" },
+  green: { css: "--accent-green" },
+  greenEnd: { css: "--accent-green-end" },
+  greenText: { css: "--accent-green-text" },
+  greenBorder: { css: "--accent-green-border" },
+  greenBorderSubtle: { css: "--accent-green-border-subtle" },
+  greenBgSubtle: { css: "--accent-green-bg-subtle" },
+  greenBgFaint: { css: "--accent-green-bg-faint" },
+  amber: { css: "--accent-amber" },
+  amberEnd: { css: "--accent-amber-end" },
+  amberText: { css: "--accent-amber-text" },
+  amberDim: { css: "--accent-amber-dim" },
+  amberBorder: { css: "--accent-amber-border" },
+  amberBorderSubtle: { css: "--accent-amber-border-subtle" },
+  amberBg: { css: "--accent-amber-bg" },
+  amberBgFaint: { css: "--accent-amber-bg-faint" },
+  danger: { css: "--accent-danger" },
+  dangerMuted: { css: "--accent-danger-muted" },
+  dangerBorderSubtle: { css: "--accent-danger-border-subtle" },
+  overlayText: { css: "--overlay-text" },
+};
+
+/** Shared spacing tokens: Swift SPSpacing name -> CSS custom property. */
+const SHARED_SPACING_MAP = {
+  s1: { css: "--s1" },
+  s2: { css: "--s2" },
+  s3: { css: "--s3" },
+  s4: { css: "--s4" },
+  s5: { css: "--s5" },
+  s6: { css: "--s6" },
+};
+
+/** Web-only tokens that intentionally have no iOS counterpart. */
+const CSS_ONLY_VARS = new Set([
+  "--accent-green-strong",
+  "--accent-green-dim",
+  "--accent-green-bg",
+  "--accent-green-glow",
+  "--accent-green-muted",
+  "--accent-amber-hint",
+  "--accent-amber-muted",
+  "--accent-danger-border",
+  "--overlay-bg",
+  "--nav-h",
+]);
+
+const SHARED_CSS_VARS = new Set([
+  ...Object.values(SHARED_COLOR_MAP).map((entry) => entry.css),
+  ...Object.values(SHARED_SPACING_MAP).map((entry) => entry.css),
+]);
+
+function evalFraction(raw) {
+  if (raw.includes("/")) {
+    const [numerator, denominator] = raw.split("/").map(Number);
+    return numerator / denominator;
+  }
+  return Number(raw);
+}
+
+/** @param {string} css */
+function parseCssVars(css) {
+  const rootMatch = css.match(/:root\s*\{([\s\S]*?)\}/);
+  if (!rootMatch) {
+    throw new Error("Could not find :root block in globals.css");
+  }
+
+  /** @type {Record<string, string>} */
+  const vars = {};
+  const declRe = /--([a-z0-9-]+)\s*:\s*([^;]+);/gi;
+  let match;
+  while ((match = declRe.exec(rootMatch[1])) !== null) {
+    vars[`--${match[1]}`] = match[2].trim();
+  }
+  return vars;
+}
+
+/** @param {string} value @returns {Rgba | null} */
+function parseCssColor(value) {
+  let match = value.match(/^rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*([\d.]+)\s*\)$/);
+  if (match) {
+    return { r: Number(match[1]), g: Number(match[2]), b: Number(match[3]), a: Number(match[4]) };
+  }
+
+  match = value.match(/^rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$/);
+  if (match) {
+    return { r: Number(match[1]), g: Number(match[2]), b: Number(match[3]), a: 1 };
+  }
+
+  match = value.match(/^#([0-9a-f]{6})$/i);
+  if (match) {
+    const hex = match[1];
+    return {
+      r: parseInt(hex.slice(0, 2), 16),
+      g: parseInt(hex.slice(2, 4), 16),
+      b: parseInt(hex.slice(4, 6), 16),
+      a: 1,
+    };
+  }
+
+  match = value.match(/^(\d+)\s*,\s*(\d+)\s*,\s*(\d+)$/);
+  if (match) {
+    return { r: Number(match[1]), g: Number(match[2]), b: Number(match[3]), a: 1 };
+  }
+
+  return null;
+}
+
+/** @param {Rgba} color */
+function formatRgba(color) {
+  if (color.a === 1) {
+    return `rgb(${color.r}, ${color.g}, ${color.b})`;
+  }
+  return `rgba(${color.r}, ${color.g}, ${color.b}, ${color.a})`;
+}
+
+/** @param {Rgba} left @param {Rgba} right */
+function rgbaEqual(left, right) {
+  return (
+    left.r === right.r &&
+    left.g === right.g &&
+    left.b === right.b &&
+    Math.abs(left.a - right.a) < 0.001
+  );
+}
+
+/**
+ * @param {string} swift
+ * @returns {{ colors: Record<string, Rgba>, rawExprs: Record<string, string> }}
+ */
+function parseSwiftColors(swift) {
+  const spColorBlock = swift.match(/public enum SPColor\s*\{([\s\S]*?)\n\}/);
+  if (!spColorBlock) {
+    throw new Error("Could not find SPColor enum in DesignTokens.swift");
+  }
+
+  /** @type {Record<string, Rgba>} */
+  const colors = {};
+  /** @type {Record<string, string>} */
+  const rawExprs = {};
+  const declRe = /static let (\w+) = (.+)/g;
+  let match;
+
+  while ((match = declRe.exec(spColorBlock[1])) !== null) {
+    rawExprs[match[1]] = match[2].trim();
+  }
+
+  /** @param {string} name @returns {Rgba} */
+  function resolveColor(name) {
+    if (colors[name]) {
+      return colors[name];
+    }
+
+    const expr = rawExprs[name];
+    if (!expr) {
+      throw new Error(`Unknown Swift color token: ${name}`);
+    }
+
+    const rgbMatch = expr.match(
+      /^Color\(red:\s*([\d.]+(?:\/\d+)?),\s*green:\s*([\d.]+(?:\/\d+)?),\s*blue:\s*([\d.]+(?:\/\d+)?)\)(?:\.opacity\(([\d.]+)\))?$/
+    );
+    if (rgbMatch) {
+      const color = {
+        r: Math.round(evalFraction(rgbMatch[1]) * 255),
+        g: Math.round(evalFraction(rgbMatch[2]) * 255),
+        b: Math.round(evalFraction(rgbMatch[3]) * 255),
+        a: rgbMatch[4] ? Number(rgbMatch[4]) : 1,
+      };
+      colors[name] = color;
+      return color;
+    }
+
+    const derivedMatch = expr.match(/^([\w.]+)\.opacity\(([\d.]+)\)$/);
+    if (derivedMatch) {
+      const baseToken = derivedMatch[1].replace(/^Color\./, "");
+      if (baseToken === "red") {
+        throw new Error(
+          `SPColor.${name} uses system Color.red; use explicit Tailwind red-500 RGB (239, 68, 68) instead`
+        );
+      }
+      if (baseToken === "black") {
+        const color = { r: 0, g: 0, b: 0, a: Number(derivedMatch[2]) };
+        colors[name] = color;
+        return color;
+      }
+      const base = resolveColor(baseToken);
+      const color = { ...base, a: Number(derivedMatch[2]) };
+      colors[name] = color;
+      return color;
+    }
+
+    throw new Error(`Unsupported SPColor expression for ${name}: ${expr}`);
+  }
+
+  for (const name of Object.keys(rawExprs)) {
+    resolveColor(name);
+  }
+
+  return { colors, rawExprs };
+}
+
+/** @param {string} swift @returns {Record<string, number>} */
+function parseSwiftSpacing(swift) {
+  const spSpacingBlock = swift.match(/public enum SPSpacing\s*\{([\s\S]*?)\n\}/);
+  if (!spSpacingBlock) {
+    throw new Error("Could not find SPSpacing enum in DesignTokens.swift");
+  }
+
+  /** @type {Record<string, number>} */
+  const spacing = {};
+  const declRe = /static let (\w+):\s*CGFloat\s*=\s*(\d+)/g;
+  let match;
+  while ((match = declRe.exec(spSpacingBlock[1])) !== null) {
+    spacing[match[1]] = Number(match[2]);
+  }
+  return spacing;
+}
+
+/** @param {string} cssValue @returns {number | null} */
+function parseCssSpacing(cssValue) {
+  const match = cssValue.match(/^(\d+)px$/);
+  return match ? Number(match[1]) : null;
+}
+
+function main() {
+  const cssContent = readFileSync(GLOBALS_CSS, "utf8");
+  const swiftContent = readFileSync(DESIGN_TOKENS, "utf8");
+  const cssVars = parseCssVars(cssContent);
+  const { colors: swiftColors } = parseSwiftColors(swiftContent);
+  const swiftSpacing = parseSwiftSpacing(swiftContent);
+
+  const violations = [];
+
+  for (const [swiftName, { css, format }] of Object.entries(SHARED_COLOR_MAP)) {
+    const cssValue = cssVars[css];
+    if (!cssValue) {
+      violations.push(`Missing CSS variable ${css} for shared token SPColor.${swiftName}`);
+      continue;
+    }
+
+    const swiftColor = swiftColors[swiftName];
+    if (!swiftColor) {
+      violations.push(`Missing Swift token SPColor.${swiftName} for shared CSS variable ${css}`);
+      continue;
+    }
+
+    const cssColor = parseCssColor(cssValue);
+    if (!cssColor) {
+      violations.push(`Could not parse CSS color for ${css}: ${cssValue}`);
+      continue;
+    }
+
+    if (format === "rgb-triple") {
+      if (!rgbaEqual(swiftColor, cssColor)) {
+        violations.push(
+          `SPColor.${swiftName} (${formatRgba(swiftColor)}) != ${css} (${cssValue})`
+        );
+      }
+      continue;
+    }
+
+    if (!rgbaEqual(swiftColor, cssColor)) {
+      violations.push(
+        `SPColor.${swiftName} (${formatRgba(swiftColor)}) != ${css} (${cssValue})`
+      );
+    }
+  }
+
+  for (const [swiftName, { css }] of Object.entries(SHARED_SPACING_MAP)) {
+    const cssValue = cssVars[css];
+    if (!cssValue) {
+      violations.push(`Missing CSS variable ${css} for shared token SPSpacing.${swiftName}`);
+      continue;
+    }
+
+    const swiftValue = swiftSpacing[swiftName];
+    if (swiftValue == null) {
+      violations.push(`Missing Swift token SPSpacing.${swiftName} for shared CSS variable ${css}`);
+      continue;
+    }
+
+    const cssSpacing = parseCssSpacing(cssValue);
+    if (cssSpacing == null) {
+      violations.push(`Could not parse CSS spacing for ${css}: ${cssValue}`);
+      continue;
+    }
+
+    if (swiftValue !== cssSpacing) {
+      violations.push(`SPSpacing.${swiftName} (${swiftValue}) != ${css} (${cssValue})`);
+    }
+  }
+
+  for (const cssVar of Object.keys(cssVars)) {
+    if (SHARED_CSS_VARS.has(cssVar) || CSS_ONLY_VARS.has(cssVar)) {
+      continue;
+    }
+    violations.push(
+      `Unexpected CSS token ${cssVar} is neither shared nor listed as platform-specific`
+    );
+  }
+
+  if (violations.length > 0) {
+    console.error("Design token parity check failed:");
+    for (const violation of violations) {
+      console.error(`  - ${violation}`);
+    }
+    console.error("");
+    console.error(
+      "Shared tokens must stay aligned between ios/StillPointApp/Theme/DesignTokens.swift and src/app/globals.css."
+    );
+    process.exit(1);
+  }
+
+  const sharedColorCount = Object.keys(SHARED_COLOR_MAP).length;
+  const sharedSpacingCount = Object.keys(SHARED_SPACING_MAP).length;
+  console.log(
+    `Design token parity check passed (${sharedColorCount} shared colors, ${sharedSpacingCount} shared spacing values, ${CSS_ONLY_VARS.size} web-only CSS tokens).`
+  );
+}
+
+main();

--- a/scripts/e2e/run-ios-tests.sh
+++ b/scripts/e2e/run-ios-tests.sh
@@ -207,6 +207,11 @@ is_retriable_failure() {
   if grep -qE 'Asynchronous wait failed: Exceeded timeout' "$log"; then
     return 0
   fi
+  # macos-26/iOS 26 launchd terminate race: XCTest logs "Failed to terminate … :0"
+  # when SIGTERM hits a process still winding down navigation/audio. Infra-shaped.
+  if grep -qE 'Failed to terminate .*: Failed to terminate .*:0' "$log"; then
+    return 0
+  fi
   # XCTAssert* failures (other than timeout-shaped XCTAssertTrue handled above):
   # e.g., "XCTAssertEqual failed - (<a>) is not equal to (<b>)".
   if grep -qE 'XCTAssert[A-Za-z]* failed' "$log"; then

--- a/scripts/e2e/run-ios-tests.sh
+++ b/scripts/e2e/run-ios-tests.sh
@@ -207,15 +207,19 @@ is_retriable_failure() {
   if grep -qE 'Asynchronous wait failed: Exceeded timeout' "$log"; then
     return 0
   fi
+  # XCTAssert* failures (other than timeout-shaped XCTAssertTrue handled above):
+  # e.g., "XCTAssertEqual failed - (<a>) is not equal to (<b>)". Checked before
+  # the terminate-race grep below: `terminateAppReliably` can emit "Failed to
+  # terminate" lines during teardown even when the run also hit a real
+  # assertion failure, so a genuine failure must win over that infra-shaped
+  # noise rather than being masked as retriable.
+  if grep -qE 'XCTAssert[A-Za-z]* failed' "$log"; then
+    return 1
+  fi
   # macos-26/iOS 26 launchd terminate race: XCTest logs "Failed to terminate … :0"
   # when SIGTERM hits a process still winding down navigation/audio. Infra-shaped.
   if grep -qE 'Failed to terminate .*: Failed to terminate .*:0' "$log"; then
     return 0
-  fi
-  # XCTAssert* failures (other than timeout-shaped XCTAssertTrue handled above):
-  # e.g., "XCTAssertEqual failed - (<a>) is not equal to (<b>)".
-  if grep -qE 'XCTAssert[A-Za-z]* failed' "$log"; then
-    return 1
   fi
   # XCTest method-level error frames referencing a test selector starting
   # with "test...". Accept both Swift-style "Module.Class" and ObjC-style


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #420

## Summary

Adds a CI lint that keeps shared design tokens aligned between `ios/StillPointApp/Theme/DesignTokens.swift` and `src/app/globals.css`, following the existing `e2e:policy:*` script pattern.

Also fixes the known divergence: iOS danger colors now use explicit Tailwind red-500 RGB (`239, 68, 68`) instead of system `Color.red`.

Includes CI hardening for the unrelated `ios-e2e-smoke` terminate flake: wait for session timer before terminate, retry with home-button fallback, and classify macos-26 launchd `"Failed to terminate … :0"` as retriable infra.

## Changes

- **`scripts/e2e/check-design-tokens.mjs`** — parses and compares 30 shared color tokens + 6 spacing tokens; normalizes color formats; recognizes 10 web-only CSS variables; rejects `Color.red`.
- **`DesignTokens.swift`** — `danger`, `dangerMuted`, and `dangerBorderSubtle` now match `--accent-danger*` in `globals.css`.
- **`package.json`** — `npm run e2e:policy:design-tokens`
- **`.github/workflows/web-build.yml`** — runs the lint on every PR/push to `main`
- **`StillPointAppUITests.swift` / `run-ios-tests.sh`** — harden terminate helper and retriable classification for simulator launchd race

## Test plan

- [x] `npm run e2e:policy:design-tokens` passes locally
- [x] CI `Web Build` workflow runs the new step successfully
- [x] CI `ios-e2e-smoke` passes (or retries on terminate infra flake)
- [x] Visual spot-check: iOS danger/destructive UI still renders red, now consistent with web

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d51d00a-60f9-432f-b5b5-992689e1c85e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d51d00a-60f9-432f-b5b5-992689e1c85e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

