### PR TITLE
ci: gate mobile-web e2e on TestFlight release instead of every PR

### DIFF
--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -1,10 +1,40 @@
 name: E2E Mobile Web
 
+# Reusable mobile-web Playwright suite. As of #494, this NO LONGER runs on
+# `pull_request` — it was the slowest, flakiest per-PR check (3-project matrix,
+# no path filter) and blocked PRs that couldn't affect mobile web at all. It
+# now runs ONLY:
+#   - as part of the release pipeline — `ios-testflight-auto.yml` calls it via
+#     `workflow_call` and gates the build-number bump + TestFlight build on a
+#     green run;
+#   - on demand via `workflow_dispatch` for ad-hoc verification.
+# The manual `ios-v*-build*` tag path (`ios-testflight.yml`) intentionally does
+# NOT call this workflow — it's the break-glass escape hatch for shipping when
+# e2e infra itself is down. Mirrors auerbachb/skingod#1402.
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  workflow_call:
+    inputs:
+      ref:
+        description: "Commit ref (SHA, branch, or tag) to check out and test"
+        type: string
+        required: true
+    secrets:
+      POSTGRES_URL:
+        required: true
+      E2E_WEB_EMAIL:
+        required: true
+      E2E_WEB_PASSWORD:
+        required: true
+      E2E_TEST_USER_EMAIL:
+        required: true
+      E2E_TEST_USER_PASSWORD:
+        required: true
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Commit ref (SHA, branch, or tag) to check out and test. Defaults to the ref this run was dispatched from."
+        type: string
+        required: false
 
 jobs:
   e2e-mobile:
@@ -28,6 +58,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
       - name: Setup Node.js

--- a/.github/workflows/ios-testflight-auto.yml
+++ b/.github/workflows/ios-testflight-auto.yml
@@ -5,16 +5,26 @@ name: Auto TestFlight on merge
 # adapted for Still Point's self-hosted xcodebuild pipeline (skingod uses EAS).
 #
 # Flow:
-#   1. Read CURRENT_PROJECT_VERSION from ios/project.yml at the merge commit.
-#   2. Increment it (build-number source of truth: the committed project.yml).
-#   3. Commit the bump back to main with [skip ci].
-#   4. Cut an ios-v<marketing>-build<n> tag on that commit.
-#   5. Call the shared reusable workflow to build + upload from that commit.
+#   1. Run the mobile-web e2e suite (e2e-mobile.yml) against the merge commit.
+#   2. Only if it's green: read CURRENT_PROJECT_VERSION from ios/project.yml
+#      at the merge commit.
+#   3. Increment it (build-number source of truth: the committed project.yml).
+#   4. Commit the bump back to main with [skip ci].
+#   5. Cut an ios-v<marketing>-build<n> tag on that commit.
+#   6. Call the shared reusable workflow to build + upload from that commit.
+#
+# The e2e gate runs BEFORE the bump/tag step (not just before the build) on
+# purpose (#494): the bump commit + tag push are themselves release side
+# effects, and this workflow only fires once per merged PR (no natural retry
+# trigger), so a failing e2e must prevent them too — not just skip the build
+# after a tag already exists. `tag`'s `if:` checks `needs.e2e.result ==
+# 'success'`; a failed OR skipped e2e run (no release:ios label) leaves `tag`
+# skipped and nothing is committed/tagged/built.
 #
 # The bump commit and tag are pushed with the default GITHUB_TOKEN. GitHub does
 # NOT start new workflow runs for GITHUB_TOKEN-authored pushes, so:
-#   * push-on-main CI (e2e-mobile, web-build) does not fire on the bump — the
-#     [skip ci] is belt-and-suspenders for that, plus clarity for humans;
+#   * push-on-main CI (web-build) does not fire on the bump — the [skip ci] is
+#     belt-and-suspenders for that, plus clarity for humans;
 #   * the new ios-v*-build* tag does NOT re-trigger ios-testflight.yml, so there
 #     is no double build. The reusable build is invoked directly below instead.
 #     If this is ever switched to a PAT, add a guard so the manual workflow does
@@ -34,12 +44,21 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  tag:
-    name: Bump build number and cut TestFlight tag
+  e2e:
+    name: release e2e (mobile web)
     if: >-
       github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'main' &&
       contains(github.event.pull_request.labels.*.name, 'release:ios')
+    uses: ./.github/workflows/e2e-mobile.yml
+    with:
+      ref: ${{ github.event.pull_request.merge_commit_sha }}
+    secrets: inherit
+
+  tag:
+    name: Bump build number and cut TestFlight tag
+    needs: e2e
+    if: needs.e2e.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -6,6 +6,13 @@ name: Build & Upload to TestFlight
 # the shared reusable workflow ios-testflight-build.yml, so the build/upload
 # logic has a single source of truth.
 #
+# Unlike ios-testflight-auto.yml, this path intentionally does NOT run the
+# mobile-web e2e gate (e2e-mobile.yml) — it's the break-glass path for shipping
+# a build by hand when e2e infra itself is down, or for an ad-hoc ref that
+# didn't go through the normal PR-merge flow. Run
+# `gh workflow run e2e-mobile.yml -f ref=<ref>` first if you want the signal
+# without gating on it. See #494.
+#
 # Semver-only tags (ios-v1.0.0) trigger App Store release — see
 # ios-app-store-release.yml.
 

