### PR TITLE
Extract shared API route auth/error helper (requireAuth/withApiHandler)

### DIFF
--- a/src/app/api/account/route.ts
+++ b/src/app/api/account/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from "next/server";
 import { deleteUserAccount } from "@/lib/accountDeletion";
-import { clearAuthCookie, getCurrentUser } from "@/lib/auth";
+import { clearAuthCookie } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 
 /**
  * `DELETE /api/account` — permanently delete the authenticated user's account.
  * JWT-only session: clearing the auth cookie invalidates the client (same as logout).
  */
-export async function DELETE() {
+export const DELETE = withApiHandler("Account deletion", async () => {
   const clearCookieBestEffort = async () => {
     try {
       await clearAuthCookie();
@@ -15,23 +17,16 @@ export async function DELETE() {
     }
   };
 
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
 
-    const deleted = await deleteUserAccount(auth.userId);
+  const deleted = await deleteUserAccount(auth.user.userId);
 
-    if (!deleted) {
-      await clearCookieBestEffort();
-      return NextResponse.json({ error: "Account not found" }, { status: 404 });
-    }
-
+  if (!deleted) {
     await clearCookieBestEffort();
-    return NextResponse.json({ ok: true });
-  } catch (error) {
-    console.error("Account deletion error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    return NextResponse.json({ error: "Account not found" }, { status: 404 });
   }
-}
+
+  await clearCookieBestEffort();
+  return NextResponse.json({ ok: true });
+});

--- a/src/app/api/auth/apple-native/route.ts
+++ b/src/app/api/auth/apple-native/route.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { createToken, SP_TOKEN_COOKIE } from "@/lib/auth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { resolveOAuthUserId, OAuthEmailRequiredError } from "@/lib/oauth-user-resolution";
 
 const APPLE_JWKS = createRemoteJWKSet(new URL("https://appleid.apple.com/auth/keys"));
@@ -31,7 +32,7 @@ function displayNameFromAppleUser(u: AppleUserPayload | undefined): string | nul
   return combined || null;
 }
 
-export async function POST(request: NextRequest) {
+export const POST = withApiHandler("apple-native", async (request: NextRequest) => {
   let body: RequestBody;
   try {
     body = (await request.json()) as RequestBody;
@@ -116,4 +117,4 @@ export async function POST(request: NextRequest) {
     path: "/",
   });
   return res;
-}
+});

--- a/src/app/api/auth/apple/notifications/route.ts
+++ b/src/app/api/auth/apple/notifications/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { verifyAppleJwt } from "@/lib/apple-auth";
 import {
   finalizeAppleNotificationLog,
@@ -15,7 +16,7 @@ import {
  * middleware public list — the Apple-signed JWT (verified against Apple's JWKS
  * with issuer + audience checks) is the authentication.
  */
-export async function POST(request: NextRequest) {
+export const POST = withApiHandler("apple notifications", async (request: NextRequest) => {
   let body: { payload?: unknown };
   try {
     body = (await request.json()) as { payload?: unknown };
@@ -73,4 +74,4 @@ export async function POST(request: NextRequest) {
     });
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
-}
+});

--- a/src/app/api/auth/google-native/route.ts
+++ b/src/app/api/auth/google-native/route.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { createToken, SP_TOKEN_COOKIE } from "@/lib/auth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { resolveOAuthUserId, OAuthEmailRequiredError } from "@/lib/oauth-user-resolution";
 
 const GOOGLE_JWKS = createRemoteJWKSet(new URL("https://www.googleapis.com/oauth2/v3/certs"));
@@ -30,7 +31,7 @@ type RequestBody = {
   serverAuthCode?: string;
 };
 
-export async function POST(request: NextRequest) {
+export const POST = withApiHandler("google-native", async (request: NextRequest) => {
   let body: RequestBody;
   try {
     body = (await request.json()) as RequestBody;
@@ -124,4 +125,4 @@ export async function POST(request: NextRequest) {
     path: "/",
   });
   return res;
-}
+});

--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -1,27 +1,29 @@
 import { NextResponse } from "next/server";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import {
   GoogleCalendarUnavailableError,
   buildGoogleAuthUrl,
   makeGoogleOAuthState,
 } from "@/lib/googleOAuth";
 
-export async function GET() {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const GET = withApiHandler(
+  "Google OAuth start",
+  async () => {
+    const auth = await requireAuth();
+    if (!auth.ok) return auth.response;
 
-    const oauthState = makeGoogleOAuthState(auth.userId);
+    const oauthState = makeGoogleOAuthState(auth.user.userId);
     const response = NextResponse.redirect(buildGoogleAuthUrl(oauthState.state));
     response.cookies.set(oauthState.cookie);
     return response;
-  } catch (error) {
-    if (error instanceof GoogleCalendarUnavailableError) {
-      return NextResponse.json({ error: error.message }, { status: 503 });
-    }
-    console.error("Google OAuth start error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  },
+  {
+    mapError: (error) => {
+      if (error instanceof GoogleCalendarUnavailableError) {
+        return NextResponse.json({ error: error.message }, { status: 503 });
+      }
+      return null;
+    },
+  },
+);

--- a/src/app/api/auth/google/status/route.ts
+++ b/src/app/api/auth/google/status/route.ts
@@ -1,16 +1,11 @@
 import { NextResponse } from "next/server";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { loadGoogleCalendarStatus } from "@/lib/googleOAuth";
 
-export async function GET() {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-    return NextResponse.json({ google: await loadGoogleCalendarStatus(auth.userId) });
-  } catch (error) {
-    console.error("Google status error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+export const GET = withApiHandler("Google status", async () => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
+
+  return NextResponse.json({ google: await loadGoogleCalendarStatus(auth.user.userId) });
+});

--- a/src/app/api/auth/login/route.test.ts
+++ b/src/app/api/auth/login/route.test.ts
@@ -108,4 +108,20 @@ describe("POST /api/auth/login", () => {
     expect(createToken).not.toHaveBeenCalled();
     expect(setAuthCookie).not.toHaveBeenCalled();
   });
+
+  test("returns 400 for malformed JSON", async () => {
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      new Request("http://test.local/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: '{"email":"user@example.com","password":"pw"',
+      }) as NextRequest,
+    );
+
+    await expect(response.json()).resolves.toEqual({ error: "Invalid JSON body" });
+    expect(response.status).toBe(400);
+    expect(wasAccountDeleted).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -2,72 +2,68 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { verifyPassword, createToken, setAuthCookie } from "@/lib/auth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { wasAccountDeleted } from "@/lib/accountDeletion";
 import { DELETED_ACCOUNT_MESSAGE } from "@/lib/authErrors";
 import { eq } from "drizzle-orm";
 
 const DUMMY_PASSWORD_HASH = "$2b$12$Y9nc0LdvLO3K5rJBlkE0qOAEOlfYYvCj5ra9LaWHKE9PCUvfdlUnq";
 
-export async function POST(request: NextRequest) {
-  try {
-    const includeToken = request.headers.get("x-still-point-client") === "ios";
-    const body = await request.json();
-    const email = typeof body?.email === "string" ? body.email.trim().toLowerCase() : "";
-    const password = typeof body?.password === "string" ? body.password : "";
+export const POST = withApiHandler("Login", async (request: NextRequest) => {
+  const includeToken = request.headers.get("x-still-point-client") === "ios";
+  const body = await request.json();
+  const email = typeof body?.email === "string" ? body.email.trim().toLowerCase() : "";
+  const password = typeof body?.password === "string" ? body.password : "";
 
-    if (!email || !password) {
-      return NextResponse.json({ error: "Email and password required" }, { status: 400 });
-    }
-
-    const [userRows, deleted] = await Promise.all([
-      db.select().from(users).where(eq(users.email, email)).limit(1),
-      wasAccountDeleted(email),
-    ]);
-    const [user] = userRows;
-    if (!user) {
-      if (deleted) {
-        return NextResponse.json({ error: DELETED_ACCOUNT_MESSAGE }, { status: 410 });
-      }
-      await verifyPassword(password, DUMMY_PASSWORD_HASH);
-      return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
-    }
-
-    if (!user.passwordHash) {
-      // OAuth-only account (#136): no password ever set. Run a dummy
-      // compare so timing matches the password-set path, then reject with
-      // the same generic message as wrong-password / unknown-email — a
-      // distinct message would let attackers enumerate which emails exist
-      // AND which auth method they use.
-      await verifyPassword(password, DUMMY_PASSWORD_HASH);
-      return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
-    }
-
-    const valid = await verifyPassword(password, user.passwordHash);
-    if (!valid) {
-      return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
-    }
-
-    const token = await createToken({ userId: user.id, email: user.email });
-    await setAuthCookie(token);
-
-    return NextResponse.json({
-      user: {
-        id: user.id,
-        email: user.email,
-        username: user.username,
-        isPublic: user.isPublic,
-        currentDay: user.currentDay,
-        aphorismsEnabled: user.aphorismsEnabled,
-        recoveryTargetDay: user.recoveryTargetDay,
-        recoveryCurrentStep: user.recoveryCurrentStep,
-        recoveryTotalSteps: user.recoveryTotalSteps,
-        dualTrackEnabled: user.dualTrackEnabled,
-        secondTrackDay: user.secondTrackDay,
-      },
-      ...(includeToken ? { token } : {}),
-    });
-  } catch (error) {
-    console.error("Login error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  if (!email || !password) {
+    return NextResponse.json({ error: "Email and password required" }, { status: 400 });
   }
-}
+
+  const [userRows, deleted] = await Promise.all([
+    db.select().from(users).where(eq(users.email, email)).limit(1),
+    wasAccountDeleted(email),
+  ]);
+  const [user] = userRows;
+  if (!user) {
+    if (deleted) {
+      return NextResponse.json({ error: DELETED_ACCOUNT_MESSAGE }, { status: 410 });
+    }
+    await verifyPassword(password, DUMMY_PASSWORD_HASH);
+    return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
+  }
+
+  if (!user.passwordHash) {
+    // OAuth-only account (#136): no password ever set. Run a dummy
+    // compare so timing matches the password-set path, then reject with
+    // the same generic message as wrong-password / unknown-email — a
+    // distinct message would let attackers enumerate which emails exist
+    // AND which auth method they use.
+    await verifyPassword(password, DUMMY_PASSWORD_HASH);
+    return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
+  }
+
+  const valid = await verifyPassword(password, user.passwordHash);
+  if (!valid) {
+    return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
+  }
+
+  const token = await createToken({ userId: user.id, email: user.email });
+  await setAuthCookie(token);
+
+  return NextResponse.json({
+    user: {
+      id: user.id,
+      email: user.email,
+      username: user.username,
+      isPublic: user.isPublic,
+      currentDay: user.currentDay,
+      aphorismsEnabled: user.aphorismsEnabled,
+      recoveryTargetDay: user.recoveryTargetDay,
+      recoveryCurrentStep: user.recoveryCurrentStep,
+      recoveryTotalSteps: user.recoveryTotalSteps,
+      dualTrackEnabled: user.dualTrackEnabled,
+      secondTrackDay: user.secondTrackDay,
+    },
+    ...(includeToken ? { token } : {}),
+  });
+});

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -5,15 +5,18 @@ import { verifyPassword, createToken, setAuthCookie } from "@/lib/auth";
 import { withApiHandler } from "@/lib/api/withApiHandler";
 import { wasAccountDeleted } from "@/lib/accountDeletion";
 import { DELETED_ACCOUNT_MESSAGE } from "@/lib/authErrors";
+import { readJsonObject } from "@/lib/readJsonObject";
 import { eq } from "drizzle-orm";
 
 const DUMMY_PASSWORD_HASH = "$2b$12$Y9nc0LdvLO3K5rJBlkE0qOAEOlfYYvCj5ra9LaWHKE9PCUvfdlUnq";
 
 export const POST = withApiHandler("Login", async (request: NextRequest) => {
   const includeToken = request.headers.get("x-still-point-client") === "ios";
-  const body = await request.json();
-  const email = typeof body?.email === "string" ? body.email.trim().toLowerCase() : "";
-  const password = typeof body?.password === "string" ? body.password : "";
+  const json = await readJsonObject(request);
+  if (!json.ok) return json.response;
+
+  const email = typeof json.body.email === "string" ? json.body.email.trim().toLowerCase() : "";
+  const password = typeof json.body.password === "string" ? json.body.password : "";
 
   if (!email || !password) {
     return NextResponse.json({ error: "Email and password required" }, { status: 400 });

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
 import { clearAuthCookie } from "@/lib/auth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { clearAuthJsCookies } from "@/lib/authJsCookies";
 
-export async function POST() {
+export const POST = withApiHandler("Logout", async () => {
   await clearAuthCookie();
   // Belt-and-suspenders: clear any lingering Auth.js cookies (#136). Most
   // OAuth users only carry sp_token because oauth-complete drops the
@@ -16,4 +17,4 @@ export async function POST() {
     console.error("logout cookie cleanup failed:", err);
   }
   return NextResponse.json({ ok: true });
-}
+});

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { sessions, users } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { activeRecovery, detectMissedDayGap } from "@/lib/duration";
 import { isValidSessionCalendarDate } from "@/lib/sessionCalendar";
 import { and, desc, eq } from "drizzle-orm";
@@ -10,74 +11,67 @@ function todayIsoUtc(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
-export async function GET(request: NextRequest) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const GET = withApiHandler("Auth me", async (request: NextRequest) => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
 
-    const [user] = await db.select({
-      id: users.id,
-      email: users.email,
-      username: users.username,
-      isPublic: users.isPublic,
-      currentDay: users.currentDay,
-      aphorismsEnabled: users.aphorismsEnabled,
-      recoveryTargetDay: users.recoveryTargetDay,
-      recoveryCurrentStep: users.recoveryCurrentStep,
-      recoveryTotalSteps: users.recoveryTotalSteps,
-      dualTrackEnabled: users.dualTrackEnabled,
-      secondTrackDay: users.secondTrackDay,
-    }).from(users).where(eq(users.id, auth.userId)).limit(1);
+  const [user] = await db.select({
+    id: users.id,
+    email: users.email,
+    username: users.username,
+    isPublic: users.isPublic,
+    currentDay: users.currentDay,
+    aphorismsEnabled: users.aphorismsEnabled,
+    recoveryTargetDay: users.recoveryTargetDay,
+    recoveryCurrentStep: users.recoveryCurrentStep,
+    recoveryTotalSteps: users.recoveryTotalSteps,
+    dualTrackEnabled: users.dualTrackEnabled,
+    secondTrackDay: users.secondTrackDay,
+  }).from(users).where(eq(users.id, auth.user.userId)).limit(1);
 
-    if (!user) {
-      return NextResponse.json({ error: "User not found" }, { status: 404 });
-    }
-
-    // Missed-day recovery detection (#238): only worth checking when not already
-    // recovering — an active ramp is left alone rather than restarted mid-stream.
-    if (!activeRecovery(user)) {
-      const requestedDate = request.nextUrl.searchParams.get("date");
-      const todayIso = isValidSessionCalendarDate(requestedDate) ? requestedDate! : todayIsoUtc();
-
-      const [lastSession] = await db.select({ sessionDate: sessions.sessionDate })
-        .from(sessions)
-        .where(and(
-          eq(sessions.userId, auth.userId),
-          eq(sessions.completed, true),
-          eq(sessions.sessionType, "standard"),
-          // #240: recovery tracks the primary track's currentDay, so a recent
-          // second-track sit must not mask a gap since the last primary sit.
-          eq(sessions.track, "primary"),
-        ))
-        .orderBy(desc(sessions.sessionDate))
-        .limit(1);
-
-      const recovery = detectMissedDayGap({
-        lastCompletedSessionDate: lastSession?.sessionDate ?? null,
-        todayIso,
-        currentDay: user.currentDay,
-        recovery: user,
-      });
-
-      if (recovery) {
-        await db.update(users).set({
-          recoveryTargetDay: recovery.recoveryTargetDay,
-          recoveryCurrentStep: recovery.recoveryCurrentStep,
-          recoveryTotalSteps: recovery.recoveryTotalSteps,
-          updatedAt: new Date(),
-        }).where(eq(users.id, auth.userId));
-
-        user.recoveryTargetDay = recovery.recoveryTargetDay;
-        user.recoveryCurrentStep = recovery.recoveryCurrentStep;
-        user.recoveryTotalSteps = recovery.recoveryTotalSteps;
-      }
-    }
-
-    return NextResponse.json({ user });
-  } catch (error) {
-    console.error("Auth me error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
   }
-}
+
+  // Missed-day recovery detection (#238): only worth checking when not already
+  // recovering — an active ramp is left alone rather than restarted mid-stream.
+  if (!activeRecovery(user)) {
+    const requestedDate = request.nextUrl.searchParams.get("date");
+    const todayIso = isValidSessionCalendarDate(requestedDate) ? requestedDate! : todayIsoUtc();
+
+    const [lastSession] = await db.select({ sessionDate: sessions.sessionDate })
+      .from(sessions)
+      .where(and(
+        eq(sessions.userId, auth.user.userId),
+        eq(sessions.completed, true),
+        eq(sessions.sessionType, "standard"),
+        // #240: recovery tracks the primary track's currentDay, so a recent
+        // second-track sit must not mask a gap since the last primary sit.
+        eq(sessions.track, "primary"),
+      ))
+      .orderBy(desc(sessions.sessionDate))
+      .limit(1);
+
+    const recovery = detectMissedDayGap({
+      lastCompletedSessionDate: lastSession?.sessionDate ?? null,
+      todayIso,
+      currentDay: user.currentDay,
+      recovery: user,
+    });
+
+    if (recovery) {
+      await db.update(users).set({
+        recoveryTargetDay: recovery.recoveryTargetDay,
+        recoveryCurrentStep: recovery.recoveryCurrentStep,
+        recoveryTotalSteps: recovery.recoveryTotalSteps,
+        updatedAt: new Date(),
+      }).where(eq(users.id, auth.user.userId));
+
+      user.recoveryTargetDay = recovery.recoveryTargetDay;
+      user.recoveryCurrentStep = recovery.recoveryCurrentStep;
+      user.recoveryTotalSteps = recovery.recoveryTotalSteps;
+    }
+  }
+
+  return NextResponse.json({ user });
+});

--- a/src/app/api/auth/oauth-complete/route.ts
+++ b/src/app/api/auth/oauth-complete/route.ts
@@ -5,6 +5,7 @@ import { clearAuthJsCookies } from "@/lib/authJsCookies";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { createToken, setAuthCookie } from "@/lib/auth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { isOAuthProvider } from "@/lib/lastAuthProvider";
 
 /** Sanitize a `?return=` param into a same-origin path. Anything other
@@ -25,7 +26,7 @@ function sanitizeReturnTarget(raw: string | null): string {
  *  cookie (set on the request host) is sent on the redirect — using a
  *  fixed canonical APP_URL would cross hosts on previews/localhost and
  *  drop the cookie. */
-export async function GET(request: NextRequest) {
+export const GET = withApiHandler("oauth-complete bridge", async (request: NextRequest) => {
   const requestUrl = new URL(request.url);
   const successTarget = sanitizeReturnTarget(requestUrl.searchParams.get("return"));
   let errorPath: string | null = null;
@@ -71,4 +72,4 @@ export async function GET(request: NextRequest) {
     finalUrl.searchParams.set("auth_provider", completedProvider);
   }
   return NextResponse.redirect(finalUrl);
-}
+});

--- a/src/app/api/auth/password-reset/confirm/route.ts
+++ b/src/app/api/auth/password-reset/confirm/route.ts
@@ -3,61 +3,57 @@ import { and, eq, gt, isNull } from "drizzle-orm";
 import { poolDb } from "@/db/pool";
 import { passwordResetTokens, users } from "@/db/schema";
 import { hashPassword } from "@/lib/auth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { getPasswordResetPayload } from "@/lib/passwordReset";
 
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json().catch(() => null);
-    if (!body || typeof body !== "object") {
-      return NextResponse.json(
-        { error: "Valid token and password of at least 8 characters required" },
-        { status: 400 },
-      );
-    }
-    const token = typeof body?.token === "string" ? body.token.trim() : "";
-    const password = typeof body?.password === "string" ? body.password : "";
-
-    if (!token || password.length < 8) {
-      return NextResponse.json(
-        { error: "Valid token and password of at least 8 characters required" },
-        { status: 400 },
-      );
-    }
-
-    const resetPayload = await getPasswordResetPayload(token);
-    if (!resetPayload) {
-      return NextResponse.json({ error: "Reset link is invalid or expired" }, { status: 400 });
-    }
-
-    const passwordHash = await hashPassword(password);
-    const updated = await poolDb.transaction(async (tx) => {
-      const [resetToken] = await tx
-        .update(passwordResetTokens)
-        .set({ usedAt: new Date() })
-        .where(
-          and(
-            eq(passwordResetTokens.userId, resetPayload.userId),
-            eq(passwordResetTokens.tokenHash, resetPayload.tokenHash),
-            isNull(passwordResetTokens.usedAt),
-            gt(passwordResetTokens.expiresAt, new Date()),
-          ),
-        )
-        .returning({ userId: passwordResetTokens.userId });
-      if (!resetToken) {
-        return false;
-      }
-      await tx.update(users)
-        .set({ passwordHash, updatedAt: new Date() })
-        .where(eq(users.id, resetToken.userId));
-      return true;
-    });
-    if (!updated) {
-      return NextResponse.json({ error: "Reset link is invalid or expired" }, { status: 400 });
-    }
-
-    return NextResponse.json({ ok: true });
-  } catch (error) {
-    console.error("Password reset confirm error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+export const POST = withApiHandler("Password reset confirm", async (request: NextRequest) => {
+  const body = await request.json().catch(() => null);
+  if (!body || typeof body !== "object") {
+    return NextResponse.json(
+      { error: "Valid token and password of at least 8 characters required" },
+      { status: 400 },
+    );
   }
-}
+  const token = typeof body?.token === "string" ? body.token.trim() : "";
+  const password = typeof body?.password === "string" ? body.password : "";
+
+  if (!token || password.length < 8) {
+    return NextResponse.json(
+      { error: "Valid token and password of at least 8 characters required" },
+      { status: 400 },
+    );
+  }
+
+  const resetPayload = await getPasswordResetPayload(token);
+  if (!resetPayload) {
+    return NextResponse.json({ error: "Reset link is invalid or expired" }, { status: 400 });
+  }
+
+  const passwordHash = await hashPassword(password);
+  const updated = await poolDb.transaction(async (tx) => {
+    const [resetToken] = await tx
+      .update(passwordResetTokens)
+      .set({ usedAt: new Date() })
+      .where(
+        and(
+          eq(passwordResetTokens.userId, resetPayload.userId),
+          eq(passwordResetTokens.tokenHash, resetPayload.tokenHash),
+          isNull(passwordResetTokens.usedAt),
+          gt(passwordResetTokens.expiresAt, new Date()),
+        ),
+      )
+      .returning({ userId: passwordResetTokens.userId });
+    if (!resetToken) {
+      return false;
+    }
+    await tx.update(users)
+      .set({ passwordHash, updatedAt: new Date() })
+      .where(eq(users.id, resetToken.userId));
+    return true;
+  });
+  if (!updated) {
+    return NextResponse.json({ error: "Reset link is invalid or expired" }, { status: 400 });
+  }
+
+  return NextResponse.json({ ok: true });
+});

--- a/src/app/api/auth/password-reset/request/route.ts
+++ b/src/app/api/auth/password-reset/request/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { poolDb } from "@/db/pool";
 import { passwordResetTokens, users } from "@/db/schema";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { sendPasswordResetEmail } from "@/lib/email";
 import {
   PASSWORD_RESET_REQUEST_MESSAGE,
@@ -15,96 +16,91 @@ import {
 } from "@/lib/passwordReset";
 import { and, eq, gt, isNull, sql } from "drizzle-orm";
 
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json().catch(() => ({}));
-    const email = normalizeResetEmail(body?.email);
+export const POST = withApiHandler("Password reset request", async (request: NextRequest) => {
+  const body = await request.json().catch(() => ({}));
+  const email = normalizeResetEmail(body?.email);
 
-    if (!email) {
-      return NextResponse.json({ error: "A valid email is required" }, { status: 400 });
-    }
+  if (!email) {
+    return NextResponse.json({ error: "A valid email is required" }, { status: 400 });
+  }
 
-    const hashedIp = requestIpHash(request);
-    if (isPasswordResetRateLimited(email, hashedIp)) {
-      return NextResponse.json({ message: PASSWORD_RESET_REQUEST_MESSAGE });
-    }
-    recordPasswordResetAttempt(email, hashedIp);
+  const hashedIp = requestIpHash(request);
+  if (isPasswordResetRateLimited(email, hashedIp)) {
+    return NextResponse.json({ message: PASSWORD_RESET_REQUEST_MESSAGE });
+  }
+  recordPasswordResetAttempt(email, hashedIp);
 
-    const [user] = await db
-      .select({
-        id: users.id,
-        email: users.email,
-      })
-      .from(users)
-      .where(eq(users.email, email))
+  const [user] = await db
+    .select({
+      id: users.id,
+      email: users.email,
+    })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1);
+
+  if (!user) {
+    return NextResponse.json({ message: PASSWORD_RESET_REQUEST_MESSAGE });
+  }
+
+  const tokenIssue = await poolDb.transaction(async (tx) => {
+    await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${`password-reset:${user.id}`}))`);
+
+    const recentCutoff = new Date(Date.now() - 1000 * 60 * 5);
+    const [activeToken] = await tx
+      .select({ id: passwordResetTokens.id })
+      .from(passwordResetTokens)
+      .where(
+        and(
+          eq(passwordResetTokens.userId, user.id),
+          isNull(passwordResetTokens.usedAt),
+          gt(passwordResetTokens.createdAt, recentCutoff),
+        ),
+      )
       .limit(1);
 
-    if (!user) {
-      return NextResponse.json({ message: PASSWORD_RESET_REQUEST_MESSAGE });
+    if (activeToken) {
+      return null;
     }
 
-    const tokenIssue = await poolDb.transaction(async (tx) => {
-      await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${`password-reset:${user.id}`}))`);
+    const [previousToken] = await tx
+      .update(passwordResetTokens)
+      .set({ usedAt: new Date() })
+      .where(and(eq(passwordResetTokens.userId, user.id), isNull(passwordResetTokens.usedAt)))
+      .returning({ id: passwordResetTokens.id });
 
-      const recentCutoff = new Date(Date.now() - 1000 * 60 * 5);
-      const [activeToken] = await tx
-        .select({ id: passwordResetTokens.id })
-        .from(passwordResetTokens)
-        .where(
-          and(
-            eq(passwordResetTokens.userId, user.id),
-            isNull(passwordResetTokens.usedAt),
-            gt(passwordResetTokens.createdAt, recentCutoff),
-          ),
-        )
-        .limit(1);
-
-      if (activeToken) {
-        return null;
-      }
-
-      const [previousToken] = await tx
-        .update(passwordResetTokens)
-        .set({ usedAt: new Date() })
-        .where(and(eq(passwordResetTokens.userId, user.id), isNull(passwordResetTokens.usedAt)))
-        .returning({ id: passwordResetTokens.id });
-
-      const resetToken = await createPasswordResetToken({ userId: user.id });
-      const [newToken] = await tx
-        .insert(passwordResetTokens)
-        .values({
-          userId: user.id,
-          tokenHash: hashResetToken(resetToken),
-          requestIpHash: hashedIp,
-          expiresAt: passwordResetExpiresAt(),
-        })
-        .returning({ id: passwordResetTokens.id });
-      return { token: resetToken, newTokenId: newToken.id, previousTokenId: previousToken?.id ?? null };
-    });
-    if (tokenIssue) {
-      try {
-        await sendPasswordResetEmail({ to: user.email, token: tokenIssue.token });
-      } catch (error) {
-        await poolDb.transaction(async (tx) => {
-          await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${`password-reset:${user.id}`}))`);
+    const resetToken = await createPasswordResetToken({ userId: user.id });
+    const [newToken] = await tx
+      .insert(passwordResetTokens)
+      .values({
+        userId: user.id,
+        tokenHash: hashResetToken(resetToken),
+        requestIpHash: hashedIp,
+        expiresAt: passwordResetExpiresAt(),
+      })
+      .returning({ id: passwordResetTokens.id });
+    return { token: resetToken, newTokenId: newToken.id, previousTokenId: previousToken?.id ?? null };
+  });
+  if (tokenIssue) {
+    try {
+      await sendPasswordResetEmail({ to: user.email, token: tokenIssue.token });
+    } catch (error) {
+      await poolDb.transaction(async (tx) => {
+        await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${`password-reset:${user.id}`}))`);
+        await tx
+          .update(passwordResetTokens)
+          .set({ usedAt: new Date() })
+          .where(eq(passwordResetTokens.id, tokenIssue.newTokenId));
+        if (tokenIssue.previousTokenId) {
           await tx
             .update(passwordResetTokens)
-            .set({ usedAt: new Date() })
-            .where(eq(passwordResetTokens.id, tokenIssue.newTokenId));
-          if (tokenIssue.previousTokenId) {
-            await tx
-              .update(passwordResetTokens)
-              .set({ usedAt: null })
-              .where(eq(passwordResetTokens.id, tokenIssue.previousTokenId));
-          }
-        });
-        console.error("Password reset email delivery error:", error);
-      }
+            .set({ usedAt: null })
+            .where(eq(passwordResetTokens.id, tokenIssue.previousTokenId));
+        }
+      });
+      console.error("Password reset email delivery error:", error);
     }
-
-    return NextResponse.json({ message: PASSWORD_RESET_REQUEST_MESSAGE });
-  } catch (error) {
-    console.error("Password reset request error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
-}
+
+  return NextResponse.json({ message: PASSWORD_RESET_REQUEST_MESSAGE });
+});

