### PR TITLE
feat(ios): thumb-reach zone for session tracking controls (#183)

### DIFF
--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -3,8 +3,10 @@ import StillPointShared
 import UIKit
 
 struct SessionView: View {
-    /// Space reserved when both distraction hold bar and controls are visible (includes persistent Capture row).
-    private static let bottomOverlayReserveWithControls: CGFloat = 324
+    /// Space reserved when tracking info, secondary controls, and thumb-reach holds are visible.
+    private static let bottomOverlayReserveWithControls: CGFloat = 348
+    /// Minimum vertical hit target for hold-to-track controls (Apple HIG ~44pt+).
+    private static let thumbReachHoldMinHeight: CGFloat = 56
 
     let appVM: AppViewModel
     @State private var vm: SessionViewModel
@@ -70,15 +72,18 @@ struct SessionView: View {
                 }
             }
 
-            // Bottom chrome: hold tracking never collapses; secondary controls dim while running.
-            VStack {
+            // Bottom chrome: secondary controls above; primary hold targets pinned to thumb-reach zone.
+            VStack(spacing: 0) {
                 Spacer()
                 if sessionInProgress {
-                    persistentDistractionBar
+                    sessionTrackingInfoBar
                 }
                 controlPanel
                     .opacity(secondaryChromeDimmed ? 0.32 : 1)
                     .accessibilityValue(secondaryChromeDimmed ? "dimmed" : "visible")
+                if sessionInProgress {
+                    thumbReachHoldControls
+                }
                 Color.clear
                     .frame(width: 1, height: 1)
                     .accessibilityElement(children: .ignore)
@@ -251,8 +256,8 @@ struct SessionView: View {
         vm.isActive && !vm.controlsVisible
     }
 
-    /// Hold control + state dot: visible for the whole active sit path (not hidden with other chrome).
-    private var persistentDistractionBar: some View {
+    /// Status + hints above the thumb zone; hold controls live in `thumbReachHoldControls`.
+    private var sessionTrackingInfoBar: some View {
         VStack(spacing: SPSpacing.s2) {
             HStack(spacing: SPSpacing.s2) {
                 Circle()
@@ -327,71 +332,83 @@ struct SessionView: View {
                 .animation(.easeInOut(duration: 0.3), value: vm.controlsVisible)
                 .padding(.top, SPSpacing.s1)
             }
-
-            HStack(spacing: SPSpacing.s2) {
-                Text("Hold — light distraction")
-                    .font(SPFont.serifItalic(15))
-                    .foregroundStyle(Color(SPColor.fg))
-                    .multilineTextAlignment(.center)
-                    .spCapsuleButtonStyle(
-                        vm.mindState == "thinking" ? .amber : .green,
-                        size: .fullWidth,
-                        horizontalPadding: SPSpacing.s3
-                    )
-                    .foregroundStyle(Color(SPColor.fg))
-                    .opacity(vm.isActive ? 1 : 0.45)
-                    .accessibilityValue(vm.mindState == "thinking" ? "active" : "inactive")
-                    .accessibilityLabel("Hold for light distraction. Release when aware again.")
-                    .accessibilityIdentifier("session.lightDistractionHoldButton")
-                    .simultaneousGesture(
-                        DragGesture(minimumDistance: 0)
-                            .onChanged { _ in
-                                if vm.isActive { vm.beginDistraction() }
-                            }
-                            .onEnded { _ in
-                                vm.endDistraction()
-                            }
-                    )
-
-                Text("Hold — hyperfocus")
-                    .font(SPFont.serifItalic(15))
-                    .foregroundStyle(Color(SPColor.fg))
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, SPSpacing.s3)
-                    .padding(.vertical, SPSpacing.s2)
-                    .frame(maxWidth: .infinity)
-                    .background(
-                        vm.mindState == "hyperfocus"
-                            ? Color(red: 0.15, green: 0.22, blue: 0.38).opacity(0.55)
-                            : SPColor.surface2
-                    )
-                    .clipShape(Capsule())
-                    .overlay(
-                        Capsule().stroke(
-                            vm.mindState == "hyperfocus"
-                                ? Color.blue.opacity(0.45)
-                                : SPColor.border2
-                        )
-                    )
-                    .opacity(vm.isActive ? 1 : 0.45)
-                    .accessibilityValue(vm.mindState == "hyperfocus" ? "active" : "inactive")
-                    .accessibilityLabel("Hold for hyperfocus. Release to return to aware.")
-                    .accessibilityIdentifier("session.hyperfocusHoldButton")
-                    .simultaneousGesture(
-                        DragGesture(minimumDistance: 0)
-                            .onChanged { _ in
-                                if vm.isActive { vm.beginHyperfocus() }
-                            }
-                            .onEnded { _ in
-                                vm.endHyperfocus()
-                            }
-                    )
-            }
-            .padding(.horizontal, SPSpacing.s2)
         }
-        .padding(.vertical, SPSpacing.s3)
+        .padding(.top, SPSpacing.s3)
+        .padding(.bottom, SPSpacing.s2)
         .background(
             SPColor.bg.opacity(0.92)
+                .background(.ultraThinMaterial)
+        )
+    }
+
+    /// Primary hold targets pinned to the lower third + home-indicator safe area.
+    private var thumbReachHoldControls: some View {
+        HStack(spacing: SPSpacing.s2) {
+            Text("\(vm.mindState == "thinking" ? "Release" : "Hold") — light distraction")
+                .font(SPFont.serifItalic(15))
+                .foregroundStyle(Color(SPColor.fg))
+                .multilineTextAlignment(.center)
+                .spCapsuleButtonStyle(
+                    vm.mindState == "thinking" ? .amber : .green,
+                    size: .fullWidth,
+                    tall: true,
+                    minHeight: Self.thumbReachHoldMinHeight,
+                    horizontalPadding: SPSpacing.s3
+                )
+                .foregroundStyle(Color(SPColor.fg))
+                .opacity(vm.isActive ? 1 : 0.45)
+                .accessibilityValue(vm.mindState == "thinking" ? "active" : "inactive")
+                .accessibilityLabel("Hold for light distraction. Release when aware again.")
+                .accessibilityIdentifier("session.lightDistractionHoldButton")
+                .simultaneousGesture(
+                    DragGesture(minimumDistance: 0)
+                        .onChanged { _ in
+                            if vm.isActive { vm.beginDistraction() }
+                        }
+                        .onEnded { _ in
+                            vm.endDistraction()
+                        }
+                )
+
+            Text("\(vm.mindState == "hyperfocus" ? "Release" : "Hold") — hyperfocus")
+                .font(SPFont.serifItalic(15))
+                .foregroundStyle(Color(SPColor.fg))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, SPSpacing.s3)
+                .frame(maxWidth: .infinity, minHeight: Self.thumbReachHoldMinHeight)
+                .background(
+                    vm.mindState == "hyperfocus"
+                        ? Color(red: 0.15, green: 0.22, blue: 0.38).opacity(0.55)
+                        : SPColor.surface2
+                )
+                .clipShape(Capsule())
+                .overlay(
+                    Capsule().stroke(
+                        vm.mindState == "hyperfocus"
+                            ? Color.blue.opacity(0.45)
+                            : SPColor.border2
+                    )
+                )
+                .opacity(vm.isActive ? 1 : 0.45)
+                .accessibilityValue(vm.mindState == "hyperfocus" ? "active" : "inactive")
+                .accessibilityLabel("Hold for hyperfocus. Release to return to aware.")
+                .accessibilityIdentifier("session.hyperfocusHoldButton")
+                .simultaneousGesture(
+                    DragGesture(minimumDistance: 0)
+                        .onChanged { _ in
+                            if vm.isActive { vm.beginHyperfocus() }
+                        }
+                        .onEnded { _ in
+                            vm.endHyperfocus()
+                        }
+                )
+        }
+        .padding(.horizontal, SPSpacing.s2)
+        .padding(.top, SPSpacing.s2)
+        .padding(.bottom, SPSpacing.s2)
+        .safeAreaPadding(.bottom, SPSpacing.s1)
+        .background(
+            SPColor.bg.opacity(0.95)
                 .background(.ultraThinMaterial)
                 .ignoresSafeArea(edges: .bottom)
         )
@@ -495,7 +512,6 @@ struct SessionView: View {
         .background(
             SPColor.bg.opacity(0.9)
                 .background(.ultraThinMaterial)
-                .ignoresSafeArea(edges: .bottom)
         )
     }
 


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #183

## Summary

Layout-only change to `SessionView` that pins primary session hold controls (light distraction + hyperfocus) to the bottom thumb-reach zone on iPhone, with larger hit targets and safe-area padding.

## Changes

- Split the old `persistentDistractionBar` into:
  - `sessionTrackingInfoBar` — status dot, hints, and Capture (above thumb zone)
  - `thumbReachHoldControls` — hold/release targets pinned to the screen bottom
- Reordered bottom chrome so secondary controls (pause, end early, sound toggles) sit **above** the hold row; hold buttons are now the lowest interactive elements.
- Increased hold button minimum height to **56pt** (`thumbReachHoldMinHeight`) and added `.safeAreaPadding(.bottom)` so targets clear the home indicator.
- Hold labels now switch to **Release** while active (matching web semantics).
- Bumped `bottomOverlayReserveWithControls` to 348 to account for the taller hold row.

## Test plan

- [ ] Start a session on iPhone (or simulator) and confirm hold buttons sit in the lower third, above the home indicator.
- [ ] Press-and-hold **light distraction** and **hyperfocus** — verify reliable hold/release with large tap targets.
- [ ] Confirm labels read "Release" while holding and revert to "Hold" on release.
- [ ] Verify VoiceOver labels/identifiers unchanged (`session.lightDistractionHoldButton`, `session.hyperfocusHoldButton`).
- [ ] Tap screen to reveal dimmed secondary controls; confirm hold row stays fully visible and interactive.
- [ ] CI: `ios-testflight-build` / compile gate passes (local `xcodebuild` unavailable).

## Notes

- Feeds build15.
- Pause / end early / abandon remain in the auto-hiding secondary panel (per issue open question).
- No ViewModel or gesture logic changes — layout only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19faaf3a-7f19-4a40-85dc-2c6339960db1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19faaf3a-7f19-4a40-85dc-2c6339960db1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Move session hold controls into a thumb-reach zone on iPhone**

### What Changed
- The light distraction and hyperfocus hold buttons now sit at the bottom of the session screen, below the secondary controls, for easier one-handed use.
- The hold buttons are taller with larger touch targets and extra bottom spacing so they stay clear of the home indicator.
- Hold labels now switch to “Release” while active, making the current action clearer.
- The tracking status, hints, and Capture button are shown separately above the hold buttons so the main controls stay anchored in the lower area.

### Impact
`✅ Easier one-handed session controls`
`✅ Fewer missed hold presses`
`✅ Clearer active state labels`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
