### PR TITLE
feat(ios): reusable SPCapsuleButtonStyle ViewModifier

### DIFF
--- a/docs/testing/e2e-policy.md
+++ b/docs/testing/e2e-policy.md
@@ -28,10 +28,11 @@ Rules:
 **Enforcement (iOS lanes):** `scripts/e2e/run-ios-tests.sh` runs a 4-tier classifier on each failed attempt:
 
 1. **Crash check first** — if a `*StillPoint*` diagnostic report under `~/Library/Logs/DiagnosticReports/` was written after the attempt-start sentinel (`<lane>-attempt-N.start`), the failure is treated as infra and consumes a retry, **regardless of any concurrent assertion-shape line in the log**. This catches macos-26 simulator XPC faults that surface as timeout-shaped assertions like `XCTAssertTrue failed - Session screen did not appear after Begin tap` but are actually launchd/sim-level crashes.
-2. **Timeout-shaped UI wait second** — if no crash report is correlated, treat the failure as retriable when the log contains either of:
+2. **Timeout-shaped UI wait second** — if no crash report is correlated, treat the failure as retriable when the log contains any of:
     - `XCTAssertTrue failed - <msg>` where `<msg>` matches `did not appear / never appear(ed) / did not exist / does not exist / should be visible / should appear / should exist / not found / never became / did not become / did not show` (case-insensitive — typical `waitForExistence(timeout:)` shape).
     - `Asynchronous wait failed: Exceeded timeout` (XCTestExpectation/`wait(for:)` predicate-value waits, e.g. `Expect predicate value == "visible" for object "session.secondaryChromeMarker"`).
-   These are UI timing flakes (mocked-API stalls, animation handoff delays, focus timing) that don't always trigger an `.ips` but reproduce inconsistently across attempts.
+    - `Failed to set device orientation:` (simulator automation stalls in `setUpWithError()` before the app launches).
+   These are UI timing flakes (mocked-API stalls, animation handoff delays, focus timing, simulator orientation confirmation) that don't always trigger an `.ips` but reproduce inconsistently across attempts.
 3. **Strict assertion check third** — for value assertions (`XCTAssertEqual`, `XCTAssertNotNil`, `XCTAssertGreaterThan`, etc.) and any `XCTAssertTrue` whose message does NOT match the timeout indicators above, the script exits without consuming the retry budget. Method-level frames like `error: -[<Module.>?<TestClass> <testMethod>]` are also non-retriable.
 4. **Default** — any other failure (infra/transient/unknown) consumes retries up to the table value.
 

--- a/ios/StillPoint.xcodeproj/project.pbxproj
+++ b/ios/StillPoint.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		6760DF427777049973A0D182 /* AppleSignInController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8807A08DBDE8A121951350FD /* AppleSignInController.swift */; };
 		6B6572152FB23B94F990D66B /* AppBlockingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F0B6135A30B315B9962460 /* AppBlockingManager.swift */; };
 		6E8830D16FED5FBB78B6DF34 /* XCUIElement+TapAndType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E69E315D37F87410DBE4B8C /* XCUIElement+TapAndType.swift */; };
+		A7B8C9D0E1F2031425364758 /* XCUIDevice+Portrait.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B8C9D0E1F2031425364759 /* XCUIDevice+Portrait.swift */; };
 		74AE784447C3D50E1E6980E9 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7766937C968433C205A250C /* HistoryView.swift */; };
 		750987110FAE532744F6571E /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 45BC84AB51307C865EF7257A /* README.md */; };
 		80005A5883007151E3A9C5C3 /* MindStateBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB771FA099C779B2F3A86AB /* MindStateBarView.swift */; };
@@ -116,6 +117,7 @@
 		2FF304356E66657666901E4F /* SessionStateBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStateBadge.swift; sourceTree = "<group>"; };
 		3D00E2E996D254A5D3D96DF9 /* BuddySessionHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddySessionHubView.swift; sourceTree = "<group>"; };
 		3E69E315D37F87410DBE4B8C /* XCUIElement+TapAndType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElement+TapAndType.swift"; sourceTree = "<group>"; };
+		A7B8C9D0E1F2031425364759 /* XCUIDevice+Portrait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIDevice+Portrait.swift"; sourceTree = "<group>"; };
 		42927B68B0A976D71FE0637F /* ThoughtJournalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThoughtJournalViewModel.swift; sourceTree = "<group>"; };
 		4448B4F081A909461B669A8B /* StillPointApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = StillPointApp.entitlements; sourceTree = "<group>"; };
 		44912B427658554F984CCC3A /* ThoughtJournalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThoughtJournalView.swift; sourceTree = "<group>"; };
@@ -283,6 +285,7 @@
 		54D40F602F07E94E9BD6CF37 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				A7B8C9D0E1F2031425364759 /* XCUIDevice+Portrait.swift */,
 				3E69E315D37F87410DBE4B8C /* XCUIElement+TapAndType.swift */,
 			);
 			path = Helpers;
@@ -539,6 +542,7 @@
 				1AD1C504911C0820878EFAA4 /* SnapshotHelper.swift in Sources */,
 				E636EACFC27E6022A80898FC /* SnapshotTests.swift in Sources */,
 				A564D3891222DA735A7F96B7 /* StillPointAppUITests.swift in Sources */,
+				A7B8C9D0E1F2031425364758 /* XCUIDevice+Portrait.swift in Sources */,
 				6E8830D16FED5FBB78B6DF34 /* XCUIElement+TapAndType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/StillPoint.xcodeproj/project.pbxproj
+++ b/ios/StillPoint.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		B6A3805810E44935E75EEC11 /* AppBlockingSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B72DC4A41DAD78C377853469 /* AppBlockingSettingsView.swift */; };
 		C0FD436A962D0DC179B37D73 /* NotificationsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A34376705757DF9CD77D013A /* NotificationsSettingsView.swift */; };
 		C57D92D33ED679E23F5E2E49 /* DesignTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB4B1423B22DD22F5B6E069 /* DesignTokens.swift */; };