--- a/src/app/api/auth/signup/route.test.ts
+++ b/src/app/api/auth/signup/route.test.ts
@@ -162,4 +162,32 @@ describe("POST /api/auth/signup uniqueness handling", () => {
     await expect(response.json()).resolves.toEqual({ error: "Internal server error" });
     expect(response.status).toBe(500);
   });
+
+  test("returns 400 for malformed JSON", async () => {
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      new Request("http://test.local/api/auth/signup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "null",
+      }) as NextRequest,
+    );
+
+    await expect(response.json()).resolves.toEqual({ error: "Invalid JSON body" });
+    expect(response.status).toBe(400);
+    expect(dbInsert).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when password is not a string", async () => {
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      makeRequest({ email: "alice@example.com", username: "alice", password: 123456789 }),
+    );
+
+    await expect(response.json()).resolves.toEqual({ error: "All fields required" });
+    expect(response.status).toBe(400);
+    expect(hashPassword).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -2,92 +2,88 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { hashPassword, createToken, setAuthCookie } from "@/lib/auth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { uniqueViolationConstraint } from "@/lib/dbErrors";
 import { USERNAME_ERROR, isValidUsername } from "@/lib/username";
 import { eq, sql } from "drizzle-orm";
 
-export async function POST(request: NextRequest) {
-  try {
-    const includeToken = request.headers.get("x-still-point-client") === "ios";
-    const { email, username, password } = await request.json();
+export const POST = withApiHandler("Signup", async (request: NextRequest) => {
+  const includeToken = request.headers.get("x-still-point-client") === "ios";
+  const { email, username, password } = await request.json();
 
-    if (!email || !username || !password) {
-      return NextResponse.json({ error: "All fields required" }, { status: 400 });
-    }
-
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
-      return NextResponse.json({ error: "Invalid email format" }, { status: 400 });
-    }
-
-    if (!isValidUsername(username)) {
-      return NextResponse.json({ error: USERNAME_ERROR }, { status: 400 });
-    }
-
-    if (password.length < 8) {
-      return NextResponse.json({ error: "Password must be at least 8 characters" }, { status: 400 });
-    }
-
-    const normalizedEmail = email.toLowerCase();
-
-    const existingEmail = await db.select().from(users).where(eq(users.email, normalizedEmail)).limit(1);
-    if (existingEmail.length > 0) {
-      return NextResponse.json({ error: "Email already in use" }, { status: 409 });
-    }
-
-    const existingUsername = await db
-      .select()
-      .from(users)
-      .where(sql`lower(${users.username}) = lower(${username})`)
-      .limit(1);
-    if (existingUsername.length > 0) {
-      return NextResponse.json({ error: "Username already taken" }, { status: 409 });
-    }
-
-    const passwordHash = await hashPassword(password);
-
-    let newUser;
-    try {
-      [newUser] = await db.insert(users).values({
-        email: normalizedEmail,
-        username,
-        passwordHash,
-      }).returning();
-    } catch (err) {
-      const constraint = uniqueViolationConstraint(err);
-      if (constraint !== null) {
-        if (constraint.includes("email")) {
-          return NextResponse.json({ error: "Email already in use" }, { status: 409 });
-        }
-        if (constraint.includes("username")) {
-          return NextResponse.json({ error: "Username already taken" }, { status: 409 });
-        }
-        return NextResponse.json({ error: "Email or username already in use" }, { status: 409 });
-      }
-      throw err;
-    }
-
-    const token = await createToken({ userId: newUser.id, email: newUser.email });
-    await setAuthCookie(token);
-
-    return NextResponse.json({
-      user: {
-        id: newUser.id,
-        email: newUser.email,
-        username: newUser.username,
-        isPublic: newUser.isPublic,
-        currentDay: newUser.currentDay,
-        aphorismsEnabled: newUser.aphorismsEnabled,
-        recoveryTargetDay: newUser.recoveryTargetDay,
-        recoveryCurrentStep: newUser.recoveryCurrentStep,
-        recoveryTotalSteps: newUser.recoveryTotalSteps,
-        dualTrackEnabled: newUser.dualTrackEnabled,
-        secondTrackDay: newUser.secondTrackDay,
-      },
-      ...(includeToken ? { token } : {}),
-    });
-  } catch (error) {
-    console.error("Signup error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  if (!email || !username || !password) {
+    return NextResponse.json({ error: "All fields required" }, { status: 400 });
   }
-}
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(email)) {
+    return NextResponse.json({ error: "Invalid email format" }, { status: 400 });
+  }
+
+  if (!isValidUsername(username)) {
+    return NextResponse.json({ error: USERNAME_ERROR }, { status: 400 });
+  }
+
+  if (password.length < 8) {
+    return NextResponse.json({ error: "Password must be at least 8 characters" }, { status: 400 });
+  }
+
+  const normalizedEmail = email.toLowerCase();
+
+  const existingEmail = await db.select().from(users).where(eq(users.email, normalizedEmail)).limit(1);
+  if (existingEmail.length > 0) {
+    return NextResponse.json({ error: "Email already in use" }, { status: 409 });
+  }
+
+  const existingUsername = await db
+    .select()
+    .from(users)
+    .where(sql`lower(${users.username}) = lower(${username})`)
+    .limit(1);
+  if (existingUsername.length > 0) {
+    return NextResponse.json({ error: "Username already taken" }, { status: 409 });
+  }
+
+  const passwordHash = await hashPassword(password);
+
+  let newUser;
+  try {
+    [newUser] = await db.insert(users).values({
+      email: normalizedEmail,
+      username,
+      passwordHash,
+    }).returning();
+  } catch (err) {
+    const constraint = uniqueViolationConstraint(err);
+    if (constraint !== null) {
+      if (constraint.includes("email")) {
+        return NextResponse.json({ error: "Email already in use" }, { status: 409 });
+      }
+      if (constraint.includes("username")) {
+        return NextResponse.json({ error: "Username already taken" }, { status: 409 });
+      }
+      return NextResponse.json({ error: "Email or username already in use" }, { status: 409 });
+    }
+    throw err;
+  }
+
+  const token = await createToken({ userId: newUser.id, email: newUser.email });
+  await setAuthCookie(token);
+
+  return NextResponse.json({
+    user: {
+      id: newUser.id,
+      email: newUser.email,
+      username: newUser.username,
+      isPublic: newUser.isPublic,
+      currentDay: newUser.currentDay,
+      aphorismsEnabled: newUser.aphorismsEnabled,
+      recoveryTargetDay: newUser.recoveryTargetDay,
+      recoveryCurrentStep: newUser.recoveryCurrentStep,
+      recoveryTotalSteps: newUser.recoveryTotalSteps,
+      dualTrackEnabled: newUser.dualTrackEnabled,
+      secondTrackDay: newUser.secondTrackDay,
+    },
+    ...(includeToken ? { token } : {}),
+  });
+});

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -4,14 +4,27 @@ import { users } from "@/db/schema";
 import { hashPassword, createToken, setAuthCookie } from "@/lib/auth";
 import { withApiHandler } from "@/lib/api/withApiHandler";
 import { uniqueViolationConstraint } from "@/lib/dbErrors";
