### PR TITLE
History redesign: month grid + compact prior-month summaries (#83)

### DIFF
--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -4,10 +4,12 @@ import { atomicCreateSessionWithProgression } from "@/db/atomic";
 import { requireAuth } from "@/lib/api/requireAuth";
 import { withApiHandler } from "@/lib/api/withApiHandler";
 import { calculateSessionStats, parseCompleted, parseOptionalSessionType, parseOptionalTrack } from "@/lib/constants";
+import { calculateHistoryPeriodStats } from "@/lib/historyStats";
+import { isValidSessionCalendarDate, todayLocalIsoDate } from "@/lib/sessionCalendar";
 import { eq, desc } from "drizzle-orm";
 import { sessions } from "@/db/schema";
 
-export const GET = withApiHandler("Get sessions", async () => {
+export const GET = withApiHandler("Get sessions", async (request: NextRequest) => {
   const auth = await requireAuth();
   if (!auth.ok) return auth.response;
 
@@ -17,11 +19,18 @@ export const GET = withApiHandler("Get sessions", async () => {
     .orderBy(desc(sessions.dayNumber));
   const stats = calculateSessionStats(userSessions);
 
+  const todayParam = request.nextUrl.searchParams.get("today")?.trim();
+  const todayIso = todayParam && isValidSessionCalendarDate(todayParam)
+    ? todayParam
+    : todayLocalIsoDate();
+  const periodStats = calculateHistoryPeriodStats(userSessions, todayIso);
+
   return NextResponse.json({
     sessions: userSessions,
     stats: {
       ...stats,
       bonusMinutesTotal: Math.round(stats.bonusSecondsTotal / 60),
+      ...periodStats,
     },
   });
 });

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -5,6 +5,7 @@ import type { Session, Thought } from "@/lib/api";
 import { sessionDurationForUser, type RecoveryFields } from "@/lib/duration";
 import { buildCurrentMonthGrid, buildPriorMonthSummaries, formatTotalTime } from "@/lib/historyMonthGrid";
 import { buildHistoryJourneyRows } from "@/lib/historyJourney";
+import { calculateHistoryPeriodStats } from "@/lib/historyStats";
 import { useIsMobile } from "@/lib/useIsMobile";
 import { todayLocalIsoDate } from "@/lib/sessionCalendar";
 
@@ -108,17 +109,16 @@ export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: Hi
         avgThoughtsPerSession: sessData.stats?.avgThoughtsPerSession ?? 0,
         avgThoughtsPerMinute: sessData.stats?.avgThoughtsPerMinute ?? 0,
         bonusMinutesTotal: sessData.stats?.bonusMinutesTotal ?? 0,
-        trailing4WeekDays: sessData.stats?.trailing4WeekDays ?? 0,
-        trailing4WeekDayPercent: sessData.stats?.trailing4WeekDayPercent ?? 0,
-        trailing4WeekTotalTime: sessData.stats?.trailing4WeekTotalTime ?? 0,
-        trailing4WeekTimePercent: sessData.stats?.trailing4WeekTimePercent ?? 0,
-        totalTimeAllTime: sessData.stats?.totalTimeAllTime ?? 0,
-        progressTo10kHours: sessData.stats?.progressTo10kHours ?? 0,
       });
       setThoughts(thoughtData.thoughts || []);
       setLoading(false);
     }).catch(() => setLoading(false));
   }, []);
+
+  const periodStats = useMemo(
+    () => calculateHistoryPeriodStats(sessions, todayDate),
+    [sessions, todayDate],
+  );
 
   useEffect(() => {
     const id = setInterval(() => {
@@ -284,10 +284,10 @@ export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: Hi
             display: "flex", gap: isMobile ? "12px" : "20px", flexWrap: "wrap", justifyContent: "center", ...mono,
           }}>
             {[
-              { label: "days meditated", value: String(stats.trailing4WeekDays) },
-              { label: "of days", value: `${stats.trailing4WeekDayPercent}%` },
-              { label: "total time", value: formatTotalTime(stats.trailing4WeekTotalTime) },
-              { label: "of time", value: `${stats.trailing4WeekTimePercent.toFixed(2)}%` },
+              { label: "days meditated", value: String(periodStats.trailing4WeekDays) },
+              { label: "of days", value: `${periodStats.trailing4WeekDayPercent}%` },
+              { label: "total time", value: formatTotalTime(periodStats.trailing4WeekTotalTime) },
+              { label: "of time", value: `${periodStats.trailing4WeekTimePercent.toFixed(2)}%` },
             ].map(s => (
               <div key={s.label} style={statCardStyle}>
                 <div style={{ fontSize: "24px", fontWeight: 200, color: "var(--fg)" }}>{s.value}</div>
@@ -304,15 +304,15 @@ export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: Hi
               display: "flex", justifyContent: "space-between", alignItems: "baseline",
               marginBottom: "8px", ...mono, fontSize: "11px", color: "var(--fg-3)",
             }}>
-              <span>{formatTotalTime(stats.totalTimeAllTime)} all time</span>
-              <span>{stats.progressTo10kHours.toFixed(2)}% to 10,000 hours</span>
+              <span>{formatTotalTime(periodStats.totalTimeAllTime)} all time</span>
+              <span>{periodStats.progressTo10kHours.toFixed(2)}% to 10,000 hours</span>
             </div>
             <div style={{
               height: "6px", borderRadius: "3px", background: "var(--surface-1)", overflow: "hidden",
             }}>
               <div style={{
                 height: "100%",
-                width: `${Math.min(100, stats.progressTo10kHours)}%`,
+                width: `${Math.min(100, periodStats.progressTo10kHours)}%`,
                 background: "var(--accent-green-bg)",
                 borderRadius: "3px",
               }} />

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -5,7 +5,6 @@ import type { Session, Thought } from "@/lib/api";
 import { sessionDurationForUser, type RecoveryFields } from "@/lib/duration";
 import { buildCurrentMonthGrid, buildPriorMonthSummaries, formatTotalTime } from "@/lib/historyMonthGrid";
 import { buildHistoryJourneyRows } from "@/lib/historyJourney";
-import { calculateHistoryPeriodStats } from "@/lib/historyStats";
 import { useIsMobile } from "@/lib/useIsMobile";
 import { todayLocalIsoDate } from "@/lib/sessionCalendar";
 
@@ -109,16 +108,17 @@ export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: Hi
         avgThoughtsPerSession: sessData.stats?.avgThoughtsPerSession ?? 0,
         avgThoughtsPerMinute: sessData.stats?.avgThoughtsPerMinute ?? 0,
         bonusMinutesTotal: sessData.stats?.bonusMinutesTotal ?? 0,
+        trailing4WeekDays: sessData.stats?.trailing4WeekDays ?? 0,
+        trailing4WeekDayPercent: sessData.stats?.trailing4WeekDayPercent ?? 0,
+        trailing4WeekTotalTime: sessData.stats?.trailing4WeekTotalTime ?? 0,
+        trailing4WeekTimePercent: sessData.stats?.trailing4WeekTimePercent ?? 0,
+        totalTimeAllTime: sessData.stats?.totalTimeAllTime ?? 0,
+        progressTo10kHours: sessData.stats?.progressTo10kHours ?? 0,
       });
       setThoughts(thoughtData.thoughts || []);
       setLoading(false);
     }).catch(() => setLoading(false));
   }, []);
