### PR TITLE
test(e2e): port #473 mobile layout regression spec (#478)

### DIFF
--- a/e2e/fixtures/auth.fixture.ts
+++ b/e2e/fixtures/auth.fixture.ts
@@ -184,6 +184,17 @@ async function installMockApiRoutes(page: Page, state: MockApiState) {
       return json(route, 200, { session });
     }
 
+    if (pathname === "/api/board" && method === "GET") {
+      if (!state.authenticated) return json(route, 401, { error: "Unauthorized" });
+      const board = [
+        { username: "contemplative_practitioner", currentDay: 128, streak: 42, avgClear: 91 },
+        { username: state.user.username, currentDay: state.user.currentDay, streak: 9, avgClear: 84 },
+        { username: "quiet_mind", currentDay: 64, streak: 7, avgClear: 77 },
+        { username: "stillness_seeker_2026", currentDay: 31, streak: 3, avgClear: 68 },
+      ];
+      return json(route, 200, { board });
+    }
+
     if (pathname === "/api/thoughts" && method === "GET") {
       if (!state.authenticated) return json(route, 401, { error: "Unauthorized" });
       const thoughts = [...state.thoughts].sort((a, b) => {

--- a/e2e/layout/issue-473-mobile-web-layout.spec.ts
+++ b/e2e/layout/issue-473-mobile-web-layout.spec.ts
@@ -111,6 +111,8 @@ for (const width of MOBILE_WIDTHS) {
       await ensureLoggedIn();
       await page.goto("/app/journal");
       await expect(page.getByRole("heading", { name: "Thought Journal" })).toBeVisible();
+      // Wait for fetch to finish — the heading also renders during loading, before FlashHint mounts.
+      await expect(page.getByText("Loading...")).toHaveCount(0);
       await expect(
         page.getByText(/Every thought that felt urgent in the moment/i),
       ).toHaveCount(0);

--- a/e2e/layout/issue-473-mobile-web-layout.spec.ts
+++ b/e2e/layout/issue-473-mobile-web-layout.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from "../fixtures/auth.fixture";
+import {
+  expectMinimumTapTarget,
+  expectNoHorizontalOverflow,
+  expectVisibleInViewport,
+} from "../utils/mobile-helpers";
+
+// Regression coverage for #473 / #474 (mobile web layout at 320–375px). Widths are
+// set explicitly so the spec does not depend on Playwright device presets.
+const MOBILE_WIDTHS = [320, 375] as const;
+const MOBILE_VIEWPORT_HEIGHT = 667;
+const NAV_LABELS = ["home", "history", "journal", "board", "friends", "settings"] as const;
+
+for (const width of MOBILE_WIDTHS) {
+  test.describe(`#473 mobile web layout @ ${width}px`, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.setViewportSize({ width, height: MOBILE_VIEWPORT_HEIGHT });
+    });
+
+    test("bottom tab bar: icon nav fits all six labels without clipping SETTINGS", async ({
+      page,
+      ensureLoggedIn,
+    }) => {
+      await ensureLoggedIn();
+
+      const boxes: Array<{ label: string; left: number; right: number }> = [];
+      for (const label of NAV_LABELS) {
+        const btn = page.getByRole("button", { name: new RegExp(`^${label}$`, "i") });
+        await expect(btn.locator("svg")).toBeVisible();
+        await expectVisibleInViewport(page, btn, `${label} nav`, 1);
+        await expectMinimumTapTarget(btn, `${label} nav`);
+        const box = (await btn.boundingBox())!;
+        boxes.push({ label, left: box.x, right: box.x + box.width });
+      }
+
+      boxes.sort((a, b) => a.left - b.left);
+      for (let i = 1; i < boxes.length; i += 1) {
+        expect(
+          boxes[i].left,
+          `${boxes[i].label} should start after ${boxes[i - 1].label} ends`,
+        ).toBeGreaterThanOrEqual(boxes[i - 1].right - 1);
+      }
+
+      await expectNoHorizontalOverflow(page);
+    });
+
+    test("public board: responsive grid keeps CLEAR column on-screen", async ({
+      page,
+      ensureLoggedIn,
+    }) => {
+      await ensureLoggedIn();
+      await page.goto("/app/board");
+      await expect(page.getByRole("heading", { name: "Practitioners" })).toBeVisible();
+
+      const clearHeader = page.getByText("clear", { exact: true });
+      await expectVisibleInViewport(page, clearHeader, "board CLEAR header", 1);
+      await expectVisibleInViewport(page, page.getByText("91%"), "board CLEAR value", 1);
+      await expectNoHorizontalOverflow(page);
+    });
+
+    test("immersive session: scroll resets to top so the timer is visible", async ({
+      page,
+      ensureLoggedIn,
+    }) => {
+      await ensureLoggedIn();
+      await page.goto("/app");
+
+      await page.evaluate(() => window.scrollTo(0, 900));
+      expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+
+      const begin = page.getByRole("button", { name: "Begin" });
+      await expect(begin).toBeVisible();
+      // Direct DOM click so the fixed bottom nav cannot intercept the tap.
+      await begin.evaluate((el: HTMLElement) => el.click());
+
+      const endEarly = page.getByRole("button", { name: /end early/i });
+      await expect(endEarly).toBeVisible();
+      expect(await page.evaluate(() => window.scrollY)).toBe(0);
+      await expectVisibleInViewport(page, endEarly, "session end early control", 1);
+
+      const ratio = await page.evaluate(() => {
+        const docHeight = Math.max(
+          document.documentElement.scrollHeight,
+          document.body.scrollHeight,
+        );
+        return docHeight / window.innerHeight;
+      });
+      expect(ratio, "session content should not roughly double the viewport height").toBeLessThan(1.9);
+      await expectNoHorizontalOverflow(page);
+    });
+
+    test("session FlashHint: instructional copy unmounts after the brief flash", async ({
+      page,
+      ensureLoggedIn,
+    }) => {
+      await ensureLoggedIn();
+      await page.goto("/app");
+      const begin = page.getByRole("button", { name: "Begin" });
+      await begin.evaluate((el: HTMLElement) => el.click());
+      await expect(page.getByRole("button", { name: /end early/i })).toBeVisible();
+
+      await expect(
+        page.getByText(/Light distraction holds only log awareness segments/i),
+      ).toHaveCount(0);
+    });
+
+    test("thought journal FlashHint: reflective prompt unmounts on mobile", async ({
+      page,
+      ensureLoggedIn,
+    }) => {
+      await ensureLoggedIn();
+      await page.goto("/app/journal");
+      await expect(page.getByRole("heading", { name: "Thought Journal" })).toBeVisible();
+      await expect(
+        page.getByText(/Every thought that felt urgent in the moment/i),
+      ).toHaveCount(0);
+      await expectNoHorizontalOverflow(page);
+    });
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #478

Reconstructs the mobile-layout e2e regression test lost when the #476 branch was removed. Targets the shipped #474 internals:

- **Icon nav** — all six bottom-tab labels fit without overlap; each tab exposes an SVG icon and meets the 44px tap target
- **Responsive board grid** — CLEAR column header and sample value stay in viewport at narrow widths
- **Immersive scroll-to-top** — starting a session from a scrolled home tab resets `scrollY` to 0 and keeps session controls visible
- **FlashHint** — session and journal instructional copy unmounts after the brief flash (no persistent vertical bloat)

Both **320px** and **375px** widths are driven explicitly via `page.setViewportSize` (no device preset dependency). Adds a small `/api/board` mock to `e2e/fixtures/auth.fixture.ts` for board assertions.

## Test plan

- [x] `npx playwright test e2e/layout/issue-473-mobile-web-layout.spec.ts --project mobile-chromium-narrow` — 10/10 passed (320px + 375px × 5 cases)
- [ ] Mobile e2e gate (`e2e-mobile.yml`) on merge commit

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee92e146-59e6-4e72-a697-1e564826db96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee92e146-59e6-4e72-a697-1e564826db96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