+import { readJsonObject } from "@/lib/readJsonObject";
 import { USERNAME_ERROR, isValidUsername } from "@/lib/username";
 import { eq, sql } from "drizzle-orm";
 
 export const POST = withApiHandler("Signup", async (request: NextRequest) => {
   const includeToken = request.headers.get("x-still-point-client") === "ios";
-  const { email, username, password } = await request.json();
+  const json = await readJsonObject(request);
+  if (!json.ok) return json.response;
 
-  if (!email || !username || !password) {
+  const email = json.body.email;
+  const username = json.body.username;
+  const password = json.body.password;
+
+  if (
+    typeof email !== "string" ||
+    typeof username !== "string" ||
+    typeof password !== "string" ||
+    !email ||
+    !username ||
+    !password
+  ) {
     return NextResponse.json({ error: "All fields required" }, { status: 400 });
   }
 

--- a/src/app/api/board/route.ts
+++ b/src/app/api/board/route.ts
@@ -3,7 +3,7 @@ import { db } from "@/db";
 import { users, sessions } from "@/db/schema";
 import { withApiHandler } from "@/lib/api/withApiHandler";
 import { calculateSessionStats } from "@/lib/constants";
-import { eq, desc, and } from "drizzle-orm";
+import { eq, desc, and, inArray } from "drizzle-orm";
 
 export const GET = withApiHandler("Board", async () => {
   // Get all public users
@@ -17,22 +17,37 @@ export const GET = withApiHandler("Board", async () => {
     .orderBy(desc(users.currentDay))
     .limit(50);
 
-  // For each public user, compute stats
-  const board = await Promise.all(publicUsers.map(async (user) => {
-    const userSessions = await db.select({
-      dayNumber: sessions.dayNumber,
-      sessionType: sessions.sessionType,
-      duration: sessions.duration,
-      bonusSeconds: sessions.bonusSeconds,
-      completed: sessions.completed,
-      clearPercent: sessions.clearPercent,
-      thoughtCount: sessions.thoughtCount,
-      sessionDate: sessions.sessionDate,
-    })
-      .from(sessions)
-      .where(and(eq(sessions.userId, user.id), eq(sessions.sessionType, "standard")))
-      .orderBy(desc(sessions.dayNumber));
+  const userIds = publicUsers.map((u) => u.id);
+  const allSessions = userIds.length > 0
+    ? await db.select({
+        userId: sessions.userId,
+        dayNumber: sessions.dayNumber,
+        sessionType: sessions.sessionType,
+        duration: sessions.duration,
+        bonusSeconds: sessions.bonusSeconds,
+        completed: sessions.completed,
+        clearPercent: sessions.clearPercent,
+        thoughtCount: sessions.thoughtCount,
+        sessionDate: sessions.sessionDate,
+      })
+        .from(sessions)
+        .where(and(inArray(sessions.userId, userIds), eq(sessions.sessionType, "standard")))
+        .orderBy(desc(sessions.dayNumber))
+    : [];
 
+  const sessionsByUser = new Map<string, typeof allSessions>();
+  for (const session of allSessions) {
+    const existing = sessionsByUser.get(session.userId);
+    if (existing) {
+      existing.push(session);
+    } else {
+      sessionsByUser.set(session.userId, [session]);
+    }
+  }
+
+  // Compute stats per public user from the pre-fetched session map
+  const board = publicUsers.map((user) => {
+    const userSessions = sessionsByUser.get(user.id) ?? [];
     const stats = calculateSessionStats(userSessions);
     const totalSessions = userSessions.filter(s => s.completed).length;
 
@@ -43,7 +58,7 @@ export const GET = withApiHandler("Board", async () => {
       avgClear: stats.avgClearPercent,
       totalSessions,
     };
-  }));
+  });
 
   return NextResponse.json({ board });
 });

--- a/src/app/api/board/route.ts
+++ b/src/app/api/board/route.ts
@@ -1,53 +1,49 @@
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { users, sessions } from "@/db/schema";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { calculateSessionStats } from "@/lib/constants";
 import { eq, desc, and } from "drizzle-orm";
 
-export async function GET() {
-  try {
-    // Get all public users
-    const publicUsers = await db.select({
-      id: users.id,
-      username: users.username,
-      currentDay: users.currentDay,
+export const GET = withApiHandler("Board", async () => {
+  // Get all public users
+  const publicUsers = await db.select({
+    id: users.id,
+    username: users.username,
+    currentDay: users.currentDay,
+  })
+    .from(users)
+    .where(eq(users.isPublic, true))
+    .orderBy(desc(users.currentDay))
+    .limit(50);
+
+  // For each public user, compute stats
+  const board = await Promise.all(publicUsers.map(async (user) => {
+    const userSessions = await db.select({
+      dayNumber: sessions.dayNumber,
+      sessionType: sessions.sessionType,
+      duration: sessions.duration,
+      bonusSeconds: sessions.bonusSeconds,
+      completed: sessions.completed,
+      clearPercent: sessions.clearPercent,
+      thoughtCount: sessions.thoughtCount,
+      sessionDate: sessions.sessionDate,
     })
-      .from(users)
-      .where(eq(users.isPublic, true))
-      .orderBy(desc(users.currentDay))
-      .limit(50);
+      .from(sessions)
+      .where(and(eq(sessions.userId, user.id), eq(sessions.sessionType, "standard")))
+      .orderBy(desc(sessions.dayNumber));
 
-    // For each public user, compute stats
-    const board = await Promise.all(publicUsers.map(async (user) => {
-      const userSessions = await db.select({
-        dayNumber: sessions.dayNumber,
-        sessionType: sessions.sessionType,
-        duration: sessions.duration,
-        bonusSeconds: sessions.bonusSeconds,
-        completed: sessions.completed,
-        clearPercent: sessions.clearPercent,
-        thoughtCount: sessions.thoughtCount,
-        sessionDate: sessions.sessionDate,
-      })
-        .from(sessions)
-        .where(and(eq(sessions.userId, user.id), eq(sessions.sessionType, "standard")))
-        .orderBy(desc(sessions.dayNumber));
+    const stats = calculateSessionStats(userSessions);
+    const totalSessions = userSessions.filter(s => s.completed).length;
 
-      const stats = calculateSessionStats(userSessions);
-      const totalSessions = userSessions.filter(s => s.completed).length;
+    return {
+      username: user.username,
+      currentDay: user.currentDay,
+      streak: stats.streak,
+      avgClear: stats.avgClearPercent,
+      totalSessions,
+    };
+  }));
 
-      return {
-        username: user.username,
-        currentDay: user.currentDay,
-        streak: stats.streak,
-        avgClear: stats.avgClearPercent,
-        totalSessions,
-      };
-    }));
-
-    return NextResponse.json({ board });
-  } catch (error) {
-    console.error("Board error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  return NextResponse.json({ board });
+});

--- a/src/app/api/buddy/sessions/[id]/cancel/route.ts
+++ b/src/app/api/buddy/sessions/[id]/cancel/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { buddySessions, buddySessionParticipants } from "@/db/schema";
 import { requireAuth } from "@/lib/api/requireAuth";
-import { withApiHandler } from "@/lib/api/withApiHandler";
+import { RouteParams, withApiHandler } from "@/lib/api/withApiHandler";
 import { reconcileBuddySession } from "@/lib/buddySession";
 import {
   BUDDY_POLICY_CODES,
@@ -13,13 +13,15 @@ import {
 import { isUuid } from "@/lib/friends";
 import { and, eq, inArray, sql } from "drizzle-orm";
 
+type RouteContext = RouteParams<{ id: string }>;
+
 export const POST = withApiHandler(
   "Buddy cancel",
-  async (_request, context) => {
+  async (_request: NextRequest, context: RouteContext) => {
     const auth = await requireAuth();
     if (!auth.ok) return auth.response;
 
-    const { id: sessionId } = await (context as { params: Promise<{ id: string }> }).params;
+    const { id: sessionId } = await context.params;
     if (!isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }

--- a/src/app/api/buddy/sessions/[id]/cancel/route.ts
+++ b/src/app/api/buddy/sessions/[id]/cancel/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { buddySessions, buddySessionParticipants } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { reconcileBuddySession } from "@/lib/buddySession";
 import {
   BUDDY_POLICY_CODES,
@@ -12,16 +13,13 @@ import {
 import { isUuid } from "@/lib/friends";
 import { and, eq, inArray, sql } from "drizzle-orm";
 
-type Params = { params: Promise<{ id: string }> };
+export const POST = withApiHandler(
+  "Buddy cancel",
+  async (_request, context) => {
+    const auth = await requireAuth();
+    if (!auth.ok) return auth.response;
 
-export async function POST(_request: Request, context: Params) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { id: sessionId } = await context.params;
+    const { id: sessionId } = await (context as { params: Promise<{ id: string }> }).params;
     if (!isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }
@@ -32,7 +30,7 @@ export async function POST(_request: Request, context: Params) {
       .where(
         and(
           eq(buddySessionParticipants.buddySessionId, sessionId),
-          eq(buddySessionParticipants.userId, auth.userId),
+          eq(buddySessionParticipants.userId, auth.user.userId),
         ),
       )
       .limit(1);
@@ -78,8 +76,5 @@ export async function POST(_request: Request, context: Params) {
     await reconcileBuddySession(sessionId);
 
     return NextResponse.json({ ok: true });
-  } catch (error) {
-    console.error("Buddy cancel error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  },
+);

--- a/src/app/api/buddy/sessions/[id]/leave/route.ts
+++ b/src/app/api/buddy/sessions/[id]/leave/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { buddySessions, buddySessionParticipants } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import {
   bumpBuddyRevision,
   reconcileBuddySession,
@@ -12,16 +13,13 @@ import { hostLeaveShouldAbandonSession } from "@/lib/buddySessionControlsPolicy"
 import { isUuid } from "@/lib/friends";
 import { and, eq, sql } from "drizzle-orm";
 
-type Params = { params: Promise<{ id: string }> };
+export const POST = withApiHandler(
+  "Buddy leave",
+  async (_request, context) => {
+    const auth = await requireAuth();
+    if (!auth.ok) return auth.response;
 
-export async function POST(_request: Request, context: Params) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { id: sessionId } = await context.params;
+    const { id: sessionId } = await (context as { params: Promise<{ id: string }> }).params;
     if (!isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }
@@ -32,7 +30,7 @@ export async function POST(_request: Request, context: Params) {
       .where(
         and(
           eq(buddySessionParticipants.buddySessionId, sessionId),
-          eq(buddySessionParticipants.userId, auth.userId),
+          eq(buddySessionParticipants.userId, auth.user.userId),
         ),
       )
       .limit(1);
@@ -73,8 +71,5 @@ export async function POST(_request: Request, context: Params) {
     await reconcileBuddySession(sessionId);
 
     return NextResponse.json({ ok: true });
-  } catch (error) {
-    console.error("Buddy leave error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  },
+);

--- a/src/app/api/buddy/sessions/[id]/leave/route.ts
+++ b/src/app/api/buddy/sessions/[id]/leave/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { buddySessions, buddySessionParticipants } from "@/db/schema";
 import { requireAuth } from "@/lib/api/requireAuth";
-import { withApiHandler } from "@/lib/api/withApiHandler";
+import { RouteParams, withApiHandler } from "@/lib/api/withApiHandler";
 import {
   bumpBuddyRevision,
   reconcileBuddySession,
@@ -13,13 +13,15 @@ import { hostLeaveShouldAbandonSession } from "@/lib/buddySessionControlsPolicy"
 import { isUuid } from "@/lib/friends";
 import { and, eq, sql } from "drizzle-orm";
 
+type RouteContext = RouteParams<{ id: string }>;
+
 export const POST = withApiHandler(
   "Buddy leave",
-  async (_request, context) => {
+  async (_request: NextRequest, context: RouteContext) => {
     const auth = await requireAuth();
     if (!auth.ok) return auth.response;
 
-    const { id: sessionId } = await (context as { params: Promise<{ id: string }> }).params;
+    const { id: sessionId } = await context.params;
     if (!isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }

--- a/src/app/api/buddy/sessions/[id]/meeting-token/route.ts
+++ b/src/app/api/buddy/sessions/[id]/meeting-token/route.ts
@@ -1,23 +1,21 @@
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { buddySessions, buddySessionParticipants, users } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { reconcileBuddySession } from "@/lib/buddySession";
 import { BUDDY_POLICY_CODES } from "@/lib/buddyPolicyCodes";
 import { DailyApiError, createMeetingToken } from "@/lib/daily";
 import { isUuid } from "@/lib/friends";
 import { and, eq } from "drizzle-orm";
 
-type Params = { params: Promise<{ id: string }> };
+export const POST = withApiHandler(
+  "Buddy meeting-token route",
+  async (_request, context) => {
+    const auth = await requireAuth();
+    if (!auth.ok) return auth.response;
 
-export async function POST(_request: Request, context: Params) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { id: sessionId } = await context.params;
+    const { id: sessionId } = await (context as { params: Promise<{ id: string }> }).params;
     if (!isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }
@@ -28,7 +26,7 @@ export async function POST(_request: Request, context: Params) {
       .where(
         and(
           eq(buddySessionParticipants.buddySessionId, sessionId),
-          eq(buddySessionParticipants.userId, auth.userId),
+          eq(buddySessionParticipants.userId, auth.user.userId),
         ),
       )
       .limit(1);
@@ -61,14 +59,14 @@ export async function POST(_request: Request, context: Params) {
     const [u] = await db
       .select({ username: users.username })
       .from(users)
-      .where(eq(users.id, auth.userId))
+      .where(eq(users.id, auth.user.userId))
       .limit(1);
 
     try {
       const token = await createMeetingToken({
         roomName: session.dailyRoomName,
         userName: u?.username ?? "Participant",
-        userId: auth.userId,
+        userId: auth.user.userId,
       });
       return NextResponse.json({ token });
     } catch (e) {
@@ -81,8 +79,5 @@ export async function POST(_request: Request, context: Params) {
       }
       throw e;
     }
-  } catch (error) {
-    console.error("Buddy meeting-token route error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  },
+);

--- a/src/app/api/buddy/sessions/[id]/meeting-token/route.ts
+++ b/src/app/api/buddy/sessions/[id]/meeting-token/route.ts
@@ -1,21 +1,23 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { buddySessions, buddySessionParticipants, users } from "@/db/schema";
 import { requireAuth } from "@/lib/api/requireAuth";
-import { withApiHandler } from "@/lib/api/withApiHandler";
+import { RouteParams, withApiHandler } from "@/lib/api/withApiHandler";
 import { reconcileBuddySession } from "@/lib/buddySession";
 import { BUDDY_POLICY_CODES } from "@/lib/buddyPolicyCodes";
 import { DailyApiError, createMeetingToken } from "@/lib/daily";
 import { isUuid } from "@/lib/friends";
 import { and, eq } from "drizzle-orm";
 
+type RouteContext = RouteParams<{ id: string }>;
+
 export const POST = withApiHandler(
   "Buddy meeting-token route",
-  async (_request, context) => {
+  async (_request: NextRequest, context: RouteContext) => {
     const auth = await requireAuth();
     if (!auth.ok) return auth.response;
 
-    const { id: sessionId } = await (context as { params: Promise<{ id: string }> }).params;
+    const { id: sessionId } = await context.params;
     if (!isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }

--- a/src/app/api/buddy/sessions/[id]/participant-complete/route.ts
+++ b/src/app/api/buddy/sessions/[id]/participant-complete/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { buddySessions, buddySessionParticipants } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { bumpBuddyRevision } from "@/lib/buddySession";
 import {
   requireBuddyActiveParticipant,
@@ -10,20 +11,17 @@ import {
 import { isUuid } from "@/lib/friends";
 import { and, eq, isNull } from "drizzle-orm";
 
-type Params = { params: Promise<{ id: string }> };
-
 /**
  * #119: Marks this participant as finished with the shared sit (no journaling here).
  * #118: Per-user only; does not mutate shared timer — see `buddySessionControlsPolicy.ts`.
  */
-export async function POST(_request: Request, context: Params) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const POST = withApiHandler(
+  "Buddy participant-complete",
+  async (_request, context) => {
+    const auth = await requireAuth();
+    if (!auth.ok) return auth.response;
 
-    const { id: sessionId } = await context.params;
+    const { id: sessionId } = await (context as { params: Promise<{ id: string }> }).params;
     if (!isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }
@@ -46,7 +44,7 @@ export async function POST(_request: Request, context: Params) {
       .where(
         and(
           eq(buddySessionParticipants.buddySessionId, sessionId),
-          eq(buddySessionParticipants.userId, auth.userId),
+          eq(buddySessionParticipants.userId, auth.user.userId),
         ),
       )
       .limit(1);
@@ -77,9 +75,5 @@ export async function POST(_request: Request, context: Params) {
     await bumpBuddyRevision(sessionId);
 
     return NextResponse.json({ ok: true, participantCompletedAt: now.toISOString() });
-  } catch (error) {
-    console.error("Buddy participant-complete error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
-
+  },
+);

--- a/src/app/api/buddy/sessions/[id]/participant-complete/route.ts
+++ b/src/app/api/buddy/sessions/[id]/participant-complete/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { buddySessions, buddySessionParticipants } from "@/db/schema";
 import { requireAuth } from "@/lib/api/requireAuth";
-import { withApiHandler } from "@/lib/api/withApiHandler";
+import { RouteParams, withApiHandler } from "@/lib/api/withApiHandler";
 import { bumpBuddyRevision } from "@/lib/buddySession";
 import {
   requireBuddyActiveParticipant,
@@ -11,17 +11,19 @@ import {
 import { isUuid } from "@/lib/friends";
 import { and, eq, isNull } from "drizzle-orm";
 
+type RouteContext = RouteParams<{ id: string }>;
+
 /**
  * #119: Marks this participant as finished with the shared sit (no journaling here).
  * #118: Per-user only; does not mutate shared timer — see `buddySessionControlsPolicy.ts`.
  */
 export const POST = withApiHandler(
   "Buddy participant-complete",
-  async (_request, context) => {
+  async (_request: NextRequest, context: RouteContext) => {
     const auth = await requireAuth();
     if (!auth.ok) return auth.response;
 
-    const { id: sessionId } = await (context as { params: Promise<{ id: string }> }).params;
+    const { id: sessionId } = await context.params;
     if (!isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }

--- a/src/app/api/buddy/sessions/[id]/ready/route.ts
+++ b/src/app/api/buddy/sessions/[id]/ready/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { buddySessions, buddySessionParticipants } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import {
   bumpBuddyRevision,
   reconcileBuddySession,
@@ -14,16 +15,13 @@ import { isUuid } from "@/lib/friends";
 import { readJsonObject } from "@/lib/readJsonObject";
 import { and, eq } from "drizzle-orm";
 
-type Params = { params: Promise<{ id: string }> };
+export const PATCH = withApiHandler(
+  "Buddy ready PATCH",
+  async (request: NextRequest, context) => {
+    const auth = await requireAuth();
+    if (!auth.ok) return auth.response;
 
-export async function PATCH(request: NextRequest, context: Params) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { id: sessionId } = await context.params;
+    const { id: sessionId } = await (context as { params: Promise<{ id: string }> }).params;
     if (!isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }
@@ -52,7 +50,7 @@ export async function PATCH(request: NextRequest, context: Params) {
       .where(
         and(
           eq(buddySessionParticipants.buddySessionId, sessionId),
-          eq(buddySessionParticipants.userId, auth.userId),
+          eq(buddySessionParticipants.userId, auth.user.userId),
         ),
       )
       .limit(1);
@@ -69,8 +67,5 @@ export async function PATCH(request: NextRequest, context: Params) {
     await reconcileBuddySession(sessionId);
 
     return NextResponse.json({ ok: true });
-  } catch (error) {
-    console.error("Buddy ready PATCH error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  },
+);

--- a/src/app/api/buddy/sessions/[id]/ready/route.ts
+++ b/src/app/api/buddy/sessions/[id]/ready/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { buddySessions, buddySessionParticipants } from "@/db/schema";
 import { requireAuth } from "@/lib/api/requireAuth";
-import { withApiHandler } from "@/lib/api/withApiHandler";
+import { RouteParams, withApiHandler } from "@/lib/api/withApiHandler";
 import {
   bumpBuddyRevision,
   reconcileBuddySession,
@@ -15,13 +15,15 @@ import { isUuid } from "@/lib/friends";
 import { readJsonObject } from "@/lib/readJsonObject";
 import { and, eq } from "drizzle-orm";
 
+type RouteContext = RouteParams<{ id: string }>;
+
 export const PATCH = withApiHandler(
   "Buddy ready PATCH",
-  async (request: NextRequest, context) => {
+  async (request: NextRequest, context: RouteContext) => {
     const auth = await requireAuth();
     if (!auth.ok) return auth.response;
 
-    const { id: sessionId } = await (context as { params: Promise<{ id: string }> }).params;
+    const { id: sessionId } = await context.params;
     if (!isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }

--- a/src/app/api/buddy/sessions/[id]/record-personal-session/route.ts
+++ b/src/app/api/buddy/sessions/[id]/record-personal-session/route.ts
@@ -9,7 +9,7 @@ import {
   users,
 } from "@/db/schema";
 import { requireAuth } from "@/lib/api/requireAuth";
-import { withApiHandler } from "@/lib/api/withApiHandler";
+import { RouteParams, withApiHandler } from "@/lib/api/withApiHandler";
 import { isUuid } from "@/lib/friends";
 import { reconcileBuddySession } from "@/lib/buddySession";
 import {
@@ -20,6 +20,8 @@ import { hasRejectedSubmittedThoughts, normalizeThoughtInputs } from "@/lib/thou
 import { isUniqueViolation } from "@/lib/dbErrors";
 import { advanceProgression } from "@/lib/duration";
 import { and, eq, sql } from "drizzle-orm";
+
+type RouteContext = RouteParams<{ id: string }>;
 
 function parseMindStateLog(raw: unknown): Array<{ time: number; state: string }> {
   if (!Array.isArray(raw)) return [];
@@ -44,11 +46,11 @@ function sessionDateOk(s: string): boolean {
  */
 export const POST = withApiHandler(
   "Buddy record-personal-session",
-  async (request: NextRequest, context) => {
+  async (request: NextRequest, context: RouteContext) => {
     const auth = await requireAuth();
     if (!auth.ok) return auth.response;
 
-    const { id: sessionId } = await (context as { params: Promise<{ id: string }> }).params;
+    const { id: sessionId } = await context.params;
     if (!isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }

--- a/src/app/api/buddy/sessions/[id]/record-personal-session/route.ts
+++ b/src/app/api/buddy/sessions/[id]/record-personal-session/route.ts
@@ -8,7 +8,8 @@ import {
   thoughts,
   users,
 } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { isUuid } from "@/lib/friends";
 import { reconcileBuddySession } from "@/lib/buddySession";
 import {
@@ -19,8 +20,6 @@ import { hasRejectedSubmittedThoughts, normalizeThoughtInputs } from "@/lib/thou
 import { isUniqueViolation } from "@/lib/dbErrors";
 import { advanceProgression } from "@/lib/duration";
 import { and, eq, sql } from "drizzle-orm";
-
-type Params = { params: Promise<{ id: string }> };
 
 function parseMindStateLog(raw: unknown): Array<{ time: number; state: string }> {
   if (!Array.isArray(raw)) return [];
@@ -40,17 +39,16 @@ function sessionDateOk(s: string): boolean {
 }
 
 /**
- * #119: After the shared sit completes, create this user’s own `sessions` row (idempotent)
+ * #119: After the shared sit completes, create this user's own `sessions` row (idempotent)
  * and optional in-sit `thoughts`. Journal completion notes use POST /api/thoughts/batch.
  */
-export async function POST(request: NextRequest, context: Params) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const POST = withApiHandler(
+  "Buddy record-personal-session",
+  async (request: NextRequest, context) => {
+    const auth = await requireAuth();
+    if (!auth.ok) return auth.response;
 
-    const { id: sessionId } = await context.params;
+    const { id: sessionId } = await (context as { params: Promise<{ id: string }> }).params;
     if (!isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }
@@ -72,7 +70,7 @@ export async function POST(request: NextRequest, context: Params) {
       .where(
         and(
           eq(buddySessionParticipants.buddySessionId, sessionId),
-          eq(buddySessionParticipants.userId, auth.userId),
+          eq(buddySessionParticipants.userId, auth.user.userId),
         ),
       )
       .limit(1);
@@ -84,7 +82,7 @@ export async function POST(request: NextRequest, context: Params) {
       .select()
       .from(sessions)
       .where(
-        and(eq(sessions.userId, auth.userId), eq(sessions.buddySessionId, sessionId)),
+        and(eq(sessions.userId, auth.user.userId), eq(sessions.buddySessionId, sessionId)),
       )
       .limit(1);
 
@@ -120,7 +118,7 @@ export async function POST(request: NextRequest, context: Params) {
     if (body.thoughts != null && !Array.isArray(body.thoughts)) {
       console.warn("Buddy personal session rejected invalid thoughts payload", {
         buddySessionId: sessionId,
-        userId: auth.userId,
+        userId: auth.user.userId,
         submittedType: typeof body.thoughts,
       });
       return NextResponse.json({ error: "Invalid thoughts payload" }, { status: 400 });
@@ -129,7 +127,7 @@ export async function POST(request: NextRequest, context: Params) {
     if (hasRejectedSubmittedThoughts(normalizedThoughts)) {
       console.warn("Buddy personal session rejected invalid thoughts payload", {
         buddySessionId: sessionId,
-        userId: auth.userId,
+        userId: auth.user.userId,
         submittedCount: normalizedThoughts.submittedCount,
         invalidCount: normalizedThoughts.invalidCount,
       });
@@ -157,7 +155,7 @@ export async function POST(request: NextRequest, context: Params) {
             recoveryTotalSteps: users.recoveryTotalSteps,
           })
           .from(users)
-          .where(eq(users.id, auth.userId))
+          .where(eq(users.id, auth.user.userId))
           .limit(1);
         if (!u) {
           throw new Error("USER_NOT_FOUND");
@@ -171,7 +169,7 @@ export async function POST(request: NextRequest, context: Params) {
         const [created] = await tx
           .insert(sessions)
           .values({
-            userId: auth.userId,
+            userId: auth.user.userId,
             buddySessionId: sessionId,
             dayNumber,
             sessionType: "standard",
@@ -198,7 +196,7 @@ export async function POST(request: NextRequest, context: Params) {
             recoveryTotalSteps: nextProgress.recoveryTotalSteps,
             updatedAt: new Date(),
           })
-          .where(eq(users.id, auth.userId));
+          .where(eq(users.id, auth.user.userId));
 
         await tx
           .update(buddySessionParticipants)
@@ -221,7 +219,7 @@ export async function POST(request: NextRequest, context: Params) {
             .insert(thoughts)
             .values(
               thoughtItems.map((t) => ({
-                userId: auth.userId,
+                userId: auth.user.userId,
                 sessionId: created.id,
                 dayNumber,
                 timeInSession: t.timeInSession,
@@ -247,7 +245,7 @@ export async function POST(request: NextRequest, context: Params) {
           .select()
           .from(sessions)
           .where(
-            and(eq(sessions.userId, auth.userId), eq(sessions.buddySessionId, sessionId)),
+            and(eq(sessions.userId, auth.user.userId), eq(sessions.buddySessionId, sessionId)),
           )
           .limit(1);
         if (again) {
@@ -256,8 +254,5 @@ export async function POST(request: NextRequest, context: Params) {
       }
       throw err;
     }
-  } catch (error) {
-    console.error("Buddy record-personal-session error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  },
+);

--- a/src/app/api/buddy/sessions/[id]/record-personal-session/route.ts
+++ b/src/app/api/buddy/sessions/[id]/record-personal-session/route.ts
@@ -120,7 +120,6 @@ export const POST = withApiHandler(
     if (body.thoughts != null && !Array.isArray(body.thoughts)) {
       console.warn("Buddy personal session rejected invalid thoughts payload", {
         buddySessionId: sessionId,
-        userId: auth.user.userId,
         submittedType: typeof body.thoughts,
       });
       return NextResponse.json({ error: "Invalid thoughts payload" }, { status: 400 });
@@ -129,7 +128,6 @@ export const POST = withApiHandler(
     if (hasRejectedSubmittedThoughts(normalizedThoughts)) {
       console.warn("Buddy personal session rejected invalid thoughts payload", {
         buddySessionId: sessionId,
-        userId: auth.user.userId,
         submittedCount: normalizedThoughts.submittedCount,
         invalidCount: normalizedThoughts.invalidCount,
       });

--- a/src/app/api/buddy/sessions/[id]/route.ts
+++ b/src/app/api/buddy/sessions/[id]/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { buddySessionParticipants } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import {
   buildBuddySnapshot,
   loadBuddySnapshotContext,
@@ -11,16 +12,13 @@ import { BUDDY_POLICY_CODES } from "@/lib/buddyPolicyCodes";
 import { isUuid } from "@/lib/friends";
 import { and, eq } from "drizzle-orm";
 
-type Params = { params: Promise<{ id: string }> };
+export const GET = withApiHandler(
+  "Buddy session GET",
+  async (_request, context) => {
+    const auth = await requireAuth();
+    if (!auth.ok) return auth.response;
 
-export async function GET(_request: Request, context: Params) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { id: sessionId } = await context.params;
+    const { id: sessionId } = await (context as { params: Promise<{ id: string }> }).params;
     if (!isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }
@@ -31,7 +29,7 @@ export async function GET(_request: Request, context: Params) {
       .where(
         and(
           eq(buddySessionParticipants.buddySessionId, sessionId),
-          eq(buddySessionParticipants.userId, auth.userId),
+          eq(buddySessionParticipants.userId, auth.user.userId),
         ),
       )
       .limit(1);
@@ -56,10 +54,7 @@ export async function GET(_request: Request, context: Params) {
     }
 
     return NextResponse.json({
-      snapshot: buildBuddySnapshot(ctx.session, ctx.participants, auth.userId),
+      snapshot: buildBuddySnapshot(ctx.session, ctx.participants, auth.user.userId),
     });
-  } catch (error) {
-    console.error("Buddy session GET error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  },
+);

--- a/src/app/api/buddy/sessions/[id]/route.ts
+++ b/src/app/api/buddy/sessions/[id]/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { buddySessionParticipants } from "@/db/schema";
 import { requireAuth } from "@/lib/api/requireAuth";
-import { withApiHandler } from "@/lib/api/withApiHandler";
+import { RouteParams, withApiHandler } from "@/lib/api/withApiHandler";
 import {
   buildBuddySnapshot,
   loadBuddySnapshotContext,
@@ -12,13 +12,15 @@ import { BUDDY_POLICY_CODES } from "@/lib/buddyPolicyCodes";
 import { isUuid } from "@/lib/friends";
 import { and, eq } from "drizzle-orm";
 
+type RouteContext = RouteParams<{ id: string }>;
+
 export const GET = withApiHandler(
   "Buddy session GET",
-  async (_request, context) => {
+  async (_request: NextRequest, context: RouteContext) => {
     const auth = await requireAuth();
     if (!auth.ok) return auth.response;
 
-    const { id: sessionId } = await (context as { params: Promise<{ id: string }> }).params;
+    const { id: sessionId } = await context.params;
     if (!isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }

--- a/src/app/api/buddy/sessions/[id]/start/route.ts
+++ b/src/app/api/buddy/sessions/[id]/start/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { buddySessions, buddySessionParticipants } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { reconcileBuddySession } from "@/lib/buddySession";
 import {
   DailyApiError,
@@ -19,16 +20,13 @@ import {
 import { isUuid } from "@/lib/friends";
 import { and, eq, sql } from "drizzle-orm";
 
-type Params = { params: Promise<{ id: string }> };
+export const POST = withApiHandler(
+  "Buddy start",
+  async (_request, context) => {
+    const auth = await requireAuth();
+    if (!auth.ok) return auth.response;
 
-export async function POST(_request: Request, context: Params) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { id: sessionId } = await context.params;
+    const { id: sessionId } = await (context as { params: Promise<{ id: string }> }).params;
     if (!isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }
@@ -39,7 +37,7 @@ export async function POST(_request: Request, context: Params) {
       .where(
         and(
           eq(buddySessionParticipants.buddySessionId, sessionId),
-          eq(buddySessionParticipants.userId, auth.userId),
+          eq(buddySessionParticipants.userId, auth.user.userId),
         ),
       )
       .limit(1);
@@ -172,8 +170,5 @@ export async function POST(_request: Request, context: Params) {
       .where(eq(buddySessionParticipants.buddySessionId, sessionId));
 
     return NextResponse.json({ ok: true, startedAt: startedAt.toISOString() });
-  } catch (error) {
-    console.error("Buddy start error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  },
+);

--- a/src/app/api/buddy/sessions/[id]/start/route.ts
+++ b/src/app/api/buddy/sessions/[id]/start/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { buddySessions, buddySessionParticipants } from "@/db/schema";
 import { requireAuth } from "@/lib/api/requireAuth";
-import { withApiHandler } from "@/lib/api/withApiHandler";
+import { RouteParams, withApiHandler } from "@/lib/api/withApiHandler";
 import { reconcileBuddySession } from "@/lib/buddySession";
 import {
   DailyApiError,
@@ -20,13 +20,15 @@ import {
 import { isUuid } from "@/lib/friends";
 import { and, eq, sql } from "drizzle-orm";
 
+type RouteContext = RouteParams<{ id: string }>;
+
 export const POST = withApiHandler(
   "Buddy start",
-  async (_request, context) => {
+  async (_request: NextRequest, context: RouteContext) => {
     const auth = await requireAuth();
     if (!auth.ok) return auth.response;
 
-    const { id: sessionId } = await (context as { params: Promise<{ id: string }> }).params;
+    const { id: sessionId } = await context.params;
     if (!isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }

--- a/src/app/api/buddy/sessions/calendar/[buddyId]/route.ts
+++ b/src/app/api/buddy/sessions/calendar/[buddyId]/route.ts
@@ -1,23 +1,21 @@
-import { NextResponse } from "next/server";
-import { getCurrentUser } from "@/lib/auth";
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { listBuddyCalendarSessionsForBuddy } from "@/lib/buddyCalendar";
 import { parseBuddyCalendarRange } from "@/lib/buddyCalendarRange";
 import { isUuid } from "@/lib/friends";
-
-type Params = { params: Promise<{ buddyId: string }> };
 
 /**
  * Per-buddy shared-session calendar (#350).
  * iOS: mirror `GET /api/buddy/sessions/calendar/[buddyId]` — see `listBuddyCalendarSessionsForBuddy`.
  */
-export async function GET(request: Request, context: Params) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const GET = withApiHandler(
+  "Buddy per-buddy calendar GET",
+  async (request: NextRequest, context) => {
+    const auth = await requireAuth();
+    if (!auth.ok) return auth.response;
 
-    const { buddyId } = await context.params;
+    const { buddyId } = await (context as { params: Promise<{ buddyId: string }> }).params;
     if (!isUuid(buddyId)) {
       return NextResponse.json({ error: "Invalid buddy id" }, { status: 400 });
     }
@@ -37,7 +35,7 @@ export async function GET(request: Request, context: Params) {
       throw e;
     }
 
-    const result = await listBuddyCalendarSessionsForBuddy(auth.userId, buddyId, range);
+    const result = await listBuddyCalendarSessionsForBuddy(auth.user.userId, buddyId, range);
     if ("error" in result) {
       if (result.error === "NOT_FRIEND") {
         return NextResponse.json({ error: "Not friends with this user" }, { status: 403 });
@@ -46,8 +44,5 @@ export async function GET(request: Request, context: Params) {
     }
 
     return NextResponse.json(result);
-  } catch (error) {
-    console.error("Buddy per-buddy calendar GET error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  },
+);

--- a/src/app/api/buddy/sessions/calendar/[buddyId]/route.ts
+++ b/src/app/api/buddy/sessions/calendar/[buddyId]/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/api/requireAuth";
-import { withApiHandler } from "@/lib/api/withApiHandler";
+import { RouteParams, withApiHandler } from "@/lib/api/withApiHandler";
 import { listBuddyCalendarSessionsForBuddy } from "@/lib/buddyCalendar";
 import { parseBuddyCalendarRange } from "@/lib/buddyCalendarRange";
 import { isUuid } from "@/lib/friends";
+
+type RouteContext = RouteParams<{ buddyId: string }>;
 
 /**
  * Per-buddy shared-session calendar (#350).
@@ -11,11 +13,11 @@ import { isUuid } from "@/lib/friends";
  */
 export const GET = withApiHandler(
   "Buddy per-buddy calendar GET",
-  async (request: NextRequest, context) => {
+  async (request: NextRequest, context: RouteContext) => {
     const auth = await requireAuth();
     if (!auth.ok) return auth.response;
 
-    const { buddyId } = await (context as { params: Promise<{ buddyId: string }> }).params;
+    const { buddyId } = await context.params;
     if (!isUuid(buddyId)) {
       return NextResponse.json({ error: "Invalid buddy id" }, { status: 400 });
     }

--- a/src/app/api/buddy/sessions/calendar/route.test.ts
+++ b/src/app/api/buddy/sessions/calendar/route.test.ts
@@ -1,3 +1,4 @@
+import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const getCurrentUser = vi.fn();
@@ -35,13 +36,13 @@ describe("GET /api/buddy/sessions/calendar", () => {
   test("returns 401 when unauthenticated", async () => {
     getCurrentUser.mockResolvedValue(null);
     const { GET } = await import("./route");
-    const res = await GET(new Request("http://test/api/buddy/sessions/calendar"));
+    const res = await GET(new NextRequest("http://test/api/buddy/sessions/calendar"));
     expect(res.status).toBe(401);
   });
 
   test("returns calendar sessions for authenticated user", async () => {
     const { GET } = await import("./route");
-    const res = await GET(new Request("http://test/api/buddy/sessions/calendar"));
+    const res = await GET(new NextRequest("http://test/api/buddy/sessions/calendar"));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.sessions).toEqual([]);

--- a/src/app/api/buddy/sessions/calendar/route.ts
+++ b/src/app/api/buddy/sessions/calendar/route.ts
@@ -1,5 +1,6 @@
-import { NextResponse } from "next/server";
-import { getCurrentUser } from "@/lib/auth";
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { listBuddyCalendarSessions } from "@/lib/buddyCalendar";
 import { parseBuddyCalendarRange } from "@/lib/buddyCalendarRange";
 
@@ -7,32 +8,25 @@ import { parseBuddyCalendarRange } from "@/lib/buddyCalendarRange";
  * Unified multi-buddy calendar session list (#350).
  * iOS: mirror `GET /api/buddy/sessions/calendar` — see `listBuddyCalendarSessions`.
  */
-export async function GET(request: Request) {
+export const GET = withApiHandler("Buddy calendar GET", async (request: NextRequest) => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
+
+  let range;
   try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    range = parseBuddyCalendarRange(new URL(request.url).searchParams);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "";
+    if (
+      msg === "INVALID_FROM_DATE" ||
+      msg === "INVALID_TO_DATE" ||
+      msg === "INVALID_DATE_RANGE"
+    ) {
+      return NextResponse.json({ error: "Invalid date range" }, { status: 400 });
     }
-
-    let range;
-    try {
-      range = parseBuddyCalendarRange(new URL(request.url).searchParams);
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : "";
-      if (
-        msg === "INVALID_FROM_DATE" ||
-        msg === "INVALID_TO_DATE" ||
-        msg === "INVALID_DATE_RANGE"
-      ) {
-        return NextResponse.json({ error: "Invalid date range" }, { status: 400 });
-      }
-      throw e;
-    }
-
-    const result = await listBuddyCalendarSessions(auth.userId, range);
-    return NextResponse.json(result);
-  } catch (error) {
-    console.error("Buddy calendar GET error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    throw e;
   }
-}
+
+  const result = await listBuddyCalendarSessions(auth.user.userId, range);
+  return NextResponse.json(result);
+});

--- a/src/app/api/buddy/sessions/join/route.ts
+++ b/src/app/api/buddy/sessions/join/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { buddySessions, buddySessionParticipants } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import {
   assertBuddyFriendshipIfRequired,
   bumpBuddyRevision,
@@ -35,128 +36,121 @@ async function syncCalendarBestEffort(
   }
 }
 
-export async function POST(request: NextRequest) {
+export const POST = withApiHandler("Buddy join", async (request: NextRequest) => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
+
+  const json = await readJsonObject(request);
+  if (!json.ok) return json.response;
+
+  const token = json.body.token;
+  if (typeof token !== "string" || !token.trim()) {
+    return NextResponse.json({ error: "token is required" }, { status: 400 });
+  }
+  const trimmed = token.trim();
+
+  const [session] = await db
+    .select()
+    .from(buddySessions)
+    .where(eq(buddySessions.shareToken, trimmed))
+    .limit(1);
+
+  if (!session) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  if (session.state === "abandoned" || session.state === "completed") {
+    return NextResponse.json(
+      { error: "This session is no longer available" },
+      { status: 409 },
+    );
+  }
+
   try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const json = await readJsonObject(request);
-    if (!json.ok) return json.response;
-
-    const token = json.body.token;
-    if (typeof token !== "string" || !token.trim()) {
-      return NextResponse.json({ error: "token is required" }, { status: 400 });
-    }
-    const trimmed = token.trim();
-
-    const [session] = await db
-      .select()
-      .from(buddySessions)
-      .where(eq(buddySessions.shareToken, trimmed))
-      .limit(1);
-
-    if (!session) {
-      return NextResponse.json({ error: "Session not found" }, { status: 404 });
-    }
-
-    if (session.state === "abandoned" || session.state === "completed") {
+    await assertBuddyFriendshipIfRequired(session.hostUserId, auth.user.userId);
+  } catch (e) {
+    if ((e as Error & { code?: string }).code === "NOT_FRIENDS") {
       return NextResponse.json(
-        { error: "This session is no longer available" },
+        { error: "You must be friends with the host to join" },
+        { status: 403 },
+      );
+    }
+    throw e;
+  }
+
+  const [existing] = await db
+    .select()
+    .from(buddySessionParticipants)
+    .where(
+      and(
+        eq(buddySessionParticipants.buddySessionId, session.id),
+        eq(buddySessionParticipants.userId, auth.user.userId),
+      ),
+    )
+    .limit(1);
+
+  if (session.state === "active") {
+    if (!existing) {
+      return NextResponse.json(
+        { error: "Session already started; new guests cannot join" },
         { status: 409 },
       );
     }
+    await db
+      .update(buddySessionParticipants)
+      .set({ leftAt: null, lastSeenAt: new Date() })
+      .where(eq(buddySessionParticipants.id, existing.id));
+    await bumpBuddyRevision(session.id);
+    await reconcileBuddySession(session.id);
+    const calendarSync = await syncCalendarBestEffort(session, auth.user.userId);
+    return NextResponse.json({
+      sessionId: session.id,
+      scheduledStartAt: session.scheduledStartAt?.toISOString() ?? null,
+      calendarSync,
+    });
+  }
 
-    try {
-      await assertBuddyFriendshipIfRequired(session.hostUserId, auth.userId);
-    } catch (e) {
-      if ((e as Error & { code?: string }).code === "NOT_FRIENDS") {
-        return NextResponse.json(
-          { error: "You must be friends with the host to join" },
-          { status: 403 },
-        );
-      }
-      throw e;
-    }
-
-    const [existing] = await db
-      .select()
-      .from(buddySessionParticipants)
-      .where(
-        and(
-          eq(buddySessionParticipants.buddySessionId, session.id),
-          eq(buddySessionParticipants.userId, auth.userId),
-        ),
-      )
-      .limit(1);
-
-    if (session.state === "active") {
-      if (!existing) {
-        return NextResponse.json(
-          { error: "Session already started; new guests cannot join" },
-          { status: 409 },
-        );
-      }
+  if (session.state === "waiting" || session.state === "ready_check") {
+    const now = new Date();
+    if (existing) {
       await db
         .update(buddySessionParticipants)
-        .set({ leftAt: null, lastSeenAt: new Date() })
-        .where(eq(buddySessionParticipants.id, existing.id));
-      await bumpBuddyRevision(session.id);
-      await reconcileBuddySession(session.id);
-      const calendarSync = await syncCalendarBestEffort(session, auth.userId);
-      return NextResponse.json({
-        sessionId: session.id,
-        scheduledStartAt: session.scheduledStartAt?.toISOString() ?? null,
-        calendarSync,
-      });
-    }
-
-    if (session.state === "waiting" || session.state === "ready_check") {
-      const now = new Date();
-      if (existing) {
-        await db
-          .update(buddySessionParticipants)
-          .set({
-            leftAt: null,
-            lastSeenAt: now,
-            ready: existing.leftAt != null ? false : existing.ready,
-          })
-          .where(eq(buddySessionParticipants.id, existing.id));
-      } else {
-        await db.insert(buddySessionParticipants).values({
-          buddySessionId: session.id,
-          userId: auth.userId,
-          isHost: false,
-          ready: false,
+        .set({
+          leftAt: null,
           lastSeenAt: now,
-        });
-      }
-      const normalizedDuration = await syncBuddySessionDurationForParticipants(session.id);
-      await bumpBuddyRevision(session.id);
-      await reconcileBuddySession(session.id);
-      let sessionForCalendar = session;
-      if (normalizedDuration != null) {
-        sessionForCalendar = { ...session, durationSeconds: normalizedDuration };
-      } else {
-        const [fresh] = await db
-          .select()
-          .from(buddySessions)
-          .where(eq(buddySessions.id, session.id))
-          .limit(1);
-        if (fresh) sessionForCalendar = fresh;
-      }
-      const calendarSync = await syncCalendarBestEffort(sessionForCalendar, auth.userId);
-      return NextResponse.json({
-        sessionId: session.id,
-        scheduledStartAt: session.scheduledStartAt?.toISOString() ?? null,
-        calendarSync,
+          ready: existing.leftAt != null ? false : existing.ready,
+        })
+        .where(eq(buddySessionParticipants.id, existing.id));
+    } else {
+      await db.insert(buddySessionParticipants).values({
+        buddySessionId: session.id,
+        userId: auth.user.userId,
+        isHost: false,
+        ready: false,
+        lastSeenAt: now,
       });
     }
-
-    return NextResponse.json({ error: "Cannot join this session" }, { status: 409 });
-  } catch (error) {
-    console.error("Buddy join error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    const normalizedDuration = await syncBuddySessionDurationForParticipants(session.id);
+    await bumpBuddyRevision(session.id);
+    await reconcileBuddySession(session.id);
+    let sessionForCalendar = session;
+    if (normalizedDuration != null) {
+      sessionForCalendar = { ...session, durationSeconds: normalizedDuration };
+    } else {
+      const [fresh] = await db
+        .select()
+        .from(buddySessions)
+        .where(eq(buddySessions.id, session.id))
+        .limit(1);
+      if (fresh) sessionForCalendar = fresh;
+    }
+    const calendarSync = await syncCalendarBestEffort(sessionForCalendar, auth.user.userId);
+    return NextResponse.json({
+      sessionId: session.id,
+      scheduledStartAt: session.scheduledStartAt?.toISOString() ?? null,
+      calendarSync,
+    });
   }
-}
+
+  return NextResponse.json({ error: "Cannot join this session" }, { status: 409 });
+});

--- a/src/app/api/buddy/sessions/route.test.ts
+++ b/src/app/api/buddy/sessions/route.test.ts
@@ -18,6 +18,14 @@ vi.mock("@/db", () => ({
   },
 }));
 
+const poolDbTransaction = vi.fn((callback: (tx: { insert: typeof dbInsert; select: typeof dbSelect }) => unknown) =>
+  callback({ insert: dbInsert, select: dbSelect }),
+);
+
+vi.mock("@/db/pool", () => ({
+  poolDb: { transaction: poolDbTransaction },
+}));
+
 vi.mock("@/db/schema", () => ({
   buddySessions: {},
   buddySessionParticipants: {},

--- a/src/app/api/buddy/sessions/route.ts
+++ b/src/app/api/buddy/sessions/route.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
+import { poolDb } from "@/db/pool";
 import { buddySessions, buddySessionParticipants, users } from "@/db/schema";
 import { requireAuth } from "@/lib/api/requireAuth";
 import { withApiHandler } from "@/lib/api/withApiHandler";
@@ -29,27 +30,35 @@ export const POST = withApiHandler("Buddy create session", async (request: NextR
   const durationSeconds = normalizedBuddySessionDurationSeconds([host.currentDay]);
   const shareToken = randomBytes(24).toString("base64url");
 
-  const [session] = await db
-    .insert(buddySessions)
-    .values({
-      shareToken,
-      hostUserId: auth.user.userId,
-      durationSeconds,
-      scheduledStartAt,
-      state: "waiting",
-    })
-    .returning();
+  // Wrap the session + host-participant inserts in one transaction so a failure
+  // on the second insert never leaves an orphaned waiting session without a host.
+  const session = await poolDb.transaction(async (tx) => {
+    const [created] = await tx
+      .insert(buddySessions)
+      .values({
+        shareToken,
+        hostUserId: auth.user.userId,
+        durationSeconds,
+        scheduledStartAt,
+        state: "waiting",
+      })
+      .returning();
+
+    if (!created) return null;
+
+    await tx.insert(buddySessionParticipants).values({
+      buddySessionId: created.id,
+      userId: auth.user.userId,
+      isHost: true,
+      ready: false,
+    });
+
+    return created;
+  });
 
   if (!session) {
     return NextResponse.json({ error: "Failed to create session" }, { status: 500 });
   }
-
-  await db.insert(buddySessionParticipants).values({
-    buddySessionId: session.id,
-    userId: auth.user.userId,
-    isHost: true,
-    ready: false,
-  });
 
   const sharePath = `/app?buddy=${encodeURIComponent(shareToken)}`;
   let calendarSync: Awaited<ReturnType<typeof syncBuddySessionCalendarForUser>>[] = [];

--- a/src/app/api/buddy/sessions/route.ts
+++ b/src/app/api/buddy/sessions/route.ts
@@ -2,85 +2,80 @@ import { randomBytes } from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { buddySessions, buddySessionParticipants, users } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { normalizedBuddySessionDurationSeconds } from "@/lib/buddySession";
 import { readBuddySessionCreateBody } from "@/lib/buddySessionCreateBody";
 import { GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE, syncBuddySessionCalendarForUser } from "@/lib/googleCalendar";
 import { eq } from "drizzle-orm";
 
-export async function POST(request: NextRequest) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-    const createBody = await readBuddySessionCreateBody(request);
-    if (createBody instanceof NextResponse) return createBody;
-    const { scheduledStartAt } = createBody;
+export const POST = withApiHandler("Buddy create session", async (request: NextRequest) => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
 
-    const [host] = await db
-      .select({ currentDay: users.currentDay })
-      .from(users)
-      .where(eq(users.id, auth.userId))
-      .limit(1);
-    if (!host) {
-      return NextResponse.json({ error: "User not found" }, { status: 404 });
-    }
+  const createBody = await readBuddySessionCreateBody(request);
+  if (createBody instanceof NextResponse) return createBody;
+  const { scheduledStartAt } = createBody;
 
-    const durationSeconds = normalizedBuddySessionDurationSeconds([host.currentDay]);
-    const shareToken = randomBytes(24).toString("base64url");
-
-    const [session] = await db
-      .insert(buddySessions)
-      .values({
-        shareToken,
-        hostUserId: auth.userId,
-        durationSeconds,
-        scheduledStartAt,
-        state: "waiting",
-      })
-      .returning();
-
-    if (!session) {
-      return NextResponse.json({ error: "Failed to create session" }, { status: 500 });
-    }
-
-    await db.insert(buddySessionParticipants).values({
-      buddySessionId: session.id,
-      userId: auth.userId,
-      isHost: true,
-      ready: false,
-    });
-
-    const sharePath = `/app?buddy=${encodeURIComponent(shareToken)}`;
-    let calendarSync: Awaited<ReturnType<typeof syncBuddySessionCalendarForUser>>[] = [];
-    if (session.scheduledStartAt) {
-      try {
-        calendarSync = [await syncBuddySessionCalendarForUser(session, auth.userId)];
-      } catch (syncError) {
-        console.error("Buddy create Google Calendar sync error:", syncError);
-        calendarSync = [
-          {
-            status: "failed",
-            userId: auth.userId,
-            error: GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE,
-          },
-        ];
-      }
-    }
-
-    return NextResponse.json({
-      session: {
-        id: session.id,
-        shareToken: session.shareToken,
-        sharePath,
-        durationSeconds: session.durationSeconds,
-        scheduledStartAt: session.scheduledStartAt?.toISOString() ?? null,
-        calendarSync,
-      },
-    });
-  } catch (error) {
-    console.error("Buddy create session error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  const [host] = await db
+    .select({ currentDay: users.currentDay })
+    .from(users)
+    .where(eq(users.id, auth.user.userId))
+    .limit(1);
+  if (!host) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
   }
-}
+
+  const durationSeconds = normalizedBuddySessionDurationSeconds([host.currentDay]);
+  const shareToken = randomBytes(24).toString("base64url");
+
+  const [session] = await db
+    .insert(buddySessions)
+    .values({
+      shareToken,
+      hostUserId: auth.user.userId,
+      durationSeconds,
+      scheduledStartAt,
+      state: "waiting",
+    })
+    .returning();
+
+  if (!session) {
+    return NextResponse.json({ error: "Failed to create session" }, { status: 500 });
+  }
+
+  await db.insert(buddySessionParticipants).values({
+    buddySessionId: session.id,
+    userId: auth.user.userId,
+    isHost: true,
+    ready: false,
+  });
+
+  const sharePath = `/app?buddy=${encodeURIComponent(shareToken)}`;
+  let calendarSync: Awaited<ReturnType<typeof syncBuddySessionCalendarForUser>>[] = [];
+  if (session.scheduledStartAt) {
+    try {
+      calendarSync = [await syncBuddySessionCalendarForUser(session, auth.user.userId)];
+    } catch (syncError) {
+      console.error("Buddy create Google Calendar sync error:", syncError);
+      calendarSync = [
+        {
+          status: "failed",
+          userId: auth.user.userId,
+          error: GOOGLE_CALENDAR_SYNC_FAILED_MESSAGE,
+        },
+      ];
+    }
+  }
+
+  return NextResponse.json({
+    session: {
+      id: session.id,
+      shareToken: session.shareToken,
+      sharePath,
+      durationSeconds: session.durationSeconds,
+      scheduledStartAt: session.scheduledStartAt?.toISOString() ?? null,
+      calendarSync,
+    },
+  });
+});

--- a/src/app/api/cron/dispatch-notifications/route.ts
+++ b/src/app/api/cron/dispatch-notifications/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { dispatchDueNotifications } from "@/lib/notification-scheduler";
 
 function isAuthorizedCron(request: NextRequest): boolean {
@@ -10,20 +11,20 @@ function isAuthorizedCron(request: NextRequest): boolean {
   return authHeader === `Bearer ${secret}`;
 }
 
-export async function GET(request: NextRequest) {
+export const GET = withApiHandler("dispatch-notifications cron", async (request: NextRequest) => {
   if (!isAuthorizedCron(request)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  try {
-    const result = await dispatchDueNotifications();
-    return NextResponse.json({ ok: true, ...result });
-  } catch (error) {
-    console.error("dispatch-notifications cron error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  const result = await dispatchDueNotifications();
+  return NextResponse.json({ ok: true, ...result });
+});
 
-export async function POST(request: NextRequest) {
-  return GET(request);
-}
+export const POST = withApiHandler("dispatch-notifications cron", async (request: NextRequest) => {
+  if (!isAuthorizedCron(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const result = await dispatchDueNotifications();
+  return NextResponse.json({ ok: true, ...result });
+});

--- a/src/app/api/device-token/route.ts
+++ b/src/app/api/device-token/route.ts
@@ -1,117 +1,104 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { deviceTokens } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { hashDeviceToken, isValidDeviceToken } from "@/lib/apns";
 import { readJsonObject } from "@/lib/readJsonObject";
 import { and, eq } from "drizzle-orm";
 
 const apnsEnvironments = new Set(["development", "production"]);
 
-export async function POST(request: NextRequest) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const POST = withApiHandler("Device token registration", async (request: NextRequest) => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
 
-    const json = await readJsonObject(request);
-    if (!json.ok) {
-      return json.response;
-    }
+  const json = await readJsonObject(request);
+  if (!json.ok) {
+    return json.response;
+  }
 
-    const token = json.body.token;
-    if (typeof token !== "string" || !isValidDeviceToken(token)) {
-      return NextResponse.json({ error: "token must be a valid APNs device token" }, { status: 400 });
-    }
+  const token = json.body.token;
+  if (typeof token !== "string" || !isValidDeviceToken(token)) {
+    return NextResponse.json({ error: "token must be a valid APNs device token" }, { status: 400 });
+  }
 
-    const platform = json.body.platform ?? "ios";
-    if (platform !== "ios") {
-      return NextResponse.json({ error: "platform must be \"ios\"" }, { status: 400 });
-    }
+  const platform = json.body.platform ?? "ios";
+  if (platform !== "ios") {
+    return NextResponse.json({ error: "platform must be \"ios\"" }, { status: 400 });
+  }
 
-    const apnsEnvironment = json.body.apnsEnvironment;
-    if (typeof apnsEnvironment !== "string" || !apnsEnvironments.has(apnsEnvironment)) {
-      return NextResponse.json(
-        { error: "apnsEnvironment must be \"development\" or \"production\"" },
-        { status: 400 },
-      );
-    }
+  const apnsEnvironment = json.body.apnsEnvironment;
+  if (typeof apnsEnvironment !== "string" || !apnsEnvironments.has(apnsEnvironment)) {
+    return NextResponse.json(
+      { error: "apnsEnvironment must be \"development\" or \"production\"" },
+      { status: 400 },
+    );
+  }
 
-    const now = new Date();
-    const normalizedToken = token.trim().toLowerCase();
-    const tokenHash = hashDeviceToken(normalizedToken);
-    const [registered] = await db
-      .insert(deviceTokens)
-      .values({
-        userId: auth.userId,
-        platform,
+  const now = new Date();
+  const normalizedToken = token.trim().toLowerCase();
+  const tokenHash = hashDeviceToken(normalizedToken);
+  const [registered] = await db
+    .insert(deviceTokens)
+    .values({
+      userId: auth.user.userId,
+      platform,
+      token: normalizedToken,
+      tokenHash,
+      apnsEnvironment,
+      enabled: true,
+      lastRegisteredAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [deviceTokens.tokenHash, deviceTokens.apnsEnvironment],
+      set: {
+        userId: auth.user.userId,
         token: normalizedToken,
-        tokenHash,
-        apnsEnvironment,
         enabled: true,
         lastRegisteredAt: now,
         updatedAt: now,
-      })
-      .onConflictDoUpdate({
-        target: [deviceTokens.tokenHash, deviceTokens.apnsEnvironment],
-        set: {
-          userId: auth.userId,
-          token: normalizedToken,
-          enabled: true,
-          lastRegisteredAt: now,
-          updatedAt: now,
-        },
-      })
-      .returning({ id: deviceTokens.id, platform: deviceTokens.platform, apnsEnvironment: deviceTokens.apnsEnvironment });
+      },
+    })
+    .returning({ id: deviceTokens.id, platform: deviceTokens.platform, apnsEnvironment: deviceTokens.apnsEnvironment });
 
-    return NextResponse.json({ deviceToken: registered }, { status: 201 });
-  } catch (error) {
-    console.error("Device token registration error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  return NextResponse.json({ deviceToken: registered }, { status: 201 });
+});
+
+export const DELETE = withApiHandler("Device token removal", async (request: NextRequest) => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
+
+  const json = await readJsonObject(request);
+  if (!json.ok) {
+    return json.response;
   }
-}
 
-export async function DELETE(request: NextRequest) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const json = await readJsonObject(request);
-    if (!json.ok) {
-      return json.response;
-    }
-
-    const token = json.body.token;
-    if (typeof token !== "string" || !isValidDeviceToken(token)) {
-      return NextResponse.json({ error: "token must be a valid APNs device token" }, { status: 400 });
-    }
-
-    const apnsEnvironment = json.body.apnsEnvironment;
-    if (typeof apnsEnvironment !== "string" || !apnsEnvironments.has(apnsEnvironment)) {
-      return NextResponse.json(
-        { error: "apnsEnvironment must be \"development\" or \"production\"" },
-        { status: 400 },
-      );
-    }
-
-    const [updated] = await db
-      .update(deviceTokens)
-      .set({ enabled: false, updatedAt: new Date() })
-      .where(
-        and(
-          eq(deviceTokens.userId, auth.userId),
-          eq(deviceTokens.tokenHash, hashDeviceToken(token)),
-          eq(deviceTokens.apnsEnvironment, apnsEnvironment),
-        ),
-      )
-      .returning({ id: deviceTokens.id });
-
-    return NextResponse.json({ ok: true, removed: Boolean(updated) });
-  } catch (error) {
-    console.error("Device token removal error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  const token = json.body.token;
+  if (typeof token !== "string" || !isValidDeviceToken(token)) {
+    return NextResponse.json({ error: "token must be a valid APNs device token" }, { status: 400 });
   }
-}
+
+  const apnsEnvironment = json.body.apnsEnvironment;
+  if (typeof apnsEnvironment !== "string" || !apnsEnvironments.has(apnsEnvironment)) {
+    return NextResponse.json(
+      { error: "apnsEnvironment must be \"development\" or \"production\"" },
+      { status: 400 },
+    );
+  }
+
+  const [updated] = await db
+    .update(deviceTokens)
+    .set({ enabled: false, updatedAt: new Date() })
+    .where(
+      and(
+        eq(deviceTokens.userId, auth.user.userId),
+        eq(deviceTokens.tokenHash, hashDeviceToken(token)),
+        eq(deviceTokens.apnsEnvironment, apnsEnvironment),
+      ),
+    )
+    .returning({ id: deviceTokens.id });
+
+  return NextResponse.json({ ok: true, removed: Boolean(updated) });
+});

--- a/src/app/api/failure-reasons/route.ts
+++ b/src/app/api/failure-reasons/route.ts
@@ -2,11 +2,16 @@ import { NextRequest, NextResponse } from "next/server";
 import { and, eq } from "drizzle-orm";
 import { db } from "@/db";
 import { failureReasons } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { readJsonObject } from "@/lib/readJsonObject";
 import { addDaysToIsoDate, isValidSessionCalendarDate } from "@/lib/sessionCalendar";
 
 const MAX_REASON_LENGTH = 1000;
+
+const failureReasonsLogError = (label: string, error: unknown) => {
+  console.error(`${label} error:`, error instanceof Error ? error.message : "unknown error");
+};
 
 /**
  * Latest date a reason may be logged for. The server doesn't know the caller's
@@ -28,12 +33,11 @@ function serializeFailureReason(row: typeof failureReasons.$inferSelect) {
   };
 }
 
-export async function GET(request: NextRequest) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const GET = withApiHandler(
+  "Failure reasons GET",
+  async (request: NextRequest) => {
+    const auth = await requireAuth();
+    if (!auth.ok) return auth.response;
 
     const date = new URL(request.url).searchParams.get("date");
     if (!date || !isValidSessionCalendarDate(date)) {
@@ -43,25 +47,22 @@ export async function GET(request: NextRequest) {
     const [row] = await db
       .select()
       .from(failureReasons)
-      .where(and(eq(failureReasons.userId, auth.userId), eq(failureReasons.reasonDate, date)))
+      .where(and(eq(failureReasons.userId, auth.user.userId), eq(failureReasons.reasonDate, date)))
       .limit(1);
 
     return NextResponse.json({
       exists: !!row,
       failureReason: row ? serializeFailureReason(row) : null,
     });
-  } catch (error) {
-    console.error("Failure reasons GET error:", error instanceof Error ? error.message : "unknown error");
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  },
+  { logError: failureReasonsLogError },
+);
 
-export async function POST(request: NextRequest) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const POST = withApiHandler(
+  "Failure reasons POST",
+  async (request: NextRequest) => {
+    const auth = await requireAuth();
+    if (!auth.ok) return auth.response;
 
     const json = await readJsonObject(request);
     if (!json.ok) {
@@ -96,7 +97,7 @@ export async function POST(request: NextRequest) {
     const [row] = await db
       .insert(failureReasons)
       .values({
-        userId: auth.userId,
+        userId: auth.user.userId,
         reasonDate,
         text: trimmed,
         createdAt: now,
@@ -109,10 +110,6 @@ export async function POST(request: NextRequest) {
       .returning();
 
     return NextResponse.json({ failureReason: serializeFailureReason(row) });
-  } catch (error) {
-    // Log only the error message, never the raw error — a DB driver error's `detail`/
-    // `parameters` fields can echo the user's submitted reason text into server logs.
-    console.error("Failure reasons POST error:", error instanceof Error ? error.message : "unknown error");
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  },
+  { logError: failureReasonsLogError },
+);

--- a/src/app/api/friends/[friendUserId]/route.ts
+++ b/src/app/api/friends/[friendUserId]/route.ts
@@ -1,29 +1,27 @@
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { friendships } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { orderedUserPair, isUuid } from "@/lib/friends";
 import { and, eq } from "drizzle-orm";
 
-type Params = { params: Promise<{ friendUserId: string }> };
+export const DELETE = withApiHandler(
+  "Unfriend",
+  async (_request, context) => {
+    const auth = await requireAuth();
+    if (!auth.ok) return auth.response;
 
-export async function DELETE(_request: Request, context: Params) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { friendUserId } = await context.params;
+    const { friendUserId } = await (context as { params: Promise<{ friendUserId: string }> }).params;
 
     if (!isUuid(friendUserId)) {
       return NextResponse.json({ error: "friendUserId must be a valid UUID" }, { status: 400 });
     }
-    if (friendUserId === auth.userId) {
+    if (friendUserId === auth.user.userId) {
       return NextResponse.json({ error: "Invalid friend user id" }, { status: 400 });
     }
 
-    const [u1, u2] = orderedUserPair(auth.userId, friendUserId);
+    const [u1, u2] = orderedUserPair(auth.user.userId, friendUserId);
 
     const removed = await db
       .delete(friendships)
@@ -35,8 +33,5 @@ export async function DELETE(_request: Request, context: Params) {
     }
 
     return NextResponse.json({ ok: true });
-  } catch (error) {
-    console.error("Unfriend error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  },
+);

--- a/src/app/api/friends/[friendUserId]/route.ts
+++ b/src/app/api/friends/[friendUserId]/route.ts
@@ -1,18 +1,20 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { friendships } from "@/db/schema";
 import { requireAuth } from "@/lib/api/requireAuth";
-import { withApiHandler } from "@/lib/api/withApiHandler";
+import { RouteParams, withApiHandler } from "@/lib/api/withApiHandler";
 import { orderedUserPair, isUuid } from "@/lib/friends";
 import { and, eq } from "drizzle-orm";
 
+type RouteContext = RouteParams<{ friendUserId: string }>;
+
 export const DELETE = withApiHandler(
   "Unfriend",
-  async (_request, context) => {
+  async (_request: NextRequest, context: RouteContext) => {
     const auth = await requireAuth();
     if (!auth.ok) return auth.response;
 
-    const { friendUserId } = await (context as { params: Promise<{ friendUserId: string }> }).params;
+    const { friendUserId } = await context.params;
 
     if (!isUuid(friendUserId)) {
       return NextResponse.json({ error: "friendUserId must be a valid UUID" }, { status: 400 });

--- a/src/app/api/friends/requests/[id]/route.ts
+++ b/src/app/api/friends/requests/[id]/route.ts
@@ -2,21 +2,19 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { poolDb } from "@/db/pool";
 import { friendRequests, friendships } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { orderedUserPair, isUuid } from "@/lib/friends";
 import { readJsonObject } from "@/lib/readJsonObject";
 import { and, eq, ne } from "drizzle-orm";
 
-type Params = { params: Promise<{ id: string }> };
+export const PATCH = withApiHandler(
+  "Friend request patch",
+  async (request: NextRequest, context) => {
+    const auth = await requireAuth();
+    if (!auth.ok) return auth.response;
 
-export async function PATCH(request: NextRequest, context: Params) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { id } = await context.params;
+    const { id } = await (context as { params: Promise<{ id: string }> }).params;
     if (!isUuid(id)) {
       return NextResponse.json({ error: "Invalid request id" }, { status: 400 });
     }
@@ -48,7 +46,7 @@ export async function PATCH(request: NextRequest, context: Params) {
     }
 
     if (action === "cancel") {
-      if (row.fromUserId !== auth.userId) {
+      if (row.fromUserId !== auth.user.userId) {
         return NextResponse.json({ error: "Only the sender can cancel this request" }, { status: 403 });
       }
       const [updated] = await db
@@ -69,7 +67,7 @@ export async function PATCH(request: NextRequest, context: Params) {
       return NextResponse.json({ request: updated });
     }
 
-    if (row.toUserId !== auth.userId) {
+    if (row.toUserId !== auth.user.userId) {
       return NextResponse.json({ error: "Only the recipient can accept or reject this request" }, { status: 403 });
     }
 
@@ -103,7 +101,7 @@ export async function PATCH(request: NextRequest, context: Params) {
           and(
             eq(friendRequests.id, id),
             eq(friendRequests.status, "pending"),
-            eq(friendRequests.toUserId, auth.userId),
+            eq(friendRequests.toUserId, auth.user.userId),
           ),
         )
         .returning({
@@ -141,8 +139,5 @@ export async function PATCH(request: NextRequest, context: Params) {
     }
 
     return NextResponse.json({ request: updated });
-  } catch (error) {
-    console.error("Friend request patch error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  },
+);

--- a/src/app/api/friends/requests/[id]/route.ts
+++ b/src/app/api/friends/requests/[id]/route.ts
@@ -3,18 +3,20 @@ import { db } from "@/db";
 import { poolDb } from "@/db/pool";
 import { friendRequests, friendships } from "@/db/schema";
 import { requireAuth } from "@/lib/api/requireAuth";
-import { withApiHandler } from "@/lib/api/withApiHandler";
+import { RouteParams, withApiHandler } from "@/lib/api/withApiHandler";
 import { orderedUserPair, isUuid } from "@/lib/friends";
 import { readJsonObject } from "@/lib/readJsonObject";
 import { and, eq, ne } from "drizzle-orm";
 
+type RouteContext = RouteParams<{ id: string }>;
+
 export const PATCH = withApiHandler(
   "Friend request patch",
-  async (request: NextRequest, context) => {
+  async (request: NextRequest, context: RouteContext) => {
     const auth = await requireAuth();
     if (!auth.ok) return auth.response;
 
-    const { id } = await (context as { params: Promise<{ id: string }> }).params;
+    const { id } = await context.params;
     if (!isUuid(id)) {
       return NextResponse.json({ error: "Invalid request id" }, { status: 400 });
     }

--- a/src/app/api/friends/requests/route.ts
+++ b/src/app/api/friends/requests/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/db";
 import { friendRequests, friendships, notificationPreferences, users } from "@/db/schema";
 import { requireAuth } from "@/lib/api/requireAuth";
 import { withApiHandler } from "@/lib/api/withApiHandler";
+import { isUniqueViolation } from "@/lib/dbErrors";
 import { orderedUserPair, isUuid } from "@/lib/friends";
 import { friendRequestNotificationsAllowed } from "@/lib/notification-preferences";
 import { sendFriendRequestNotification } from "@/lib/notifications";
@@ -145,8 +146,7 @@ export const POST = withApiHandler("Friend request create", async (request: Next
 
     return NextResponse.json({ request: created }, { status: 201 });
   } catch (e: unknown) {
-    const code = typeof e === "object" && e !== null && "code" in e ? String((e as { code: unknown }).code) : "";
-    if (code === "23505") {
+    if (isUniqueViolation(e)) {
       return NextResponse.json(
         { error: "A pending friend request already exists between these users" },
         { status: 409 },

--- a/src/app/api/friends/requests/route.ts
+++ b/src/app/api/friends/requests/route.ts
@@ -1,170 +1,157 @@
 import { after, NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { friendRequests, friendships, notificationPreferences, users } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { orderedUserPair, isUuid } from "@/lib/friends";
 import { friendRequestNotificationsAllowed } from "@/lib/notification-preferences";
 import { sendFriendRequestNotification } from "@/lib/notifications";
 import { readJsonObject } from "@/lib/readJsonObject";
 import { and, eq, or } from "drizzle-orm";
 
-export async function GET() {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const GET = withApiHandler("Friend requests list", async () => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
 
-    const uid = auth.userId;
+  const uid = auth.user.userId;
 
-    const incomingRows = await db
-      .select({
-        id: friendRequests.id,
-        createdAt: friendRequests.createdAt,
-        user: { id: users.id, username: users.username },
-      })
-      .from(friendRequests)
-      .innerJoin(users, eq(friendRequests.fromUserId, users.id))
-      .where(and(eq(friendRequests.toUserId, uid), eq(friendRequests.status, "pending")));
+  const incomingRows = await db
+    .select({
+      id: friendRequests.id,
+      createdAt: friendRequests.createdAt,
+      user: { id: users.id, username: users.username },
+    })
+    .from(friendRequests)
+    .innerJoin(users, eq(friendRequests.fromUserId, users.id))
+    .where(and(eq(friendRequests.toUserId, uid), eq(friendRequests.status, "pending")));
 
-    const outgoingRows = await db
-      .select({
-        id: friendRequests.id,
-        createdAt: friendRequests.createdAt,
-        user: { id: users.id, username: users.username },
-      })
-      .from(friendRequests)
-      .innerJoin(users, eq(friendRequests.toUserId, users.id))
-      .where(and(eq(friendRequests.fromUserId, uid), eq(friendRequests.status, "pending")));
+  const outgoingRows = await db
+    .select({
+      id: friendRequests.id,
+      createdAt: friendRequests.createdAt,
+      user: { id: users.id, username: users.username },
+    })
+    .from(friendRequests)
+    .innerJoin(users, eq(friendRequests.toUserId, users.id))
+    .where(and(eq(friendRequests.fromUserId, uid), eq(friendRequests.status, "pending")));
 
-    return NextResponse.json({
-      incoming: incomingRows,
-      outgoing: outgoingRows,
-    });
-  } catch (error) {
-    console.error("Friend requests list error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  return NextResponse.json({
+    incoming: incomingRows,
+    outgoing: outgoingRows,
+  });
+});
+
+export const POST = withApiHandler("Friend request create", async (request: NextRequest) => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
+
+  const json = await readJsonObject(request);
+  if (!json.ok) {
+    return json.response;
   }
-}
 
-export async function POST(request: NextRequest) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+  const toUserId = json.body.toUserId;
+  if (!toUserId || typeof toUserId !== "string") {
+    return NextResponse.json({ error: "toUserId is required" }, { status: 400 });
+  }
+  if (!isUuid(toUserId)) {
+    return NextResponse.json({ error: "toUserId must be a valid UUID" }, { status: 400 });
+  }
+  if (toUserId === auth.user.userId) {
+    return NextResponse.json({ error: "Cannot send a friend request to yourself" }, { status: 400 });
+  }
 
-    const json = await readJsonObject(request);
-    if (!json.ok) {
-      return json.response;
-    }
+  const [target] = await db.select({ id: users.id }).from(users).where(eq(users.id, toUserId)).limit(1);
+  if (!target) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
 
-    const toUserId = json.body.toUserId;
-    if (!toUserId || typeof toUserId !== "string") {
-      return NextResponse.json({ error: "toUserId is required" }, { status: 400 });
-    }
-    if (!isUuid(toUserId)) {
-      return NextResponse.json({ error: "toUserId must be a valid UUID" }, { status: 400 });
-    }
-    if (toUserId === auth.userId) {
-      return NextResponse.json({ error: "Cannot send a friend request to yourself" }, { status: 400 });
-    }
+  const [u1, u2] = orderedUserPair(auth.user.userId, toUserId);
+  const [existingFriend] = await db
+    .select({ user1Id: friendships.user1Id })
+    .from(friendships)
+    .where(and(eq(friendships.user1Id, u1), eq(friendships.user2Id, u2)))
+    .limit(1);
 
-    const [target] = await db.select({ id: users.id }).from(users).where(eq(users.id, toUserId)).limit(1);
-    if (!target) {
-      return NextResponse.json({ error: "User not found" }, { status: 404 });
-    }
+  if (existingFriend) {
+    return NextResponse.json({ error: "Already friends" }, { status: 409 });
+  }
 
-    const [u1, u2] = orderedUserPair(auth.userId, toUserId);
-    const [existingFriend] = await db
-      .select({ user1Id: friendships.user1Id })
-      .from(friendships)
-      .where(and(eq(friendships.user1Id, u1), eq(friendships.user2Id, u2)))
-      .limit(1);
-
-    if (existingFriend) {
-      return NextResponse.json({ error: "Already friends" }, { status: 409 });
-    }
-
-    const [pendingAny] = await db
-      .select({ id: friendRequests.id })
-      .from(friendRequests)
-      .where(
-        and(
-          eq(friendRequests.status, "pending"),
-          or(
-            and(eq(friendRequests.fromUserId, auth.userId), eq(friendRequests.toUserId, toUserId)),
-            and(eq(friendRequests.fromUserId, toUserId), eq(friendRequests.toUserId, auth.userId)),
-          ),
+  const [pendingAny] = await db
+    .select({ id: friendRequests.id })
+    .from(friendRequests)
+    .where(
+      and(
+        eq(friendRequests.status, "pending"),
+        or(
+          and(eq(friendRequests.fromUserId, auth.user.userId), eq(friendRequests.toUserId, toUserId)),
+          and(eq(friendRequests.fromUserId, toUserId), eq(friendRequests.toUserId, auth.user.userId)),
         ),
-      )
-      .limit(1);
+      ),
+    )
+    .limit(1);
 
-    if (pendingAny) {
-      return NextResponse.json({ error: "A pending friend request already exists between these users" }, { status: 409 });
-    }
+  if (pendingAny) {
+    return NextResponse.json({ error: "A pending friend request already exists between these users" }, { status: 409 });
+  }
 
-    try {
-      const [created] = await db
-        .insert(friendRequests)
-        .values({
-          fromUserId: auth.userId,
-          toUserId,
-          status: "pending",
-          updatedAt: new Date(),
-        })
-        .returning({
-          id: friendRequests.id,
-          fromUserId: friendRequests.fromUserId,
-          toUserId: friendRequests.toUserId,
-          status: friendRequests.status,
-          createdAt: friendRequests.createdAt,
-          updatedAt: friendRequests.updatedAt,
-        });
-
-      const [sender] = await db
-        .select({ username: users.username })
-        .from(users)
-        .where(eq(users.id, auth.userId))
-        .limit(1);
-
-      after(async () => {
-        try {
-          const [prefs] = await db
-            .select({
-              pushEnabled: notificationPreferences.pushEnabled,
-              friendRequestNotificationsEnabled: notificationPreferences.friendRequestNotificationsEnabled,
-            })
-            .from(notificationPreferences)
-            .where(eq(notificationPreferences.userId, created.toUserId))
-            .limit(1);
-          // Only gate if a prefs row exists — no row means user hasn't configured preferences yet
-          if (prefs && !friendRequestNotificationsAllowed(prefs)) {
-            return;
-          }
-          await sendFriendRequestNotification({
-            requestId: created.id,
-            recipientUserId: created.toUserId,
-            senderUsername: sender?.username ?? "Someone",
-          });
-        } catch (error) {
-          console.error("Friend request notification error:", error);
-        }
+  try {
+    const [created] = await db
+      .insert(friendRequests)
+      .values({
+        fromUserId: auth.user.userId,
+        toUserId,
+        status: "pending",
+        updatedAt: new Date(),
+      })
+      .returning({
+        id: friendRequests.id,
+        fromUserId: friendRequests.fromUserId,
+        toUserId: friendRequests.toUserId,
+        status: friendRequests.status,
+        createdAt: friendRequests.createdAt,
+        updatedAt: friendRequests.updatedAt,
       });
 
-      return NextResponse.json({ request: created }, { status: 201 });
-    } catch (e: unknown) {
-      const code = typeof e === "object" && e !== null && "code" in e ? String((e as { code: unknown }).code) : "";
-      if (code === "23505") {
-        return NextResponse.json(
-          { error: "A pending friend request already exists between these users" },
-          { status: 409 },
-        );
+    const [sender] = await db
+      .select({ username: users.username })
+      .from(users)
+      .where(eq(users.id, auth.user.userId))
+      .limit(1);
+
+    after(async () => {
+      try {
+        const [prefs] = await db
+          .select({
+            pushEnabled: notificationPreferences.pushEnabled,
+            friendRequestNotificationsEnabled: notificationPreferences.friendRequestNotificationsEnabled,
+          })
+          .from(notificationPreferences)
+          .where(eq(notificationPreferences.userId, created.toUserId))
+          .limit(1);
+        // Only gate if a prefs row exists — no row means user hasn't configured preferences yet
+        if (prefs && !friendRequestNotificationsAllowed(prefs)) {
+          return;
+        }
+        await sendFriendRequestNotification({
+          requestId: created.id,
+          recipientUserId: created.toUserId,
+          senderUsername: sender?.username ?? "Someone",
+        });
+      } catch (error) {
+        console.error("Friend request notification error:", error);
       }
-      throw e;
+    });
+
+    return NextResponse.json({ request: created }, { status: 201 });
+  } catch (e: unknown) {
+    const code = typeof e === "object" && e !== null && "code" in e ? String((e as { code: unknown }).code) : "";
+    if (code === "23505") {
+      return NextResponse.json(
+        { error: "A pending friend request already exists between these users" },
+        { status: 409 },
+      );
     }
-  } catch (error) {
-    console.error("Friend request create error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    throw e;
   }
-}
+});

--- a/src/app/api/friends/route.ts
+++ b/src/app/api/friends/route.ts
@@ -1,97 +1,91 @@
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { buddySessionParticipants, friendships, sessions, users } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { and, eq, isNotNull, ne, or, sql } from "drizzle-orm";
 
-export async function GET() {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const GET = withApiHandler("Friends list", async () => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
 
-    const uid = auth.userId;
+  const uid = auth.user.userId;
 
-    const friendSelect = { id: users.id, username: users.username };
+  const friendSelect = { id: users.id, username: users.username };
 
-    const asUser1 = db
-      .select(friendSelect)
-      .from(friendships)
-      .innerJoin(users, eq(friendships.user2Id, users.id))
-      .where(eq(friendships.user1Id, uid));
+  const asUser1 = db
+    .select(friendSelect)
+    .from(friendships)
+    .innerJoin(users, eq(friendships.user2Id, users.id))
+    .where(eq(friendships.user1Id, uid));
 
-    const asUser2 = db
-      .select(friendSelect)
-      .from(friendships)
-      .innerJoin(users, eq(friendships.user1Id, users.id))
-      .where(eq(friendships.user2Id, uid));
+  const asUser2 = db
+    .select(friendSelect)
+    .from(friendships)
+    .innerJoin(users, eq(friendships.user1Id, users.id))
+    .where(eq(friendships.user2Id, uid));
 
-    // #343: "most meditated with" per friend. Joins the current user's own
-    // completed `sessions` rows created from shared buddy sits (see
-    // record-personal-session/route.ts) against `buddy_session_participants`
-    // on the same `buddy_session_id` to find the other participant, then
-    // aggregates per friend.
-    //
-    // The friendships table enforces user1Id < user2Id, so a friend can appear
-    // in either column. We join against friendships to restrict aggregation to
-    // actual friends, avoiding work for non-friend participants.
-    const meditatedWithSelect = db
-      .select({
-        friendId: buddySessionParticipants.userId,
-        sessionCount: sql<number>`count(distinct ${sessions.id})`.mapWith(Number),
-        totalDurationSeconds: sql<number>`coalesce(sum(coalesce(${sessions.actualTime}, ${sessions.duration})), 0)`.mapWith(Number),
-      })
-      .from(sessions)
-      .innerJoin(
-        buddySessionParticipants,
-        eq(buddySessionParticipants.buddySessionId, sessions.buddySessionId),
-      )
-      .innerJoin(
-        friendships,
-        or(
-          and(eq(friendships.user1Id, uid), eq(friendships.user2Id, buddySessionParticipants.userId)),
-          and(eq(friendships.user2Id, uid), eq(friendships.user1Id, buddySessionParticipants.userId)),
-        ),
-      )
-      .where(
-        and(
-          eq(sessions.userId, uid),
-          eq(sessions.completed, true),
-          isNotNull(sessions.buddySessionId),
-          ne(buddySessionParticipants.userId, uid),
-        ),
-      )
-      .groupBy(buddySessionParticipants.userId);
+  // #343: "most meditated with" per friend. Joins the current user's own
+  // completed `sessions` rows created from shared buddy sits (see
+  // record-personal-session/route.ts) against `buddy_session_participants`
+  // on the same `buddy_session_id` to find the other participant, then
+  // aggregates per friend.
+  //
+  // The friendships table enforces user1Id < user2Id, so a friend can appear
+  // in either column. We join against friendships to restrict aggregation to
+  // actual friends, avoiding work for non-friend participants.
+  const meditatedWithSelect = db
+    .select({
+      friendId: buddySessionParticipants.userId,
+      sessionCount: sql<number>`count(distinct ${sessions.id})`.mapWith(Number),
+      totalDurationSeconds: sql<number>`coalesce(sum(coalesce(${sessions.actualTime}, ${sessions.duration})), 0)`.mapWith(Number),
+    })
+    .from(sessions)
+    .innerJoin(
+      buddySessionParticipants,
+      eq(buddySessionParticipants.buddySessionId, sessions.buddySessionId),
+    )
+    .innerJoin(
+      friendships,
+      or(
+        and(eq(friendships.user1Id, uid), eq(friendships.user2Id, buddySessionParticipants.userId)),
+        and(eq(friendships.user2Id, uid), eq(friendships.user1Id, buddySessionParticipants.userId)),
+      ),
+    )
+    .where(
+      and(
+        eq(sessions.userId, uid),
+        eq(sessions.completed, true),
+        isNotNull(sessions.buddySessionId),
+        ne(buddySessionParticipants.userId, uid),
+      ),
+    )
+    .groupBy(buddySessionParticipants.userId);
 
-    const [rows, meditatedWith] = await Promise.all([
-      asUser1.union(asUser2),
-      meditatedWithSelect,
-    ]);
+  const [rows, meditatedWith] = await Promise.all([
+    asUser1.union(asUser2),
+    meditatedWithSelect,
+  ]);
 
-    const statsByFriendId = new Map(
-      meditatedWith.map((row) => [
-        row.friendId,
-        { sessionCount: row.sessionCount, totalDurationSeconds: row.totalDurationSeconds },
-      ]),
-    );
+  const statsByFriendId = new Map(
+    meditatedWith.map((row) => [
+      row.friendId,
+      { sessionCount: row.sessionCount, totalDurationSeconds: row.totalDurationSeconds },
+    ]),
+  );
 
-    const friends = rows
-      .map((row) => {
-        const stats = statsByFriendId.get(row.id) ?? { sessionCount: 0, totalDurationSeconds: 0 };
-        return { ...row, ...stats };
-      })
-      .sort((a, b) => {
-        if (b.sessionCount !== a.sessionCount) return b.sessionCount - a.sessionCount;
-        if (b.totalDurationSeconds !== a.totalDurationSeconds) {
-          return b.totalDurationSeconds - a.totalDurationSeconds;
-        }
-        return a.username.localeCompare(b.username);
-      });
+  const friends = rows
+    .map((row) => {
+      const stats = statsByFriendId.get(row.id) ?? { sessionCount: 0, totalDurationSeconds: 0 };
+      return { ...row, ...stats };
+    })
+    .sort((a, b) => {
+      if (b.sessionCount !== a.sessionCount) return b.sessionCount - a.sessionCount;
+      if (b.totalDurationSeconds !== a.totalDurationSeconds) {
+        return b.totalDurationSeconds - a.totalDurationSeconds;
+      }
+      return a.username.localeCompare(b.username);
+    });
 
-    return NextResponse.json({ friends });
-  } catch (error) {
-    console.error("Friends list error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  return NextResponse.json({ friends });
+});

--- a/src/app/api/friends/search/route.ts
+++ b/src/app/api/friends/search/route.ts
@@ -12,7 +12,7 @@ export const GET = withApiHandler("Friends search", async (request: NextRequest)
   const auth = await requireAuth();
   if (!auth.ok) return auth.response;
 
-  const q = (request!.nextUrl.searchParams.get("q") ?? "").trim();
+  const q = (request.nextUrl.searchParams.get("q") ?? "").trim();
   if (q.length < MIN_LEN) {
     return NextResponse.json({ users: [] });
   }

--- a/src/app/api/friends/search/route.ts
+++ b/src/app/api/friends/search/route.ts
@@ -1,45 +1,39 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { users } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { and, eq, ilike, ne } from "drizzle-orm";
 
 const MIN_LEN = 2;
 const LIMIT = 20;
 
-export async function GET(request: NextRequest) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const GET = withApiHandler("Friends search", async (request: NextRequest) => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
 
-    const q = (request.nextUrl.searchParams.get("q") ?? "").trim();
-    if (q.length < MIN_LEN) {
-      return NextResponse.json({ users: [] });
-    }
-
-    const escaped = q.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
-    const pattern = `%${escaped}%`;
-
-    const rows = await db
-      .select({
-        id: users.id,
-        username: users.username,
-      })
-      .from(users)
-      .where(
-        and(
-          eq(users.isPublic, true),
-          ne(users.id, auth.userId),
-          ilike(users.username, pattern),
-        ),
-      )
-      .limit(LIMIT);
-
-    return NextResponse.json({ users: rows });
-  } catch (error) {
-    console.error("Friends search error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  const q = (request!.nextUrl.searchParams.get("q") ?? "").trim();
+  if (q.length < MIN_LEN) {
+    return NextResponse.json({ users: [] });
   }
-}
+
+  const escaped = q.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
+  const pattern = `%${escaped}%`;
+
+  const rows = await db
+    .select({
+      id: users.id,
+      username: users.username,
+    })
+    .from(users)
+    .where(
+      and(
+        eq(users.isPublic, true),
+        ne(users.id, auth.user.userId),
+        ilike(users.username, pattern),
+      ),
+    )
+    .limit(LIMIT);
+
+  return NextResponse.json({ users: rows });
+});

--- a/src/app/api/notifications/preferences/route.ts
+++ b/src/app/api/notifications/preferences/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { notificationPreferences } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import {
   DEFAULT_NOTIFICATION_PREFERENCES,
   getOrCreateNotificationPreferences,
@@ -14,149 +15,135 @@ import {
 import { readJsonObject } from "@/lib/readJsonObject";
 import { eq } from "drizzle-orm";
 
-export async function GET() {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const GET = withApiHandler("Notification preferences GET", async () => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
 
-    const prefs = await getOrCreateNotificationPreferences(auth.userId);
-    return NextResponse.json({ preferences: serializeNotificationPreferences(prefs) });
-  } catch (error) {
-    console.error("Notification preferences GET error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  const prefs = await getOrCreateNotificationPreferences(auth.user.userId);
+  return NextResponse.json({ preferences: serializeNotificationPreferences(prefs) });
+});
+
+export const PATCH = withApiHandler("Notification preferences PATCH", async (request: NextRequest) => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
+
+  const json = await readJsonObject(request);
+  if (!json.ok) {
+    return json.response;
   }
-}
 
-export async function PATCH(request: NextRequest) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+  const body = json.body;
+  const updates: Record<string, unknown> = { updatedAt: new Date() };
+  let hasUpdate = false;
 
-    const json = await readJsonObject(request);
-    if (!json.ok) {
-      return json.response;
+  if (typeof body.pushEnabled === "boolean") {
+    updates.pushEnabled = body.pushEnabled;
+    hasUpdate = true;
+  }
+  if (typeof body.dailyReminderEnabled === "boolean") {
+    updates.dailyReminderEnabled = body.dailyReminderEnabled;
+    hasUpdate = true;
+  }
+  if (typeof body.missADayEnabled === "boolean") {
+    updates.missADayEnabled = body.missADayEnabled;
+    hasUpdate = true;
+  }
+  if (typeof body.failureReasonReminderEnabled === "boolean") {
+    updates.failureReasonReminderEnabled = body.failureReasonReminderEnabled;
+    hasUpdate = true;
+  }
+  if (typeof body.friendRequestNotificationsEnabled === "boolean") {
+    updates.friendRequestNotificationsEnabled = body.friendRequestNotificationsEnabled;
+    hasUpdate = true;
+  }
+  if (typeof body.suppressDuringSession === "boolean") {
+    updates.suppressDuringSession = body.suppressDuringSession;
+    hasUpdate = true;
+  }
+  if (typeof body.dailyReminderTime === "string") {
+    if (!isValidReminderTime(body.dailyReminderTime)) {
+      return NextResponse.json({ error: "dailyReminderTime must be HH:MM (24h)" }, { status: 400 });
     }
-
-    const body = json.body;
-    const updates: Record<string, unknown> = { updatedAt: new Date() };
-    let hasUpdate = false;
-
-    if (typeof body.pushEnabled === "boolean") {
-      updates.pushEnabled = body.pushEnabled;
-      hasUpdate = true;
-    }
-    if (typeof body.dailyReminderEnabled === "boolean") {
-      updates.dailyReminderEnabled = body.dailyReminderEnabled;
-      hasUpdate = true;
-    }
-    if (typeof body.missADayEnabled === "boolean") {
-      updates.missADayEnabled = body.missADayEnabled;
-      hasUpdate = true;
-    }
-    if (typeof body.failureReasonReminderEnabled === "boolean") {
-      updates.failureReasonReminderEnabled = body.failureReasonReminderEnabled;
-      hasUpdate = true;
-    }
-    if (typeof body.friendRequestNotificationsEnabled === "boolean") {
-      updates.friendRequestNotificationsEnabled = body.friendRequestNotificationsEnabled;
-      hasUpdate = true;
-    }
-    if (typeof body.suppressDuringSession === "boolean") {
-      updates.suppressDuringSession = body.suppressDuringSession;
-      hasUpdate = true;
-    }
-    if (typeof body.dailyReminderTime === "string") {
-      if (!isValidReminderTime(body.dailyReminderTime)) {
-        return NextResponse.json({ error: "dailyReminderTime must be HH:MM (24h)" }, { status: 400 });
-      }
-      updates.dailyReminderTime = body.dailyReminderTime;
-      hasUpdate = true;
-    }
-    if (typeof body.dailyReminderFrequency === "string") {
-      if (!isValidFrequency(body.dailyReminderFrequency)) {
-        return NextResponse.json(
-          { error: "dailyReminderFrequency must be daily, every_other, or weekly" },
-          { status: 400 },
-        );
-      }
-      updates.dailyReminderFrequency = body.dailyReminderFrequency;
-      hasUpdate = true;
-    }
-    if (body.quietHoursStart === null) {
-      updates.quietHoursStart = null;
-      hasUpdate = true;
-    } else if (typeof body.quietHoursStart === "string") {
-      if (!isValidReminderTime(body.quietHoursStart)) {
-        return NextResponse.json({ error: "quietHoursStart must be HH:MM (24h)" }, { status: 400 });
-      }
-      updates.quietHoursStart = body.quietHoursStart;
-      hasUpdate = true;
-    }
-    if (body.quietHoursEnd === null) {
-      updates.quietHoursEnd = null;
-      hasUpdate = true;
-    } else if (typeof body.quietHoursEnd === "string") {
-      if (!isValidReminderTime(body.quietHoursEnd)) {
-        return NextResponse.json({ error: "quietHoursEnd must be HH:MM (24h)" }, { status: 400 });
-      }
-      updates.quietHoursEnd = body.quietHoursEnd;
-      hasUpdate = true;
-    }
-    if (typeof body.tz === "string") {
-      if (!isValidTimezone(body.tz)) {
-        return NextResponse.json({ error: "tz must be a valid IANA timezone" }, { status: 400 });
-      }
-      updates.tz = body.tz;
-      hasUpdate = true;
-    }
-
-    if (!hasUpdate) {
-      return NextResponse.json({ error: "No supported preference fields provided" }, { status: 400 });
-    }
-
-    const quietStartTouched = Object.prototype.hasOwnProperty.call(updates, "quietHoursStart");
-    const quietEndTouched = Object.prototype.hasOwnProperty.call(updates, "quietHoursEnd");
-    if (quietStartTouched !== quietEndTouched) {
+    updates.dailyReminderTime = body.dailyReminderTime;
+    hasUpdate = true;
+  }
+  if (typeof body.dailyReminderFrequency === "string") {
+    if (!isValidFrequency(body.dailyReminderFrequency)) {
       return NextResponse.json(
-        { error: "quietHoursStart and quietHoursEnd must be updated together" },
+        { error: "dailyReminderFrequency must be daily, every_other, or weekly" },
         { status: 400 },
       );
     }
-
-    await getOrCreateNotificationPreferences(auth.userId);
-
-    const [updated] = await db
-      .update(notificationPreferences)
-      .set(updates)
-      .where(eq(notificationPreferences.userId, auth.userId))
-      .returning();
-
-    if (!updated) {
-      const now = new Date();
-      const [inserted] = await db
-        .insert(notificationPreferences)
-        .values({
-          userId: auth.userId,
-          ...DEFAULT_NOTIFICATION_PREFERENCES,
-          ...updates,
-          createdAt: now,
-          updatedAt: now,
-        })
-        .returning();
-      return NextResponse.json({
-        preferences: serializeNotificationPreferences(asNotificationPreferencesRow(inserted)),
-      });
-    }
-
-    return NextResponse.json({
-      preferences: serializeNotificationPreferences(asNotificationPreferencesRow(updated)),
-    });
-  } catch (error) {
-    console.error("Notification preferences PATCH error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    updates.dailyReminderFrequency = body.dailyReminderFrequency;
+    hasUpdate = true;
   }
-}
+  if (body.quietHoursStart === null) {
+    updates.quietHoursStart = null;
+    hasUpdate = true;
+  } else if (typeof body.quietHoursStart === "string") {
+    if (!isValidReminderTime(body.quietHoursStart)) {
+      return NextResponse.json({ error: "quietHoursStart must be HH:MM (24h)" }, { status: 400 });
+    }
+    updates.quietHoursStart = body.quietHoursStart;
+    hasUpdate = true;
+  }
+  if (body.quietHoursEnd === null) {
+    updates.quietHoursEnd = null;
+    hasUpdate = true;
+  } else if (typeof body.quietHoursEnd === "string") {
+    if (!isValidReminderTime(body.quietHoursEnd)) {
+      return NextResponse.json({ error: "quietHoursEnd must be HH:MM (24h)" }, { status: 400 });
+    }
+    updates.quietHoursEnd = body.quietHoursEnd;
+    hasUpdate = true;
+  }
+  if (typeof body.tz === "string") {
+    if (!isValidTimezone(body.tz)) {
+      return NextResponse.json({ error: "tz must be a valid IANA timezone" }, { status: 400 });
+    }
+    updates.tz = body.tz;
+    hasUpdate = true;
+  }
+
+  if (!hasUpdate) {
+    return NextResponse.json({ error: "No supported preference fields provided" }, { status: 400 });
+  }
+
+  const quietStartTouched = Object.prototype.hasOwnProperty.call(updates, "quietHoursStart");
+  const quietEndTouched = Object.prototype.hasOwnProperty.call(updates, "quietHoursEnd");
+  if (quietStartTouched !== quietEndTouched) {
+    return NextResponse.json(
+      { error: "quietHoursStart and quietHoursEnd must be updated together" },
+      { status: 400 },
+    );
+  }
+
+  await getOrCreateNotificationPreferences(auth.user.userId);
+
+  const [updated] = await db
+    .update(notificationPreferences)
+    .set(updates)
+    .where(eq(notificationPreferences.userId, auth.user.userId))
+    .returning();
+
+  if (!updated) {
+    const now = new Date();
+    const [inserted] = await db
+      .insert(notificationPreferences)
+      .values({
+        userId: auth.user.userId,
+        ...DEFAULT_NOTIFICATION_PREFERENCES,
+        ...updates,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning();
+    return NextResponse.json({
+      preferences: serializeNotificationPreferences(asNotificationPreferencesRow(inserted)),
+    });
+  }
+
+  return NextResponse.json({
+    preferences: serializeNotificationPreferences(asNotificationPreferencesRow(updated)),
+  });
+});

--- a/src/app/api/notifications/push/subscription/route.ts
+++ b/src/app/api/notifications/push/subscription/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { and, eq } from "drizzle-orm";
 import { db } from "@/db";
 import { webPushSubscriptions } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { readJsonObject } from "@/lib/readJsonObject";
 import {
   getWebPushPublicKey,
@@ -10,106 +11,92 @@ import {
   isValidPushSubscriptionInput,
 } from "@/lib/web-push";
 
-export async function GET() {
+export const GET = withApiHandler("Web Push subscription", async () => {
   const publicKey = getWebPushPublicKey();
   if (!publicKey) {
     return NextResponse.json({ error: "Web Push is not configured" }, { status: 503 });
   }
   return NextResponse.json({ publicKey });
-}
+});
 
-export async function POST(request: NextRequest) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const POST = withApiHandler("Web Push subscription registration", async (request: NextRequest) => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
 
-    if (!getWebPushPublicKey()) {
-      return NextResponse.json({ error: "Web Push is not configured" }, { status: 503 });
-    }
+  if (!getWebPushPublicKey()) {
+    return NextResponse.json({ error: "Web Push is not configured" }, { status: 503 });
+  }
 
-    const json = await readJsonObject(request);
-    if (!json.ok) {
-      return json.response;
-    }
+  const json = await readJsonObject(request);
+  if (!json.ok) {
+    return json.response;
+  }
 
-    const subscription = json.body.subscription;
-    if (!isValidPushSubscriptionInput(subscription)) {
-      return NextResponse.json(
-        { error: "subscription must include endpoint and keys.p256dh / keys.auth" },
-        { status: 400 },
-      );
-    }
+  const subscription = json.body.subscription;
+  if (!isValidPushSubscriptionInput(subscription)) {
+    return NextResponse.json(
+      { error: "subscription must include endpoint and keys.p256dh / keys.auth" },
+      { status: 400 },
+    );
+  }
 
-    const userAgent = request.headers.get("user-agent")?.slice(0, 512) ?? null;
-    const endpointHash = hashWebPushEndpoint(subscription.endpoint);
-    const now = new Date();
+  const userAgent = request.headers.get("user-agent")?.slice(0, 512) ?? null;
+  const endpointHash = hashWebPushEndpoint(subscription.endpoint);
+  const now = new Date();
 
-    const [registered] = await db
-      .insert(webPushSubscriptions)
-      .values({
-        userId: auth.userId,
+  const [registered] = await db
+    .insert(webPushSubscriptions)
+    .values({
+      userId: auth.user.userId,
+      endpoint: subscription.endpoint,
+      endpointHash,
+      p256dh: subscription.keys.p256dh,
+      auth: subscription.keys.auth,
+      userAgent,
+      enabled: true,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: webPushSubscriptions.endpointHash,
+      set: {
+        userId: auth.user.userId,
         endpoint: subscription.endpoint,
-        endpointHash,
         p256dh: subscription.keys.p256dh,
         auth: subscription.keys.auth,
         userAgent,
         enabled: true,
         updatedAt: now,
-      })
-      .onConflictDoUpdate({
-        target: webPushSubscriptions.endpointHash,
-        set: {
-          userId: auth.userId,
-          endpoint: subscription.endpoint,
-          p256dh: subscription.keys.p256dh,
-          auth: subscription.keys.auth,
-          userAgent,
-          enabled: true,
-          updatedAt: now,
-        },
-      })
-      .returning({ id: webPushSubscriptions.id });
+      },
+    })
+    .returning({ id: webPushSubscriptions.id });
 
-    return NextResponse.json({ subscription: { id: registered.id } }, { status: 201 });
-  } catch (error) {
-    console.error("Web Push subscription registration error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  return NextResponse.json({ subscription: { id: registered.id } }, { status: 201 });
+});
+
+export const DELETE = withApiHandler("Web Push subscription removal", async (request: NextRequest) => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
+
+  const json = await readJsonObject(request);
+  if (!json.ok) {
+    return json.response;
   }
-}
 
-export async function DELETE(request: NextRequest) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const json = await readJsonObject(request);
-    if (!json.ok) {
-      return json.response;
-    }
-
-    const endpoint = json.body.endpoint;
-    if (typeof endpoint !== "string" || endpoint.length < 8) {
-      return NextResponse.json({ error: "endpoint is required" }, { status: 400 });
-    }
-
-    const [updated] = await db
-      .update(webPushSubscriptions)
-      .set({ enabled: false, updatedAt: new Date() })
-      .where(
-        and(
-          eq(webPushSubscriptions.userId, auth.userId),
-          eq(webPushSubscriptions.endpointHash, hashWebPushEndpoint(endpoint)),
-        ),
-      )
-      .returning({ id: webPushSubscriptions.id });
-
-    return NextResponse.json({ ok: true, removed: Boolean(updated) });
-  } catch (error) {
-    console.error("Web Push subscription removal error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  const endpoint = json.body.endpoint;
+  if (typeof endpoint !== "string" || endpoint.length < 8) {
+    return NextResponse.json({ error: "endpoint is required" }, { status: 400 });
   }
-}
+
+  const [updated] = await db
+    .update(webPushSubscriptions)
+    .set({ enabled: false, updatedAt: new Date() })
+    .where(
+      and(
+        eq(webPushSubscriptions.userId, auth.user.userId),
+        eq(webPushSubscriptions.endpointHash, hashWebPushEndpoint(endpoint)),
+      ),
+    )
+    .returning({ id: webPushSubscriptions.id });
+
+  return NextResponse.json({ ok: true, removed: Boolean(updated) });
+});

--- a/src/app/api/sessions/[dayNumber]/route.ts
+++ b/src/app/api/sessions/[dayNumber]/route.ts
@@ -2,16 +2,18 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { sessions, thoughts } from "@/db/schema";
 import { requireAuth } from "@/lib/api/requireAuth";
-import { withApiHandler } from "@/lib/api/withApiHandler";
+import { RouteParams, withApiHandler } from "@/lib/api/withApiHandler";
 import { eq, and, asc } from "drizzle-orm";
+
+type RouteContext = RouteParams<{ dayNumber: string }>;
 
 export const GET = withApiHandler(
   "Get session",
-  async (_request: NextRequest, context) => {
+  async (_request: NextRequest, context: RouteContext) => {
     const auth = await requireAuth();
     if (!auth.ok) return auth.response;
 
-    const { dayNumber } = await (context as { params: Promise<{ dayNumber: string }> }).params;
+    const { dayNumber } = await context.params;
     const dayNum = parseInt(dayNumber, 10);
     if (isNaN(dayNum)) {
       return NextResponse.json({ error: "Invalid day number" }, { status: 400 });

--- a/src/app/api/sessions/[dayNumber]/route.ts
+++ b/src/app/api/sessions/[dayNumber]/route.ts
@@ -1,20 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { sessions, thoughts } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { eq, and, asc } from "drizzle-orm";
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ dayNumber: string }> }
-) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const GET = withApiHandler(
+  "Get session",
+  async (_request: NextRequest, context) => {
+    const auth = await requireAuth();
+    if (!auth.ok) return auth.response;
 
-    const { dayNumber } = await params;
+    const { dayNumber } = await (context as { params: Promise<{ dayNumber: string }> }).params;
     const dayNum = parseInt(dayNumber, 10);
     if (isNaN(dayNum)) {
       return NextResponse.json({ error: "Invalid day number" }, { status: 400 });
@@ -23,7 +20,7 @@ export async function GET(
     const [session] = await db.select()
       .from(sessions)
       .where(and(
-        eq(sessions.userId, auth.userId),
+        eq(sessions.userId, auth.user.userId),
         eq(sessions.dayNumber, dayNum),
       ))
       .limit(1);
@@ -43,7 +40,7 @@ export async function GET(
       .where(
         and(
           eq(thoughts.sessionId, session.id),
-          eq(thoughts.userId, auth.userId),
+          eq(thoughts.userId, auth.user.userId),
         ),
       )
       .orderBy(
@@ -53,8 +50,5 @@ export async function GET(
       );
 
     return NextResponse.json({ session, thoughts: sessionThoughts });
-  } catch (error) {
-    console.error("Get session error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  },
+);

--- a/src/app/api/sessions/by-session/[sessionId]/route.ts
+++ b/src/app/api/sessions/by-session/[sessionId]/route.ts
@@ -1,21 +1,24 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { sessions, thoughts } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { isUuid } from "@/lib/friends";
 import { eq, and, asc } from "drizzle-orm";
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ sessionId: string }> },
-) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+const RATING_FIELDS = ["focusRating", "happinessRating"] as const;
 
-    const { sessionId } = await params;
+function isValidRating(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 10;
+}
+
+export const GET = withApiHandler(
+  "Get session by id",
+  async (_request: NextRequest, context) => {
+    const auth = await requireAuth();
+    if (!auth.ok) return auth.response;
+
+    const { sessionId } = await (context as { params: Promise<{ sessionId: string }> }).params;
     if (!sessionId || !isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }
@@ -23,7 +26,7 @@ export async function GET(
     const [session] = await db.select()
       .from(sessions)
       .where(and(
-        eq(sessions.userId, auth.userId),
+        eq(sessions.userId, auth.user.userId),
         eq(sessions.id, sessionId),
       ))
       .limit(1);
@@ -43,7 +46,7 @@ export async function GET(
       .where(
         and(
           eq(thoughts.sessionId, session.id),
-          eq(thoughts.userId, auth.userId),
+          eq(thoughts.userId, auth.user.userId),
         ),
       )
       .orderBy(
@@ -53,32 +56,19 @@ export async function GET(
       );
 
     return NextResponse.json({ session, thoughts: sessionThoughts });
-  } catch (error) {
-    console.error("Get session by id error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
-
-const RATING_FIELDS = ["focusRating", "happinessRating"] as const;
-
-function isValidRating(value: unknown): value is number {
-  return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 10;
-}
+  },
+);
 
 /** #109: post-hoc CompletionScreen ratings update, matching the existing
  *  pattern of adding data to a session after it was created (see
  *  POST /api/thoughts/batch for the completion-note equivalent). */
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ sessionId: string }> },
-) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const PATCH = withApiHandler(
+  "Update session ratings",
+  async (request: NextRequest, context) => {
+    const auth = await requireAuth();
+    if (!auth.ok) return auth.response;
 
-    const { sessionId } = await params;
+    const { sessionId } = await (context as { params: Promise<{ sessionId: string }> }).params;
     if (!sessionId || !isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }
@@ -110,7 +100,7 @@ export async function PATCH(
     const [updated] = await db
       .update(sessions)
       .set(updates)
-      .where(and(eq(sessions.id, sessionId), eq(sessions.userId, auth.userId)))
+      .where(and(eq(sessions.id, sessionId), eq(sessions.userId, auth.user.userId)))
       .returning();
 
     if (!updated) {
@@ -118,8 +108,5 @@ export async function PATCH(
     }
 
     return NextResponse.json({ session: updated });
-  } catch (error) {
-    console.error("Update session ratings error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  },
+);

--- a/src/app/api/sessions/by-session/[sessionId]/route.ts
+++ b/src/app/api/sessions/by-session/[sessionId]/route.ts
@@ -2,9 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { sessions, thoughts } from "@/db/schema";
 import { requireAuth } from "@/lib/api/requireAuth";
-import { withApiHandler } from "@/lib/api/withApiHandler";
+import { RouteParams, withApiHandler } from "@/lib/api/withApiHandler";
 import { isUuid } from "@/lib/friends";
 import { eq, and, asc } from "drizzle-orm";
+
+type RouteContext = RouteParams<{ sessionId: string }>;
 
 const RATING_FIELDS = ["focusRating", "happinessRating"] as const;
 
@@ -14,11 +16,11 @@ function isValidRating(value: unknown): value is number {
 
 export const GET = withApiHandler(
   "Get session by id",
-  async (_request: NextRequest, context) => {
+  async (_request: NextRequest, context: RouteContext) => {
     const auth = await requireAuth();
     if (!auth.ok) return auth.response;
 
-    const { sessionId } = await (context as { params: Promise<{ sessionId: string }> }).params;
+    const { sessionId } = await context.params;
     if (!sessionId || !isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }
@@ -64,11 +66,11 @@ export const GET = withApiHandler(
  *  POST /api/thoughts/batch for the completion-note equivalent). */
 export const PATCH = withApiHandler(
   "Update session ratings",
-  async (request: NextRequest, context) => {
+  async (request: NextRequest, context: RouteContext) => {
     const auth = await requireAuth();
     if (!auth.ok) return auth.response;
 
-    const { sessionId } = await (context as { params: Promise<{ sessionId: string }> }).params;
+    const { sessionId } = await context.params;
     if (!sessionId || !isUuid(sessionId)) {
       return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
     }

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -31,7 +31,15 @@ export const POST = withApiHandler("Create session", async (request: NextRequest
   const auth = await requireAuth();
   if (!auth.ok) return auth.response;
 
-  const body = await request.json();
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
   const { dayNumber, duration, actualTime, clearPercent, thoughtCount, mindStateLog, sessionDate } = body;
   const completed = parseCompleted(body.completed);
   const sessionType = parseOptionalSessionType(body.sessionType);
@@ -101,7 +109,8 @@ export const POST = withApiHandler("Create session", async (request: NextRequest
         })
         .from(users)
         .where(eq(users.id, auth.user.userId))
-        .limit(1);
+        .limit(1)
+        .for("update");
 
       if (current) {
         if (track === "second") {

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -2,154 +2,141 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { poolDb } from "@/db/pool";
 import { sessions, users } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { calculateSessionStats, parseCompleted, parseOptionalSessionType, parseOptionalTrack, shouldAdvanceDay } from "@/lib/constants";
 import { advanceProgression, advanceSecondTrackDay } from "@/lib/duration";
 import { eq, desc } from "drizzle-orm";
 
-export async function GET() {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const GET = withApiHandler("Get sessions", async () => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
 
-    const userSessions = await db.select()
-      .from(sessions)
-      .where(eq(sessions.userId, auth.userId))
-      .orderBy(desc(sessions.dayNumber));
-    const stats = calculateSessionStats(userSessions);
+  const userSessions = await db.select()
+    .from(sessions)
+    .where(eq(sessions.userId, auth.user.userId))
+    .orderBy(desc(sessions.dayNumber));
+  const stats = calculateSessionStats(userSessions);
 
-    return NextResponse.json({
-      sessions: userSessions,
-      stats: {
-        ...stats,
-        bonusMinutesTotal: Math.round(stats.bonusSecondsTotal / 60),
-      },
-    });
-  } catch (error) {
-    console.error("Get sessions error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  return NextResponse.json({
+    sessions: userSessions,
+    stats: {
+      ...stats,
+      bonusMinutesTotal: Math.round(stats.bonusSecondsTotal / 60),
+    },
+  });
+});
+
+export const POST = withApiHandler("Create session", async (request: NextRequest) => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
+
+  const body = await request.json();
+  const { dayNumber, duration, actualTime, clearPercent, thoughtCount, mindStateLog, sessionDate } = body;
+  const completed = parseCompleted(body.completed);
+  const sessionType = parseOptionalSessionType(body.sessionType);
+  // #240: which daily track this sit belongs to. Absent/legacy payloads → primary.
+  const track = parseOptionalTrack(body.track);
+  // #374: taps-per-breath count. Only persisted for breath sessions (so a stray
+  // breathCount on a standard/quick payload can't violate the data contract), and
+  // clamped to the Postgres integer range so an out-of-range value can't turn into
+  // a 500 at insert time.
+  const breathCountRaw = body.breathCount;
+  const breathCount =
+    sessionType === "breath" && typeof breathCountRaw === "number" && Number.isFinite(breathCountRaw)
+      ? Math.min(2_147_483_647, Math.max(0, Math.floor(breathCountRaw)))
+      : null;
+  const bonusSecondsRaw = body.bonusSeconds;
+  const bonusSeconds =
+    typeof bonusSecondsRaw === "number" && Number.isFinite(bonusSecondsRaw)
+      ? Math.max(0, Math.min(86_400, Math.floor(bonusSecondsRaw)))
+      : 0;
+
+  if (!dayNumber || !duration || clearPercent === undefined || !sessionDate) {
+    return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
   }
-}
+  if (completed === null) {
+    return NextResponse.json({ error: "Invalid completed value" }, { status: 400 });
+  }
+  if (!sessionType) {
+    return NextResponse.json({ error: "Invalid session type" }, { status: 400 });
+  }
+  if (!track) {
+    return NextResponse.json({ error: "Invalid track" }, { status: 400 });
+  }
 
-export async function POST(request: NextRequest) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+  // Quick sessions are extra practice and do not advance the daily progression.
+  // Wrap the insert + any progression update in a single transaction and lock the
+  // user row for update so concurrent standard-session completions can't clobber
+  // each other's advancement (#238 race condition).
+  const session = await poolDb.transaction(async (tx) => {
+    const [created] = await tx.insert(sessions).values({
+      userId: auth.user.userId,
+      dayNumber,
+      sessionType,
+      track,
+      duration,
+      bonusSeconds,
+      completed,
+      actualTime: actualTime ?? duration,
+      clearPercent,
+      thoughtCount: thoughtCount ?? 0,
+      breathCount,
+      mindStateLog: mindStateLog ?? [],
+      sessionDate,
+    }).returning();
 
-    const body = await request.json();
-    const { dayNumber, duration, actualTime, clearPercent, thoughtCount, mindStateLog, sessionDate } = body;
-    const completed = parseCompleted(body.completed);
-    const sessionType = parseOptionalSessionType(body.sessionType);
-    // #240: which daily track this sit belongs to. Absent/legacy payloads → primary.
-    const track = parseOptionalTrack(body.track);
-    // #374: taps-per-breath count. Only persisted for breath sessions (so a stray
-    // breathCount on a standard/quick payload can't violate the data contract), and
-    // clamped to the Postgres integer range so an out-of-range value can't turn into
-    // a 500 at insert time.
-    const breathCountRaw = body.breathCount;
-    const breathCount =
-      sessionType === "breath" && typeof breathCountRaw === "number" && Number.isFinite(breathCountRaw)
-        ? Math.min(2_147_483_647, Math.max(0, Math.floor(breathCountRaw)))
-        : null;
-    const bonusSecondsRaw = body.bonusSeconds;
-    const bonusSeconds =
-      typeof bonusSecondsRaw === "number" && Number.isFinite(bonusSecondsRaw)
-        ? Math.max(0, Math.min(86_400, Math.floor(bonusSecondsRaw)))
-        : 0;
+    if (shouldAdvanceDay(sessionType, completed)) {
+      // Read the user's current progression inside the transaction so the
+      // insert + update are atomic. Concurrent completions now serialize
+      // at the transaction boundary rather than racing on a shared snapshot.
+      const [current] = await tx
+        .select({
+          currentDay: users.currentDay,
+          recoveryTargetDay: users.recoveryTargetDay,
+          recoveryCurrentStep: users.recoveryCurrentStep,
+          recoveryTotalSteps: users.recoveryTotalSteps,
+          dualTrackEnabled: users.dualTrackEnabled,
+          secondTrackDay: users.secondTrackDay,
+        })
+        .from(users)
+        .where(eq(users.id, auth.user.userId))
+        .limit(1);
 
-    if (!dayNumber || !duration || clearPercent === undefined || !sessionDate) {
-      return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
-    }
-    if (completed === null) {
-      return NextResponse.json({ error: "Invalid completed value" }, { status: 400 });
-    }
-    if (!sessionType) {
-      return NextResponse.json({ error: "Invalid session type" }, { status: 400 });
-    }
-    if (!track) {
-      return NextResponse.json({ error: "Invalid track" }, { status: 400 });
-    }
-
-    // Quick sessions are extra practice and do not advance the daily progression.
-    // Wrap the insert + any progression update in a single transaction and lock the
-    // user row for update so concurrent standard-session completions can't clobber
-    // each other's advancement (#238 race condition).
-    const session = await poolDb.transaction(async (tx) => {
-      const [created] = await tx.insert(sessions).values({
-        userId: auth.userId,
-        dayNumber,
-        sessionType,
-        track,
-        duration,
-        bonusSeconds,
-        completed,
-        actualTime: actualTime ?? duration,
-        clearPercent,
-        thoughtCount: thoughtCount ?? 0,
-        breathCount,
-        mindStateLog: mindStateLog ?? [],
-        sessionDate,
-      }).returning();
-
-      if (shouldAdvanceDay(sessionType, completed)) {
-        // Read the user's current progression inside the transaction so the
-        // insert + update are atomic. Concurrent completions now serialize
-        // at the transaction boundary rather than racing on a shared snapshot.
-        const [current] = await tx
-          .select({
-            currentDay: users.currentDay,
-            recoveryTargetDay: users.recoveryTargetDay,
-            recoveryCurrentStep: users.recoveryCurrentStep,
-            recoveryTotalSteps: users.recoveryTotalSteps,
-            dualTrackEnabled: users.dualTrackEnabled,
-            secondTrackDay: users.secondTrackDay,
-          })
-          .from(users)
-          .where(eq(users.id, auth.userId))
-          .limit(1);
-
-        if (current) {
-          if (track === "second") {
-            // #240: the second track advances its own counter, and only when the
-            // user has actually opted into dual-track. It has no recovery ramp and
-            // never touches `currentDay` (the primary track), so the two progress
-            // independently. A `second` payload from a non-dual user is ignored
-            // defensively rather than trusted.
-            if (current.dualTrackEnabled) {
-              await tx.update(users)
-                .set({
-                  secondTrackDay: advanceSecondTrackDay(sessionType, completed, current.secondTrackDay),
-                  updatedAt: new Date(),
-                })
-                .where(eq(users.id, auth.userId));
-            }
-          } else {
-            // #238: while recovering, a completed primary sit steps the ramp forward
-            // instead of bumping `currentDay` — see advanceProgression for the full rule.
-            const next = advanceProgression(sessionType, completed, current);
+      if (current) {
+        if (track === "second") {
+          // #240: the second track advances its own counter, and only when the
+          // user has actually opted into dual-track. It has no recovery ramp and
+          // never touches `currentDay` (the primary track), so the two progress
+          // independently. A `second` payload from a non-dual user is ignored
+          // defensively rather than trusted.
+          if (current.dualTrackEnabled) {
             await tx.update(users)
               .set({
-                currentDay: next.currentDay,
-                recoveryTargetDay: next.recoveryTargetDay,
-                recoveryCurrentStep: next.recoveryCurrentStep,
-                recoveryTotalSteps: next.recoveryTotalSteps,
+                secondTrackDay: advanceSecondTrackDay(sessionType, completed, current.secondTrackDay),
                 updatedAt: new Date(),
               })
-              .where(eq(users.id, auth.userId));
+              .where(eq(users.id, auth.user.userId));
           }
+        } else {
+          // #238: while recovering, a completed primary sit steps the ramp forward
+          // instead of bumping `currentDay` — see advanceProgression for the full rule.
+          const next = advanceProgression(sessionType, completed, current);
+          await tx.update(users)
+            .set({
+              currentDay: next.currentDay,
+              recoveryTargetDay: next.recoveryTargetDay,
+              recoveryCurrentStep: next.recoveryCurrentStep,
+              recoveryTotalSteps: next.recoveryTotalSteps,
+              updatedAt: new Date(),
+            })
+            .where(eq(users.id, auth.user.userId));
         }
       }
+    }
 
-      return created;
-    });
+    return created;
+  });
 
-    return NextResponse.json({ session });
-  } catch (error) {
-    console.error("Create session error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  return NextResponse.json({ session });
+});

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { poolDb } from "@/db/pool";
 import { users } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { USERNAME_ERROR, isValidUsername } from "@/lib/username";
 import { and, eq, ne, sql } from "drizzle-orm";
 
@@ -19,12 +20,11 @@ const RETURN_FIELDS = {
   secondTrackDay: users.secondTrackDay,
 };
 
-export async function PATCH(request: NextRequest) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const PATCH = withApiHandler(
+  "Settings",
+  async (request: NextRequest) => {
+    const auth = await requireAuth();
+    if (!auth.ok) return auth.response;
 
     const body = await request.json();
     const updates: Record<string, unknown> = { updatedAt: new Date() };
@@ -63,7 +63,7 @@ export async function PATCH(request: NextRequest) {
           .where(
             and(
               sql`lower(${users.username}) = lower(${username})`,
-              ne(users.id, auth.userId),
+              ne(users.id, auth.user.userId),
             ),
           )
           .limit(1);
@@ -76,7 +76,7 @@ export async function PATCH(request: NextRequest) {
         const [updated] = await tx
           .update(users)
           .set(updates)
-          .where(eq(users.id, auth.userId))
+          .where(eq(users.id, auth.user.userId))
           .returning(RETURN_FIELDS);
         return { taken: false as const, user: updated };
       });
@@ -97,23 +97,25 @@ export async function PATCH(request: NextRequest) {
     const [updated] = await db
       .update(users)
       .set(updates)
-      .where(eq(users.id, auth.userId))
+      .where(eq(users.id, auth.user.userId))
       .returning(RETURN_FIELDS);
 
     return NextResponse.json({ user: updated });
-  } catch (error) {
-    // Defensive: if a concurrent signup commits the case-EXACT username between
-    // the SELECT inside the transaction and the UPDATE, Postgres' case-sensitive
-    // unique index will raise SQLSTATE 23505. Surface as 409 rather than 500.
-    if (
-      error &&
-      typeof error === "object" &&
-      "code" in error &&
-      (error as { code: unknown }).code === "23505"
-    ) {
-      return NextResponse.json({ error: USERNAME_TAKEN_ERROR }, { status: 409 });
-    }
-    console.error("Settings error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  },
+  {
+    mapError: (error) => {
+      // Defensive: if a concurrent signup commits the case-EXACT username between
+      // the SELECT inside the transaction and the UPDATE, Postgres' case-sensitive
+      // unique index will raise SQLSTATE 23505. Surface as 409 rather than 500.
+      if (
+        error &&
+        typeof error === "object" &&
+        "code" in error &&
+        (error as { code: unknown }).code === "23505"
+      ) {
+        return NextResponse.json({ error: USERNAME_TAKEN_ERROR }, { status: 409 });
+      }
+      return null;
+    },
+  },
+);

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -4,6 +4,7 @@ import { poolDb } from "@/db/pool";
 import { users } from "@/db/schema";
 import { requireAuth } from "@/lib/api/requireAuth";
 import { withApiHandler } from "@/lib/api/withApiHandler";
+import { isUniqueViolation } from "@/lib/dbErrors";
 import { USERNAME_ERROR, isValidUsername } from "@/lib/username";
 import { and, eq, ne, sql } from "drizzle-orm";
 
@@ -107,12 +108,7 @@ export const PATCH = withApiHandler(
       // Defensive: if a concurrent signup commits the case-EXACT username between
       // the SELECT inside the transaction and the UPDATE, Postgres' case-sensitive
       // unique index will raise SQLSTATE 23505. Surface as 409 rather than 500.
-      if (
-        error &&
-        typeof error === "object" &&
-        "code" in error &&
-        (error as { code: unknown }).code === "23505"
-      ) {
+      if (isUniqueViolation(error)) {
         return NextResponse.json({ error: USERNAME_TAKEN_ERROR }, { status: 409 });
       }
       return null;

--- a/src/app/api/thoughts/batch/route.ts
+++ b/src/app/api/thoughts/batch/route.ts
@@ -4,6 +4,8 @@ import { poolDb } from "@/db/pool";
 import { sessions, thoughts } from "@/db/schema";
 import { requireAuth } from "@/lib/api/requireAuth";
 import { withApiHandler } from "@/lib/api/withApiHandler";
+import { isUuid } from "@/lib/friends";
+import { readJsonObject } from "@/lib/readJsonObject";
 import { hasRejectedSubmittedThoughts, normalizeThoughtInputs } from "@/lib/thoughtSaving";
 import { and, eq } from "drizzle-orm";
 
@@ -11,11 +13,13 @@ export const POST = withApiHandler("Batch thoughts", async (request: NextRequest
   const auth = await requireAuth();
   if (!auth.ok) return auth.response;
 
-  const { sessionId, dayNumber, thoughts: thoughtItems } = await request.json();
+  const json = await readJsonObject(request);
+  if (!json.ok) return json.response;
+  const { sessionId, dayNumber, thoughts: thoughtItems } = json.body;
 
   if (
     typeof sessionId !== "string" ||
-    sessionId.length === 0 ||
+    !isUuid(sessionId) ||
     typeof dayNumber !== "number" ||
     !Number.isFinite(dayNumber) ||
     !Array.isArray(thoughtItems)

--- a/src/app/api/thoughts/batch/route.ts
+++ b/src/app/api/thoughts/batch/route.ts
@@ -2,118 +2,112 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { poolDb } from "@/db/pool";
 import { sessions, thoughts } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { hasRejectedSubmittedThoughts, normalizeThoughtInputs } from "@/lib/thoughtSaving";
 import { and, eq } from "drizzle-orm";
 
-export async function POST(request: NextRequest) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const POST = withApiHandler("Batch thoughts", async (request: NextRequest) => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
 
-    const { sessionId, dayNumber, thoughts: thoughtItems } = await request.json();
+  const { sessionId, dayNumber, thoughts: thoughtItems } = await request.json();
 
-    if (
-      typeof sessionId !== "string" ||
-      sessionId.length === 0 ||
-      typeof dayNumber !== "number" ||
-      !Number.isFinite(dayNumber) ||
-      !Array.isArray(thoughtItems)
-    ) {
-      return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
-    }
-
-    if (thoughtItems.length === 0) {
-      return NextResponse.json({ thoughts: [] });
-    }
-
-    const [session] = await db
-      .select()
-      .from(sessions)
-      .where(and(eq(sessions.id, sessionId), eq(sessions.userId, auth.userId)))
-      .limit(1);
-
-    if (!session) {
-      return NextResponse.json({ error: "Session not found" }, { status: 404 });
-    }
-
-    if (session.dayNumber !== dayNumber) {
-      return NextResponse.json({ error: "Day number mismatch" }, { status: 400 });
-    }
-
-    const normalizedResult = normalizeThoughtInputs(thoughtItems);
-    if (hasRejectedSubmittedThoughts(normalizedResult)) {
-      console.warn("Batch thoughts rejected invalid payload", {
-        sessionId,
-        userId: auth.userId,
-        submittedCount: normalizedResult.submittedCount,
-        invalidCount: normalizedResult.invalidCount,
-      });
-      return NextResponse.json({ error: "Invalid thoughts payload" }, { status: 400 });
-    }
-    const normalized = normalizedResult.thoughts;
-    const completionNoteCount = normalized.filter((t) => t.timeInSession === -1).length;
-    if (completionNoteCount > 1) {
-      console.warn("Batch thoughts rejected duplicate completion notes", {
-        sessionId,
-        userId: auth.userId,
-        completionNoteCount,
-      });
-      return NextResponse.json({ error: "Invalid thoughts payload" }, { status: 400 });
-    }
-
-    const completionNote = normalized.filter((t) => t.timeInSession === -1).at(-1);
-    const rowsToInsert = [
-      ...normalized.filter((t) => t.timeInSession !== -1),
-      ...(completionNote ? [completionNote] : []),
-    ];
-
-    const inserted = await poolDb.transaction(async (tx) => {
-      if (completionNote) {
-        await tx
-          .delete(thoughts)
-          .where(
-            and(
-              eq(thoughts.sessionId, sessionId),
-              eq(thoughts.userId, auth.userId),
-              eq(thoughts.timeInSession, -1),
-            ),
-          );
-      }
-
-      if (rowsToInsert.length === 0) {
-        return [];
-      }
-
-      const insertedThoughts = await tx
-        .insert(thoughts)
-        .values(
-          rowsToInsert.map((t) => ({
-            userId: auth.userId,
-            sessionId,
-            dayNumber,
-            timeInSession: t.timeInSession,
-            text: t.text,
-          })),
-        )
-        .returning({
-          id: thoughts.id,
-          sessionId: thoughts.sessionId,
-          dayNumber: thoughts.dayNumber,
-          timeInSession: thoughts.timeInSession,
-          text: thoughts.text,
-        });
-      if (insertedThoughts.length !== rowsToInsert.length) {
-        throw new Error("THOUGHT_INSERT_MISMATCH");
-      }
-      return insertedThoughts;
-    });
-
-    return NextResponse.json({ thoughts: inserted });
-  } catch (error) {
-    console.error("Batch thoughts error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  if (
+    typeof sessionId !== "string" ||
+    sessionId.length === 0 ||
+    typeof dayNumber !== "number" ||
+    !Number.isFinite(dayNumber) ||
+    !Array.isArray(thoughtItems)
+  ) {
+    return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
   }
-}
+
+  if (thoughtItems.length === 0) {
+    return NextResponse.json({ thoughts: [] });
+  }
+
+  const [session] = await db
+    .select()
+    .from(sessions)
+    .where(and(eq(sessions.id, sessionId), eq(sessions.userId, auth.user.userId)))
+    .limit(1);
+
+  if (!session) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  if (session.dayNumber !== dayNumber) {
+    return NextResponse.json({ error: "Day number mismatch" }, { status: 400 });
+  }
+
+  const normalizedResult = normalizeThoughtInputs(thoughtItems);
+  if (hasRejectedSubmittedThoughts(normalizedResult)) {
+    console.warn("Batch thoughts rejected invalid payload", {
+      sessionId,
+      userId: auth.user.userId,
+      submittedCount: normalizedResult.submittedCount,
+      invalidCount: normalizedResult.invalidCount,
+    });
+    return NextResponse.json({ error: "Invalid thoughts payload" }, { status: 400 });
+  }
+  const normalized = normalizedResult.thoughts;
+  const completionNoteCount = normalized.filter((t) => t.timeInSession === -1).length;
+  if (completionNoteCount > 1) {
+    console.warn("Batch thoughts rejected duplicate completion notes", {
+      sessionId,
+      userId: auth.user.userId,
+      completionNoteCount,
+    });
+    return NextResponse.json({ error: "Invalid thoughts payload" }, { status: 400 });
+  }
+
+  const completionNote = normalized.filter((t) => t.timeInSession === -1).at(-1);
+  const rowsToInsert = [
+    ...normalized.filter((t) => t.timeInSession !== -1),
+    ...(completionNote ? [completionNote] : []),
+  ];
+
+  const inserted = await poolDb.transaction(async (tx) => {
+    if (completionNote) {
+      await tx
+        .delete(thoughts)
+        .where(
+          and(
+            eq(thoughts.sessionId, sessionId),
+            eq(thoughts.userId, auth.user.userId),
+            eq(thoughts.timeInSession, -1),
+          ),
+        );
+    }
+
+    if (rowsToInsert.length === 0) {
+      return [];
+    }
+
+    const insertedThoughts = await tx
+      .insert(thoughts)
+      .values(
+        rowsToInsert.map((t) => ({
+          userId: auth.user.userId,
+          sessionId,
+          dayNumber,
+          timeInSession: t.timeInSession,
+          text: t.text,
+        })),
+      )
+      .returning({
+        id: thoughts.id,
+        sessionId: thoughts.sessionId,
+        dayNumber: thoughts.dayNumber,
+        timeInSession: thoughts.timeInSession,
+        text: thoughts.text,
+      });
+    if (insertedThoughts.length !== rowsToInsert.length) {
+      throw new Error("THOUGHT_INSERT_MISMATCH");
+    }
+    return insertedThoughts;
+  });
+
+  return NextResponse.json({ thoughts: inserted });
+});

--- a/src/app/api/thoughts/route.ts
+++ b/src/app/api/thoughts/route.ts
@@ -1,30 +1,24 @@
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { thoughts } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { eq, desc, asc } from "drizzle-orm";
 
-export async function GET() {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const GET = withApiHandler("Get thoughts", async () => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
 
-    const userThoughts = await db.select({
-      id: thoughts.id,
-      sessionId: thoughts.sessionId,
-      dayNumber: thoughts.dayNumber,
-      timeInSession: thoughts.timeInSession,
-      text: thoughts.text,
-    })
-      .from(thoughts)
-      .where(eq(thoughts.userId, auth.userId))
-      .orderBy(desc(thoughts.dayNumber), asc(thoughts.timeInSession));
+  const userThoughts = await db.select({
+    id: thoughts.id,
+    sessionId: thoughts.sessionId,
+    dayNumber: thoughts.dayNumber,
+    timeInSession: thoughts.timeInSession,
+    text: thoughts.text,
+  })
+    .from(thoughts)
+    .where(eq(thoughts.userId, auth.user.userId))
+    .orderBy(desc(thoughts.dayNumber), asc(thoughts.timeInSession));
 
-    return NextResponse.json({ thoughts: userThoughts });
-  } catch (error) {
-    console.error("Get thoughts error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  return NextResponse.json({ thoughts: userThoughts });
+});

--- a/src/lib/api/requireAuth.test.ts
+++ b/src/lib/api/requireAuth.test.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from "next/server";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-const getCurrentUser = vi.fn();
+const { getCurrentUser } = vi.hoisted(() => ({
+  getCurrentUser: vi.fn(),
+}));
 
 vi.mock("@/lib/auth", () => ({
   getCurrentUser,

--- a/src/lib/api/requireAuth.test.ts
+++ b/src/lib/api/requireAuth.test.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const getCurrentUser = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  getCurrentUser,
+}));
+
+import { requireAuth } from "./requireAuth";
+
+describe("requireAuth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns user when authenticated", async () => {
+    getCurrentUser.mockResolvedValue({ userId: "u1", email: "a@b.com" });
+
+    const result = await requireAuth();
+
+    expect(result).toEqual({
+      ok: true,
+      user: { userId: "u1", email: "a@b.com" },
+    });
+  });
+
+  test("returns 401 when unauthenticated", async () => {
+    getCurrentUser.mockResolvedValue(null);
+
+    const result = await requireAuth();
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+      await expect(result.response.json()).resolves.toEqual({ error: "Unauthorized" });
+    }
+  });
+});

--- a/src/lib/api/requireAuth.ts
+++ b/src/lib/api/requireAuth.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth";
+
+export type AuthUser = { userId: string; email: string };
+
+export type RequireAuthResult =
+  | { ok: true; user: AuthUser }
+  | { ok: false; response: NextResponse };
+
+/** Returns the authenticated user or a 401 JSON response. */
+export async function requireAuth(): Promise<RequireAuthResult> {
+  const user = await getCurrentUser();
+  if (!user) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+  return { ok: true, user };
+}

--- a/src/lib/api/withApiHandler.test.ts
+++ b/src/lib/api/withApiHandler.test.ts
@@ -52,12 +52,15 @@ describe("withApiHandler", () => {
   });
 
   test("passes request and context through", async () => {
-    const handler = withApiHandler("Test route", async (request, context) => {
-      return NextResponse.json({
-        method: request?.method,
-        id: (context as { params: { id: string } })?.params.id,
-      });
-    });
+    const handler = withApiHandler(
+      "Test route",
+      async (request: NextRequest, context: { params: { id: string } }) => {
+        return NextResponse.json({
+          method: request.method,
+          id: context.params.id,
+        });
+      },
+    );
 
     const request = new NextRequest("http://test.local/api/x", { method: "PATCH" });
     const response = await handler(request, { params: { id: "abc" } });

--- a/src/lib/api/withApiHandler.test.ts
+++ b/src/lib/api/withApiHandler.test.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { describe, expect, test, vi } from "vitest";
+import { withApiHandler } from "./withApiHandler";
+
+describe("withApiHandler", () => {
+  test("returns handler response on success", async () => {
+    const handler = withApiHandler("Test route", async () =>
+      NextResponse.json({ ok: true }),
+    );
+
+    const response = await handler();
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+
+  test("returns 500 on uncaught error with default logging", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const handler = withApiHandler("Test route", async () => {
+      throw new Error("boom");
+    });
+
+    const response = await handler();
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "Internal server error" });
+    expect(consoleError).toHaveBeenCalledWith("Test route error:", expect.any(Error));
+    consoleError.mockRestore();
+  });
+
+  test("uses mapError when provided", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const handler = withApiHandler(
+      "Test route",
+      async () => {
+        throw new Error("conflict");
+      },
+      {
+        mapError: (error) => {
+          if (error instanceof Error && error.message === "conflict") {
+            return NextResponse.json({ error: "Conflict" }, { status: 409 });
+          }
+          return null;
+        },
+      },
+    );
+
+    const response = await handler();
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: "Conflict" });
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  test("passes request and context through", async () => {
+    const handler = withApiHandler("Test route", async (request, context) => {
+      return NextResponse.json({
+        method: request?.method,
+        id: (context as { params: { id: string } })?.params.id,
+      });
+    });
+
+    const request = new NextRequest("http://test.local/api/x", { method: "PATCH" });
+    const response = await handler(request, { params: { id: "abc" } });
+
+    await expect(response.json()).resolves.toEqual({ method: "PATCH", id: "abc" });
+  });
+});

--- a/src/lib/api/withApiHandler.test.ts
+++ b/src/lib/api/withApiHandler.test.ts
@@ -1,8 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { withApiHandler } from "./withApiHandler";
 
 describe("withApiHandler", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   test("returns handler response on success", async () => {
     const handler = withApiHandler("Test route", async () =>
       NextResponse.json({ ok: true }),
@@ -23,7 +27,6 @@ describe("withApiHandler", () => {
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toEqual({ error: "Internal server error" });
     expect(consoleError).toHaveBeenCalledWith("Test route error:", expect.any(Error));
-    consoleError.mockRestore();
   });
 
   test("uses mapError when provided", async () => {
@@ -48,7 +51,6 @@ describe("withApiHandler", () => {
     expect(response.status).toBe(409);
     await expect(response.json()).resolves.toEqual({ error: "Conflict" });
     expect(consoleError).not.toHaveBeenCalled();
-    consoleError.mockRestore();
   });
 
   test("passes request and context through", async () => {

--- a/src/lib/api/withApiHandler.ts
+++ b/src/lib/api/withApiHandler.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export type ApiHandlerContext = unknown;
+
+export type WithApiHandlerOptions = {
+  /** Maps known errors to responses; return null/undefined to fall through to 500. */
+  mapError?: (error: unknown) => NextResponse | null | undefined;
+  /** Overrides default `console.error` logging before the 500 response. */
+  logError?: (label: string, error: unknown) => void;
+};
+
+type ApiHandlerFn = (
+  request?: NextRequest,
+  context?: ApiHandlerContext,
+) => Promise<NextResponse>;
+
+function defaultLogError(label: string, error: unknown): void {
+  console.error(`${label} error:`, error);
+}
+
+/**
+ * Wraps a route handler with consistent uncaught-error handling.
+ * Preserves each route's domain-specific status codes by only catching
+ * errors that escape the handler body.
+ */
+export function withApiHandler(
+  label: string,
+  handler: ApiHandlerFn,
+  options?: WithApiHandlerOptions,
+): ApiHandlerFn {
+  const logError = options?.logError ?? defaultLogError;
+  const mapError = options?.mapError;
+
+  return async (request?: NextRequest, context?: ApiHandlerContext) => {
+    try {
+      return await handler(request, context);
+    } catch (error) {
+      const mapped = mapError?.(error);
+      if (mapped) return mapped;
+      logError(label, error);
+      return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+  };
+}

--- a/src/lib/api/withApiHandler.ts
+++ b/src/lib/api/withApiHandler.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 
 export type ApiHandlerContext = unknown;
 
+export type RouteParams<T extends Record<string, string>> = {
+  params: Promise<T>;
+};
+
 export type WithApiHandlerOptions = {
   /** Maps known errors to responses; return null/undefined to fall through to 500. */
   mapError?: (error: unknown) => NextResponse | null | undefined;
@@ -9,13 +13,31 @@ export type WithApiHandlerOptions = {
   logError?: (label: string, error: unknown) => void;
 };
 
-type ApiHandlerFn = (
-  request?: NextRequest,
-  context?: ApiHandlerContext,
-) => Promise<NextResponse>;
-
 function defaultLogError(label: string, error: unknown): void {
   console.error(`${label} error:`, error);
+}
+
+function wrapHandler(
+  label: string,
+  handler: (...args: never[]) => Promise<NextResponse>,
+  options?: WithApiHandlerOptions,
+) {
+  const logError = options?.logError ?? defaultLogError;
+  const mapError = options?.mapError;
+
+  return (...args: never[]) => {
+    const run = async () => {
+      try {
+        return await handler(...args);
+      } catch (error) {
+        const mapped = mapError?.(error);
+        if (mapped) return mapped;
+        logError(label, error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+      }
+    };
+    return run();
+  };
 }
 
 /**
@@ -25,20 +47,26 @@ function defaultLogError(label: string, error: unknown): void {
  */
 export function withApiHandler(
   label: string,
-  handler: ApiHandlerFn,
+  handler: () => Promise<NextResponse>,
   options?: WithApiHandlerOptions,
-): ApiHandlerFn {
-  const logError = options?.logError ?? defaultLogError;
-  const mapError = options?.mapError;
+): () => Promise<NextResponse>;
 
-  return async (request?: NextRequest, context?: ApiHandlerContext) => {
-    try {
-      return await handler(request, context);
-    } catch (error) {
-      const mapped = mapError?.(error);
-      if (mapped) return mapped;
-      logError(label, error);
-      return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-    }
-  };
+export function withApiHandler(
+  label: string,
+  handler: (request: NextRequest) => Promise<NextResponse>,
+  options?: WithApiHandlerOptions,
+): (request: NextRequest) => Promise<NextResponse>;
+
+export function withApiHandler<TContext extends ApiHandlerContext>(
+  label: string,
+  handler: (request: NextRequest, context: TContext) => Promise<NextResponse>,
+  options?: WithApiHandlerOptions,
+): (request: NextRequest, context: TContext) => Promise<NextResponse>;
+
+export function withApiHandler(
+  label: string,
+  handler: (...args: never[]) => Promise<NextResponse>,
+  options?: WithApiHandlerOptions,
+): (...args: never[]) => Promise<NextResponse> {
+  return wrapHandler(label, handler, options);
 }

--- a/src/lib/api/withApiHandler.ts
+++ b/src/lib/api/withApiHandler.ts
@@ -30,9 +30,17 @@ function wrapHandler(
       try {
         return await handler(...args);
       } catch (error) {
-        const mapped = mapError?.(error);
-        if (mapped) return mapped;
-        logError(label, error);
+        try {
+          const mapped = mapError?.(error);
+          if (mapped) return mapped;
+        } catch (mapErrorError) {
+          defaultLogError(`${label} mapError error:`, mapErrorError);
+        }
+        try {
+          logError(label, error);
+        } catch (logErrorError) {
+          defaultLogError(`${label} logError error:`, logErrorError);
+        }
         return NextResponse.json({ error: "Internal server error" }, { status: 500 });
       }
     };


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #414

## Summary

Issue #414’s **title** describes this work; the issue body is a stale google.ts split proposal (already done in `googleOAuth.ts` / `googleCalendar.ts`). This PR implements the title intent: shared route infrastructure for auth checks and uncaught-error handling.

Adds two helpers under `src/lib/api/`:

- **`requireAuth()`** — wraps `getCurrentUser()`, returns `{ ok: true, user }` or `{ ok: false, response: 401 }` (same discriminated-union pattern as `readJsonObject`)
- **`withApiHandler(label, handler, options?)`** — outer try/catch with consistent 500 responses; optional `mapError` / `logError` for route-specific semantics

Applied across **42** `src/app/api/**/route.ts` handlers. Intentionally **not** migrated:

| Route | Reason |
|-------|--------|
| `auth/[...nextauth]` | NextAuth handler re-export |
| `auth/google/callback` | Redirects on missing auth / errors (not 401 JSON) |

### Route-specific behavior preserved

- **settings** — `mapError` maps Postgres `23505` → 409 username taken
- **failure-reasons** — `logError` logs only `error.message` (PII-safe)
- **auth/google** — `mapError` maps `GoogleCalendarUnavailableError` → 503
- All other status codes unchanged (400/403/404/409/410/201/etc.)

### Review feedback addressed

- **login/signup** — use `readJsonObject` so malformed JSON / non-object bodies return **400** instead of 500 via `withApiHandler`
- **signup** — require `email`, `username`, and `password` to be strings before validation/hashing

## Test plan

- [x] `npm run test:unit` — 488 tests pass (includes new auth JSON validation tests)
- [x] `npm run typecheck` — clean
- [x] Manual smoke: authenticated GET `/api/auth/me` returns 200; unauthenticated returns 401
- [x] Manual smoke: PATCH `/api/settings` with invalid body returns 400; username conflict returns 409
- [x] Manual smoke: public GET `/api/board` still works without auth

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1b2e352-e704-4e3e-9025-54f52f7d552a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1b2e352-e704-4e3e-9025-54f52f7d552a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Centralize API route auth checks and error handling**

### What Changed
- API routes now share the same sign-in check and uncaught-error handling, so unauthenticated requests still get 401 responses and unexpected failures return a consistent 500
- Several user-facing routes keep their special responses, including username conflicts, Google Calendar unavailability, and PII-safe logging for failure reasons
- Buddy, friends, sessions, notifications, password reset, and account routes were switched to the shared behavior without changing their normal success responses

### Impact
`✅ Fewer unexpected 500 responses`
`✅ Consistent unauthorized responses across API routes`
`✅ Safer error logs for submitted failure reasons`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency across account, auth, sessions, friends, notifications, and buddy flows with more reliable sign-in checks and error responses.
  * Added stronger validation for malformed requests, reducing unexpected failures and improving feedback for invalid input.

* **Tests**
  * Expanded coverage for login, signup, calendar, and auth helper behavior to verify invalid JSON and unauthorized cases are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->