-
-  const periodStats = useMemo(
-    () => calculateHistoryPeriodStats(sessions, todayDate),
-    [sessions, todayDate],
-  );
 
   useEffect(() => {
     const id = setInterval(() => {
@@ -284,10 +284,10 @@ export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: Hi
             display: "flex", gap: isMobile ? "12px" : "20px", flexWrap: "wrap", justifyContent: "center", ...mono,
           }}>
             {[
-              { label: "days meditated", value: String(periodStats.trailing4WeekDays) },
-              { label: "of days", value: `${periodStats.trailing4WeekDayPercent}%` },
-              { label: "total time", value: formatTotalTime(periodStats.trailing4WeekTotalTime) },
-              { label: "of time", value: `${periodStats.trailing4WeekTimePercent.toFixed(2)}%` },
+              { label: "days meditated", value: String(stats.trailing4WeekDays) },
+              { label: "of days", value: `${stats.trailing4WeekDayPercent}%` },
+              { label: "total time", value: formatTotalTime(stats.trailing4WeekTotalTime) },
+              { label: "of time", value: `${stats.trailing4WeekTimePercent.toFixed(2)}%` },
             ].map(s => (
               <div key={s.label} style={statCardStyle}>
                 <div style={{ fontSize: "24px", fontWeight: 200, color: "var(--fg)" }}>{s.value}</div>
@@ -304,15 +304,15 @@ export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: Hi
               display: "flex", justifyContent: "space-between", alignItems: "baseline",
               marginBottom: "8px", ...mono, fontSize: "11px", color: "var(--fg-3)",
             }}>
-              <span>{formatTotalTime(periodStats.totalTimeAllTime)} all time</span>
-              <span>{periodStats.progressTo10kHours.toFixed(2)}% to 10,000 hours</span>
+              <span>{formatTotalTime(stats.totalTimeAllTime)} all time</span>
+              <span>{stats.progressTo10kHours.toFixed(2)}% to 10,000 hours</span>
             </div>
             <div style={{
               height: "6px", borderRadius: "3px", background: "var(--surface-1)", overflow: "hidden",
             }}>
               <div style={{
                 height: "100%",
-                width: `${Math.min(100, periodStats.progressTo10kHours)}%`,
+                width: `${Math.min(100, stats.progressTo10kHours)}%`,
                 background: "var(--accent-green-bg)",
                 borderRadius: "3px",
               }} />

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, type CSSProperties } from "react";
 import type { Session, Thought } from "@/lib/api";
 import { sessionDurationForUser, type RecoveryFields } from "@/lib/duration";
-import { useIsMobile } from "@/lib/useIsMobile";
+import { buildCurrentMonthGrid, buildPriorMonthSummaries, formatTotalTime } from "@/lib/historyMonthGrid";
 import { buildHistoryJourneyRows } from "@/lib/historyJourney";
+import { useIsMobile } from "@/lib/useIsMobile";
 import { todayLocalIsoDate } from "@/lib/sessionCalendar";
 
 const NO_RECOVERY: RecoveryFields = {
@@ -12,6 +13,8 @@ const NO_RECOVERY: RecoveryFields = {
   recoveryCurrentStep: null,
   recoveryTotalSteps: null,
 };
+
+const WEEKDAY_LABELS = ["S", "M", "T", "W", "T", "F", "S"] as const;
 
 type HistoryEntry = {
   sessionId?: string;
@@ -25,12 +28,9 @@ type HistoryEntry = {
   thoughtCount: number;
   sessionType?: Session["sessionType"];
   missed?: boolean;
-  /** Collapsed run of 3+ consecutive missed days (single "N days missed" row). */
   collapsed?: boolean;
   collapsedDayCount?: number;
-  /** Inclusive end of the collapsed range (`date` holds the start). */
   collapsedEndDate?: string;
-  /** 1-based index among same-type sessions on the same calendar day */
   sessionIndexInDay?: number;
 };
 
@@ -50,7 +50,6 @@ function formatShortDateLabel(isoDate: string): string {
   return d.toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
 }
 
-/** Month + day only (e.g. "Jun 10") — used for the collapsed-gap date range. */
 function formatCompactDateLabel(isoDate: string): string {
   const d = new Date(isoDate + "T12:00:00");
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
@@ -68,26 +67,39 @@ type HistoryViewProps = {
 
 export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: HistoryViewProps) {
   const [sessions, setSessions] = useState<Session[]>([]);
-  const [thoughts, setThoughts] = useState<Thought[]>([]);
   const [stats, setStats] = useState({
     streak: 0,
     avgClearPercent: 0,
     avgThoughtsPerSession: 0,
     avgThoughtsPerMinute: 0,
     bonusMinutesTotal: 0,
+    trailing4WeekDays: 0,
+    trailing4WeekDayPercent: 0,
+    trailing4WeekTotalTime: 0,
+    trailing4WeekTimePercent: 0,
+    totalTimeAllTime: 0,
+    progressTo10kHours: 0,
   });
   const [expandedEntryId, setExpandedEntryId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
-  // UTC calendar day for the trailing gap-to-today, refreshed on day rollover so the
-  // journey stays correct if the view is left open past midnight (PR #426 review).
+  const [thoughts, setThoughts] = useState<Thought[]>([]);
+  const [viewMode, setViewMode] = useState<"calendar" | "journey">("calendar");
   const [todayDate, setTodayDate] = useState<string>(() => todayLocalIsoDate());
   const isMobile = useIsMobile();
   const sessionLabelColWidth = isMobile ? "88px" : "100px";
+  const cellSize = isMobile ? "36px" : "44px";
 
   useEffect(() => {
+    const today = todayLocalIsoDate();
+    const readJson = async (response: Response) => {
+      if (!response.ok) {
+        throw new Error(`Request failed (${response.status})`);
+      }
+      return response.json();
+    };
     Promise.all([
-      fetch("/api/sessions").then(r => r.json()),
-      fetch("/api/thoughts").then(r => r.json()),
+      fetch(`/api/sessions?today=${encodeURIComponent(today)}`).then(readJson),
+      fetch("/api/thoughts").then(readJson),
     ]).then(([sessData, thoughtData]) => {
       setSessions(sessData.sessions || []);
       setStats({
@@ -96,14 +108,18 @@ export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: Hi
         avgThoughtsPerSession: sessData.stats?.avgThoughtsPerSession ?? 0,
         avgThoughtsPerMinute: sessData.stats?.avgThoughtsPerMinute ?? 0,
         bonusMinutesTotal: sessData.stats?.bonusMinutesTotal ?? 0,
+        trailing4WeekDays: sessData.stats?.trailing4WeekDays ?? 0,
+        trailing4WeekDayPercent: sessData.stats?.trailing4WeekDayPercent ?? 0,
+        trailing4WeekTotalTime: sessData.stats?.trailing4WeekTotalTime ?? 0,
+        trailing4WeekTimePercent: sessData.stats?.trailing4WeekTimePercent ?? 0,
+        totalTimeAllTime: sessData.stats?.totalTimeAllTime ?? 0,
+        progressTo10kHours: sessData.stats?.progressTo10kHours ?? 0,
       });
       setThoughts(thoughtData.thoughts || []);
       setLoading(false);
     }).catch(() => setLoading(false));
   }, []);
 
-  // Re-evaluate "today" once a minute; only re-renders when the UTC day actually
-  // changes, keeping the trailing gap fresh across midnight without a refetch.
   useEffect(() => {
     const id = setInterval(() => {
       const d = todayLocalIsoDate();
@@ -112,10 +128,17 @@ export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: Hi
     return () => clearInterval(id);
   }, []);
 
+  const monthGrid = useMemo(
+    () => buildCurrentMonthGrid(sessions, todayDate),
+    [sessions, todayDate],
+  );
+
+  const priorMonths = useMemo(
+    () => buildPriorMonthSummaries(sessions, todayDate),
+    [sessions, todayDate],
+  );
+
   const journeyRows = useMemo(() => {
-    // Include all session types (quick + standard) — quick sits are rendered with
-    // visual distinction rather than filtered out (#381). Pass today so the gap
-    // between the last session and now is also collapsed.
     return buildHistoryJourneyRows(
       sessions.map(s => ({
         sessionDate: s.sessionDate,
@@ -195,18 +218,26 @@ export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: Hi
   const getThoughtsForSession = (sessionId?: string) =>
     sessionId ? (thoughtsBySession[sessionId] ?? []) : [];
 
+  const mono: CSSProperties = {
+    fontFamily: "var(--font-mono)",
+  };
+
+  const statCardStyle: CSSProperties = {
+    textAlign: "center",
+    minWidth: isMobile ? "72px" : "88px",
+  };
+
   if (loading) {
     return (
       <div style={{
         display: "flex", flexDirection: "column", alignItems: "center",
-        gap: "32px", animation: "fadeIn 0.6s ease", width: "100%", maxWidth: "min(720px, calc(100vw - 24px))",
+        gap: "var(--s5)", animation: "fadeIn 0.6s ease", width: "100%", maxWidth: "min(720px, calc(100vw - 24px))",
       }}>
         <h2 style={{ fontSize: "28px", fontWeight: 300, fontStyle: "italic", margin: 0,
           fontFamily: "var(--font-serif)", color: "var(--fg)" }}>
           Progress
         </h2>
-        <div style={{ fontFamily: "var(--font-mono)",
-          fontSize: "12px", color: "var(--fg-3)" }}>
+        <div style={{ ...mono, fontSize: "12px", color: "var(--fg-3)" }}>
           Loading...
         </div>
       </div>
@@ -216,359 +247,537 @@ export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: Hi
   return (
     <div style={{
       display: "flex", flexDirection: "column", alignItems: "center",
-      gap: "32px", animation: "fadeIn 0.6s ease", width: "100%", maxWidth: "min(720px, calc(100vw - 24px))",
+      gap: "var(--s5)", animation: "fadeIn 0.6s ease", width: "100%", maxWidth: "min(720px, calc(100vw - 24px))",
     }}>
       <h2 style={{ fontSize: "28px", fontWeight: 300, fontStyle: "italic", margin: 0,
         fontFamily: "var(--font-serif)", color: "var(--fg)" }}>
         Progress
       </h2>
 
-      {/* Stats */}
-      <div style={{
-        display: "flex", gap: isMobile ? "16px" : "28px", flexWrap: "wrap", justifyContent: "center",
-        fontFamily: "var(--font-mono)",
-      }}>
-        {[
-          { label: "streak", value: String(stats.streak) },
-          { label: "avg clear mind", value: `${stats.avgClearPercent}%` },
-          { label: "\uD83D\uDCAD/session", value: String(stats.avgThoughtsPerSession) },
-          { label: "\uD83D\uDCAD/min", value: String(stats.avgThoughtsPerMinute) },
-          { label: "bonus min total", value: String(stats.bonusMinutesTotal) },
-        ].map(s => (
-          <div key={s.label} style={{ textAlign: "center" }}>
-            <div style={{ fontSize: "28px", fontWeight: 200, color: "var(--fg)" }}>{s.value}</div>
-            <div style={{ fontSize: "11px", color: "var(--fg-3)", letterSpacing: "0.12em", textTransform: "uppercase", marginTop: "4px" }}>
-              {s.label}
-            </div>
-          </div>
+      {/* View toggle */}
+      <div style={{ display: "flex", gap: "8px", ...mono, fontSize: "11px" }}>
+        {(["calendar", "journey"] as const).map(mode => (
+          <button
+            key={mode}
+            type="button"
+            onClick={() => setViewMode(mode)}
+            style={{
+              padding: "6px 14px",
+              borderRadius: "4px",
+              border: viewMode === mode ? "1px solid var(--border-3)" : "1px solid var(--border-1)",
+              background: viewMode === mode ? "var(--surface-2)" : "transparent",
+              color: viewMode === mode ? "var(--fg)" : "var(--fg-3)",
+              cursor: "pointer",
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+            }}
+          >
+            {mode === "calendar" ? "Calendar" : "Session buildup"}
+          </button>
         ))}
       </div>
 
-      {/* Journey */}
-      <div style={{ width: "100%", maxWidth: "660px" }}>
-        <div style={{
-          fontFamily: "var(--font-serif)",
-          fontSize: "14px", color: "var(--fg-2)",
-          marginBottom: "20px", letterSpacing: "0.07em", textTransform: "uppercase",
-        }}>
-          Journey
-        </div>
-
-        <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
-          {history.map((entry, idx) => {
-            const prev = idx > 0 ? history[idx - 1] : undefined;
-            const showDateColumn = entry.missed
-              ? true
-              : !prev || prev.missed || prev.date !== entry.date;
-
-            if (entry.collapsed) {
-              const rangeLabel = `${formatCompactDateLabel(entry.date)} – ${formatCompactDateLabel(entry.collapsedEndDate ?? entry.date)}`;
-              return (
-                <div key={`collapsed-${idx}`} style={{
-                  display: "flex", alignItems: "center", gap: isMobile ? "8px" : "12px",
-                  padding: "2px 0", opacity: 0.35,
-                }}>
-                  <div style={{
-                    fontFamily: "var(--font-mono)",
-                    fontSize: isMobile ? "10px" : "11px", color: "var(--fg-4)",
-                    width: isMobile ? undefined : "160px", minWidth: isMobile ? "72px" : undefined,
-                    textAlign: "right", whiteSpace: "nowrap",
-                  }}>
-                    {rangeLabel}
-                  </div>
-                  <div style={{
-                    fontFamily: "var(--font-mono)",
-                    fontSize: "11px", color: "var(--fg-3)",
-                    width: sessionLabelColWidth, textAlign: "right",
-                  }}>
-                    &mdash;
-                  </div>
-                  <div style={{
-                    flex: 1, height: "24px", borderRadius: "3px",
-                    border: "1px dashed var(--border-1)",
-                    display: "flex", alignItems: "center", paddingLeft: "10px",
-                  }}>
-                    <span style={{
-                      fontFamily: "var(--font-mono)",
-                      fontSize: "11px", color: "var(--fg-4)", fontStyle: "italic",
-                    }}>
-                      {entry.collapsedDayCount} days missed
-                    </span>
-                  </div>
-                  <div style={{ width: isMobile ? "80px" : "120px" }} />
+      {viewMode === "calendar" ? (
+        <>
+          {/* Trailing 4-week stats */}
+          <div style={{
+            display: "flex", gap: isMobile ? "12px" : "20px", flexWrap: "wrap", justifyContent: "center", ...mono,
+          }}>
+            {[
+              { label: "days meditated", value: String(stats.trailing4WeekDays) },
+              { label: "of days", value: `${stats.trailing4WeekDayPercent}%` },
+              { label: "total time", value: formatTotalTime(stats.trailing4WeekTotalTime) },
+              { label: "of time", value: `${stats.trailing4WeekTimePercent.toFixed(2)}%` },
+            ].map(s => (
+              <div key={s.label} style={statCardStyle}>
+                <div style={{ fontSize: "24px", fontWeight: 200, color: "var(--fg)" }}>{s.value}</div>
+                <div style={{ fontSize: "10px", color: "var(--fg-3)", letterSpacing: "0.12em", textTransform: "uppercase", marginTop: "4px" }}>
+                  {s.label}
                 </div>
-              );
-            }
-
-            if (entry.missed) {
-              const dateLabel = formatFullDateLabel(entry.date);
-              return (
-                <div key={`missed-${idx}`} style={{
-                  display: "flex", alignItems: "center", gap: isMobile ? "8px" : "12px",
-                  padding: "2px 0", opacity: 0.35,
-                }}>
-                  {!isMobile ? (
-                    <div style={{
-                      fontFamily: "var(--font-mono)",
-                      fontSize: "11px", color: "var(--fg-4)",
-                      width: "160px", textAlign: "right", whiteSpace: "nowrap",
-                    }}>
-                      {dateLabel}
-                    </div>
-                  ) : (
-                    <div style={{
-                      fontFamily: "var(--font-mono)",
-                      fontSize: "10px", color: "var(--fg-4)",
-                      minWidth: "72px", textAlign: "right", whiteSpace: "nowrap",
-                    }}>
-                      {formatShortDateLabel(entry.date)}
-                    </div>
-                  )}
-                  <div style={{
-                    fontFamily: "var(--font-mono)",
-                    fontSize: "11px", color: "var(--fg-3)",
-                    width: sessionLabelColWidth, textAlign: "right",
-                  }}>
-                    &mdash;
-                  </div>
-                  <div style={{
-                    flex: 1, height: "24px", borderRadius: "3px",
-                    border: "1px dashed var(--border-1)",
-                    display: "flex", alignItems: "center", paddingLeft: "10px",
-                  }}>
-                    <span style={{
-                      fontFamily: "var(--font-mono)",
-                      fontSize: "11px", color: "var(--fg-4)", fontStyle: "italic",
-                    }}>
-                      missed
-                    </span>
-                  </div>
-                  <div style={{ width: isMobile ? "80px" : "120px" }} />
-                </div>
-              );
-            }
-
-            const dateLabelFull = formatFullDateLabel(entry.date);
-            const dateLabelShort = formatShortDateLabel(entry.date);
-            const isQuick = entry.sessionType === "quick";
-            const isBreath = entry.sessionType === "breath";
-            const sessionOrdinal = entry.sessionIndexInDay ?? 1;
-            const sessionLabel = isQuick ? "Quick" : isBreath ? "Breath" : `Session ${sessionOrdinal}`;
-
-            const entryId = entry.sessionId ? `sess-${entry.sessionId}` : `day-${entry.day}-${idx}`;
-            const isExpanded = expandedEntryId === entryId;
-            const entryThoughts = getThoughtsForSession(entry.sessionId);
-            const canExpand = entryThoughts.length > 0;
-
-            return (
-              <div key={entryId}>
-                <div
-                  role={canExpand ? "button" : undefined}
-                  tabIndex={canExpand ? 0 : undefined}
-                  aria-expanded={canExpand ? isExpanded : undefined}
-                  aria-controls={canExpand ? `${entryId}-thoughts` : undefined}
-                  onClick={() => {
-                    if (canExpand) setExpandedEntryId(isExpanded ? null : entryId);
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      if (canExpand) setExpandedEntryId(isExpanded ? null : entryId);
-                    }
-                  }}
-                  style={{
-                    display: "flex", alignItems: "center", gap: isMobile ? "8px" : "12px",
-                    cursor: canExpand ? "pointer" : "default", padding: "2px 0", borderRadius: "4px",
-                    transition: "background 0.2s", outline: "none",
-                  }}
-                  onFocus={e => {
-                    if (e.currentTarget.matches(":focus-visible")) {
-                      e.currentTarget.style.background = "var(--surface-1)";
-                      e.currentTarget.style.outline = "2px solid var(--border-3)";
-                      e.currentTarget.style.outlineOffset = "2px";
-                    }
-                  }}
-                  onBlur={e => {
-                    e.currentTarget.style.outline = "none";
-                    e.currentTarget.style.background = "none";
-                  }}
-                  onMouseEnter={e => e.currentTarget.style.background = "var(--surface-1)"}
-                  onMouseLeave={e => e.currentTarget.style.background = "none"}
-                >
-                  {!isMobile && (
-                    <div style={{
-                      fontFamily: "var(--font-mono)",
-                      fontSize: "11px", color: "var(--fg-4)",
-                      width: "160px", textAlign: "right", whiteSpace: "nowrap",
-                    }}>
-                      {showDateColumn ? dateLabelFull : ""}
-                    </div>
-                  )}
-                  {isMobile && (
-                    <div style={{
-                      fontFamily: "var(--font-mono)",
-                      fontSize: "10px", color: "var(--fg-4)",
-                      minWidth: "72px", textAlign: "right", whiteSpace: "nowrap",
-                    }}>
-                      {showDateColumn ? dateLabelShort : ""}
-                    </div>
-                  )}
-                  <div style={{
-                    fontFamily: "var(--font-mono)",
-                    fontSize: "11px", color: isQuick ? "var(--fg-4)" : "var(--fg-3)",
-                    width: sessionLabelColWidth, textAlign: "right",
-                  }}>
-                    {sessionLabel}
-                  </div>
-                  <div style={{
-                    flex: 1, height: "24px", borderRadius: "3px", overflow: "hidden",
-                    background: "var(--surface-1)", position: "relative",
-                  }}>
-                    <div style={{
-                      height: "100%",
-                      width: `${(entry.actualTime / maxDuration) * 100}%`,
-                      borderRadius: "3px", overflow: "hidden", display: "flex",
-                      opacity: isQuick ? 0.55 : 1,
-                    }}>
-                      <div style={{
-                        width: `${entry.clearPercent}%`, height: "100%",
-                        background: "linear-gradient(to right, var(--accent-green), var(--accent-green-end))",
-                        opacity: entry.completed ? 0.7 : 0.4,
-                      }} />
-                      <div style={{
-                        width: `${100 - entry.clearPercent}%`, height: "100%",
-                        background: "linear-gradient(to right, var(--accent-amber), var(--accent-amber-end))",
-                        opacity: entry.completed ? 0.5 : 0.3,
-                      }} />
-                    </div>
-                  </div>
-                  <div style={{
-                    fontFamily: "var(--font-mono)",
-                    fontSize: "11px",
-                    color: entry.completed ? "var(--accent-green-dim)" : "var(--accent-danger-muted)",
-                    width: isMobile ? "80px" : "120px", display: "flex", gap: "6px", flexWrap: "wrap",
-                  }}>
-                    <span style={{ color: "var(--fg-3)" }}>{entry.actualTime}s</span>
-                    <span style={{ color: "var(--fg-4)" }}>&middot;</span>
-                    <span>{entry.clearPercent}%</span>
-                    <span style={{ color: "var(--fg-4)" }}>&middot;</span>
-                    <span style={{ color: "var(--accent-amber-border)" }}>{entry.thoughtCount}\uD83D\uDCAD</span>
-                    {entry.bonusSeconds > 0 && (
-                      <>
-                        <span style={{ color: "var(--fg-4)" }}>&middot;</span>
-                        <span style={{ color: "var(--fg-2)" }}>+{Math.round(entry.bonusSeconds / 60)}m bonus</span>
-                      </>
-                    )}
-                  </div>
-                </div>
-
-                {canExpand && isExpanded && (
-                  <div
-                    id={`${entryId}-thoughts`}
-                    role="region"
-                    aria-label={`${sessionLabel} on ${dateLabelFull} captured thoughts`}
-                    style={{
-                    marginLeft: isMobile ? "44px" : "216px", marginTop: "4px", marginBottom: "8px",
-                    padding: "10px 14px", background: "var(--surface-1)",
-                    borderLeft: "2px solid var(--accent-amber-bg)",
-                    borderRadius: "0 6px 6px 0", animation: "fadeIn 0.2s ease",
-                  }}>
-                    {entryThoughts.map((t) => (
-                      <div key={t.id} style={{ display: "flex", gap: "10px", alignItems: "baseline", padding: "3px 0" }}>
-                        <span style={{
-                          fontFamily: "var(--font-mono)",
-                          fontSize: "11px", color: "var(--accent-amber-hint)", whiteSpace: "nowrap",
-                        }}>
-                          @{t.timeInSession}s
-                        </span>
-                        <span style={{
-                          fontFamily: "var(--font-serif)",
-                          fontSize: "13px", fontStyle: "italic", color: "var(--fg-2)",
-                        }}>
-                          {t.text}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                )}
               </div>
-            );
-          })}
+            ))}
+          </div>
 
-          {/* Current day preview */}
-          <div style={{ display: "flex", alignItems: "center", gap: isMobile ? "8px" : "12px" }}>
-            {!isMobile && (
-              <div style={{
-                fontFamily: "var(--font-mono)",
-                fontSize: "11px", color: "var(--fg-4)",
-                width: "160px", textAlign: "right", whiteSpace: "nowrap",
-              }}>
-                today
-              </div>
-            )}
-            {isMobile && (
-              <div style={{
-                fontFamily: "var(--font-mono)",
-                fontSize: "10px", color: "var(--fg-4)",
-                minWidth: "72px", textAlign: "right", whiteSpace: "nowrap",
-              }} />
-            )}
+          {/* All-time progress toward 10,000 hours */}
+          <div style={{ width: "100%", maxWidth: "480px" }}>
             <div style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: "11px", color: "var(--fg-4)",
-              width: sessionLabelColWidth, textAlign: "right",
+              display: "flex", justifyContent: "space-between", alignItems: "baseline",
+              marginBottom: "8px", ...mono, fontSize: "11px", color: "var(--fg-3)",
             }}>
-              D{currentDay}
+              <span>{formatTotalTime(stats.totalTimeAllTime)} all time</span>
+              <span>{stats.progressTo10kHours.toFixed(2)}% to 10,000 hours</span>
             </div>
             <div style={{
-              flex: 1, height: "24px", borderRadius: "3px", overflow: "hidden",
-              background: "var(--surface-1)",
-              border: "1px dashed var(--surface-3)",
+              height: "6px", borderRadius: "3px", background: "var(--surface-1)", overflow: "hidden",
             }}>
               <div style={{
                 height: "100%",
-                width: `${(todayDuration / maxDuration) * 100}%`,
-                background: "linear-gradient(to right, var(--surface-3), var(--surface-1))",
+                width: `${Math.min(100, stats.progressTo10kHours)}%`,
+                background: "var(--accent-green-bg)",
                 borderRadius: "3px",
               }} />
             </div>
+          </div>
+
+          {/* Legacy aggregate stats */}
+          <div style={{
+            display: "flex", gap: isMobile ? "16px" : "28px", flexWrap: "wrap", justifyContent: "center", ...mono,
+          }}>
+            {[
+              { label: "streak", value: String(stats.streak) },
+              { label: "avg clear mind", value: `${stats.avgClearPercent}%` },
+              { label: "\uD83D\uDCAD/session", value: String(stats.avgThoughtsPerSession) },
+              { label: "\uD83D\uDCAD/min", value: String(stats.avgThoughtsPerMinute) },
+              { label: "bonus min total", value: String(stats.bonusMinutesTotal) },
+            ].map(s => (
+              <div key={s.label} style={statCardStyle}>
+                <div style={{ fontSize: "22px", fontWeight: 200, color: "var(--fg)" }}>{s.value}</div>
+                <div style={{ fontSize: "10px", color: "var(--fg-3)", letterSpacing: "0.12em", textTransform: "uppercase", marginTop: "4px" }}>
+                  {s.label}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Prior months — compact summary rows */}
+          {priorMonths.length > 0 && (
+            <div style={{ width: "100%", maxWidth: "480px", display: "flex", flexDirection: "column", gap: "6px" }}>
+              {priorMonths.map(month => (
+                <div
+                  key={month.yearMonth}
+                  style={{
+                    display: "flex", justifyContent: "space-between", alignItems: "center",
+                    padding: "8px 12px", borderRadius: "4px",
+                    background: "var(--surface-1)", border: "1px solid var(--border-1)",
+                    ...mono, fontSize: "11px", color: "var(--fg-3)",
+                  }}
+                >
+                  <span style={{ color: "var(--fg-2)" }}>{month.label}</span>
+                  <span>
+                    {month.daysActive}/{month.daysInMonth} days
+                    <span style={{ color: "var(--fg-4)", margin: "0 6px" }}>&middot;</span>
+                    {formatTotalTime(month.totalTimeSeconds)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Current month grid */}
+          <div style={{ width: "100%", maxWidth: "480px" }}>
             <div style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: "11px", color: "var(--fg-4)", width: isMobile ? "80px" : "120px",
+              fontFamily: "var(--font-serif)",
+              fontSize: "14px", color: "var(--fg-2)",
+              marginBottom: "12px", letterSpacing: "0.07em", textTransform: "uppercase",
+              textAlign: "center",
             }}>
-              {todayDuration}s
+              {monthGrid.monthLabel}
+            </div>
+
+            <div style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(7, 1fr)",
+              gap: "4px",
+            }}>
+              {WEEKDAY_LABELS.map((label, i) => (
+                <div
+                  key={`${label}-${i}`}
+                  style={{
+                    ...mono, fontSize: "10px", color: "var(--fg-3)",
+                    textAlign: "center", paddingBottom: "4px",
+                  }}
+                >
+                  {label}
+                </div>
+              ))}
+
+              {monthGrid.cells.map((cell, idx) => {
+                if (cell.kind === "blank") {
+                  return <div key={`blank-${idx}`} style={{ minHeight: cellSize }} />;
+                }
+
+                const { day } = cell;
+                const isTodayCell = day.isoDate === todayDate;
+                const isMeditated = day.state === "meditated";
+                const isMissed = day.state === "missed";
+                const isFuture = day.state === "future";
+
+                const bg = isMeditated
+                  ? "var(--accent-green-bg)"
+                  : isTodayCell
+                    ? "var(--surface-3)"
+                    : "var(--surface-1)";
+                const border = isTodayCell
+                  ? "2px solid var(--border-3)"
+                  : isMeditated
+                    ? "1px solid var(--accent-green-border)"
+                    : "1px solid var(--border-1)";
+
+                return (
+                  <div
+                    key={day.isoDate}
+                    title={day.durationLabels.length > 0 ? day.durationLabels.join(", ") : undefined}
+                    style={{
+                      minHeight: cellSize,
+                      borderRadius: "4px",
+                      border,
+                      background: bg,
+                      opacity: isMissed ? 0.45 : isFuture ? 0.35 : 1,
+                      display: "flex",
+                      flexDirection: "column",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      gap: "2px",
+                      padding: "2px",
+                    }}
+                  >
+                    <span style={{
+                      ...mono, fontSize: isMobile ? "10px" : "11px",
+                      color: isMeditated ? "var(--accent-green-dim)" : "var(--fg-3)",
+                      lineHeight: 1,
+                    }}>
+                      {day.dayOfMonth}
+                    </span>
+                    {day.durationLabels.length > 0 && (
+                      <span style={{
+                        ...mono, fontSize: "8px", color: "var(--fg-4)",
+                        lineHeight: 1, textAlign: "center",
+                        maxWidth: "100%", overflow: "hidden", textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}>
+                        {day.durationLabels.join(", ")}
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Legend */}
+            <div style={{ display: "flex", gap: "16px", marginTop: "16px", justifyContent: "center", flexWrap: "wrap" }}>
+              {[
+                { color: "var(--accent-green-bg)", border: "var(--accent-green-border)", label: "meditated" },
+                { color: "var(--surface-1)", border: "var(--border-1)", label: "missed" },
+                { color: "var(--surface-3)", border: "var(--border-3)", label: "today" },
+              ].map(l => (
+                <div key={l.label} style={{
+                  display: "flex", alignItems: "center", gap: "6px",
+                  ...mono, fontSize: "10px", color: "var(--fg-3)",
+                }}>
+                  <div style={{
+                    width: "10px", height: "10px", borderRadius: "2px",
+                    background: l.color, border: `1px solid ${l.border}`,
+                  }} />
+                  {l.label}
+                </div>
+              ))}
             </div>
           </div>
-        </div>
+        </>
+      ) : (
+        /* Journey — relative session buildup (gap-collapse per #421) */
+        <div style={{ width: "100%", maxWidth: "660px" }}>
+          <div style={{
+            fontFamily: "var(--font-serif)",
+            fontSize: "14px", color: "var(--fg-2)",
+            marginBottom: "20px", letterSpacing: "0.07em", textTransform: "uppercase",
+          }}>
+            Journey
+          </div>
 
-        {/* Legend */}
-        <div style={{ display: "flex", gap: "20px", marginTop: "20px", justifyContent: "center" }}>
-          {[
-            { color: "var(--accent-green)", label: "clear mind" },
-            { color: "var(--accent-amber)", label: "thinking" },
-            { color: "var(--border-2)", label: "today" },
-          ].map(l => (
-            <div key={l.label} style={{
-              display: "flex", alignItems: "center", gap: "6px",
-              fontFamily: "var(--font-mono)",
-              fontSize: "11px", color: "var(--fg-3)",
-            }}>
+          <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+            {history.map((entry, idx) => {
+              const prev = idx > 0 ? history[idx - 1] : undefined;
+              const showDateColumn = entry.missed
+                ? true
+                : !prev || prev.missed || prev.date !== entry.date;
+
+              if (entry.collapsed) {
+                const rangeLabel = `${formatCompactDateLabel(entry.date)} – ${formatCompactDateLabel(entry.collapsedEndDate ?? entry.date)}`;
+                return (
+                  <div key={`collapsed-${idx}`} style={{
+                    display: "flex", alignItems: "center", gap: isMobile ? "8px" : "12px",
+                    padding: "2px 0", opacity: 0.35,
+                  }}>
+                    <div style={{
+                      ...mono, fontSize: isMobile ? "10px" : "11px", color: "var(--fg-4)",
+                      width: isMobile ? undefined : "160px", minWidth: isMobile ? "72px" : undefined,
+                      textAlign: "right", whiteSpace: "nowrap",
+                    }}>
+                      {rangeLabel}
+                    </div>
+                    <div style={{
+                      ...mono, fontSize: "11px", color: "var(--fg-3)",
+                      width: sessionLabelColWidth, textAlign: "right",
+                    }}>
+                      &mdash;
+                    </div>
+                    <div style={{
+                      flex: 1, height: "24px", borderRadius: "3px",
+                      border: "1px dashed var(--border-1)",
+                      display: "flex", alignItems: "center", paddingLeft: "10px",
+                    }}>
+                      <span style={{ ...mono, fontSize: "11px", color: "var(--fg-4)", fontStyle: "italic" }}>
+                        {entry.collapsedDayCount} days missed
+                      </span>
+                    </div>
+                    <div style={{ width: isMobile ? "80px" : "120px" }} />
+                  </div>
+                );
+              }
+
+              if (entry.missed) {
+                const dateLabel = formatFullDateLabel(entry.date);
+                return (
+                  <div key={`missed-${idx}`} style={{
+                    display: "flex", alignItems: "center", gap: isMobile ? "8px" : "12px",
+                    padding: "2px 0", opacity: 0.35,
+                  }}>
+                    {!isMobile ? (
+                      <div style={{
+                        ...mono, fontSize: "11px", color: "var(--fg-4)",
+                        width: "160px", textAlign: "right", whiteSpace: "nowrap",
+                      }}>
+                        {dateLabel}
+                      </div>
+                    ) : (
+                      <div style={{
+                        ...mono, fontSize: "10px", color: "var(--fg-4)",
+                        minWidth: "72px", textAlign: "right", whiteSpace: "nowrap",
+                      }}>
+                        {formatShortDateLabel(entry.date)}
+                      </div>
+                    )}
+                    <div style={{
+                      ...mono, fontSize: "11px", color: "var(--fg-3)",
+                      width: sessionLabelColWidth, textAlign: "right",
+                    }}>
+                      &mdash;
+                    </div>
+                    <div style={{
+                      flex: 1, height: "24px", borderRadius: "3px",
+                      border: "1px dashed var(--border-1)",
+                      display: "flex", alignItems: "center", paddingLeft: "10px",
+                    }}>
+                      <span style={{ ...mono, fontSize: "11px", color: "var(--fg-4)", fontStyle: "italic" }}>
+                        missed
+                      </span>
+                    </div>
+                    <div style={{ width: isMobile ? "80px" : "120px" }} />
+                  </div>
+                );
+              }
+
+              const dateLabelFull = formatFullDateLabel(entry.date);
+              const dateLabelShort = formatShortDateLabel(entry.date);
+              const isQuick = entry.sessionType === "quick";
+              const isBreath = entry.sessionType === "breath";
+              const sessionOrdinal = entry.sessionIndexInDay ?? 1;
+              const sessionLabel = isQuick ? "Quick" : isBreath ? "Breath" : `Session ${sessionOrdinal}`;
+
+              const entryId = entry.sessionId ? `sess-${entry.sessionId}` : `day-${entry.day}-${idx}`;
+              const isExpanded = expandedEntryId === entryId;
+              const entryThoughts = getThoughtsForSession(entry.sessionId);
+              const canExpand = entryThoughts.length > 0;
+
+              return (
+                <div key={entryId}>
+                  <div
+                    role={canExpand ? "button" : undefined}
+                    tabIndex={canExpand ? 0 : undefined}
+                    aria-expanded={canExpand ? isExpanded : undefined}
+                    aria-controls={canExpand ? `${entryId}-thoughts` : undefined}
+                    onClick={() => {
+                      if (canExpand) setExpandedEntryId(isExpanded ? null : entryId);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        if (canExpand) setExpandedEntryId(isExpanded ? null : entryId);
+                      }
+                    }}
+                    style={{
+                      display: "flex", alignItems: "center", gap: isMobile ? "8px" : "12px",
+                      cursor: canExpand ? "pointer" : "default", padding: "2px 0", borderRadius: "4px",
+                      transition: "background 0.2s", outline: "none",
+                    }}
+                    onFocus={e => {
+                      if (e.currentTarget.matches(":focus-visible")) {
+                        e.currentTarget.style.background = "var(--surface-1)";
+                        e.currentTarget.style.outline = "2px solid var(--border-3)";
+                        e.currentTarget.style.outlineOffset = "2px";
+                      }
+                    }}
+                    onBlur={e => {
+                      e.currentTarget.style.outline = "none";
+                      e.currentTarget.style.background = "none";
+                    }}
+                    onMouseEnter={e => e.currentTarget.style.background = "var(--surface-1)"}
+                    onMouseLeave={e => e.currentTarget.style.background = "none"}
+                  >
+                    {!isMobile && (
+                      <div style={{
+                        ...mono, fontSize: "11px", color: "var(--fg-4)",
+                        width: "160px", textAlign: "right", whiteSpace: "nowrap",
+                      }}>
+                        {showDateColumn ? dateLabelFull : ""}
+                      </div>
+                    )}
+                    {isMobile && (
+                      <div style={{
+                        ...mono, fontSize: "10px", color: "var(--fg-4)",
+                        minWidth: "72px", textAlign: "right", whiteSpace: "nowrap",
+                      }}>
+                        {showDateColumn ? dateLabelShort : ""}
+                      </div>
+                    )}
+                    <div style={{
+                      ...mono, fontSize: "11px", color: isQuick ? "var(--fg-4)" : "var(--fg-3)",
+                      width: sessionLabelColWidth, textAlign: "right",
+                    }}>
+                      {sessionLabel}
+                    </div>
+                    <div style={{
+                      flex: 1, height: "24px", borderRadius: "3px", overflow: "hidden",
+                      background: "var(--surface-1)", position: "relative",
+                    }}>
+                      <div style={{
+                        height: "100%",
+                        width: `${(entry.actualTime / maxDuration) * 100}%`,
+                        borderRadius: "3px", overflow: "hidden", display: "flex",
+                        opacity: isQuick ? 0.55 : 1,
+                      }}>
+                        <div style={{
+                          width: `${entry.clearPercent}%`, height: "100%",
+                          background: "linear-gradient(to right, var(--accent-green), var(--accent-green-end))",
+                          opacity: entry.completed ? 0.7 : 0.4,
+                        }} />
+                        <div style={{
+                          width: `${100 - entry.clearPercent}%`, height: "100%",
+                          background: "linear-gradient(to right, var(--accent-amber), var(--accent-amber-end))",
+                          opacity: entry.completed ? 0.5 : 0.3,
+                        }} />
+                      </div>
+                    </div>
+                    <div style={{
+                      ...mono, fontSize: "11px",
+                      color: entry.completed ? "var(--accent-green-dim)" : "var(--accent-danger-muted)",
+                      width: isMobile ? "80px" : "120px", display: "flex", gap: "6px", flexWrap: "wrap",
+                    }}>
+                      <span style={{ color: "var(--fg-3)" }}>{entry.actualTime}s</span>
+                      <span style={{ color: "var(--fg-4)" }}>&middot;</span>
+                      <span>{entry.clearPercent}%</span>
+                      <span style={{ color: "var(--fg-4)" }}>&middot;</span>
+                      <span style={{ color: "var(--accent-amber-border)" }}>{entry.thoughtCount}\uD83D\uDCAD</span>
+                      {entry.bonusSeconds > 0 && (
+                        <>
+                          <span style={{ color: "var(--fg-4)" }}>&middot;</span>
+                          <span style={{ color: "var(--fg-2)" }}>+{Math.round(entry.bonusSeconds / 60)}m bonus</span>
+                        </>
+                      )}
+                    </div>
+                  </div>
+
+                  {canExpand && isExpanded && (
+                    <div
+                      id={`${entryId}-thoughts`}
+                      role="region"
+                      aria-label={`${sessionLabel} on ${dateLabelFull} captured thoughts`}
+                      style={{
+                        marginLeft: isMobile ? "44px" : "216px", marginTop: "4px", marginBottom: "8px",
+                        padding: "10px 14px", background: "var(--surface-1)",
+                        borderLeft: "2px solid var(--accent-amber-bg)",
+                        borderRadius: "0 6px 6px 0", animation: "fadeIn 0.2s ease",
+                      }}
+                    >
+                      {entryThoughts.map((t) => (
+                        <div key={t.id} style={{ display: "flex", gap: "10px", alignItems: "baseline", padding: "3px 0" }}>
+                          <span style={{
+                            ...mono, fontSize: "11px", color: "var(--accent-amber-hint)", whiteSpace: "nowrap",
+                          }}>
+                            @{t.timeInSession}s
+                          </span>
+                          <span style={{
+                            fontFamily: "var(--font-serif)",
+                            fontSize: "13px", fontStyle: "italic", color: "var(--fg-2)",
+                          }}>
+                            {t.text}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+
+            <div style={{ display: "flex", alignItems: "center", gap: isMobile ? "8px" : "12px" }}>
+              {!isMobile && (
+                <div style={{
+                  ...mono, fontSize: "11px", color: "var(--fg-4)",
+                  width: "160px", textAlign: "right", whiteSpace: "nowrap",
+                }}>
+                  today
+                </div>
+              )}
+              {isMobile && (
+                <div style={{
+                  ...mono, fontSize: "10px", color: "var(--fg-4)",
+                  minWidth: "72px", textAlign: "right", whiteSpace: "nowrap",
+                }} />
+              )}
               <div style={{
-                width: "10px", height: "10px", borderRadius: "2px",
-                background: l.color, opacity: l.label === "today" ? 1 : 0.6,
-              }} />
-              {l.label}
+                ...mono, fontSize: "11px", color: "var(--fg-4)",
+                width: sessionLabelColWidth, textAlign: "right",
+              }}>
+                D{currentDay}
+              </div>
+              <div style={{
+                flex: 1, height: "24px", borderRadius: "3px", overflow: "hidden",
+                background: "var(--surface-1)",
+                border: "1px dashed var(--surface-3)",
+              }}>
+                <div style={{
+                  height: "100%",
+                  width: `${(todayDuration / maxDuration) * 100}%`,
+                  background: "linear-gradient(to right, var(--surface-3), var(--surface-1))",
+                  borderRadius: "3px",
+                }} />
+              </div>
+              <div style={{
+                ...mono, fontSize: "11px", color: "var(--fg-4)", width: isMobile ? "80px" : "120px",
+              }}>
+                {todayDuration}s
+              </div>
             </div>
-          ))}
-        </div>
-      </div>
+          </div>
 
-      <p style={{
-        fontFamily: "var(--font-mono)",
-        fontSize: "11px", color: "var(--fg-4)", textAlign: "center",
-      }}>
-        click any session row to see captured thoughts
-      </p>
+          <div style={{ display: "flex", gap: "20px", marginTop: "20px", justifyContent: "center" }}>
+            {[
+              { color: "var(--accent-green)", label: "clear mind" },
+              { color: "var(--accent-amber)", label: "thinking" },
+              { color: "var(--border-2)", label: "today" },
+            ].map(l => (
+              <div key={l.label} style={{
+                display: "flex", alignItems: "center", gap: "6px",
+                ...mono, fontSize: "11px", color: "var(--fg-3)",
+              }}>
+                <div style={{
+                  width: "10px", height: "10px", borderRadius: "2px",
+                  background: l.color, opacity: l.label === "today" ? 1 : 0.6,
+                }} />
+                {l.label}
+              </div>
+            ))}
+          </div>
+
+          <p style={{
+            ...mono, fontSize: "11px", color: "var(--fg-4)", textAlign: "center", marginTop: "16px",
+          }}>
+            click any session row to see captured thoughts
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -189,14 +189,20 @@ export const api = {
   me: () =>
     request<{ user: User }>("/api/auth/me"),
 
-  getSessions: () =>
+  getSessions: (today?: string) =>
     request<{ sessions: Session[]; stats: {
       streak: number;
       avgClearPercent: number;
       avgThoughtsPerSession: number;
       avgThoughtsPerMinute: number;
       bonusMinutesTotal: number;
-    } }>("/api/sessions"),
+      trailing4WeekDays: number;
+      trailing4WeekDayPercent: number;
+      trailing4WeekTotalTime: number;
+      trailing4WeekTimePercent: number;
+      totalTimeAllTime: number;
+      progressTo10kHours: number;
+    } }>(today ? `/api/sessions?today=${encodeURIComponent(today)}` : "/api/sessions"),
 
   createSession: (data: {
     dayNumber: number;

--- a/src/lib/historyMonthGrid.test.ts
+++ b/src/lib/historyMonthGrid.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildCurrentMonthGrid,
+  buildPriorMonthSummaries,
+  formatSessionDurationLabel,
+  formatTotalTime,
+} from "./historyMonthGrid";
+
+describe("formatSessionDurationLabel", () => {
+  test("shows seconds under one minute", () => {
+    expect(formatSessionDurationLabel(45)).toBe("45s");
+  });
+
+  test("shows rounded minutes at or above one minute", () => {
+    expect(formatSessionDurationLabel(480)).toBe("8m");
+  });
+});
+
+describe("buildCurrentMonthGrid", () => {
+  test("marks days with any session as meditated and missed days as gray state", () => {
+    const grid = buildCurrentMonthGrid(
+      [
+        { sessionDate: "2026-07-01", duration: 480, actualTime: 480 },
+        { sessionDate: "2026-07-02", duration: 60, actualTime: 60, sessionType: "quick" } as never,
+      ],
+      "2026-07-02",
+    );
+
+    expect(grid.yearMonth).toBe("2026-07");
+    const dayCells = grid.cells.filter(c => c.kind === "day").map(c => c.day!);
+    const jul1 = dayCells.find(d => d.isoDate === "2026-07-01")!;
+    const jul2 = dayCells.find(d => d.isoDate === "2026-07-02")!;
+    const jul3 = dayCells.find(d => d.isoDate === "2026-07-03")!;
+
+    expect(jul1.state).toBe("meditated");
+    expect(jul1.durationLabels).toEqual(["8m"]);
+    expect(jul2.state).toBe("meditated");
+    expect(jul3.state).toBe("future");
+  });
+
+  test("shows today without a session as today state", () => {
+    const grid = buildCurrentMonthGrid(
+      [{ sessionDate: "2026-07-01", duration: 60, actualTime: 60 }],
+      "2026-07-02",
+    );
+    const today = grid.cells
+      .filter(c => c.kind === "day")
+      .map(c => c.day!)
+      .find(d => d.isoDate === "2026-07-02")!;
+    expect(today.state).toBe("today");
+  });
+
+  test("comma-delimits multiple sessions on one day via durationLabels", () => {
+    const grid = buildCurrentMonthGrid(
+      [
+        { sessionDate: "2026-07-01", duration: 480, actualTime: 480 },
+        { sessionDate: "2026-07-01", duration: 60, actualTime: 60 },
+      ],
+      "2026-07-02",
+    );
+    const jul1 = grid.cells
+      .filter(c => c.kind === "day")
+      .map(c => c.day!)
+      .find(d => d.isoDate === "2026-07-01")!;
+    expect(jul1.durationLabels).toEqual(["8m", "1m"]);
+  });
+});
+
+describe("buildPriorMonthSummaries", () => {
+  test("aggregates days active and total time for months before current", () => {
+    const summaries = buildPriorMonthSummaries(
+      [
+        { sessionDate: "2026-05-10", duration: 600, actualTime: 600 },
+        { sessionDate: "2026-05-20", duration: 300, actualTime: 300 },
+        { sessionDate: "2026-06-15", duration: 120, actualTime: 120 },
+        { sessionDate: "2026-07-01", duration: 60, actualTime: 60 },
+      ],
+      "2026-07-02",
+    );
+
+    expect(summaries.map(s => s.yearMonth)).toEqual(["2026-05", "2026-06"]);
+    expect(summaries[0]).toMatchObject({ daysActive: 2, daysInMonth: 31, totalTimeSeconds: 900 });
+    expect(summaries[1]).toMatchObject({ daysActive: 1, daysInMonth: 30, totalTimeSeconds: 120 });
+  });
+
+  test("returns empty when all sessions are in the current month", () => {
+    expect(
+      buildPriorMonthSummaries(
+        [{ sessionDate: "2026-07-01", duration: 60, actualTime: 60 }],
+        "2026-07-02",
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("formatTotalTime", () => {
+  test("formats hours and minutes", () => {
+    expect(formatTotalTime(8100)).toBe("2h 15m");
+    expect(formatTotalTime(3600)).toBe("1h");
+    expect(formatTotalTime(90)).toBe("2m");
+  });
+});

--- a/src/lib/historyMonthGrid.ts
+++ b/src/lib/historyMonthGrid.ts
@@ -176,7 +176,7 @@ export function buildPriorMonthSummaries(
 export function formatTotalTime(seconds: number): string {
   if (seconds < 60) return `${seconds}s`;
   const hours = Math.floor(seconds / 3600);
-  const minutes = Math.round((seconds % 3600) / 60);
+  const minutes = Math.floor((seconds % 3600) / 60);
   if (hours === 0) return `${minutes}m`;
   if (minutes === 0) return `${hours}h`;
   return `${hours}h ${minutes}m`;

--- a/src/lib/historyMonthGrid.ts
+++ b/src/lib/historyMonthGrid.ts
@@ -66,7 +66,7 @@ function groupSessionsByDate(
 }
 
 function dayState(isoDate: string, todayIso: string, hasSession: boolean): MonthDayState {
-  if (isoDate > todayIso) return "future";
+  if (isoDate > todayIso) return hasSession ? "meditated" : "future";
   if (isoDate === todayIso) return hasSession ? "meditated" : "today";
   return hasSession ? "meditated" : "missed";
 }
@@ -176,7 +176,9 @@ export function buildPriorMonthSummaries(
 export function formatTotalTime(seconds: number): string {
   if (seconds < 60) return `${seconds}s`;
   const hours = Math.floor(seconds / 3600);
-  const minutes = Math.floor((seconds % 3600) / 60);
+  const minutes = hours === 0
+    ? Math.round(seconds / 60)
+    : Math.floor((seconds % 3600) / 60);
   if (hours === 0) return `${minutes}m`;
   if (minutes === 0) return `${hours}h`;
   return `${hours}h ${minutes}m`;

--- a/src/lib/historyMonthGrid.ts
+++ b/src/lib/historyMonthGrid.ts
@@ -1,0 +1,183 @@
+import { isValidSessionCalendarDate } from "./sessionCalendar";
+import { sessionTimeSeconds, type HistorySessionTimeInput } from "./historyStats";
+
+export type MonthDayState = "future" | "today" | "meditated" | "missed";
+
+export type MonthGridDay = {
+  isoDate: string;
+  dayOfMonth: number;
+  state: MonthDayState;
+  /** Short labels per session that day, e.g. ["8m", "1m"]. */
+  durationLabels: string[];
+};
+
+export type MonthGridCell =
+  | { kind: "blank" }
+  | { kind: "day"; day: MonthGridDay };
+
+export type PriorMonthSummary = {
+  yearMonth: string;
+  label: string;
+  daysActive: number;
+  daysInMonth: number;
+  totalTimeSeconds: number;
+};
+
+function parseYearMonth(isoDate: string): { year: number; month: number } {
+  const [y, m] = isoDate.split("-").map(Number);
+  return { year: y, month: m };
+}
+
+function yearMonthKey(year: number, month: number): string {
+  return `${year}-${String(month).padStart(2, "0")}`;
+}
+
+function daysInCalendarMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+function weekdayUtc(isoDate: string): number {
+  const [y, m, d] = isoDate.split("-").map(Number);
+  return new Date(Date.UTC(y, m - 1, d)).getUTCDay();
+}
+
+function monthLabel(year: number, month: number): string {
+  const d = new Date(Date.UTC(year, month - 1, 1, 12));
+  return d.toLocaleDateString("en-US", { month: "long", year: "numeric", timeZone: "UTC" });
+}
+
+/** Format sit length for calendar cells — minutes when ≥60s, else seconds. */
+export function formatSessionDurationLabel(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  return `${minutes}m`;
+}
+
+function groupSessionsByDate(
+  sessions: HistorySessionTimeInput[],
+): Map<string, HistorySessionTimeInput[]> {
+  const map = new Map<string, HistorySessionTimeInput[]>();
+  for (const session of sessions) {
+    if (!isValidSessionCalendarDate(session.sessionDate)) continue;
+    const date = session.sessionDate!;
+    (map.get(date) ?? map.set(date, []).get(date)!).push(session);
+  }
+  return map;
+}
+
+function dayState(isoDate: string, todayIso: string, hasSession: boolean): MonthDayState {
+  if (isoDate > todayIso) return "future";
+  if (isoDate === todayIso) return hasSession ? "meditated" : "today";
+  return hasSession ? "meditated" : "missed";
+}
+
+/**
+ * Builds a Sunday-start month grid for the calendar month containing `todayIso`.
+ * Any session on a day (including quick sits) marks the cell meditated (#379/#83).
+ */
+export function buildCurrentMonthGrid(
+  sessions: HistorySessionTimeInput[],
+  todayIso: string,
+): { yearMonth: string; monthLabel: string; cells: MonthGridCell[] } {
+  const { year, month } = parseYearMonth(todayIso);
+  const ym = yearMonthKey(year, month);
+  const byDate = groupSessionsByDate(sessions);
+  const dim = daysInCalendarMonth(year, month);
+  const firstIso = `${ym}-01`;
+  const leadingBlanks = weekdayUtc(firstIso);
+
+  const cells: MonthGridCell[] = [];
+  for (let i = 0; i < leadingBlanks; i++) {
+    cells.push({ kind: "blank" });
+  }
+
+  for (let day = 1; day <= dim; day++) {
+    const dd = String(day).padStart(2, "0");
+    const isoDate = `${ym}-${dd}`;
+    const daySessions = byDate.get(isoDate) ?? [];
+    const durationLabels = daySessions.map(s => formatSessionDurationLabel(sessionTimeSeconds(s)));
+    cells.push({
+      kind: "day",
+      day: {
+        isoDate,
+        dayOfMonth: day,
+        state: dayState(isoDate, todayIso, daySessions.length > 0),
+        durationLabels,
+      },
+    });
+  }
+
+  return { yearMonth: ym, monthLabel: monthLabel(year, month), cells };
+}
+
+/**
+ * One compact row per calendar month strictly before the month of `todayIso`.
+ * Spans from the earliest session month through the month before current.
+ */
+export function buildPriorMonthSummaries(
+  sessions: HistorySessionTimeInput[],
+  todayIso: string,
+): PriorMonthSummary[] {
+  const { year: todayYear, month: todayMonth } = parseYearMonth(todayIso);
+  const currentYm = yearMonthKey(todayYear, todayMonth);
+
+  const validDates = sessions
+    .map(s => s.sessionDate)
+    .filter((d): d is string => isValidSessionCalendarDate(d));
+  if (validDates.length === 0) return [];
+
+  const earliest = validDates.reduce((a, b) => (a < b ? a : b));
+  const { year: startYear, month: startMonth } = parseYearMonth(earliest);
+  const byDate = groupSessionsByDate(sessions);
+
+  const summaries: PriorMonthSummary[] = [];
+  let y = startYear;
+  let m = startMonth;
+
+  while (true) {
+    const ym = yearMonthKey(y, m);
+    if (ym >= currentYm) break;
+
+    const dim = daysInCalendarMonth(y, m);
+    let daysActive = 0;
+    let totalTimeSeconds = 0;
+
+    for (let day = 1; day <= dim; day++) {
+      const dd = String(day).padStart(2, "0");
+      const isoDate = `${ym}-${dd}`;
+      const daySessions = byDate.get(isoDate);
+      if (daySessions && daySessions.length > 0) {
+        daysActive++;
+        for (const s of daySessions) {
+          totalTimeSeconds += sessionTimeSeconds(s);
+        }
+      }
+    }
+
+    summaries.push({
+      yearMonth: ym,
+      label: monthLabel(y, m),
+      daysActive,
+      daysInMonth: dim,
+      totalTimeSeconds,
+    });
+
+    m++;
+    if (m > 12) {
+      m = 1;
+      y++;
+    }
+  }
+
+  return summaries;
+}
+
+/** Human-readable total time for summary rows. */
+export function formatTotalTime(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.round((seconds % 3600) / 60);
+  if (hours === 0) return `${minutes}m`;
+  if (minutes === 0) return `${hours}h`;
+  return `${hours}h ${minutes}m`;
+}

--- a/src/lib/historyStats.test.ts
+++ b/src/lib/historyStats.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import { calculateHistoryPeriodStats, sessionTimeSeconds } from "./historyStats";
+
+describe("sessionTimeSeconds", () => {
+  test("uses actualTime and includes bonus seconds", () => {
+    expect(sessionTimeSeconds({ duration: 60, actualTime: 90, bonusSeconds: 30 })).toBe(120);
+  });
+
+  test("falls back to duration when actualTime is null", () => {
+    expect(sessionTimeSeconds({ duration: 300, actualTime: null })).toBe(300);
+  });
+});
+
+describe("calculateHistoryPeriodStats", () => {
+  const today = "2026-07-02";
+
+  test("counts unique session dates and sums time in trailing 28 days", () => {
+    const stats = calculateHistoryPeriodStats(
+      [
+        { sessionDate: "2026-05-01", duration: 60, actualTime: 60 },
+        { sessionDate: "2026-07-01", duration: 120, actualTime: 120 },
+        { sessionDate: "2026-07-02", duration: 60, actualTime: 60 },
+        { sessionDate: "2026-07-02", duration: 60, actualTime: 30 },
+      ],
+      today,
+    );
+
+    expect(stats.trailing4WeekDays).toBe(2);
+    expect(stats.trailing4WeekTotalTime).toBe(210);
+    expect(stats.trailing4WeekDayPercent).toBeCloseTo(7.1, 1);
+    expect(stats.trailing4WeekTimePercent).toBeCloseTo(0.01, 2);
+  });
+
+  test("computes all-time total and 10k-hour progress", () => {
+    const stats = calculateHistoryPeriodStats(
+      [
+        { sessionDate: "2026-01-01", duration: 3600, actualTime: 3600 },
+        { sessionDate: "2026-07-02", duration: 600, actualTime: 600 },
+      ],
+      today,
+    );
+
+    expect(stats.totalTimeAllTime).toBe(4200);
+    expect(stats.progressTo10kHours).toBeCloseTo(0.01, 2);
+  });
+
+  test("returns zeros when there are no sessions", () => {
+    expect(calculateHistoryPeriodStats([], today)).toEqual({
+      trailing4WeekDays: 0,
+      trailing4WeekDayPercent: 0,
+      trailing4WeekTotalTime: 0,
+      trailing4WeekTimePercent: 0,
+      totalTimeAllTime: 0,
+      progressTo10kHours: 0,
+    });
+  });
+
+  test("excludes sessions outside the trailing window from period counts but includes in all-time", () => {
+    const stats = calculateHistoryPeriodStats(
+      [{ sessionDate: "2026-05-01", duration: 100, actualTime: 100 }],
+      today,
+    );
+    expect(stats.trailing4WeekDays).toBe(0);
+    expect(stats.totalTimeAllTime).toBe(100);
+  });
+});

--- a/src/lib/historyStats.test.ts
+++ b/src/lib/historyStats.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, test } from "vitest";
 import { calculateHistoryPeriodStats, sessionTimeSeconds } from "./historyStats";
 
 describe("sessionTimeSeconds", () => {
-  test("uses actualTime and includes bonus seconds", () => {
-    expect(sessionTimeSeconds({ duration: 60, actualTime: 90, bonusSeconds: 30 })).toBe(120);
+  test("uses actualTime when present", () => {
+    expect(sessionTimeSeconds({ duration: 60, actualTime: 90, bonusSeconds: 30 })).toBe(90);
   });
 
   test("falls back to duration when actualTime is null", () => {

--- a/src/lib/historyStats.ts
+++ b/src/lib/historyStats.ts
@@ -20,10 +20,9 @@ export type HistoryPeriodStats = {
   progressTo10kHours: number;
 };
 
-/** Seconds counted toward history time totals (actual sit + bonus extensions). */
+/** Seconds counted toward history time totals (elapsed wall time for the sit). */
 export function sessionTimeSeconds(session: HistorySessionTimeInput): number {
-  const base = session.actualTime ?? session.duration;
-  return base + (session.bonusSeconds ?? 0);
+  return session.actualTime ?? session.duration;
 }
 
 /**

--- a/src/lib/historyStats.ts
+++ b/src/lib/historyStats.ts
@@ -1,0 +1,72 @@
+import { addDaysToIsoDate, isValidSessionCalendarDate } from "./sessionCalendar";
+
+export const TRAILING_4_WEEK_DAYS = 28;
+const SECONDS_IN_4_WEEKS = TRAILING_4_WEEK_DAYS * 24 * 60 * 60;
+const TEN_THOUSAND_HOURS_SECONDS = 10_000 * 60 * 60;
+
+export type HistorySessionTimeInput = {
+  sessionDate?: string;
+  actualTime?: number | null;
+  duration: number;
+  bonusSeconds?: number;
+};
+
+export type HistoryPeriodStats = {
+  trailing4WeekDays: number;
+  trailing4WeekDayPercent: number;
+  trailing4WeekTotalTime: number;
+  trailing4WeekTimePercent: number;
+  totalTimeAllTime: number;
+  progressTo10kHours: number;
+};
+
+/** Seconds counted toward history time totals (actual sit + bonus extensions). */
+export function sessionTimeSeconds(session: HistorySessionTimeInput): number {
+  const base = session.actualTime ?? session.duration;
+  return base + (session.bonusSeconds ?? 0);
+}
+
+/**
+ * Trailing 4-week and all-time stats for the History view (#83).
+ * `todayIso` should match the client's local calendar day (same convention as
+ * `sessionDate` stamping) so the window ends on the user's "today".
+ */
+export function calculateHistoryPeriodStats(
+  sessions: HistorySessionTimeInput[],
+  todayIso: string,
+): HistoryPeriodStats {
+  const periodStart = addDaysToIsoDate(todayIso, -(TRAILING_4_WEEK_DAYS - 1));
+  const datesInPeriod = new Set<string>();
+  let trailing4WeekTotalTime = 0;
+  let totalTimeAllTime = 0;
+
+  for (const session of sessions) {
+    if (!isValidSessionCalendarDate(session.sessionDate)) continue;
+    const secs = sessionTimeSeconds(session);
+    totalTimeAllTime += secs;
+    if (session.sessionDate! >= periodStart && session.sessionDate! <= todayIso) {
+      datesInPeriod.add(session.sessionDate!);
+      trailing4WeekTotalTime += secs;
+    }
+  }
+
+  const trailing4WeekDays = datesInPeriod.size;
+  const trailing4WeekDayPercent = parseFloat(
+    ((trailing4WeekDays / TRAILING_4_WEEK_DAYS) * 100).toFixed(1),
+  );
+  const trailing4WeekTimePercent = parseFloat(
+    ((trailing4WeekTotalTime / SECONDS_IN_4_WEEKS) * 100).toFixed(2),
+  );
+  const progressTo10kHours = parseFloat(
+    ((totalTimeAllTime / TEN_THOUSAND_HOURS_SECONDS) * 100).toFixed(2),
+  );
+
+  return {
+    trailing4WeekDays,
+    trailing4WeekDayPercent,
+    trailing4WeekTotalTime,
+    trailing4WeekTimePercent,
+    totalTimeAllTime,
+    progressTo10kHours,
+  };
+}


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #83

## Summary

Redesigns the web History tab with a calendar-first layout and server-computed period stats.

### API (`GET /api/sessions`)
- Accepts optional `?today=YYYY-MM-DD` (client local day) for accurate trailing-window boundaries
- Returns new stats alongside existing ones:
  - `trailing4WeekDays` / `trailing4WeekDayPercent`
  - `trailing4WeekTotalTime` / `trailing4WeekTimePercent`
  - `totalTimeAllTime` / `progressTo10kHours`

### HistoryView
- **Calendar** (default): trailing-4-week stat cards, all-time 10k-hour progress bar, compact prior-month summary rows, CSS Grid month calendar for the current month (green = any session incl. quick, gray = missed, today highlighted, comma-delimited durations in cells)
- **Session buildup** toggle: preserves the existing journey list with #421 gap-collapse behavior

### New libs (unit tested)
- `src/lib/historyStats.ts` — trailing 4-week + all-time aggregation
- `src/lib/historyMonthGrid.ts` — month grid day states + prior-month summaries

## Test plan

- [x] `npm run test:unit -- src/lib/historyStats.test.ts src/lib/historyMonthGrid.test.ts src/lib/historyJourney.test.ts` — 502 passed
- [x] `npm run typecheck`
- [ ] Manual: open History tab — calendar grid shows current month with green/gray/today cells
- [ ] Manual: account with prior-month sessions — compact summary rows appear above the grid
- [ ] Manual: multi-session day shows comma-delimited durations in the cell (e.g. `8m, 1m`)
- [ ] Manual: toggle "Session buildup" — journey list renders with collapsed 3+ day gaps (#421)
- [ ] Manual: account with a month-long gap — grid + summaries render (no empty view, #379 regression)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5289eea2-8cb3-4806-aabf-480a0708757b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5289eea2-8cb3-4806-aabf-480a0708757b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Redesign the History tab with a month calendar and compact month summaries**

### What Changed
- The History tab now opens in a calendar view for the current month, with clear states for meditated, missed, today, and future days.
- Days with more than one session show multiple duration labels in the cell, and earlier months are shown as compact summary rows above the grid.
- A new trailing 4-week stats block and 10,000-hour progress bar appear in the calendar view.
- The old session list is still available through a “Session buildup” toggle, keeping the existing thought expansion behavior.
- History stats stay correct after midnight and use the local day passed from the client.

### Impact
`✅ Faster at-a-glance progress checks`
`✅ Clearer monthly streak review`
`✅ Fewer wrong day totals after midnight` 
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