+		F8A2B3C4D5E60718293A4B5E /* SPCapsuleButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A2B3C4D5E60718293A4B5F /* SPCapsuleButtonStyle.swift */; };
 		D3744C3003DA233DC0B74C99 /* BuddyFilterChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DAA0ED0064C69AE18FAD991 /* BuddyFilterChips.swift */; };
 		D44FB0782DD33A5900AF8D60 /* BuddyCalendarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE015F8D72AE054E6990FB3 /* BuddyCalendarViewModel.swift */; };
 		D4BA6F49AEC3DDCE40AFE5D1 /* BuddySessionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FF5BFB92C98C791296977A /* BuddySessionViewModel.swift */; };
@@ -153,6 +154,7 @@
 		C683A9F0586D58020E60DD87 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		C7766937C968433C205A250C /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryView.swift; sourceTree = "<group>"; };
 		CDB4B1423B22DD22F5B6E069 /* DesignTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignTokens.swift; sourceTree = "<group>"; };
+		F8A2B3C4D5E60718293A4B5F /* SPCapsuleButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPCapsuleButtonStyle.swift; sourceTree = "<group>"; };
 		D15A7FF17302B1E2FD147920 /* StillPoint.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = StillPoint.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D356465C1B0F69C57FE47A80 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		F5E4D3C2B1A0918273645566 /* UsernameEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsernameEditView.swift; sourceTree = "<group>"; };
@@ -359,6 +361,7 @@
 			isa = PBXGroup;
 			children = (
 				CDB4B1423B22DD22F5B6E069 /* DesignTokens.swift */,
+				F8A2B3C4D5E60718293A4B5F /* SPCapsuleButtonStyle.swift */,
 			);
 			path = Theme;
 			sourceTree = "<group>";
@@ -566,6 +569,7 @@
 				840761F5A9A217D4441A7FB5 /* BuddyWaitingRoomView.swift in Sources */,
 				9ECB83ED063EDAA82E88004B /* CompletionView.swift in Sources */,
 				C57D92D33ED679E23F5E2E49 /* DesignTokens.swift in Sources */,
+				F8A2B3C4D5E60718293A4B5E /* SPCapsuleButtonStyle.swift in Sources */,
 				5147B5721B90EB7D83D843FF /* DeviceTokenStore.swift in Sources */,
 				74AE784447C3D50E1E6980E9 /* HistoryView.swift in Sources */,
 				50CD873CA594B5A6FCDBB251 /* HistoryViewModel.swift in Sources */,

--- a/ios/StillPointApp/Theme/SPCapsuleButtonStyle.swift
+++ b/ios/StillPointApp/Theme/SPCapsuleButtonStyle.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+
+// MARK: - Capsule button style
+
+enum SPCapsuleButtonColor {
+    case neutral
+    case amber
+    case danger
+    case green
+    case greenSolid
+    case greenGradient
+}
+
+enum SPCapsuleButtonSize {
+    case compact
+    case regular
+    case fullWidth
+}
+
+struct SPCapsuleButtonStyle: ViewModifier {
+    let color: SPCapsuleButtonColor
+    let size: SPCapsuleButtonSize
+    var prominent: Bool = false
+    var tall: Bool = false
+    var minHeight: CGFloat?
+    var horizontalPadding: CGFloat?
+    var stroke: Color?
+
+    func body(content: Content) -> some View {
+        content
+            .foregroundStyle(foregroundColor)
+            .padding(.horizontal, resolvedHorizontalPadding)
+            .padding(.vertical, verticalPadding)
+            .frame(minHeight: minHeight)
+            .frame(maxWidth: size == .fullWidth ? .infinity : nil)
+            .background(background)
+            .clipShape(Capsule())
+            .overlay(strokeOverlay)
+    }
+
+    private var foregroundColor: Color {
+        switch color {
+        case .neutral:
+            return prominent ? Color(SPColor.fg) : Color(SPColor.fg3)
+        case .amber:
+            return SPColor.amberText
+        case .danger:
+            return SPColor.dangerMuted
+        case .green:
+            return SPColor.greenText
+        case .greenSolid, .greenGradient:
+            return Color(SPColor.bg)
+        }
+    }
+
+    private var resolvedHorizontalPadding: CGFloat? {
+        if let horizontalPadding { return horizontalPadding }
+        switch size {
+        case .compact, .regular:
+            return size == .compact ? SPSpacing.s3 : SPSpacing.s4
+        case .fullWidth:
+            return nil
+        }
+    }
+
+    private var verticalPadding: CGFloat {
+        if tall { return SPSpacing.s3 }
+        switch size {
+        case .compact:
+            return SPSpacing.s1
+        case .regular, .fullWidth:
+            return SPSpacing.s2
+        }
+    }
+
+    @ViewBuilder
+    private var background: some View {
+        switch color {
+        case .neutral:
+            prominent ? SPColor.surface2 : SPColor.surface1
+        case .amber:
+            SPColor.amberBgFaint
+        case .danger:
+            SPColor.surface1
+        case .green:
+            SPColor.greenBgFaint
+        case .greenSolid:
+            SPColor.green
+        case .greenGradient:
+            LinearGradient.greenHorizontal
+        }
+    }
+
+    @ViewBuilder
+    private var strokeOverlay: some View {
+        if let strokeColor = strokeColor {
+            Capsule().stroke(strokeColor)
+        }
+    }
+
+    private var strokeColor: Color? {
+        if let stroke { return stroke }
+        switch color {
+        case .neutral:
+            return prominent ? SPColor.border2 : SPColor.border1
+        case .amber:
+            return SPColor.amberBorderSubtle
+        case .danger:
+            return SPColor.dangerBorderSubtle
+        case .green:
+            return SPColor.greenBorderSubtle
+        case .greenSolid, .greenGradient:
+            return nil
+        }
+    }
+}
+
+extension View {
+    func spCapsuleButtonStyle(
+        _ color: SPCapsuleButtonColor,
+        size: SPCapsuleButtonSize = .regular,
+        prominent: Bool = false,
+        tall: Bool = false,
+        minHeight: CGFloat? = nil,
+        horizontalPadding: CGFloat? = nil,
+        stroke: Color? = nil
+    ) -> some View {
+        modifier(
+            SPCapsuleButtonStyle(
+                color: color,
+                size: size,
+                prominent: prominent,
+                tall: tall,
+                minHeight: minHeight,
+                horizontalPadding: horizontalPadding,
+                stroke: stroke
+            )
+        )
+    }
+}

