### PR TITLE
feat(ios): habit-tracker home-screen widget (Duolingo-style) (#84)

### DIFF
--- a/ios/StillPointApp/Managers/WidgetTimelineReloader.swift
+++ b/ios/StillPointApp/Managers/WidgetTimelineReloader.swift
@@ -1,0 +1,9 @@
+import WidgetKit
+
+enum WidgetTimelineReloader {
+    static let habitWidgetKind = "HabitWidget"
+
+    static func reloadHabitWidget() {
+        WidgetCenter.shared.reloadTimelines(ofKind: habitWidgetKind)
+    }
+}

--- a/ios/StillPointApp/Managers/WidgetTimelineReloader.swift
+++ b/ios/StillPointApp/Managers/WidgetTimelineReloader.swift
@@ -4,6 +4,12 @@ enum WidgetTimelineReloader {
     static let habitWidgetKind = "HabitWidget"
 
     static func reloadHabitWidget() {
-        WidgetCenter.shared.reloadTimelines(ofKind: habitWidgetKind)
+        // WidgetCenter reload can stall cold-start auth in the UI-test simulator
+        // lane when the widget extension is embedded; the suite never exercises
+        // widgets, so skip entirely under SP_UI_TEST_MODE.
+        guard ProcessInfo.processInfo.environment["SP_UI_TEST_MODE"] != "1" else { return }
+        DispatchQueue.main.async {
+            WidgetCenter.shared.reloadTimelines(ofKind: habitWidgetKind)
+        }
     }
 }

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -172,22 +172,27 @@ final class AppViewModel {
                 PushNotificationCoordinator.shared.registerIfAlreadyAuthorized()
                 hydrateNotificationSuppressionPreference()
                 await refreshTracksDoneToday()
+                syncWidgetData()
                 await consumePendingBuddyInviteIfNeeded()
                 await consumePendingSessionDeepLinkIfNeeded()
                 return
             } else {
                 currentView = .auth
                 authStatusMessage = nil
+                syncWidgetData()
             }
         } catch let apiError as APIError where apiError.status == 401 && apiError.code == "TOKEN_EXPIRED" {
             currentView = .auth
             authStatusMessage = apiError.message
+            syncWidgetData()
         } catch let apiError as APIError {
             currentView = .auth
             authStatusMessage = apiError.message
+            syncWidgetData()
         } catch {
             currentView = .auth
             authStatusMessage = "Connection failed. Please try again."
+            syncWidgetData()
         }
         lastColdStartAuthCheckMs = Int(Date().timeIntervalSince(startedAt) * 1_000)
     }
