### PR TITLE
feat(infra): add persistent web staging environment (#332)

### DIFF
--- a/.github/workflows/staging-promotion.yml
+++ b/.github/workflows/staging-promotion.yml
@@ -1,0 +1,80 @@
+name: Staging Promotion
+
+# After each push to `staging`, open (or refresh) a promotion PR to `main`.
+# Production deploys only when that PR merges — branch protection on `main`
+# remains the gate (Web Build, unit tests, Vercel, review, etc.).
+#
+# One-time setup (see infra/web-staging.json):
+#   1. Create persistent `staging` branch from `main`
+#   2. Vercel custom environment `staging` → git branch `staging`
+#   3. Neon `staging` branch in still-point-nonprod (not noisy-cell-87641627)
+#   4. Wire Neon staging POSTGRES_URL into Vercel staging env vars
+
+on:
+  push:
+    branches:
+      - staging
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: staging-promotion
+  cancel-in-progress: false
+
+jobs:
+  open-promotion-pr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Open staging → main promotion PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          EXISTING=$(gh pr list \
+            --base main \
+            --head staging \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            echo "Promotion PR #${EXISTING} already open — skipping create."
+            exit 0
+          fi
+
+          SHA="${{ github.sha }}"
+          SHORT_SHA="$(echo "$SHA" | cut -c1-7)"
+          STAGING_URL="https://staging.still-point.me"
+
+          BODY="$(cat <<'EOF'
+## Staging promotion
+
+Auto-opened after push to `staging` (`'"${SHORT_SHA}"'`).
+
+**Staging URL:** '"${STAGING_URL}"' (or the Vercel-generated staging alias)
+
+Merging this PR deploys to **production** (`main` → Vercel Production). Branch protection on `main` is the release gate.
+
+Closes #332
+
+## Test plan
+
+- [ ] Staging deploy succeeded (Vercel Staging environment)
+- [ ] Smoke-test auth (sign in / sign out) on staging URL
+- [ ] Verify a core flow (start session, buddy hub, or history) on staging
+- [ ] Confirm staging DB is isolated (no production data changes)
+- [ ] CI checks green on this PR before merge
+EOF
+)"
+
+          gh pr create \
+            --base main \
+            --head staging \
+            --title "promote: staging → main (${SHORT_SHA})" \
+            --body "$BODY"
+
+          echo "Created promotion PR staging → main."

--- a/.github/workflows/staging-promotion.yml
+++ b/.github/workflows/staging-promotion.yml
@@ -50,14 +50,14 @@ jobs:
           SHORT_SHA="$(echo "$SHA" | cut -c1-7)"
           STAGING_URL="https://staging.still-point.me"
 
-          BODY="$(cat <<'EOF'
+          BODY="$(cat <<EOF
 ## Staging promotion
 
-Auto-opened after push to `staging` (`'"${SHORT_SHA}"'`).
+Auto-opened after push to \`staging\` (\`${SHORT_SHA}\`).
 
-**Staging URL:** '"${STAGING_URL}"' (or the Vercel-generated staging alias)
+**Staging URL:** ${STAGING_URL} (or the Vercel-generated staging alias)
 
-Merging this PR deploys to **production** (`main` → Vercel Production). Branch protection on `main` is the release gate.
+Merging this PR deploys to **production** (\`main\` → Vercel Production). Branch protection on \`main\` is the release gate.
 
 Closes #332
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - staging
 
 jobs:
   unit-tests:

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - staging
 
 jobs:
   build:

--- a/infra/web-staging.json
+++ b/infra/web-staging.json
@@ -1,0 +1,30 @@
+{
+  "description": "Persistent web staging environment (issue #332). Vercel custom environment backed by a dedicated Neon branch — isolated from the production Neon project.",
+  "gitBranch": "staging",
+  "vercel": {
+    "customEnvironmentSlug": "staging",
+    "branchMatcher": {
+      "type": "equals",
+      "pattern": "staging"
+    },
+    "suggestedDomain": "staging.still-point.me",
+    "setup": [
+      "Vercel → Project → Settings → Environments → Create Environment → slug staging",
+      "Assign git branch matcher: equals staging",
+      "Copy Preview-scoped env vars into staging; replace POSTGRES_URL with the Neon staging branch connection string",
+      "Set NEXT_PUBLIC_APP_URL to the stable staging domain (or the Vercel-generated staging URL)",
+      "Optional: attach staging.still-point.me (or staging.stillpoint.app) to the staging custom environment"
+    ]
+  },
+  "neon": {
+    "branchName": "staging",
+    "parentBranch": "main",
+    "nonprodProjectIdSecret": "NEON_NONPROD_PROJECT_ID",
+    "forbiddenProdProjectId": "noisy-cell-87641627",
+    "setup": [
+      "Create branch `staging` in the still-point-nonprod Neon project (parent: main)",
+      "Never point staging POSTGRES_URL at the production project (noisy-cell-87641627)",
+      "Run: NEON_API_KEY=… NEON_NONPROD_PROJECT_ID=… node scripts/infra/ensure-neon-staging-branch.mjs"
+    ]
+  }
+}

--- a/scripts/infra/ensure-neon-staging-branch.mjs
+++ b/scripts/infra/ensure-neon-staging-branch.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Ensures the dedicated Neon `staging` branch exists in the non-production project.
+ * Refuses to run against the production Neon project (noisy-cell-87641627).
+ *
+ * Usage:
+ *   NEON_API_KEY=… NEON_NONPROD_PROJECT_ID=… node scripts/infra/ensure-neon-staging-branch.mjs
+ */
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const configPath = join(__dirname, "../../infra/web-staging.json");
+const config = JSON.parse(readFileSync(configPath, "utf8"));
+
+const apiKey = process.env.NEON_API_KEY?.trim();
+const projectId = process.env.NEON_NONPROD_PROJECT_ID?.trim();
+const branchName = config.neon.branchName;
+const parentBranch = config.neon.parentBranch;
+const forbiddenProdProjectId = config.neon.forbiddenProdProjectId;
+
+if (!apiKey) {
+  console.error("NEON_API_KEY is required.");
+  process.exit(1);
+}
+
+if (!projectId) {
+  console.error(
+    `${config.neon.nonprodProjectIdSecret} is required (still-point-nonprod project id).`,
+  );
+  process.exit(1);
+}
+
+if (projectId === forbiddenProdProjectId) {
+  console.error(
+    `Refusing to create staging branch in production Neon project ${forbiddenProdProjectId}.`,
+  );
+  process.exit(1);
+}
+
+function runNeonctl(args) {
+  const result = spawnSync("npx", ["-y", "neonctl@2.22.0", ...args], {
+    env: { ...process.env, NEON_API_KEY: apiKey },
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    const detail = (result.stderr || result.stdout || "").trim();
+    throw new Error(detail || `neonctl ${args.join(" ")} failed`);
+  }
+  return (result.stdout || "").trim();
+}
+
+const listOutput = runNeonctl([
+  "branches",
+  "list",
+  "--project-id",
+  projectId,
+  "--output",
+  "json",
+]);
+
+const branches = JSON.parse(listOutput || "[]");
+const exists = branches.some(
+  (branch) =>
+    branch.name === branchName ||
+    branch.branch?.name === branchName ||
+    branch.id === branchName,
+);
+
+if (exists) {
+  console.log(`Neon branch '${branchName}' already exists in project ${projectId}.`);
+  process.exit(0);
+}
+
+runNeonctl([
+  "branches",
+  "create",
+  "--project-id",
+  projectId,
+  "--name",
+  branchName,
+  "--parent",
+  parentBranch,
+]);
+
+console.log(
+  `Created Neon branch '${branchName}' (parent: ${parentBranch}) in project ${projectId}.`,
+);

--- a/scripts/infra/ensure-neon-staging-branch.mjs
+++ b/scripts/infra/ensure-neon-staging-branch.mjs
@@ -53,38 +53,49 @@ function runNeonctl(args) {
   return (result.stdout || "").trim();
 }
 
-const listOutput = runNeonctl([
-  "branches",
-  "list",
-  "--project-id",
-  projectId,
-  "--output",
-  "json",
-]);
+function branchExists() {
+  const listOutput = runNeonctl([
+    "branches",
+    "list",
+    "--project-id",
+    projectId,
+    "--output",
+    "json",
+  ]);
+  const branches = JSON.parse(listOutput || "[]");
+  return branches.some(
+    (branch) =>
+      branch.name === branchName ||
+      branch.branch?.name === branchName ||
+      branch.id === branchName,
+  );
+}
 
-const branches = JSON.parse(listOutput || "[]");
-const exists = branches.some(
-  (branch) =>
-    branch.name === branchName ||
-    branch.branch?.name === branchName ||
-    branch.id === branchName,
-);
-
-if (exists) {
+if (branchExists()) {
   console.log(`Neon branch '${branchName}' already exists in project ${projectId}.`);
   process.exit(0);
 }
 
-runNeonctl([
-  "branches",
-  "create",
-  "--project-id",
-  projectId,
-  "--name",
-  branchName,
-  "--parent",
-  parentBranch,
-]);
+try {
+  runNeonctl([
+    "branches",
+    "create",
+    "--project-id",
+    projectId,
+    "--name",
+    branchName,
+    "--parent",
+    parentBranch,
+  ]);
+} catch (error) {
+  if (branchExists()) {
+    console.log(
+      `Neon branch '${branchName}' already exists in project ${projectId} (concurrent create).`,
+    );
+    process.exit(0);
+  }
+  throw error;
+}
 
 console.log(
   `Created Neon branch '${branchName}' (parent: ${parentBranch}) in project ${projectId}.`,


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the web staging pipeline infrastructure requested in #332:

- **CI:** `staging` branch added to existing `Web Build` and `Unit Tests` push triggers (no parallel workflows)
- **Promotion:** New `Staging Promotion` workflow auto-opens a `staging → main` PR after each push to `staging`; `main` branch protection remains the production gate
- **Config:** `infra/web-staging.json` documents Vercel custom environment + Neon branch wiring
- **Neon safety:** `scripts/infra/ensure-neon-staging-branch.mjs` creates the `staging` branch in the **nonprod** Neon project and **refuses** the production project (`noisy-cell-87641627`)

Migrations continue to auto-apply via `vercel.json` `buildCommand` — staging must use its own Neon branch connection string in Vercel Staging env vars.

## One-time operator setup (post-merge)

1. Create persistent `staging` git branch from `main`
2. Run Neon branch ensure script with nonprod project credentials
3. In Vercel: create custom environment `staging` → git branch `staging`; copy Preview env vars, swap `POSTGRES_URL` to Neon staging branch
4. Optional: attach stable domain (e.g. `staging.still-point.me`)
5. Add branch protection on `staging` requiring **Web Build** (and optionally Vercel Staging deployment check)

## Flow

```
feature branch → PR → Vercel Preview (ephemeral)
       ↓ merge to staging
staging branch → Vercel Staging (persistent) + Neon staging DB
       ↓ promotion PR (auto-opened)
main → Vercel Production
```

Closes #332

## Test plan

- [ ] Confirm `Web Build` and `Unit Tests` workflows list `staging` in push triggers
- [ ] After creating `staging` branch: push a commit and verify Vercel Staging deploy (not Production)
- [ ] Verify `Staging Promotion` workflow opens a `staging → main` PR (no duplicate on second push)
- [ ] Confirm staging `POSTGRES_URL` points at Neon `staging` branch in nonprod project, **not** `noisy-cell-87641627`
- [ ] Run `node scripts/infra/ensure-neon-staging-branch.mjs` against nonprod — succeeds; against prod project id — fails fast
- [ ] Merge promotion PR only after CI + review (production gate unchanged)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1636f45-fb4f-4803-874d-e1679d8f2a92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1636f45-fb4f-4803-874d-e1679d8f2a92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Add a persistent staging path for the web app and fix promotion PR details**

### What Changed
- Pushes to `staging` now run the same build and test checks as `main`
- After each `staging` push, the repo auto-opens a `staging → main` promotion PR so production still goes through `main` branch protection
- Added setup guidance for a dedicated staging website and database, including a safe script that creates the Neon staging branch only in the non-production project
- Fixed the auto-opened promotion PR body so it includes the correct short commit ID and staging URL

### Impact
`✅ Faster staging releases`
`✅ Fewer manual promotion PRs`
`✅ Safer staging database setup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