--- a/ios/StillPointApp/Theme/SPCapsuleButtonStyle.swift
+++ b/ios/StillPointApp/Theme/SPCapsuleButtonStyle.swift
@@ -53,13 +53,15 @@ struct SPCapsuleButtonStyle: ViewModifier {
         }
     }
 
-    private var resolvedHorizontalPadding: CGFloat? {
+    private var resolvedHorizontalPadding: CGFloat {
         if let horizontalPadding { return horizontalPadding }
         switch size {
-        case .compact, .regular:
-            return size == .compact ? SPSpacing.s3 : SPSpacing.s4
+        case .compact:
+            return SPSpacing.s3
+        case .regular:
+            return SPSpacing.s4
         case .fullWidth:
-            return nil
+            return 0
         }
     }
 

--- a/ios/StillPointApp/Views/AppBlockingSettingsView.swift
+++ b/ios/StillPointApp/Views/AppBlockingSettingsView.swift
@@ -49,23 +49,14 @@ struct AppBlockingSettingsView: View {
                 } label: {
                     Text(manager.hasSelection ? "Edit blocked apps" : "Choose apps")
                         .font(SPFont.mono(13, weight: .medium))
-                        .foregroundStyle(Color(SPColor.bg))
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, SPSpacing.s2)
-                        .background(SPColor.green)
-                        .clipShape(Capsule())
+                        .spCapsuleButtonStyle(.greenSolid, size: .fullWidth)
                 }
                 .accessibilityIdentifier("appBlocking.chooseAppsButton")
 
                 if manager.hasSelection && !manager.isUnlocked {
                     Text("\(manager.selectedItemCount)")
                         .font(SPFont.mono(13, weight: .medium))
-                        .foregroundStyle(SPColor.amberText)
-                        .padding(.horizontal, SPSpacing.s3)
-                        .padding(.vertical, SPSpacing.s2)
-                        .background(SPColor.amberBgFaint)
-                        .clipShape(Capsule())
-                        .overlay(Capsule().stroke(SPColor.amberBorderSubtle))
+                        .spCapsuleButtonStyle(.amber, size: .regular, horizontalPadding: SPSpacing.s3)
                         .accessibilityIdentifier("appBlocking.selectedCount")
                 }
             }

--- a/ios/StillPointApp/Views/AuthView.swift
+++ b/ios/StillPointApp/Views/AuthView.swift
@@ -88,12 +88,7 @@ struct AuthView: View {
                     } label: {
                         Text(vm.isSignUp ? "Begin the journey" : "Enter")
                             .font(SPFont.serifItalic(18, weight: .light))
-                            .foregroundStyle(Color(SPColor.fg))
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, SPSpacing.s2)
-                            .background(SPColor.surface2)
-                            .clipShape(Capsule())
-                            .overlay(Capsule().stroke(SPColor.border2))
+                            .spCapsuleButtonStyle(.neutral, size: .fullWidth, prominent: true)
                     }
                     .accessibilityIdentifier("auth.submitButton")
                     .disabled(!vm.isValid || vm.isAuthInFlight)
@@ -153,11 +148,9 @@ struct AuthView: View {
                                     .font(SPFont.serif(17))
                                     .foregroundStyle(Color(SPColor.fg))
                             }
-                            .frame(maxWidth: .infinity)
+                            .spCapsuleButtonStyle(.neutral, size: .fullWidth, stroke: SPColor.border2)
+                            .foregroundStyle(Color(SPColor.fg))
                             .frame(height: 44)
-                            .background(SPColor.surface1)
-                            .clipShape(Capsule())
-                            .overlay(Capsule().stroke(SPColor.border2))
                         }
                         .accessibilityIdentifier("auth.googleButton")
                         .disabled(vm.isAuthInFlight)

--- a/ios/StillPointApp/Views/BreathCountingView.swift
+++ b/ios/StillPointApp/Views/BreathCountingView.swift
@@ -74,12 +74,7 @@ struct BreathCountingView: View {
                 } label: {
                     Text("End")
                         .font(SPFont.mono(13, weight: .medium))
-                        .foregroundStyle(Color(SPColor.fg3))
-                        .padding(.horizontal, SPSpacing.s4)
-                        .padding(.vertical, SPSpacing.s2)
-                        .background(SPColor.surface1)
-                        .clipShape(Capsule())
-                        .overlay(Capsule().stroke(SPColor.border1))
+                        .spCapsuleButtonStyle(.neutral, size: .regular)
                 }
                 .accessibilityIdentifier("breath.endButton")
                 .accessibilityLabel("End breath counting session")