@@ -232,6 +237,7 @@ final class AppViewModel {
         hydrateNotificationSuppressionPreference()
         Task {
             await refreshTracksDoneToday()
+            syncWidgetData()
             await consumePendingBuddyInviteIfNeeded()
             await consumePendingSessionDeepLinkIfNeeded()
         }
@@ -263,6 +269,7 @@ final class AppViewModel {
         currentView = .auth
         // Drop the cached suppress opt-in so it can't leak into the next account.
         SessionNotificationSuppressionController.clearSuppressPreference()
+        syncWidgetData()
     }
 
     private func resetTrackCompletionBadges() {
@@ -303,6 +310,7 @@ final class AppViewModel {
             primaryDoneToday = false
             secondDoneToday = false
         }
+        syncWidgetData()
     }
 
     func beginBreathCounting() {
@@ -512,5 +520,21 @@ final class AppViewModel {
 
     private func extractBuddyToken(from url: URL) -> String? {
         BuddyInviteTokenParser.token(from: url)
+    }
+
+    /// Persist a widget snapshot to the App Group container and reload timelines.
+    /// Called from auth + session-completion flows; no extra API calls.
+    private func syncWidgetData() {
+        let snapshot = WidgetDataStore.makeSnapshot(
+            user: currentUser,
+            primaryDoneToday: primaryDoneToday,
+            secondDoneToday: secondDoneToday
+        )
+        if snapshot.isLoggedIn {
+            WidgetDataStore.save(snapshot)
+        } else {
+            WidgetDataStore.clear()
+        }
+        WidgetTimelineReloader.reloadHabitWidget()
     }
 }

--- a/ios/StillPointShared/Sources/StillPointShared/WidgetData.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/WidgetData.swift
@@ -146,13 +146,10 @@ public enum WidgetDataStore {
         var copy = data
         copy.primaryDoneToday = false
         copy.secondDoneToday = false
-        if let userId = data.userId {
-            copy.streak = resolvedStreak(
-                userId: userId,
-                primaryDoneToday: false,
-                previous: data,
-                now: now
-            )
+        if data.primaryDoneToday {
+            copy.streak = max(data.streak, 0)
+        } else {
+            copy.streak = 0
         }
         return copy
     }
@@ -179,7 +176,10 @@ public enum WidgetDataStore {
         }
 
         if !primaryDoneToday && !isSameLocalDay(previous.lastUpdated, now) {
-            // A new local day without a completed sit yet — streak is broken.
+            // New day before today's sit: keep streak when yesterday was completed.
+            if previous.primaryDoneToday {
+                return max(previous.streak, 0)
+            }
             return 0
         }
 

--- a/ios/StillPointShared/Sources/StillPointShared/WidgetData.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/WidgetData.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+/// App Group identifier shared with the main app, monitor extension, and widget.
+public enum WidgetAppGroup {
+    public static let id = "group.com.brettonauerbach.stillpoint"
+    public static let dataKey = "widget.habitData.v1"
+}
+
+/// Lightweight snapshot the home-screen widget reads from shared `UserDefaults`.
+public struct WidgetData: Codable, Sendable, Equatable {
+    public var isLoggedIn: Bool
+    public var userId: String?
+    public var currentDay: Int
+    public var secondTrackDay: Int
+    public var dualTrackEnabled: Bool
+    public var primaryDoneToday: Bool
+    public var secondDoneToday: Bool
+    public var streak: Int
+    public var lastUpdated: Date
+
+    public init(
+        isLoggedIn: Bool,
+        userId: String?,
+        currentDay: Int,
+        secondTrackDay: Int,
+        dualTrackEnabled: Bool,
+        primaryDoneToday: Bool,
+        secondDoneToday: Bool,
+        streak: Int,
+        lastUpdated: Date
+    ) {
+        self.isLoggedIn = isLoggedIn
+        self.userId = userId
+        self.currentDay = currentDay
+        self.secondTrackDay = secondTrackDay
+        self.dualTrackEnabled = dualTrackEnabled
+        self.primaryDoneToday = primaryDoneToday
+        self.secondDoneToday = secondDoneToday
+        self.streak = streak
+        self.lastUpdated = lastUpdated
+    }
+
+    public static let loggedOut = WidgetData(
+        isLoggedIn: false,
+        userId: nil,
+        currentDay: 1,
+        secondTrackDay: 1,
+        dualTrackEnabled: false,
+        primaryDoneToday: false,
+        secondDoneToday: false,
+        streak: 0,
+        lastUpdated: .distantPast
+    )
+
+    /// Primary-track duration in seconds for the widget readout.
+    public var primaryDurationSeconds: Int {
+        StillPoint.duration(forDay: max(currentDay, 1))
+    }
+
+    /// Whether the user has finished today's primary standard sit.
+    public var isPrimaryCompleteForToday: Bool {
+        primaryDoneToday
+    }
+}
+
+public enum WidgetDataStore {
+    public static var sharedDefaults: UserDefaults? {
+        UserDefaults(suiteName: WidgetAppGroup.id)
+    }
+
+    public static func load() -> WidgetData? {
+        guard let defaults = sharedDefaults,
+              let data = defaults.data(forKey: WidgetAppGroup.dataKey) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(WidgetData.self, from: data)
+    }
+
+    @discardableResult
+    public static func save(_ snapshot: WidgetData) -> Bool {
+        guard let data = try? JSONEncoder().encode(snapshot),
+              let defaults = sharedDefaults else {
+            return false
+        }
+        defaults.set(data, forKey: WidgetAppGroup.dataKey)
+        return true
+    }
+
+    public static func clear() {
+        sharedDefaults?.removeObject(forKey: WidgetAppGroup.dataKey)
+    }
+
+    /// Build a widget snapshot from in-memory app state, adjusting streak without
+    /// extra network calls by comparing against the last persisted snapshot.
+    public static func makeSnapshot(
+        user: UserDTO?,
+        primaryDoneToday: Bool,
+        secondDoneToday: Bool,
+        now: Date = Date(),
+        previous: WidgetData? = nil
+    ) -> WidgetData {
+        guard let user else {
+            return .loggedOut
+        }
+
+        let prior = previous ?? load()
+        let streak = resolvedStreak(
+            userId: user.id,
+            primaryDoneToday: primaryDoneToday,
+            previous: prior,
+            now: now
+        )
+
+        return WidgetData(
+            isLoggedIn: true,
+            userId: user.id,
+            currentDay: StillPoint.clampedCurrentDay(for: user),
+            secondTrackDay: max(user.secondTrackDay, 1),
+            dualTrackEnabled: user.dualTrackEnabled,
+            primaryDoneToday: primaryDoneToday,
+            secondDoneToday: secondDoneToday,
+            streak: streak,
+            lastUpdated: now
+        )
+    }
+
+    /// Increment streak once per local day when the primary track flips to done.
+    /// Preserves the last known streak across launches; resets on account switch.
+    public static func resolvedStreak(
+        userId: String,
+        primaryDoneToday: Bool,
+        previous: WidgetData?,
+        now: Date = Date()
+    ) -> Int {
+        guard let previous, previous.isLoggedIn, previous.userId == userId else {
+            return primaryDoneToday ? 1 : 0
+        }
+
+        if primaryDoneToday && !previous.primaryDoneToday {
+            return max(previous.streak, 0) + 1
+        }
+
+        if !primaryDoneToday && !isSameLocalDay(previous.lastUpdated, now) {
+            // A new local day without a completed sit yet — streak is broken.
+            return 0
+        }
+
+        return max(previous.streak, 0)
+    }
+
+    private static func isSameLocalDay(_ lhs: Date, _ rhs: Date) -> Bool {
+        Calendar.current.isDate(lhs, inSameDayAs: rhs)
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/WidgetData.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/WidgetData.swift
@@ -58,9 +58,22 @@ public struct WidgetData: Codable, Sendable, Equatable {
     }
 
     /// Whether the user has finished today's primary standard sit.
-    public var isPrimaryCompleteForToday: Bool {
-        primaryDoneToday
+    public func isPrimaryCompleteForToday(at now: Date = Date()) -> Bool {
+        primaryDoneToday && WidgetDataStore.isSameLocalDay(lastUpdated, now)
     }
+
+    /// Widget gallery / Xcode preview fixture.
+    public static let preview = WidgetData(
+        isLoggedIn: true,
+        userId: "preview",
+        currentDay: 24,
+        secondTrackDay: 8,
+        dualTrackEnabled: false,
+        primaryDoneToday: false,
+        secondDoneToday: false,
+        streak: 12,
+        lastUpdated: Date()
+    )
 }
 
 public enum WidgetDataStore {
@@ -124,6 +137,26 @@ public enum WidgetDataStore {
         )
     }
 
+    /// Normalize persisted data for widget display, clearing stale "done today"
+    /// flags and re-resolving streak after local midnight without an app sync.
+    public static func normalizedForDisplay(_ data: WidgetData, now: Date = Date()) -> WidgetData {
+        guard data.isLoggedIn else { return data }
+        guard !isSameLocalDay(data.lastUpdated, now) else { return data }
+
+        var copy = data
+        copy.primaryDoneToday = false
+        copy.secondDoneToday = false
+        if let userId = data.userId {
+            copy.streak = resolvedStreak(
+                userId: userId,
+                primaryDoneToday: false,
+                previous: data,
+                now: now
+            )
+        }
+        return copy
+    }
+
     /// Increment streak once per local day when the primary track flips to done.
     /// Preserves the last known streak across launches; resets on account switch.
     public static func resolvedStreak(
@@ -140,6 +173,11 @@ public enum WidgetDataStore {
             return max(previous.streak, 0) + 1
         }
 
+        if primaryDoneToday && !isSameLocalDay(previous.lastUpdated, now) {
+            // New local day and today is already complete (e.g. cold start after sync).
+            return max(previous.streak, 0) + 1
+        }
+
         if !primaryDoneToday && !isSameLocalDay(previous.lastUpdated, now) {
             // A new local day without a completed sit yet — streak is broken.
             return 0
@@ -148,7 +186,7 @@ public enum WidgetDataStore {
         return max(previous.streak, 0)
     }
 
-    private static func isSameLocalDay(_ lhs: Date, _ rhs: Date) -> Bool {
+    static func isSameLocalDay(_ lhs: Date, _ rhs: Date) -> Bool {
         Calendar.current.isDate(lhs, inSameDayAs: rhs)
     }
 }

--- a/ios/StillPointShared/Tests/StillPointSharedTests/WidgetDataTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/WidgetDataTests.swift
@@ -108,7 +108,7 @@ final class WidgetDataTests: XCTestCase {
             currentDay: 4,
             secondTrackDay: 1,
             dualTrackEnabled: false,
-            primaryDoneToday: true,
+            primaryDoneToday: false,
             secondDoneToday: false,
             streak: 6,
             lastUpdated: yesterday
@@ -121,6 +121,29 @@ final class WidgetDataTests: XCTestCase {
             now: Date()
         )
         XCTAssertEqual(streak, 0)
+    }
+
+    func testResolvedStreakPreservesOnNewDayAfterYesterdayComplete() {
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        let previous = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 4,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: true,
+            secondDoneToday: false,
+            streak: 6,
+            lastUpdated: yesterday
+        )
+
+        let streak = WidgetDataStore.resolvedStreak(
+            userId: "u1",
+            primaryDoneToday: false,
+            previous: previous,
+            now: Date()
+        )
+        XCTAssertEqual(streak, 6)
     }
 
     func testResolvedStreakIncrementsOnNewDayWhenAlreadyDone() {
@@ -163,7 +186,7 @@ final class WidgetDataTests: XCTestCase {
 
         let normalized = WidgetDataStore.normalizedForDisplay(stale, now: Date())
         XCTAssertFalse(normalized.isPrimaryCompleteForToday(at: Date()))
-        XCTAssertEqual(normalized.streak, 0)
+        XCTAssertEqual(normalized.streak, 6)
     }
 
     func testMakeSnapshotPreservesStreakSameDay() {

--- a/ios/StillPointShared/Tests/StillPointSharedTests/WidgetDataTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/WidgetDataTests.swift
@@ -123,6 +123,49 @@ final class WidgetDataTests: XCTestCase {
         XCTAssertEqual(streak, 0)
     }
 
+    func testResolvedStreakIncrementsOnNewDayWhenAlreadyDone() {
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        let now = Date()
+        let previous = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 4,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: true,
+            secondDoneToday: false,
+            streak: 5,
+            lastUpdated: yesterday
+        )
+
+        let streak = WidgetDataStore.resolvedStreak(
+            userId: "u1",
+            primaryDoneToday: true,
+            previous: previous,
+            now: now
+        )
+        XCTAssertEqual(streak, 6)
+    }
+
+    func testNormalizedForDisplayClearsStaleDoneToday() {
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        let stale = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 4,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: true,
+            secondDoneToday: false,
+            streak: 6,
+            lastUpdated: yesterday
+        )
+
+        let normalized = WidgetDataStore.normalizedForDisplay(stale, now: Date())
+        XCTAssertFalse(normalized.isPrimaryCompleteForToday(at: Date()))
+        XCTAssertEqual(normalized.streak, 0)
+    }
+
     func testMakeSnapshotPreservesStreakSameDay() {
         let now = Date()
         let user = makeUser()

--- a/ios/StillPointShared/Tests/StillPointSharedTests/WidgetDataTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/WidgetDataTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+import StillPointShared
+
+final class WidgetDataTests: XCTestCase {
+    private func makeUser(id: String = "user-1", currentDay: Int = 12) -> UserDTO {
+        UserDTO(
+            id: id,
+            email: "test@example.com",
+            username: "tester",
+            isPublic: false,
+            currentDay: currentDay
+        )
+    }
+
+    func testCodableRoundTrip() throws {
+        let original = WidgetData(
+            isLoggedIn: true,
+            userId: "abc",
+            currentDay: 7,
+            secondTrackDay: 3,
+            dualTrackEnabled: true,
+            primaryDoneToday: true,
+            secondDoneToday: false,
+            streak: 5,
+            lastUpdated: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(WidgetData.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testMakeSnapshotLoggedOut() {
+        let snapshot = WidgetDataStore.makeSnapshot(
+            user: nil,
+            primaryDoneToday: false,
+            secondDoneToday: false
+        )
+        XCTAssertEqual(snapshot, .loggedOut)
+    }
+
+    func testMakeSnapshotUsesClampedDay() {
+        let user = UserDTO(
+            id: "u1",
+            email: "a@b.com",
+            username: "a",
+            isPublic: false,
+            currentDay: 0
+        )
+        let snapshot = WidgetDataStore.makeSnapshot(
+            user: user,
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            previous: nil
+        )
+        XCTAssertEqual(snapshot.currentDay, 1)
+    }
+
+    func testResolvedStreakIncrementsWhenPrimaryDoneFlips() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let previous = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 4,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            streak: 3,
+            lastUpdated: now
+        )
+
+        let streak = WidgetDataStore.resolvedStreak(
+            userId: "u1",
+            primaryDoneToday: true,
+            previous: previous,
+            now: now
+        )
+        XCTAssertEqual(streak, 4)
+    }
+
+    func testResolvedStreakResetsOnAccountSwitch() {
+        let previous = WidgetData(
+            isLoggedIn: true,
+            userId: "old-user",
+            currentDay: 10,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: true,
+            secondDoneToday: false,
+            streak: 8,
+            lastUpdated: Date()
+        )
+
+        let streak = WidgetDataStore.resolvedStreak(
+            userId: "new-user",
+            primaryDoneToday: false,
+            previous: previous
+        )
+        XCTAssertEqual(streak, 0)
+    }
+
+    func testResolvedStreakResetsOnNewLocalDayWithoutCompletion() {
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        let previous = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 4,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: true,
+            secondDoneToday: false,
+            streak: 6,
+            lastUpdated: yesterday
+        )
+
+        let streak = WidgetDataStore.resolvedStreak(
+            userId: "u1",
+            primaryDoneToday: false,
+            previous: previous,
+            now: Date()
+        )
+        XCTAssertEqual(streak, 0)
+    }
+
+    func testMakeSnapshotPreservesStreakSameDay() {
+        let now = Date()
+        let user = makeUser()
+        let previous = WidgetData(
+            isLoggedIn: true,
+            userId: user.id,
+            currentDay: 12,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: true,
+            secondDoneToday: false,
+            streak: 9,
+            lastUpdated: now
+        )
+
+        let snapshot = WidgetDataStore.makeSnapshot(
+            user: user,
+            primaryDoneToday: true,
+            secondDoneToday: false,
+            now: now,
+            previous: previous
+        )
+        XCTAssertEqual(snapshot.streak, 9)
+    }
+}

--- a/ios/StillPointWidget/HabitWidget.swift
+++ b/ios/StillPointWidget/HabitWidget.swift
@@ -1,0 +1,55 @@
+import WidgetKit
+import SwiftUI
+import StillPointShared
+
+struct HabitWidget: Widget {
+    static let kind = "HabitWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: Self.kind, provider: HabitTimelineProvider()) { entry in
+            HabitWidgetEntryView(entry: entry)
+                .containerBackground(for: .widget) {
+                    WidgetPalette.background
+                }
+        }
+        .configurationDisplayName("Still Point")
+        .description("Your streak and daily sit progress.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+struct HabitEntry: TimelineEntry {
+    let date: Date
+    let data: WidgetData
+}
+
+struct HabitTimelineProvider: TimelineProvider {
+    func placeholder(in context: Context) -> HabitEntry {
+        HabitEntry(date: Date(), data: .preview)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (HabitEntry) -> Void) {
+        completion(HabitEntry(date: Date(), data: WidgetDataStore.load() ?? .preview))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<HabitEntry>) -> Void) {
+        let data = WidgetDataStore.load() ?? .loggedOut
+        let entry = HabitEntry(date: Date(), data: data)
+        let nextRefresh = Calendar.current.date(byAdding: .hour, value: 1, to: Date()) ?? Date().addingTimeInterval(3600)
+        completion(Timeline(entries: [entry], policy: .after(nextRefresh)))
+    }
+}
+
+private extension WidgetData {
+    static let preview = WidgetData(
+        isLoggedIn: true,
+        userId: "preview",
+        currentDay: 24,
+        secondTrackDay: 8,
+        dualTrackEnabled: false,
+        primaryDoneToday: false,
+        secondDoneToday: false,
+        streak: 12,
+        lastUpdated: Date()
+    )
+}

--- a/ios/StillPointWidget/HabitWidget.swift
+++ b/ios/StillPointWidget/HabitWidget.swift
@@ -29,27 +29,23 @@ struct HabitTimelineProvider: TimelineProvider {
     }
 
     func getSnapshot(in context: Context, completion: @escaping (HabitEntry) -> Void) {
-        completion(HabitEntry(date: Date(), data: WidgetDataStore.load() ?? .preview))
+        let data: WidgetData
+        if context.isPreview {
+            data = .preview
+        } else if let loaded = WidgetDataStore.load() {
+            data = WidgetDataStore.normalizedForDisplay(loaded)
+        } else {
+            data = .loggedOut
+        }
+        completion(HabitEntry(date: Date(), data: data))
     }
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<HabitEntry>) -> Void) {
-        let data = WidgetDataStore.load() ?? .loggedOut
-        let entry = HabitEntry(date: Date(), data: data)
-        let nextRefresh = Calendar.current.date(byAdding: .hour, value: 1, to: Date()) ?? Date().addingTimeInterval(3600)
+        let now = Date()
+        let raw = WidgetDataStore.load() ?? .loggedOut
+        let data = WidgetDataStore.normalizedForDisplay(raw, now: now)
+        let entry = HabitEntry(date: now, data: data)
+        let nextRefresh = Calendar.current.startOfDay(for: now.addingTimeInterval(86400))
         completion(Timeline(entries: [entry], policy: .after(nextRefresh)))
     }
-}
-
-private extension WidgetData {
-    static let preview = WidgetData(
-        isLoggedIn: true,
-        userId: "preview",
-        currentDay: 24,
-        secondTrackDay: 8,
-        dualTrackEnabled: false,
-        primaryDoneToday: false,
-        secondDoneToday: false,
-        streak: 12,
-        lastUpdated: Date()
-    )
 }

--- a/ios/StillPointWidget/HabitWidgetEntryView.swift
+++ b/ios/StillPointWidget/HabitWidgetEntryView.swift
@@ -33,7 +33,7 @@ struct HabitWidgetEntryView: View {
                     .foregroundStyle(WidgetPalette.foregroundMuted)
                     .tracking(1)
 
-                if entry.data.isPrimaryCompleteForToday {
+                if entry.data.isPrimaryCompleteForToday(at: entry.date) {
                     doneBadge
                 } else {
                     Text("\(entry.data.primaryDurationSeconds)s sit")
@@ -90,7 +90,7 @@ struct HabitWidgetEntryView: View {
                             .font(.system(size: 11, weight: .regular, design: .monospaced))
                             .foregroundStyle(WidgetPalette.foregroundMuted)
                     }
-                    if entry.data.isPrimaryCompleteForToday {
+                    if entry.data.isPrimaryCompleteForToday(at: entry.date) {
                         doneBadge
                     }
                 }

--- a/ios/StillPointWidget/HabitWidgetEntryView.swift
+++ b/ios/StillPointWidget/HabitWidgetEntryView.swift
@@ -1,0 +1,144 @@
+import SwiftUI
+import WidgetKit
+import StillPointShared
+
+struct HabitWidgetEntryView: View {
+    @Environment(\.widgetFamily) private var family
+    let entry: HabitEntry
+
+    var body: some View {
+        switch family {
+        case .systemMedium:
+            mediumLayout
+        default:
+            smallLayout
+        }
+    }
+
+    private var smallLayout: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if entry.data.isLoggedIn {
+                Label {
+                    Text("\(entry.data.streak)")
+                        .font(.system(size: 34, weight: .light, design: .serif))
+                        .foregroundStyle(WidgetPalette.foreground)
+                } icon: {
+                    Image(systemName: "flame.fill")
+                        .foregroundStyle(WidgetPalette.accent)
+                }
+                .labelStyle(.titleAndIcon)
+
+                Text("day \(entry.data.currentDay)")
+                    .font(.system(size: 13, weight: .medium, design: .monospaced))
+                    .foregroundStyle(WidgetPalette.foregroundMuted)
+                    .tracking(1)
+
+                if entry.data.isPrimaryCompleteForToday {
+                    doneBadge
+                } else {
+                    Text("\(entry.data.primaryDurationSeconds)s sit")
+                        .font(.system(size: 11, weight: .regular, design: .monospaced))
+                        .foregroundStyle(WidgetPalette.foregroundFaint)
+                }
+            } else {
+                Text("Still Point")
+                    .font(.system(size: 16, weight: .medium, design: .serif))
+                    .foregroundStyle(WidgetPalette.foreground)
+                Text("Sign in to track your streak")
+                    .font(.system(size: 12, weight: .regular))
+                    .foregroundStyle(WidgetPalette.foregroundMuted)
+            }
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(14)
+    }
+
+    private var mediumLayout: some View {
+        HStack(spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("STREAK")
+                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    .foregroundStyle(WidgetPalette.foregroundFaint)
+                    .tracking(2)
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Image(systemName: "flame.fill")
+                        .foregroundStyle(WidgetPalette.accent)
+                    Text(entry.data.isLoggedIn ? "\(entry.data.streak)" : "—")
+                        .font(.system(size: 40, weight: .light, design: .serif))
+                        .foregroundStyle(WidgetPalette.foreground)
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            if entry.data.isLoggedIn {
+                VStack(alignment: .trailing, spacing: 4) {
+                    Text("DAY")
+                        .font(.system(size: 10, weight: .medium, design: .monospaced))
+                        .foregroundStyle(WidgetPalette.foregroundFaint)
+                        .tracking(2)
+                    Text("\(entry.data.currentDay)")
+                        .font(.system(size: 40, weight: .light, design: .serif))
+                        .foregroundStyle(WidgetPalette.foreground)
+                    if entry.data.dualTrackEnabled {
+                        Text("track 2 · day \(entry.data.secondTrackDay)")
+                            .font(.system(size: 11, weight: .regular, design: .monospaced))
+                            .foregroundStyle(WidgetPalette.foregroundMuted)
+                    } else {
+                        Text("\(entry.data.primaryDurationSeconds)s · \(StillPoint.blockCount(forDuration: entry.data.primaryDurationSeconds)) blocks")
+                            .font(.system(size: 11, weight: .regular, design: .monospaced))
+                            .foregroundStyle(WidgetPalette.foregroundMuted)
+                    }
+                    if entry.data.isPrimaryCompleteForToday {
+                        doneBadge
+                    }
+                }
+            } else {
+                Text("Sign in")
+                    .font(.system(size: 14, weight: .medium, design: .serif))
+                    .foregroundStyle(WidgetPalette.foregroundMuted)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(16)
+    }
+
+    private var doneBadge: some View {
+        Label("Done today", systemImage: "checkmark.circle.fill")
+            .font(.system(size: 11, weight: .medium, design: .monospaced))
+            .foregroundStyle(WidgetPalette.success)
+    }
+}
+
+enum WidgetPalette {
+    static let background = Color(red: 26/255, green: 24/255, blue: 22/255)
+    static let foreground = Color(red: 232/255, green: 228/255, blue: 222/255).opacity(0.92)
+    static let foregroundMuted = Color(red: 232/255, green: 228/255, blue: 222/255).opacity(0.52)
+    static let foregroundFaint = Color(red: 232/255, green: 228/255, blue: 222/255).opacity(0.45)
+    static let accent = Color(red: 251/255, green: 191/255, blue: 36/255)
+    static let success = Color(red: 74/255, green: 222/255, blue: 128/255)
+}
+
+#if DEBUG
+struct HabitWidget_Previews: PreviewProvider {
+    private static let sample = WidgetData(
+        isLoggedIn: true,
+        userId: "preview",
+        currentDay: 24,
+        secondTrackDay: 8,
+        dualTrackEnabled: false,
+        primaryDoneToday: false,
+        secondDoneToday: false,
+        streak: 12,
+        lastUpdated: Date()
+    )
+
+    static var previews: some View {
+        HabitWidgetEntryView(entry: HabitEntry(date: Date(), data: sample))
+            .previewContext(WidgetPreviewContext(family: .systemSmall))
+        HabitWidgetEntryView(entry: HabitEntry(date: Date(), data: sample))
+            .previewContext(WidgetPreviewContext(family: .systemMedium))
+    }
+}
+#endif

--- a/ios/StillPointWidget/Info.plist
+++ b/ios/StillPointWidget/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Still Point Widget</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/ios/StillPointWidget/StillPointWidget.entitlements
+++ b/ios/StillPointWidget/StillPointWidget.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.brettonauerbach.stillpoint</string>
+	</array>
+</dict>
+</plist>

--- a/ios/StillPointWidget/StillPointWidgetBundle.swift
+++ b/ios/StillPointWidget/StillPointWidgetBundle.swift
@@ -1,0 +1,9 @@
+import WidgetKit
+import SwiftUI
+
+@main
+struct StillPointWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        HabitWidget()
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -28,6 +28,7 @@ targets:
       - package: GoogleSignIn
         product: GoogleSignIn
       - target: StillPointMonitor
+      - target: StillPointWidget
     info:
       path: StillPointApp/Info.plist
       properties:
@@ -85,7 +86,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint
         MARKETING_VERSION: "1.0.3"
-        CURRENT_PROJECT_VERSION: 14
+        CURRENT_PROJECT_VERSION: 15
         # Native Google Sign-In client IDs (#344). Empty by default so no real
         # client ID is committed; override per environment / in CI signing config.
         # GID_CLIENT_ID:           iOS OAuth client ID (xxxxx.apps.googleusercontent.com)
@@ -127,7 +128,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint.monitor
         MARKETING_VERSION: "1.0.3"
-        CURRENT_PROJECT_VERSION: 14
+        CURRENT_PROJECT_VERSION: 15
         DEVELOPMENT_TEAM: T5UU4BP6AV
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]: StillPointMonitor/StillPointMonitor.entitlements
@@ -137,6 +138,36 @@ targets:
         CODE_SIGN_STYLE[sdk=iphoneos*]: Manual
         CODE_SIGN_IDENTITY[sdk=iphoneos*]: "Apple Distribution"
         PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]: "StillPoint Monitor App Store"
+
+  StillPointWidget:
+    type: app-extension
+    platform: iOS
+    sources:
+      - StillPointWidget
+    dependencies:
+      - package: StillPointShared
+    info:
+      path: StillPointWidget/Info.plist
+      properties:
+        CFBundleDisplayName: Still Point Widget
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.widgetkit-extension
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint.widget
+        MARKETING_VERSION: "1.0.3"
+        CURRENT_PROJECT_VERSION: 15
+        DEVELOPMENT_TEAM: T5UU4BP6AV
+        CODE_SIGN_STYLE: Automatic
+        CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]: StillPointWidget/StillPointWidget.entitlements
+        SWIFT_VERSION: "5.9"
+        SKIP_INSTALL: YES
+        # Device (archive) signing for the embedded widget extension — its own App Store profile.
+        CODE_SIGN_STYLE[sdk=iphoneos*]: Manual
+        CODE_SIGN_IDENTITY[sdk=iphoneos*]: "Apple Distribution"
+        PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]: "StillPoint Widget App Store"
 
   StillPointAppUITests:
     type: bundle.ui-testing


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **WidgetKit home-screen widget** (small + medium) that shows streak and day progress, Duolingo-style.

- **`WidgetData` + `WidgetDataStore`** in `StillPointShared` — lightweight snapshot persisted to the existing App Group (`group.com.brettonauerbach.stillpoint`) via shared `UserDefaults`
- **`StillPointWidget`** extension target — `HabitWidget` with small (streak + day) and medium (streak | day + duration) layouts matching app palette
- **`AppViewModel` hooks** — writes widget data and reloads timelines on auth success/failure, logout, and `refreshTracksDoneToday()` (session completion / return home); **no new API calls**
- **Build 15** — `CURRENT_PROJECT_VERSION` bumped for TestFlight

Closes #84

## Test plan

- [x] `cd ios/StillPointShared && swift test` — includes new `WidgetDataTests` (Codable, streak increment, account switch reset, new-day reset, midnight normalization)
- [ ] `cd ios && xcodegen generate` — project generates with `StillPointWidget` embedded in `StillPoint`
- [ ] Simulator: sign in → add widget → verify day/streak match Home
- [ ] Complete a standard sit → return home → widget shows "Done today" and streak increments
- [ ] Log out → widget shows sign-in placeholder
- [ ] Dual-track user: medium widget shows track 2 day when enabled

## ⚠️ TestFlight / release step (new extension target)

This PR adds a **third embedded extension** (`StillPointWidget`). Before shipping build 15 to TestFlight:

1. **App ID** — register `com.brettonauerbach.stillpoint.widget` with App Groups capability (`group.com.brettonauerbach.stillpoint`)
2. **Provisioning profile** — create `"StillPoint Widget App Store"` (mirrors Monitor ext #436/#442/#451)
3. **CI secret** — add `BUILD_PROVISION_PROFILE_WIDGET_BASE64` and install it in `ios-testflight-build.yml` alongside the existing app + monitor profiles
4. **Archive smoke** — verify Release archive signs all three targets

Same pattern as the Monitor extension; not blocking merge but **required before TestFlight upload**.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c874a892-7bfc-4178-836e-fc57f46062bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c874a892-7bfc-4178-836e-fc57f46062bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