--- a/docs/testing/e2e-policy.md
+++ b/docs/testing/e2e-policy.md
@@ -216,6 +216,19 @@ For pull requests, required lanes:
 
 iOS E2E lanes are required for iOS test-plan changes and recommended otherwise; keep branch protection in sync with this policy.
 
+### Release-time gating (mobile web + iOS TestFlight)
+
+As of [#494](https://github.com/auerbachb/still-point/issues/494) (mirroring [auerbachb/skingod#1402](https://github.com/auerbachb/skingod/issues/1402)), the mobile-web Playwright suite (`e2e-mobile.yml`, the 3-project cross-browser matrix) no longer runs on `pull_request` — it was the slowest, flakiest per-PR check, had no path filter, and blocked every PR regardless of relevance. It is now a reusable workflow (`workflow_call` + `workflow_dispatch` only) that runs:
+
+- as the first job of [`ios-testflight-auto.yml`](../../.github/workflows/ios-testflight-auto.yml) (the automatic PR-merge + `release:ios`-label release path) — the build-number bump + tag step only proceeds `if: needs.e2e.result == 'success'`, so a failing e2e run leaves nothing committed, tagged, or built;
+- on demand via `gh workflow run e2e-mobile.yml -f ref=<ref>` for ad-hoc verification.
+
+[`ios-testflight.yml`](../../.github/workflows/ios-testflight.yml) (the manual `ios-v*-build*` tag push, a break-glass escape hatch for shipping when e2e infra itself is down) intentionally does **not** call this gate.
+
+`e2e-ios.yml` (native XCTest smoke/critical) is unchanged by #494 — it stays path-filtered to `ios/**` on `pull_request`, matching skingod's analogous Maestro-lane precedent (PR-time signal, not release-gated).
+
+`e2e-web.yml` is also unchanged — web has no discrete "build" step to gate against (it auto-deploys to production on every merge to `main`), unlike iOS's TestFlight build. Revisit separately if that becomes painful.
+
 ## 12) Local runbook (single command per platform)
 
 Prereqs:


### PR DESCRIPTION
## **User description**
Closes #494

## Summary

Mirrors [auerbachb/skingod#1402](https://github.com/auerbachb/skingod/issues/1402): moves the mobile-web e2e suite out of the per-PR merge gate and into the TestFlight release pipeline.

- `e2e-mobile.yml` (Playwright, 3-project cross-browser matrix) is now a reusable workflow — `workflow_call` + `workflow_dispatch` only. It no longer triggers on `pull_request` or `push: main`.
- `ios-testflight-auto.yml` (the automatic PR-merge + `release:ios`-label release path) now runs this suite as its first job. The build-number bump + tag step only proceeds `if: needs.e2e.result == 'success'` — this runs the e2e gate *before* the bump/tag (not just before the build), since this workflow fires once per merged PR with no natural retry trigger, and the bump commit + tag push are themselves release side effects we don't want on a red e2e run.
- `ios-testflight.yml` (manual `ios-v*-build*` tag push, the break-glass escape hatch) intentionally keeps bypassing the gate — documented with a comment pointing at `gh workflow run e2e-mobile.yml -f ref=<ref>` for anyone who wants the signal without gating on it.
- `e2e-ios.yml` (native XCTest) and `e2e-web.yml` are unchanged — see the issue for why (native iOS stays path-filtered/PR-gated like skingod's Maestro lane; web has no discrete "build" step to gate against).
- Documented the new policy in `docs/testing/e2e-policy.md` § 11.

`e2e-mobile`'s matrix legs were confirmed **not** required status checks on `main` before this change (verified via `gh api repos/auerbachb/still-point/branches/main/protection`), so removing the `pull_request` trigger does not block future merges.

## Test plan

- [x] `e2e-mobile.yml`, `ios-testflight-auto.yml`, `ios-testflight.yml` parse as valid YAML (`python3 -c "import yaml; yaml.safe_load(open(f))"` for each).
- [ ] A merged PR carrying `release:ios` triggers `ios-testflight-auto.yml`'s new `e2e` job before the build-number bump — cannot verify pre-merge (this workflow only fires on a real merged PR); verify on the next `release:ios` merge.
- [x] Confirm `e2e-mobile.yml` no longer appears as a check on new PRs that don't touch mobile code — verified on this PR itself: none of the old `mobile-chromium-narrow`/`mobile-chromium-wide`/`mobile-webkit-iphone` checks appear in its check-run list (13 checks total, all from unrelated workflows).
- [ ] Confirm `gh workflow run e2e-mobile.yml -f ref=<sha>` succeeds as an ad-hoc dispatch — attempted pre-merge, GitHub correctly rejected it with "Workflow does not have 'workflow_dispatch' trigger": `workflow_dispatch`/`schedule` triggers only activate from the workflow file on the default branch, so this can't be tested until after merge. Expected behavior, not a bug.


___

## **CodeAnt-AI Description**
**Move mobile web e2e checks to the TestFlight release path**

### What Changed
- Mobile web e2e no longer runs on every pull request; it now runs only during the automatic TestFlight release flow or when started manually.
- The automatic TestFlight flow now waits for mobile web e2e to pass before it bumps the build number, creates a tag, or starts the build.
- The manual TestFlight tag path still skips this gate, keeping a fallback route for shipping when e2e checks are unavailable.
- The testing policy docs now explain when mobile web e2e runs and how it affects release builds.

### Impact
`✅ Fewer pull requests blocked by slow mobile web tests`
`✅ Safer TestFlight releases with release checks before tagging`
`✅ Preserved manual shipping when e2e infrastructure is down`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