--- a/ios/StillPointApp/Views/BuddySession/BuddyActiveSessionView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyActiveSessionView.swift
@@ -157,12 +157,11 @@ struct BuddyActiveSessionView: View {
                 } label: {
                     Text(vm.mindState == "thinking" ? "Release distraction" : "Hold distraction")
                         .font(SPFont.mono(11, weight: .medium))
+                        .spCapsuleButtonStyle(
+                            vm.mindState == "thinking" ? .amber : .green,
+                            size: .fullWidth
+                        )
                         .foregroundStyle(vm.mindState == "thinking" ? SPColor.amber : SPColor.green)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, SPSpacing.s2)
-                        .background(vm.mindState == "thinking" ? SPColor.amberBgFaint : SPColor.greenBgFaint)
-                        .clipShape(Capsule())
-                        .overlay(Capsule().stroke(vm.mindState == "thinking" ? SPColor.amberBorderSubtle : SPColor.greenBorderSubtle))
                 }
 
                 Button {
@@ -174,12 +173,8 @@ struct BuddyActiveSessionView: View {
                 } label: {
                     Text(vm.mindState == "hyperfocus" ? "Release hyperfocus" : "Hold hyperfocus")
                         .font(SPFont.mono(11, weight: .medium))
+                        .spCapsuleButtonStyle(.neutral, size: .fullWidth, prominent: true)
                         .foregroundStyle(Color(SPColor.fg3))
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, SPSpacing.s2)
-                        .background(SPColor.surface2)
-                        .clipShape(Capsule())
-                        .overlay(Capsule().stroke(SPColor.border2))
                 }
             }
 
@@ -188,12 +183,7 @@ struct BuddyActiveSessionView: View {
             } label: {
                 Text(showThoughtCapture ? "Hide thought capture" : "Capture note")
                     .font(SPFont.mono(11, weight: .medium))
-                    .foregroundStyle(SPColor.amberText)
-                    .padding(.horizontal, SPSpacing.s3)
-                    .padding(.vertical, SPSpacing.s2)
-                    .background(SPColor.amberBgFaint)
-                    .clipShape(Capsule())
-                    .overlay(Capsule().stroke(SPColor.amberBorderSubtle))
+                    .spCapsuleButtonStyle(.amber, size: .regular, horizontalPadding: SPSpacing.s3)
             }
 
             if showThoughtCapture {
@@ -212,12 +202,8 @@ struct BuddyActiveSessionView: View {
                     } label: {
                         Text("Save note")
                             .font(SPFont.mono(11, weight: .medium))
+                            .spCapsuleButtonStyle(.neutral, size: .fullWidth, prominent: true)
                             .foregroundStyle(Color(SPColor.fg2))
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, SPSpacing.s2)
-                            .background(SPColor.surface2)
-                            .clipShape(Capsule())
-                            .overlay(Capsule().stroke(SPColor.border2))
                     }
                 }
             }
@@ -234,12 +220,7 @@ struct BuddyActiveSessionView: View {
             } label: {
                 Text("Leave")
                     .font(SPFont.mono(11, weight: .medium))
-                    .foregroundStyle(SPColor.dangerMuted)
-                    .padding(.horizontal, SPSpacing.s3)
-                    .padding(.vertical, SPSpacing.s2)
-                    .background(SPColor.surface1)
-                    .clipShape(Capsule())
-                    .overlay(Capsule().stroke(SPColor.dangerBorderSubtle))
+                    .spCapsuleButtonStyle(.danger, size: .regular, horizontalPadding: SPSpacing.s3)
             }
         }
         .padding(SPSpacing.s3)

--- a/ios/StillPointApp/Views/BuddySession/BuddySessionHubView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddySessionHubView.swift
@@ -104,11 +104,7 @@ struct BuddySessionHubView: View {
             } label: {
                 Text("Start shared session")
                     .font(SPFont.serifItalic(20, weight: .light))
-                    .foregroundStyle(Color(SPColor.bg))
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, SPSpacing.s3)
-                    .background(LinearGradient.greenHorizontal)
-                    .clipShape(Capsule())
+                    .spCapsuleButtonStyle(.greenGradient, size: .fullWidth, tall: true)
             }
             .disabled(busy)
             .opacity(busy ? 0.6 : 1)
@@ -186,11 +182,7 @@ struct BuddySessionHubView: View {
             } label: {
                 Text("Enter waiting room")
                     .font(SPFont.serifItalic(20, weight: .light))
-                    .foregroundStyle(Color(SPColor.bg))
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, SPSpacing.s3)
-                    .background(LinearGradient.greenHorizontal)
-                    .clipShape(Capsule())
+                    .spCapsuleButtonStyle(.greenGradient, size: .fullWidth, tall: true)
             }
         }
     }

--- a/ios/StillPointApp/Views/BuddySession/BuddyWaitingRoomView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyWaitingRoomView.swift
@@ -80,17 +80,14 @@ struct BuddyWaitingRoomView: View {
                         } label: {
                             Text("Start for everyone")
                                 .font(SPFont.serifItalic(19, weight: .light))
-                                .foregroundStyle(Color(SPColor.bg))
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, SPSpacing.s3)
-                                .background(
-                                    snapshot?.state == "ready_check" ? LinearGradient.greenHorizontal : LinearGradient(
-                                        colors: [SPColor.surface2, SPColor.surface2],
-                                        startPoint: .leading,
-                                        endPoint: .trailing
-                                    )
+                                .spCapsuleButtonStyle(
+                                    snapshot?.state == "ready_check" ? .greenGradient : .neutral,
+                                    size: .fullWidth,
+                                    prominent: snapshot?.state != "ready_check",
+                                    tall: true,
+                                    stroke: snapshot?.state == "ready_check" ? nil : Color.clear
                                 )
-                                .clipShape(Capsule())
+                                .foregroundStyle(Color(SPColor.bg))
                         }
                         .disabled(snapshot?.state != "ready_check")
                         .opacity(snapshot?.state == "ready_check" ? 1 : 0.45)
@@ -104,12 +101,7 @@ struct BuddyWaitingRoomView: View {
                         } label: {
                             Text("Cancel session")
                                 .font(SPFont.mono(11, weight: .medium))
-                                .foregroundStyle(Color(SPColor.fg3))
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, SPSpacing.s2)
-                                .background(SPColor.surface1)
-                                .clipShape(Capsule())
-                                .overlay(Capsule().stroke(SPColor.border2))
+                                .spCapsuleButtonStyle(.neutral, size: .fullWidth, stroke: SPColor.border2)
                         }
                     }
                     .padding(.horizontal, SPSpacing.s4)
@@ -130,12 +122,7 @@ struct BuddyWaitingRoomView: View {
                 } label: {
                     Text("Leave")
                         .font(SPFont.mono(11, weight: .medium))
-                        .foregroundStyle(Color(SPColor.fg3))
-                        .padding(.horizontal, SPSpacing.s3)
-                        .padding(.vertical, SPSpacing.s2)
-                        .background(SPColor.surface1)
-                        .clipShape(Capsule())
-                        .overlay(Capsule().stroke(SPColor.border2))
+                        .spCapsuleButtonStyle(.neutral, size: .regular, stroke: SPColor.border2)
                 }
                 .padding(.bottom, SPSpacing.s5)
             }

--- a/ios/StillPointApp/Views/BuddySession/BuddyWaitingRoomView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddyWaitingRoomView.swift
@@ -122,7 +122,7 @@ struct BuddyWaitingRoomView: View {
                 } label: {
                     Text("Leave")
                         .font(SPFont.mono(11, weight: .medium))
-                        .spCapsuleButtonStyle(.neutral, size: .regular, stroke: SPColor.border2)
+                        .spCapsuleButtonStyle(.neutral, size: .regular, horizontalPadding: SPSpacing.s3, stroke: SPColor.border2)
                 }
                 .padding(.bottom, SPSpacing.s5)
             }

--- a/ios/StillPointApp/Views/CompletionView.swift
+++ b/ios/StillPointApp/Views/CompletionView.swift
@@ -157,14 +157,12 @@ struct CompletionView: View {
                                 Text(isSaving ? "Saving…" : "Save note")
                             }
                             .font(SPFont.serifItalic(18, weight: .light))
-                            .foregroundStyle(isSaveDisabled ? Color(SPColor.fg3) : Color(SPColor.bg))
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, SPSpacing.s2)
-                            .background(isSaveDisabled ? SPColor.surface2 : SPColor.green)
-                            .clipShape(Capsule())
-                            .overlay(
-                                Capsule().stroke(isSaveDisabled ? SPColor.border2 : Color.clear)
+                            .spCapsuleButtonStyle(
+                                isSaveDisabled ? .neutral : .greenSolid,
+                                size: .fullWidth,
+                                prominent: isSaveDisabled
                             )
+                            .foregroundStyle(isSaveDisabled ? Color(SPColor.fg3) : Color(SPColor.bg))
                         }
                         .disabled(isSaveDisabled)
                         .accessibilityIdentifier("completion.saveNoteButton")
@@ -228,12 +226,7 @@ struct CompletionView: View {
                 } label: {
                     Text("Return")
                         .font(SPFont.serifItalic(18, weight: .light))
-                        .foregroundStyle(Color(SPColor.fg))
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, SPSpacing.s2)
-                        .background(SPColor.surface2)
-                        .clipShape(Capsule())
-                        .overlay(Capsule().stroke(SPColor.border2))
+                        .spCapsuleButtonStyle(.neutral, size: .fullWidth, prominent: true)
                 }
                 .accessibilityIdentifier("completion.returnButton")
 

--- a/ios/StillPointApp/Views/HomeView.swift
+++ b/ios/StillPointApp/Views/HomeView.swift
@@ -92,12 +92,7 @@ struct HomeView: View {
                         } label: {
                             Text("Begin")
                                 .font(SPFont.serifItalic(22, weight: .light))
-                                .foregroundStyle(Color(SPColor.fg))
-                                .padding(.horizontal, 48)
-                                .padding(.vertical, SPSpacing.s3)
-                                .background(SPColor.surface2)
-                                .clipShape(Capsule())
-                                .overlay(Capsule().stroke(SPColor.border2))
+                                .spCapsuleButtonStyle(.neutral, size: .regular, prominent: true, tall: true, horizontalPadding: SPSpacing.s6)
                         }
                         .accessibilityIdentifier("home.beginButton")
                         .accessibilityLabel("Start session")
@@ -111,12 +106,7 @@ struct HomeView: View {
                         Text("Quick minute · \(StillPoint.quickDuration)s")
                             .font(SPFont.mono(11, weight: .medium))
                             .tracking(1.4)
-                            .foregroundStyle(SPColor.greenText)
-                            .padding(.horizontal, 24)
-                            .padding(.vertical, SPSpacing.s2)
-                            .background(SPColor.greenBgFaint)
-                            .clipShape(Capsule())
-                            .overlay(Capsule().stroke(SPColor.greenBorderSubtle))
+                            .spCapsuleButtonStyle(.green, size: .regular)
                     }
                     .accessibilityIdentifier("home.quickMinuteButton")
                     .accessibilityLabel("Start quick minute")
@@ -129,12 +119,7 @@ struct HomeView: View {
                         Text("Breath counting")
                             .font(SPFont.mono(11, weight: .medium))
                             .tracking(1.4)
-                            .foregroundStyle(Color(SPColor.fg3))
-                            .padding(.horizontal, 24)
-                            .padding(.vertical, SPSpacing.s2)
-                            .background(SPColor.surface1)
-                            .clipShape(Capsule())
-                            .overlay(Capsule().stroke(SPColor.border1))
+                            .spCapsuleButtonStyle(.neutral, size: .regular)
                     }
                     .accessibilityIdentifier("home.breathCountingButton")
                     .accessibilityLabel("Start breath counting")
@@ -146,12 +131,8 @@ struct HomeView: View {
                     } label: {
                         Text("Meditate with a friend")
                             .font(SPFont.serifItalic(18, weight: .light))
+                            .spCapsuleButtonStyle(.neutral, size: .regular, horizontalPadding: SPSpacing.s5)
                             .foregroundStyle(Color(SPColor.fg2))
-                            .padding(.horizontal, 32)
-                            .padding(.vertical, SPSpacing.s2)
-                            .background(SPColor.surface1)
-                            .clipShape(Capsule())
-                            .overlay(Capsule().stroke(SPColor.border1))
                     }
                     .accessibilityIdentifier("home.buddySessionButton")
                 }
@@ -200,13 +181,10 @@ struct HomeView: View {
                         .font(SPFont.mono(11, weight: .medium))
                         .tracking(1)
                 }
-                .foregroundStyle(manager.isUnlocked ? SPColor.greenText : SPColor.amberText)
-                .padding(.horizontal, SPSpacing.s3)
-                .padding(.vertical, SPSpacing.s2)
-                .background(manager.isUnlocked ? SPColor.greenBgFaint : SPColor.amberBgFaint)
-                .clipShape(Capsule())
-                .overlay(
-                    Capsule().stroke(manager.isUnlocked ? SPColor.greenBorderSubtle : SPColor.amberBorderSubtle)
+                .spCapsuleButtonStyle(
+                    manager.isUnlocked ? .green : .amber,
+                    size: .regular,
+                    horizontalPadding: SPSpacing.s3
                 )
             }
             .accessibilityIdentifier("home.appGatePill")
@@ -277,12 +255,7 @@ struct HomeView: View {
             } label: {
                 Text(doneToday ? "Sit again" : "Begin")
                     .font(SPFont.serifItalic(20, weight: .light))
-                    .foregroundStyle(Color(SPColor.fg))
-                    .padding(.horizontal, 40)
-                    .padding(.vertical, SPSpacing.s2)
-                    .background(SPColor.surface2)
-                    .clipShape(Capsule())
-                    .overlay(Capsule().stroke(SPColor.border2))
+                    .spCapsuleButtonStyle(.neutral, size: .regular, prominent: true, horizontalPadding: 40)
             }
             .padding(.top, SPSpacing.s1)
             .accessibilityIdentifier("\(identifier).beginButton")
@@ -322,12 +295,7 @@ struct HomeView: View {
                 Text("Add second track")
                     .font(SPFont.mono(12, weight: .medium))
                     .tracking(1.4)
-                    .foregroundStyle(SPColor.greenText)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, SPSpacing.s3)
-                    .background(SPColor.greenBgFaint)
-                    .clipShape(Capsule())
-                    .overlay(Capsule().stroke(SPColor.greenBorderSubtle))
+                    .spCapsuleButtonStyle(.green, size: .fullWidth, tall: true)
             }
             .accessibilityIdentifier("home.addSecondTrackButton")
 
@@ -337,12 +305,7 @@ struct HomeView: View {
                 Text("Keep one track")
                     .font(SPFont.mono(12, weight: .medium))
                     .tracking(1.4)
-                    .foregroundStyle(Color(SPColor.fg3))
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, SPSpacing.s3)
-                    .background(SPColor.surface1)
-                    .clipShape(Capsule())
-                    .overlay(Capsule().stroke(SPColor.border1))
+                    .spCapsuleButtonStyle(.neutral, size: .fullWidth, tall: true)
             }
             .accessibilityIdentifier("home.keepOneTrackButton")
         }
@@ -430,11 +393,7 @@ private struct AppGateOnboardingSheet: View {
                 } label: {
                     Text("Choose apps")
                         .font(SPFont.mono(13, weight: .medium))
-                        .foregroundStyle(Color(SPColor.bg))
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, SPSpacing.s3)
-                        .background(SPColor.green)
-                        .clipShape(Capsule())
+                        .spCapsuleButtonStyle(.greenSolid, size: .fullWidth, tall: true)
                 }
                 .accessibilityIdentifier("onboarding.appGate.chooseApps")
 

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -320,13 +320,7 @@ struct SessionView: View {
                 } label: {
                     Text("Capture")
                         .font(SPFont.mono(12, weight: .medium))
-                        .foregroundStyle(SPColor.amberText)
-                        .padding(.horizontal, SPSpacing.s3)
-                        .padding(.vertical, SPSpacing.s1)
-                        .frame(minHeight: 44)
-                        .background(SPColor.amberBgFaint)
-                        .clipShape(Capsule())
-                        .overlay(Capsule().stroke(SPColor.amberBorderSubtle))
+                        .spCapsuleButtonStyle(.amber, size: .compact, minHeight: 44)
                 }
                 .accessibilityIdentifier("session.captureButton")
                 .opacity(vm.isActive && !vm.controlsVisible ? 0.48 : 0.88)
@@ -339,22 +333,12 @@ struct SessionView: View {
                     .font(SPFont.serifItalic(15))
                     .foregroundStyle(Color(SPColor.fg))
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, SPSpacing.s3)
-                    .padding(.vertical, SPSpacing.s2)
-                    .frame(maxWidth: .infinity)
-                    .background(
-                        vm.mindState == "thinking"
-                            ? SPColor.amberBgFaint
-                            : SPColor.greenBgFaint
+                    .spCapsuleButtonStyle(
+                        vm.mindState == "thinking" ? .amber : .green,
+                        size: .fullWidth,
+                        horizontalPadding: SPSpacing.s3
                     )
-                    .clipShape(Capsule())
-                    .overlay(
-                        Capsule().stroke(
-                            vm.mindState == "thinking"
-                                ? SPColor.amberBorderSubtle
-                                : SPColor.greenBorderSubtle
-                        )
-                    )
+                    .foregroundStyle(Color(SPColor.fg))
                     .opacity(vm.isActive ? 1 : 0.45)
                     .accessibilityValue(vm.mindState == "thinking" ? "active" : "inactive")
                     .accessibilityLabel("Hold for light distraction. Release when aware again.")
@@ -429,12 +413,7 @@ struct SessionView: View {
                 } label: {
                     Text(vm.isPaused ? "Resume" : "Pause")
                         .font(SPFont.mono(12, weight: .medium))
-                        .foregroundStyle(Color(SPColor.fg3))
-                        .padding(.horizontal, SPSpacing.s3)
-                        .padding(.vertical, SPSpacing.s1)
-                        .background(SPColor.surface1)
-                        .clipShape(Capsule())
-                        .overlay(Capsule().stroke(SPColor.border1))
+                        .spCapsuleButtonStyle(.neutral, size: .compact)
                 }
                 .accessibilityIdentifier("session.pauseResumeButton")
 
@@ -444,12 +423,7 @@ struct SessionView: View {
                 } label: {
                     Text("End Early")
                         .font(SPFont.mono(12, weight: .medium))
-                        .foregroundStyle(Color(SPColor.fg3))
-                        .padding(.horizontal, SPSpacing.s3)
-                        .padding(.vertical, SPSpacing.s1)
-                        .background(SPColor.surface1)
-                        .clipShape(Capsule())
-                        .overlay(Capsule().stroke(SPColor.border1))
+                        .spCapsuleButtonStyle(.neutral, size: .compact)
                 }
                 .accessibilityIdentifier("session.endEarlyButton")
 
@@ -459,12 +433,7 @@ struct SessionView: View {
                     } label: {
                         Text("Capture")
                             .font(SPFont.mono(12, weight: .medium))
-                            .foregroundStyle(SPColor.amberText)
-                            .padding(.horizontal, SPSpacing.s3)
-                            .padding(.vertical, SPSpacing.s1)
-                            .background(SPColor.amberBgFaint)
-                            .clipShape(Capsule())
-                            .overlay(Capsule().stroke(SPColor.amberBorderSubtle))
+                            .spCapsuleButtonStyle(.amber, size: .compact)
                     }
                     .accessibilityIdentifier("session.captureButton")
                     .disabled(!vm.isActive)
@@ -476,12 +445,8 @@ struct SessionView: View {
                 } label: {
                     Text("+1 min")
                         .font(SPFont.mono(12, weight: .medium))
+                        .spCapsuleButtonStyle(.neutral, size: .compact)
                         .foregroundStyle(Color(SPColor.fg2))
-                        .padding(.horizontal, SPSpacing.s3)
-                        .padding(.vertical, SPSpacing.s1)
-                        .background(SPColor.surface1)
-                        .clipShape(Capsule())
-                        .overlay(Capsule().stroke(SPColor.border1))
                 }
                 .disabled(vm.showPostDistractionCapture || vm.isComplete || vm.isAbandoned || !vm.isActive)
                 .opacity(vm.showPostDistractionCapture || vm.isComplete || vm.isAbandoned || !vm.isActive ? 0.45 : 1)
@@ -492,12 +457,8 @@ struct SessionView: View {
                 } label: {
                     Text("+5 min")
                         .font(SPFont.mono(12, weight: .medium))
+                        .spCapsuleButtonStyle(.neutral, size: .compact)
                         .foregroundStyle(Color(SPColor.fg2))
-                        .padding(.horizontal, SPSpacing.s3)
-                        .padding(.vertical, SPSpacing.s1)
-                        .background(SPColor.surface1)
-                        .clipShape(Capsule())
-                        .overlay(Capsule().stroke(SPColor.border1))
                 }
                 .disabled(vm.showPostDistractionCapture || vm.isComplete || vm.isAbandoned || !vm.isActive)
                 .opacity(vm.showPostDistractionCapture || vm.isComplete || vm.isAbandoned || !vm.isActive ? 0.45 : 1)
@@ -510,12 +471,7 @@ struct SessionView: View {
                 } label: {
                     Text("Abandon")
                         .font(SPFont.mono(12, weight: .medium))
-                        .foregroundStyle(SPColor.dangerMuted)
-                        .padding(.horizontal, SPSpacing.s3)
-                        .padding(.vertical, SPSpacing.s1)
-                        .background(SPColor.surface1)
-                        .clipShape(Capsule())
-                        .overlay(Capsule().stroke(SPColor.dangerBorderSubtle))
+                        .spCapsuleButtonStyle(.danger, size: .compact)
                 }
                 .accessibilityIdentifier("session.abandonButton")
             }

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -190,12 +190,7 @@ struct SettingsView: View {
                 } label: {
                     Text("Log Out")
                         .font(SPFont.mono(14, weight: .medium))
-                        .foregroundStyle(SPColor.dangerMuted)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, SPSpacing.s2)
-                        .background(SPColor.surface1)
-                        .clipShape(Capsule())
-                        .overlay(Capsule().stroke(SPColor.dangerBorderSubtle))
+                        .spCapsuleButtonStyle(.danger, size: .fullWidth)
                 }
                 .accessibilityIdentifier("settings.logoutButton")
                 .disabled(isDeletingAccount)
@@ -213,11 +208,7 @@ struct SettingsView: View {
                                 .foregroundStyle(SPColor.dangerMuted)
                         }
                     }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, SPSpacing.s2)
-                    .background(SPColor.surface1)
-                    .clipShape(Capsule())
-                    .overlay(Capsule().stroke(SPColor.dangerBorderSubtle))
+                    .spCapsuleButtonStyle(.danger, size: .fullWidth)
                 }
                 .disabled(isDeletingAccount)
                 .confirmationDialog(

--- a/ios/StillPointAppUITests/Helpers/XCUIDevice+Portrait.swift
+++ b/ios/StillPointAppUITests/Helpers/XCUIDevice+Portrait.swift
@@ -1,0 +1,12 @@
+import XCTest
+
+extension XCUIDevice {
+    /// Ensures portrait orientation without redundant simulator commands.
+    /// Skipping the set when already portrait avoids CI timeouts waiting for
+    /// confirmation of a no-op orientation change on contended simulators.
+    func ensurePortraitOrientation() {
+        guard orientation != .portrait else { return }
+        orientation = .portrait
+        RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+    }
+}

--- a/ios/StillPointAppUITests/Snapshots/SnapshotTests.swift
+++ b/ios/StillPointAppUITests/Snapshots/SnapshotTests.swift
@@ -7,13 +7,11 @@ final class SnapshotTests: XCTestCase {
 
     override func setUpWithError() throws {
         continueAfterFailure = false
-        XCUIDevice.shared.orientation = .portrait
-        RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+        XCUIDevice.shared.ensurePortraitOrientation()
     }
 
     override func tearDownWithError() throws {
-        XCUIDevice.shared.orientation = .portrait
-        RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+        XCUIDevice.shared.ensurePortraitOrientation()
     }
 
     @MainActor

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -15,13 +15,11 @@ final class StillPointAppUITests: XCTestCase {
 
     override func setUpWithError() throws {
         continueAfterFailure = false
-        XCUIDevice.shared.orientation = .portrait
-        RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+        XCUIDevice.shared.ensurePortraitOrientation()
     }
 
     override func tearDownWithError() throws {
-        XCUIDevice.shared.orientation = .portrait
-        RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+        XCUIDevice.shared.ensurePortraitOrientation()
     }
 
     @MainActor

--- a/scripts/e2e/run-ios-tests.sh
+++ b/scripts/e2e/run-ios-tests.sh
@@ -207,6 +207,11 @@ is_retriable_failure() {
   if grep -qE 'Asynchronous wait failed: Exceeded timeout' "$log"; then
     return 0
   fi
+  # Simulator orientation confirmation timeouts in setUp/tearDown (macos-26
+  # runners can stall on XCUIDevice.shared.orientation even before app launch).
+  if grep -qE 'Failed to set device orientation:' "$log"; then
+    return 0
+  fi
   # XCTAssert* failures (other than timeout-shaped XCTAssertTrue handled above):
   # e.g., "XCTAssertEqual failed - (<a>) is not equal to (<b>)".
   if grep -qE 'XCTAssert[A-Za-z]* failed' "$log"; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `SPCapsuleButtonStyle` — a reusable `ViewModifier` in `Theme/` that centralizes capsule button chrome (foreground color, padding, background, clip, optional stroke). Font remains at the call site.

**Color variants:** `neutral`, `amber`, `danger`, `green`, `greenSolid`, `greenGradient`

**Size variants:** `compact`, `regular`, `fullWidth`

Optional knobs preserve edge cases: `prominent` (surface2/border2 neutral), `tall` (s3 vertical padding), `minHeight`, `horizontalPadding`, and `stroke` overrides.

Replaces ~37 inline capsule modifier chains across 10 view files. Rebased onto `main` after #240 (dual-track fork); migrated the new HomeView track-card and fork-card buttons too.

### Follow-up fixes
- **Bugbot:** `fullWidth` now uses `0` horizontal padding (was `nil` → ~16pt platform default inset)
- **CI:** UITest portrait setup skips redundant orientation changes; iOS E2E runner treats `Failed to set device orientation:` as retriable

### Intentionally left inline
- Session hyperfocus hold button (custom blue palette)
- Auth segmented toggle + Sign in with Apple (system / segmented control patterns)
- `SessionStateBadge` and `BuddyFilterChips` (badges/chips with dynamic per-item styling)

Closes #417

## Test plan

- [ ] Build StillPoint iOS target in Xcode (or CI `ios-shared-tests` / simulator workflow)
- [ ] **HomeView:** Verify Begin, Quick minute, Breath counting, Meditate with a friend, app-gate pill, dual-track track cards, and fork-card buttons
- [ ] **SessionView:** Exercise Pause/Resume, End Early, Capture, +1/+5 min, Abandon, and distraction hold buttons
- [ ] **AuthView:** Submit button and Google OAuth capsule styling (full-width labels should be edge-to-edge)
- [ ] **CompletionView:** Save note (enabled/disabled) and Return buttons
- [ ] **SettingsView:** Log Out and Delete Account danger capsules
- [ ] **Buddy flows:** Hub CTAs, waiting room Start/Cancel/Leave, active session controls
- [ ] **AppBlockingSettingsView:** Choose apps (green solid) and selection count badge (amber)
- [ ] **BreathCountingView:** End button
- [ ] **E2E iOS smoke:** `testLaunchLoginCompleteSessionAndHistoryPersistence` passes (orientation setup no longer blocks retry on flake)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c55c22d0-d126-44d6-aa0d-ac574c1e7b0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c55c22d0-d126-44d6-aa0d-ac574c1e7b0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

