### PR TITLE
Gate and hide distraction/hyperfocus tracking controls (#186, #188)

### DIFF
--- a/e2e/session/session-flow.spec.ts
+++ b/e2e/session/session-flow.spec.ts
@@ -109,7 +109,7 @@ test.describe("mobile session flow", () => {
     expect(mockApiState.sessions[0]?.breathCount, "one tap is not yet a full breath").toBe(0);
   });
 
-  test("locked tracking controls show explainer until a five-minute sit unlocks", async ({ page, ensureLoggedIn }) => {
+  test("locked tracking controls show explainer before unlock", async ({ page, ensureLoggedIn }) => {
     await ensureLoggedIn();
     await tap(page.getByRole("button", { name: "Begin" }));
 

--- a/e2e/session/session-flow.spec.ts
+++ b/e2e/session/session-flow.spec.ts
@@ -3,6 +3,7 @@ import {
   expectMinimumTapTarget,
   expectNoHorizontalOverflow,
   expectVisibleInViewport,
+  seedTrackingControlsUnlocked,
   simulatePullToRefreshGesture,
   tap,
   tapWithControlReveal,
@@ -10,6 +11,7 @@ import {
 
 test.describe("mobile session flow", () => {
   test("tracking controls remain interactive when secondary chrome dims", async ({ page, ensureLoggedIn }) => {
+    await seedTrackingControlsUnlocked(page);
     await ensureLoggedIn();
     await tap(page.getByRole("button", { name: "Begin" }));
 
@@ -35,6 +37,7 @@ test.describe("mobile session flow", () => {
   });
 
   test("touch-only session complete flow has no hover dependency", async ({ page, ensureLoggedIn, mockApiState }) => {
+    await seedTrackingControlsUnlocked(page);
     await ensureLoggedIn();
 
     const beginButton = page.getByRole("button", { name: "Begin" });
@@ -106,7 +109,17 @@ test.describe("mobile session flow", () => {
     expect(mockApiState.sessions[0]?.breathCount, "one tap is not yet a full breath").toBe(0);
   });
 
+  test("locked tracking controls show explainer until a five-minute sit unlocks", async ({ page, ensureLoggedIn }) => {
+    await ensureLoggedIn();
+    await tap(page.getByRole("button", { name: "Begin" }));
+
+    await expect(page.locator("[data-tracking-unlock-explainer]")).toBeVisible();
+    await expect(page.locator('[data-tracking-controls="visible"]')).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /light distraction/i })).toHaveCount(0);
+  });
+
   test("pull-to-refresh style overscroll does not break active session", async ({ page, ensureLoggedIn }) => {
+    await seedTrackingControlsUnlocked(page);
     await ensureLoggedIn();
     await tap(page.getByRole("button", { name: "Begin" }));
 

--- a/e2e/utils/mobile-helpers.ts
+++ b/e2e/utils/mobile-helpers.ts
@@ -1,5 +1,18 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 
+/** #188: unlock distraction/hyperfocus controls for E2E — call before first navigation. */
+export async function seedTrackingControlsUnlocked(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      "stillpoint_tracking_control_prefs",
+      JSON.stringify({
+        hideDistractionHyperfocusControls: false,
+        trackingControlsUnlocked: true,
+      }),
+    );
+  });
+}
+
 export const MOBILE_SAFE_AREA_TOLERANCE_PX = 6;
 export const MIN_TAP_TARGET_PX = 44;
 const CONTROL_REVEAL_TAP_RETRIES = 3;

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -234,6 +234,12 @@ export default function StillPoint() {
   const loginRefreshCancelled = useRef(false);
   const isMobile = useIsMobile();
 
+  const clearAccountScopedLocalState = () => {
+    setTracksDoneToday({ primary: false, second: false });
+    setForkDismissed(false);
+    resetTrackingUnlockOnLogout();
+  };
+
   useEffect(() => {
     let cancelled = false;
 
@@ -252,6 +258,7 @@ export default function StillPoint() {
 
         if (res.status === 401 || res.status === 403) {
           setUser(null);
+          clearAccountScopedLocalState();
           setAuthError(null);
           setAuthChecked(true);
           return;
@@ -264,6 +271,7 @@ export default function StillPoint() {
         }
 
         setUser(null);
+        clearAccountScopedLocalState();
         setAuthError(null);
         setAuthChecked(true);
       } catch {
@@ -415,13 +423,7 @@ export default function StillPoint() {
     setBuddyCalendarMessage(null);
     setOverlay(null);
     setUser(null);
-    // #240: per-track completion badges and the fork-dismissal flag are
-    // account-scoped local state, not tied to the user object itself — clear
-    // them on logout so the next account's Home screen doesn't briefly show
-    // this account's "done today" badges or suppressed fork prompt.
-    setTracksDoneToday({ primary: false, second: false });
-    setForkDismissed(false);
-    resetTrackingUnlockOnLogout();
+    clearAccountScopedLocalState();
   };
 
   const handleBegin = (sessionType: SessionType = "standard", track: Track = "primary") => {

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -20,7 +20,7 @@ import { api, ApiError } from "@/lib/api";
 import type { SessionType, Track } from "@/lib/constants";
 import { advanceProgression, advanceSecondTrackDay, isDualTrackEligible, sessionDurationForUser, type RecoveryFields } from "@/lib/duration";
 import { todayLocalIsoDate } from "@/lib/sessionCalendar";
-import { syncTrackingUnlockFromSessions } from "@/lib/trackingControlPrefs";
+import { resetTrackingUnlockOnLogout, syncTrackingUnlockFromSessions } from "@/lib/trackingControlPrefs";
 
 /** Normalizes `User`'s optional recovery fields (absent on some legacy responses)
  *  into the non-optional shape `@/lib/duration` helpers expect. */
@@ -421,6 +421,7 @@ export default function StillPoint() {
     // this account's "done today" badges or suppressed fork prompt.
     setTracksDoneToday({ primary: false, second: false });
     setForkDismissed(false);
+    resetTrackingUnlockOnLogout();
   };
 
   const handleBegin = (sessionType: SessionType = "standard", track: Track = "primary") => {

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -20,6 +20,7 @@ import { api, ApiError } from "@/lib/api";
 import type { SessionType, Track } from "@/lib/constants";
 import { advanceProgression, advanceSecondTrackDay, isDualTrackEligible, sessionDurationForUser, type RecoveryFields } from "@/lib/duration";
 import { todayLocalIsoDate } from "@/lib/sessionCalendar";
+import { syncTrackingUnlockFromSessions } from "@/lib/trackingControlPrefs";
 
 /** Normalizes `User`'s optional recovery fields (absent on some legacy responses)
  *  into the non-optional shape `@/lib/duration` helpers expect. */
@@ -443,6 +444,7 @@ export default function StillPoint() {
           else primary = true;
         }
       }
+      syncTrackingUnlockFromSessions(sessions);
       setTracksDoneToday({ primary, second });
     } catch {
       // Fail closed so a failed refresh can't leave a stale "done today"

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -10,7 +10,12 @@ import { useIsMobile } from "@/lib/useIsMobile";
 import { loadSoundPrefs, saveSoundPrefs, type SoundPrefs } from "@/lib/audio";
 import { computeClearPercentFromLog } from "@/lib/mindStateSession";
 import { useMindStateHold } from "@/lib/useMindStateHold";
+import { markTrackingUnlockIfQualifying } from "@/lib/trackingControlPrefs";
 import { useKeepScreenAwakePref, useWakeLock } from "@/lib/useWakeLock";
+import {
+  useHideDistractionHyperfocusControlsPref,
+  useTrackingControlsUnlocked,
+} from "@/lib/useTrackingControlPrefs";
 import { useSessionSuppressionRelay } from "@/lib/useSessionSuppression";
 
 type MindState = "clear" | "thinking" | "hyperfocus";
@@ -89,6 +94,10 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
   const [wasPausedInSession, setWasPausedInSession] = useState(false);
   /** Live opt-in Settings pref; pause/complete/abandon drop `isActive` and toggle-off releases too. */
   const keepScreenAwakePref = useKeepScreenAwakePref();
+  const trackingControlsUnlocked = useTrackingControlsUnlocked();
+  const hideDistractionHyperfocusControls = useHideDistractionHyperfocusControlsPref();
+  const showDistractionHyperfocusCluster =
+    trackingControlsUnlocked && !hideDistractionHyperfocusControls;
   useWakeLock(keepScreenAwakePref && isActive);
   // Relay sit state to the service worker so it can suppress push display while
   // a sit is in progress when the opt-in pref is on (#431). Treat a paused sit
@@ -155,7 +164,7 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
   }, [finalizeActiveHold]);
 
   const { holdKindRef, resetHoldTracking } = useMindStateHold({
-    enabled: isActive,
+    enabled: isActive && showDistractionHyperfocusCluster,
     beginDistraction,
     beginHyperfocus,
     endHoldFromKeyboard,
@@ -190,6 +199,7 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
     setIsActive(false);
     const actualTime = Math.round((Date.now() - wallStartRef.current) / 1000);
     const endT = elapsedRef.current || totalSeconds;
+    markTrackingUnlockIfQualifying({ duration: plannedSeconds, completed: true });
     onComplete({
       dayNumber: currentDay,
       sessionType,
@@ -419,108 +429,130 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
             )}
           </div>
 
-          <div
-            style={{
-              display: "flex",
-              flexWrap: "wrap",
-              justifyContent: "center",
-              gap: "12px",
-              marginTop: "16px",
-              width: "100%",
-            }}
-          >
-            <button
-              type="button"
-              disabled={!isActive}
-              aria-pressed={mindState === "thinking"}
-              aria-label={isMobile ? "Hold for light distraction. Release when aware again." : "Hold for light distraction, or hold Space. Release when aware again."}
-              onMouseDown={e => {
-                e.preventDefault();
-                handlePointerDistractionDown();
-              }}
-              onMouseUp={handlePointerDistractionUp}
-              onMouseLeave={() => {
-                if (holdKindRef.current === "pointerHold" && mindStateRef.current === "thinking") {
-                  handlePointerDistractionUp();
-                }
-              }}
-              onTouchStart={e => {
-                e.preventDefault();
-                handlePointerDistractionDown();
-              }}
-              onTouchEnd={handlePointerDistractionUp}
-              onTouchCancel={handlePointerDistractionUp}
-              style={{
-                ...holdButtonBase,
-                borderColor:
-                  mindState === "thinking" ? "var(--accent-amber-border)" : "var(--accent-green-border-subtle)",
-                background:
-                  mindState === "thinking" ? "var(--accent-amber-bg)" : "var(--accent-green-bg-subtle)",
-                color: mindState === "thinking" ? "var(--accent-amber)" : "var(--accent-green)",
-              }}
-            >
-              <span>{mindState === "thinking" ? "Release" : "Hold"} — light distraction</span>
-              {!isMobile && (
-                <span style={{ ...mono, fontSize: "9px", letterSpacing: "0.14em", opacity: 0.85, textTransform: "none" }}>
-                  or hold Space
-                </span>
-              )}
-            </button>
-
-            <button
-              type="button"
-              disabled={!isActive}
-              aria-pressed={mindState === "hyperfocus"}
-              aria-label={isMobile ? "Hold for hyperfocus. Release to return to aware." : "Hold for hyperfocus, or hold Comma. Release to return to aware."}
-              onMouseDown={e => {
-                e.preventDefault();
-                handlePointerHyperfocusDown();
-              }}
-              onMouseUp={handlePointerHyperfocusUp}
-              onMouseLeave={() => {
-                if (holdKindRef.current === "pointerHold" && mindStateRef.current === "hyperfocus") {
-                  handlePointerHyperfocusUp();
-                }
-              }}
-              onTouchStart={e => {
-                e.preventDefault();
-                handlePointerHyperfocusDown();
-              }}
-              onTouchEnd={handlePointerHyperfocusUp}
-              onTouchCancel={handlePointerHyperfocusUp}
-              style={{
-                ...holdButtonBase,
-                borderColor:
-                  mindState === "hyperfocus" ? "rgba(59, 130, 246, 0.55)" : "var(--border-2)",
-                background:
-                  mindState === "hyperfocus" ? "rgba(59, 130, 246, 0.12)" : "var(--surface-1)",
-                color: mindState === "hyperfocus" ? "rgba(147, 197, 253, 0.95)" : "var(--fg-2)",
-              }}
-            >
-              <span>{mindState === "hyperfocus" ? "Release" : "Hold"} — hyperfocus</span>
-              {!isMobile && (
-                <span style={{ ...mono, fontSize: "9px", letterSpacing: "0.14em", opacity: 0.85, textTransform: "none" }}>
-                  or hold ,
-                </span>
-              )}
-            </button>
-          </div>
-
-          <FlashHint>
+          {!trackingControlsUnlocked && (
             <p
+              data-tracking-unlock-explainer
               style={{
-                margin: "12px 0 0",
+                margin: "16px 0 0",
                 textAlign: "center",
                 ...mono,
                 fontSize: "10px",
                 color: "var(--fg-4)",
                 letterSpacing: "0.05em",
-                lineHeight: 1.45,
+                lineHeight: 1.5,
               }}
             >
-              Light distraction holds only log awareness segments. Captured notes are reserved for explicit capture paths.
+              Distraction and hyperfocus tracking unlock after you complete one sit of five minutes or longer.
             </p>
-          </FlashHint>
+          )}
+
+          {showDistractionHyperfocusCluster && (
+            <>
+              <div
+                data-tracking-controls="visible"
+                style={{
+                  display: "flex",
+                  flexWrap: "wrap",
+                  justifyContent: "center",
+                  gap: "12px",
+                  marginTop: "16px",
+                  width: "100%",
+                }}
+              >
+                <button
+                  type="button"
+                  disabled={!isActive}
+                  aria-pressed={mindState === "thinking"}
+                  aria-label={isMobile ? "Hold for light distraction. Release when aware again." : "Hold for light distraction, or hold Space. Release when aware again."}
+                  onMouseDown={e => {
+                    e.preventDefault();
+                    handlePointerDistractionDown();
+                  }}
+                  onMouseUp={handlePointerDistractionUp}
+                  onMouseLeave={() => {
+                    if (holdKindRef.current === "pointerHold" && mindStateRef.current === "thinking") {
+                      handlePointerDistractionUp();
+                    }
+                  }}
+                  onTouchStart={e => {
+                    e.preventDefault();
+                    handlePointerDistractionDown();
+                  }}
+                  onTouchEnd={handlePointerDistractionUp}
+                  onTouchCancel={handlePointerDistractionUp}
+                  style={{
+                    ...holdButtonBase,
+                    borderColor:
+                      mindState === "thinking" ? "var(--accent-amber-border)" : "var(--accent-green-border-subtle)",
+                    background:
+                      mindState === "thinking" ? "var(--accent-amber-bg)" : "var(--accent-green-bg-subtle)",
+                    color: mindState === "thinking" ? "var(--accent-amber)" : "var(--accent-green)",
+                  }}
+                >
+                  <span>{mindState === "thinking" ? "Release" : "Hold"} — light distraction</span>
+                  {!isMobile && (
+                    <span style={{ ...mono, fontSize: "9px", letterSpacing: "0.14em", opacity: 0.85, textTransform: "none" }}>
+                      or hold Space
+                    </span>
+                  )}
+                </button>
+
+                <button
+                  type="button"
+                  disabled={!isActive}
+                  aria-pressed={mindState === "hyperfocus"}
+                  aria-label={isMobile ? "Hold for hyperfocus. Release to return to aware." : "Hold for hyperfocus, or hold Comma. Release to return to aware."}
+                  onMouseDown={e => {
+                    e.preventDefault();
+                    handlePointerHyperfocusDown();
+                  }}
+                  onMouseUp={handlePointerHyperfocusUp}
+                  onMouseLeave={() => {
+                    if (holdKindRef.current === "pointerHold" && mindStateRef.current === "hyperfocus") {
+                      handlePointerHyperfocusUp();
+                    }
+                  }}
+                  onTouchStart={e => {
+                    e.preventDefault();
+                    handlePointerHyperfocusDown();
+                  }}
+                  onTouchEnd={handlePointerHyperfocusUp}
+                  onTouchCancel={handlePointerHyperfocusUp}
+                  style={{
+                    ...holdButtonBase,
+                    borderColor:
+                      mindState === "hyperfocus" ? "rgba(59, 130, 246, 0.55)" : "var(--border-2)",
+                    background:
+                      mindState === "hyperfocus" ? "rgba(59, 130, 246, 0.12)" : "var(--surface-1)",
+                    color: mindState === "hyperfocus" ? "rgba(147, 197, 253, 0.95)" : "var(--fg-2)",
+                  }}
+                >
+                  <span>{mindState === "hyperfocus" ? "Release" : "Hold"} — hyperfocus</span>
+                  {!isMobile && (
+                    <span style={{ ...mono, fontSize: "9px", letterSpacing: "0.14em", opacity: 0.85, textTransform: "none" }}>
+                      or hold ,
+                    </span>
+                  )}
+                </button>
+              </div>
+
+              <FlashHint>
+                <p
+                  style={{
+                    margin: "12px 0 0",
+                    textAlign: "center",
+                    ...mono,
+                    fontSize: "10px",
+                    color: "var(--fg-4)",
+                    letterSpacing: "0.05em",
+                    lineHeight: 1.45,
+                  }}
+                >
+                  Light distraction holds only log awareness segments. Captured notes are reserved for explicit capture paths.
+                </p>
+              </FlashHint>
+            </>
+          )}
 
           <div
             style={{

--- a/src/components/SettingsView.tsx
+++ b/src/components/SettingsView.tsx
@@ -21,6 +21,10 @@ import {
   saveBreathKeyBinding,
   type BreathKeyBinding,
 } from "@/lib/breathKeyBinding";
+import {
+  loadTrackingControlPrefs,
+  saveHideDistractionHyperfocusControls,
+} from "@/lib/trackingControlPrefs";
 
 type User = {
   id: string;
@@ -54,6 +58,7 @@ export function SettingsView({
   const [wakeLockSupported, setWakeLockSupported] = useState(false);
   const [keepScreenAwake, setKeepScreenAwake] = useState(false);
   const [breathKeyBinding, setBreathKeyBinding] = useState<BreathKeyBinding>("Space");
+  const [hideDistractionHyperfocusControls, setHideDistractionHyperfocusControls] = useState(false);
   const [editingUsername, setEditingUsername] = useState(false);
   const [usernameInput, setUsernameInput] = useState(user.username);
   const [savingUsername, setSavingUsername] = useState(false);
@@ -151,6 +156,9 @@ export function SettingsView({
     setWakeLockSupported(isWakeLockSupported());
     setKeepScreenAwake(loadWakeLockPrefs().keepScreenAwakeDuringSession);
     setBreathKeyBinding(loadBreathKeyBinding());
+    setHideDistractionHyperfocusControls(
+      loadTrackingControlPrefs().hideDistractionHyperfocusControls,
+    );
   }, []);
 
   const handleKeepScreenAwakeToggle = () => {
@@ -162,6 +170,12 @@ export function SettingsView({
   const handleBreathKeyBindingChange = (binding: BreathKeyBinding) => {
     setBreathKeyBinding(binding);
     saveBreathKeyBinding(binding);
+  };
+
+  const handleHideDistractionHyperfocusControlsToggle = () => {
+    const next = !hideDistractionHyperfocusControls;
+    setHideDistractionHyperfocusControls(next);
+    saveHideDistractionHyperfocusControls(next);
   };
 
   const handleLogout = async () => {
@@ -414,6 +428,59 @@ export function SettingsView({
             </button>
           </div>
         )}
+
+        {/* #186: hide distraction/hyperfocus hold cluster during sessions */}
+        <div style={{
+          padding: "16px 20px",
+          background: "var(--surface-1)",
+          borderRadius: "10px",
+          display: "flex", alignItems: "center", justifyContent: "space-between",
+        }}>
+          <div>
+            <div style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "12px", color: "var(--fg)", marginBottom: "4px",
+            }}>
+              Hide distraction &amp; hyperfocus controls
+            </div>
+            <div style={{
+              fontFamily: "var(--font-serif)",
+              fontSize: "13px", fontStyle: "italic",
+              color: "var(--fg-3)",
+            }}>
+              Remove hold buttons and keyboard shortcuts during sessions. The timer is unchanged.
+            </div>
+          </div>
+          <button
+            type="button"
+            aria-label={
+              hideDistractionHyperfocusControls
+                ? "Show distraction and hyperfocus controls during sessions"
+                : "Hide distraction and hyperfocus controls during sessions"
+            }
+            aria-pressed={hideDistractionHyperfocusControls}
+            onClick={handleHideDistractionHyperfocusControlsToggle}
+            style={{
+              width: "48px", height: "26px",
+              borderRadius: "13px", border: "none",
+              background: hideDistractionHyperfocusControls
+                ? "var(--accent-green-bg)"
+                : "var(--surface-3)",
+              position: "relative", cursor: "pointer",
+              transition: "background 0.3s",
+              flexShrink: 0, marginLeft: "16px",
+            }}
+          >
+            <div style={{
+              width: "20px", height: "20px",
+              borderRadius: "10px",
+              background: hideDistractionHyperfocusControls ? "var(--accent-green)" : "var(--border-3)",
+              position: "absolute", top: "3px",
+              left: hideDistractionHyperfocusControls ? "25px" : "3px",
+              transition: "all 0.3s",
+            }} />
+          </button>
+        </div>
 
         {/* Breath counting: key binding (#376) */}
         <div style={{

--- a/src/lib/trackingControlPrefs.test.ts
+++ b/src/lib/trackingControlPrefs.test.ts
@@ -10,7 +10,9 @@ import {
   syncTrackingUnlockFromSessions,
 } from "./trackingControlPrefs";
 
-const STORAGE_KEY = "stillpoint_tracking_control_prefs";
+const LEGACY_STORAGE_KEY = "stillpoint_tracking_control_prefs";
+const HIDE_STORAGE_KEY = "stillpoint_hide_distraction_hyperfocus_controls";
+const UNLOCK_STORAGE_KEY = "stillpoint_tracking_controls_unlocked";
 
 function stubBrowserStorage(initial: Record<string, string> = {}) {
   const store = new Map(Object.entries(initial));
@@ -64,9 +66,20 @@ describe("loadTrackingControlPrefs", () => {
     });
   });
 
-  it("reads stored prefs", () => {
+  it("reads stored prefs from per-field keys", () => {
     stubBrowserStorage({
-      [STORAGE_KEY]: JSON.stringify({
+      [HIDE_STORAGE_KEY]: "true",
+      [UNLOCK_STORAGE_KEY]: "true",
+    });
+    expect(loadTrackingControlPrefs()).toEqual({
+      hideDistractionHyperfocusControls: true,
+      trackingControlsUnlocked: true,
+    });
+  });
+
+  it("migrates legacy combined blob to per-field keys", () => {
+    const store = stubBrowserStorage({
+      [LEGACY_STORAGE_KEY]: JSON.stringify({
         hideDistractionHyperfocusControls: true,
         trackingControlsUnlocked: true,
       }),
@@ -75,10 +88,13 @@ describe("loadTrackingControlPrefs", () => {
       hideDistractionHyperfocusControls: true,
       trackingControlsUnlocked: true,
     });
+    expect(store.get(HIDE_STORAGE_KEY)).toBe("true");
+    expect(store.get(UNLOCK_STORAGE_KEY)).toBe("true");
+    expect(store.has(LEGACY_STORAGE_KEY)).toBe(false);
   });
 
-  it("falls back to defaults on corrupt JSON", () => {
-    stubBrowserStorage({ [STORAGE_KEY]: "{not json" });
+  it("falls back to defaults on corrupt legacy JSON", () => {
+    stubBrowserStorage({ [LEGACY_STORAGE_KEY]: "{not json" });
     expect(loadTrackingControlPrefs()).toEqual({
       hideDistractionHyperfocusControls: false,
       trackingControlsUnlocked: false,
@@ -90,15 +106,11 @@ describe("markTrackingUnlockIfQualifying", () => {
   it("persists unlock for qualifying sessions only", () => {
     const store = stubBrowserStorage();
     markTrackingUnlockIfQualifying({ duration: 300, completed: true });
-    expect(JSON.parse(store.get(STORAGE_KEY) ?? "")).toEqual({
-      hideDistractionHyperfocusControls: false,
-      trackingControlsUnlocked: true,
-    });
+    expect(store.get(UNLOCK_STORAGE_KEY)).toBe("true");
+    expect(store.get(HIDE_STORAGE_KEY)).toBe("false");
 
     markTrackingUnlockIfQualifying({ duration: 60, completed: true });
-    expect(JSON.parse(store.get(STORAGE_KEY) ?? "")).toMatchObject({
-      trackingControlsUnlocked: true,
-    });
+    expect(store.get(UNLOCK_STORAGE_KEY)).toBe("true");
   });
 });
 
@@ -109,23 +121,17 @@ describe("syncTrackingUnlockFromSessions", () => {
       { duration: 60, completed: true },
       { duration: 300, completed: true },
     ]);
-    expect(JSON.parse(store.get(STORAGE_KEY) ?? "")).toMatchObject({
-      trackingControlsUnlocked: true,
-    });
+    expect(store.get(UNLOCK_STORAGE_KEY)).toBe("true");
   });
 
   it("is a no-op when already unlocked", () => {
     const store = stubBrowserStorage({
-      [STORAGE_KEY]: JSON.stringify({
-        hideDistractionHyperfocusControls: true,
-        trackingControlsUnlocked: true,
-      }),
+      [HIDE_STORAGE_KEY]: "true",
+      [UNLOCK_STORAGE_KEY]: "true",
     });
     syncTrackingUnlockFromSessions([{ duration: 60, completed: false }]);
-    expect(JSON.parse(store.get(STORAGE_KEY) ?? "")).toEqual({
-      hideDistractionHyperfocusControls: true,
-      trackingControlsUnlocked: true,
-    });
+    expect(store.get(HIDE_STORAGE_KEY)).toBe("true");
+    expect(store.get(UNLOCK_STORAGE_KEY)).toBe("true");
   });
 });
 
@@ -134,10 +140,8 @@ describe("saveHideDistractionHyperfocusControls", () => {
     const store = stubBrowserStorage();
     markTrackingControlsUnlocked();
     saveHideDistractionHyperfocusControls(true);
-    expect(JSON.parse(store.get(STORAGE_KEY) ?? "")).toEqual({
-      hideDistractionHyperfocusControls: true,
-      trackingControlsUnlocked: true,
-    });
+    expect(store.get(HIDE_STORAGE_KEY)).toBe("true");
+    expect(store.get(UNLOCK_STORAGE_KEY)).toBe("true");
   });
 });
 

--- a/src/lib/trackingControlPrefs.test.ts
+++ b/src/lib/trackingControlPrefs.test.ts
@@ -21,6 +21,9 @@ function stubBrowserStorage(initial: Record<string, string> = {}) {
     setItem: (key: string, value: string) => {
       store.set(key, value);
     },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
   };
   vi.stubGlobal("window", {
     localStorage: localStorageMock,
@@ -107,7 +110,7 @@ describe("markTrackingUnlockIfQualifying", () => {
     const store = stubBrowserStorage();
     markTrackingUnlockIfQualifying({ duration: 300, completed: true });
     expect(store.get(UNLOCK_STORAGE_KEY)).toBe("true");
-    expect(store.get(HIDE_STORAGE_KEY)).toBe("false");
+    expect(loadTrackingControlPrefs().hideDistractionHyperfocusControls).toBe(false);
 
     markTrackingUnlockIfQualifying({ duration: 60, completed: true });
     expect(store.get(UNLOCK_STORAGE_KEY)).toBe("true");

--- a/src/lib/trackingControlPrefs.test.ts
+++ b/src/lib/trackingControlPrefs.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  TRACKING_UNLOCK_MIN_DURATION_SECONDS,
+  loadTrackingControlPrefs,
+  markTrackingControlsUnlocked,
+  markTrackingUnlockIfQualifying,
+  saveHideDistractionHyperfocusControls,
+  sessionQualifiesForTrackingUnlock,
+  subscribeTrackingControlPrefs,
+  syncTrackingUnlockFromSessions,
+} from "./trackingControlPrefs";
+
+const STORAGE_KEY = "stillpoint_tracking_control_prefs";
+
+function stubBrowserStorage(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial));
+  const localStorageMock = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+  };
+  vi.stubGlobal("window", {
+    localStorage: localStorageMock,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+  vi.stubGlobal("localStorage", localStorageMock);
+  return store;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("sessionQualifiesForTrackingUnlock", () => {
+  it("requires completed sits with planned duration >= 300 seconds", () => {
+    expect(
+      sessionQualifiesForTrackingUnlock({
+        duration: TRACKING_UNLOCK_MIN_DURATION_SECONDS,
+        completed: true,
+      }),
+    ).toBe(true);
+    expect(
+      sessionQualifiesForTrackingUnlock({
+        duration: TRACKING_UNLOCK_MIN_DURATION_SECONDS - 1,
+        completed: true,
+      }),
+    ).toBe(false);
+    expect(
+      sessionQualifiesForTrackingUnlock({
+        duration: TRACKING_UNLOCK_MIN_DURATION_SECONDS,
+        completed: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("loadTrackingControlPrefs", () => {
+  it("returns locked/hidden defaults without window (SSR guard)", () => {
+    expect(loadTrackingControlPrefs()).toEqual({
+      hideDistractionHyperfocusControls: false,
+      trackingControlsUnlocked: false,
+    });
+  });
+
+  it("reads stored prefs", () => {
+    stubBrowserStorage({
+      [STORAGE_KEY]: JSON.stringify({
+        hideDistractionHyperfocusControls: true,
+        trackingControlsUnlocked: true,
+      }),
+    });
+    expect(loadTrackingControlPrefs()).toEqual({
+      hideDistractionHyperfocusControls: true,
+      trackingControlsUnlocked: true,
+    });
+  });
+
+  it("falls back to defaults on corrupt JSON", () => {
+    stubBrowserStorage({ [STORAGE_KEY]: "{not json" });
+    expect(loadTrackingControlPrefs()).toEqual({
+      hideDistractionHyperfocusControls: false,
+      trackingControlsUnlocked: false,
+    });
+  });
+});
+
+describe("markTrackingUnlockIfQualifying", () => {
+  it("persists unlock for qualifying sessions only", () => {
+    const store = stubBrowserStorage();
+    markTrackingUnlockIfQualifying({ duration: 300, completed: true });
+    expect(JSON.parse(store.get(STORAGE_KEY) ?? "")).toEqual({
+      hideDistractionHyperfocusControls: false,
+      trackingControlsUnlocked: true,
+    });
+
+    markTrackingUnlockIfQualifying({ duration: 60, completed: true });
+    expect(JSON.parse(store.get(STORAGE_KEY) ?? "")).toMatchObject({
+      trackingControlsUnlocked: true,
+    });
+  });
+});
+
+describe("syncTrackingUnlockFromSessions", () => {
+  it("backfills unlock from session history", () => {
+    const store = stubBrowserStorage();
+    syncTrackingUnlockFromSessions([
+      { duration: 60, completed: true },
+      { duration: 300, completed: true },
+    ]);
+    expect(JSON.parse(store.get(STORAGE_KEY) ?? "")).toMatchObject({
+      trackingControlsUnlocked: true,
+    });
+  });
+
+  it("is a no-op when already unlocked", () => {
+    const store = stubBrowserStorage({
+      [STORAGE_KEY]: JSON.stringify({
+        hideDistractionHyperfocusControls: true,
+        trackingControlsUnlocked: true,
+      }),
+    });
+    syncTrackingUnlockFromSessions([{ duration: 60, completed: false }]);
+    expect(JSON.parse(store.get(STORAGE_KEY) ?? "")).toEqual({
+      hideDistractionHyperfocusControls: true,
+      trackingControlsUnlocked: true,
+    });
+  });
+});
+
+describe("saveHideDistractionHyperfocusControls", () => {
+  it("round-trips hide preference without clearing unlock", () => {
+    const store = stubBrowserStorage();
+    markTrackingControlsUnlocked();
+    saveHideDistractionHyperfocusControls(true);
+    expect(JSON.parse(store.get(STORAGE_KEY) ?? "")).toEqual({
+      hideDistractionHyperfocusControls: true,
+      trackingControlsUnlocked: true,
+    });
+  });
+});
+
+describe("subscribeTrackingControlPrefs", () => {
+  it("notifies subscribers on save", () => {
+    stubBrowserStorage();
+    const listener = vi.fn();
+    const unsubscribe = subscribeTrackingControlPrefs(listener);
+
+    saveHideDistractionHyperfocusControls(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    markTrackingControlsUnlocked();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/trackingControlPrefs.ts
+++ b/src/lib/trackingControlPrefs.ts
@@ -14,7 +14,10 @@ export type TrackingControlPrefs = {
 /** Planned sit length (seconds) required to unlock tracking controls (#188). */
 export const TRACKING_UNLOCK_MIN_DURATION_SECONDS = 300;
 
-const STORAGE_KEY = "stillpoint_tracking_control_prefs";
+/** Legacy combined blob — migrated to per-field keys on read. */
+const LEGACY_STORAGE_KEY = "stillpoint_tracking_control_prefs";
+const HIDE_STORAGE_KEY = "stillpoint_hide_distraction_hyperfocus_controls";
+const UNLOCK_STORAGE_KEY = "stillpoint_tracking_controls_unlocked";
 
 const DEFAULTS: TrackingControlPrefs = {
   hideDistractionHyperfocusControls: false,
@@ -32,7 +35,7 @@ export function sessionQualifiesForTrackingUnlock(session: {
   return session.completed && session.duration >= TRACKING_UNLOCK_MIN_DURATION_SECONDS;
 }
 
-function parseStoredPrefs(raw: string | null): TrackingControlPrefs {
+function parseLegacyPrefs(raw: string | null): TrackingControlPrefs {
   if (!raw) return DEFAULTS;
   try {
     const parsed: unknown = JSON.parse(raw);
@@ -53,43 +56,80 @@ function parseStoredPrefs(raw: string | null): TrackingControlPrefs {
   }
 }
 
+function readBool(key: string, fallback: boolean): boolean {
+  const raw = localStorage.getItem(key);
+  if (raw === "true" || raw === "1") return true;
+  if (raw === "false" || raw === "0") return false;
+  return fallback;
+}
+
+function writeBool(key: string, value: boolean): void {
+  localStorage.setItem(key, value ? "true" : "false");
+}
+
+function migrateLegacyPrefsIfNeeded(): void {
+  const legacyRaw = localStorage.getItem(LEGACY_STORAGE_KEY);
+  if (!legacyRaw) return;
+  const legacy = parseLegacyPrefs(legacyRaw);
+  writeBool(HIDE_STORAGE_KEY, legacy.hideDistractionHyperfocusControls);
+  writeBool(UNLOCK_STORAGE_KEY, legacy.trackingControlsUnlocked);
+  localStorage.removeItem(LEGACY_STORAGE_KEY);
+}
+
 export function loadTrackingControlPrefs(): TrackingControlPrefs {
   if (typeof window === "undefined") return DEFAULTS;
   try {
-    return parseStoredPrefs(localStorage.getItem(STORAGE_KEY));
+    migrateLegacyPrefsIfNeeded();
+    return {
+      hideDistractionHyperfocusControls: readBool(
+        HIDE_STORAGE_KEY,
+        DEFAULTS.hideDistractionHyperfocusControls,
+      ),
+      trackingControlsUnlocked: readBool(
+        UNLOCK_STORAGE_KEY,
+        DEFAULTS.trackingControlsUnlocked,
+      ),
+    };
   } catch {
     return DEFAULTS;
   }
 }
 
-function saveTrackingControlPrefs(prefs: TrackingControlPrefs): void {
-  if (typeof window === "undefined") return;
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
-  } catch {
-    // Best-effort persistence: ignore storage write failures.
-  }
+function notifyPrefChange(): void {
   notifyTrackingControlPrefsListeners();
 }
 
 export function saveHideDistractionHyperfocusControls(hide: boolean): void {
-  saveTrackingControlPrefs({
-    ...loadTrackingControlPrefs(),
-    hideDistractionHyperfocusControls: hide,
-  });
+  if (typeof window === "undefined") return;
+  try {
+    writeBool(HIDE_STORAGE_KEY, hide);
+    notifyPrefChange();
+  } catch {
+    // Best-effort persistence: ignore storage write failures.
+  }
 }
 
 export function markTrackingControlsUnlocked(): void {
-  const current = loadTrackingControlPrefs();
-  if (current.trackingControlsUnlocked) return;
-  saveTrackingControlPrefs({ ...current, trackingControlsUnlocked: true });
+  if (typeof window === "undefined") return;
+  if (loadTrackingControlPrefs().trackingControlsUnlocked) return;
+  try {
+    writeBool(UNLOCK_STORAGE_KEY, true);
+    notifyPrefChange();
+  } catch {
+    // Best-effort persistence: ignore storage write failures.
+  }
 }
 
 /** Clear account-scoped unlock on logout so the next sign-in re-qualifies (#188). */
 export function resetTrackingUnlockOnLogout(): void {
-  const current = loadTrackingControlPrefs();
-  if (!current.trackingControlsUnlocked) return;
-  saveTrackingControlPrefs({ ...current, trackingControlsUnlocked: false });
+  if (typeof window === "undefined") return;
+  if (!loadTrackingControlPrefs().trackingControlsUnlocked) return;
+  try {
+    writeBool(UNLOCK_STORAGE_KEY, false);
+    notifyPrefChange();
+  } catch {
+    // Best-effort persistence: ignore storage write failures.
+  }
 }
 
 /** Persist unlock when a just-finished sit qualifies (#188). */
@@ -117,7 +157,14 @@ type TrackingControlPrefsListener = () => void;
 const listeners = new Set<TrackingControlPrefsListener>();
 
 function onStorageEvent(e: StorageEvent): void {
-  if (e.key === STORAGE_KEY || e.key === null) notifyTrackingControlPrefsListeners();
+  if (
+    e.key === HIDE_STORAGE_KEY
+    || e.key === UNLOCK_STORAGE_KEY
+    || e.key === LEGACY_STORAGE_KEY
+    || e.key === null
+  ) {
+    notifyTrackingControlPrefsListeners();
+  }
 }
 
 function notifyTrackingControlPrefsListeners(): void {

--- a/src/lib/trackingControlPrefs.ts
+++ b/src/lib/trackingControlPrefs.ts
@@ -85,6 +85,13 @@ export function markTrackingControlsUnlocked(): void {
   saveTrackingControlPrefs({ ...current, trackingControlsUnlocked: true });
 }
 
+/** Clear account-scoped unlock on logout so the next sign-in re-qualifies (#188). */
+export function resetTrackingUnlockOnLogout(): void {
+  const current = loadTrackingControlPrefs();
+  if (!current.trackingControlsUnlocked) return;
+  saveTrackingControlPrefs({ ...current, trackingControlsUnlocked: false });
+}
+
 /** Persist unlock when a just-finished sit qualifies (#188). */
 export function markTrackingUnlockIfQualifying(session: {
   duration: number;

--- a/src/lib/trackingControlPrefs.ts
+++ b/src/lib/trackingControlPrefs.ts
@@ -1,0 +1,131 @@
+/**
+ * #186 / #188: distraction/hyperfocus hold-cluster visibility.
+ * - #188 progressive unlock after one completed sit with planned duration >= 5 min
+ * - #186 user preference to hide the cluster entirely (web localStorage + iOS UserDefaults)
+ */
+
+export type TrackingControlPrefs = {
+  /** #186: hide distraction/hyperfocus hold buttons and keyboard-hint copy during sits. */
+  hideDistractionHyperfocusControls: boolean;
+  /** #188: true once the user has completed a qualifying 5+ minute sit. */
+  trackingControlsUnlocked: boolean;
+};
+
+/** Planned sit length (seconds) required to unlock tracking controls (#188). */
+export const TRACKING_UNLOCK_MIN_DURATION_SECONDS = 300;
+
+const STORAGE_KEY = "stillpoint_tracking_control_prefs";
+
+const DEFAULTS: TrackingControlPrefs = {
+  hideDistractionHyperfocusControls: false,
+  trackingControlsUnlocked: false,
+};
+
+/** iOS UserDefaults key (parity with web localStorage). */
+export const IOS_HIDE_TRACKING_CONTROLS_KEY = "sp_hideDistractionHyperfocusControls";
+export const IOS_TRACKING_UNLOCK_KEY = "sp_trackingControlsUnlocked";
+
+export function sessionQualifiesForTrackingUnlock(session: {
+  duration: number;
+  completed: boolean;
+}): boolean {
+  return session.completed && session.duration >= TRACKING_UNLOCK_MIN_DURATION_SECONDS;
+}
+
+function parseStoredPrefs(raw: string | null): TrackingControlPrefs {
+  if (!raw) return DEFAULTS;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return DEFAULTS;
+    const record = parsed as Record<string, unknown>;
+    return {
+      hideDistractionHyperfocusControls:
+        typeof record.hideDistractionHyperfocusControls === "boolean"
+          ? record.hideDistractionHyperfocusControls
+          : DEFAULTS.hideDistractionHyperfocusControls,
+      trackingControlsUnlocked:
+        typeof record.trackingControlsUnlocked === "boolean"
+          ? record.trackingControlsUnlocked
+          : DEFAULTS.trackingControlsUnlocked,
+    };
+  } catch {
+    return DEFAULTS;
+  }
+}
+
+export function loadTrackingControlPrefs(): TrackingControlPrefs {
+  if (typeof window === "undefined") return DEFAULTS;
+  try {
+    return parseStoredPrefs(localStorage.getItem(STORAGE_KEY));
+  } catch {
+    return DEFAULTS;
+  }
+}
+
+function saveTrackingControlPrefs(prefs: TrackingControlPrefs): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+  } catch {
+    // Best-effort persistence: ignore storage write failures.
+  }
+  notifyTrackingControlPrefsListeners();
+}
+
+export function saveHideDistractionHyperfocusControls(hide: boolean): void {
+  saveTrackingControlPrefs({
+    ...loadTrackingControlPrefs(),
+    hideDistractionHyperfocusControls: hide,
+  });
+}
+
+export function markTrackingControlsUnlocked(): void {
+  const current = loadTrackingControlPrefs();
+  if (current.trackingControlsUnlocked) return;
+  saveTrackingControlPrefs({ ...current, trackingControlsUnlocked: true });
+}
+
+/** Persist unlock when a just-finished sit qualifies (#188). */
+export function markTrackingUnlockIfQualifying(session: {
+  duration: number;
+  completed: boolean;
+}): void {
+  if (sessionQualifiesForTrackingUnlock(session)) {
+    markTrackingControlsUnlocked();
+  }
+}
+
+/** Backfill unlock from stored session history (e.g. existing practitioners). */
+export function syncTrackingUnlockFromSessions(
+  sessions: Array<{ duration: number; completed: boolean }>,
+): void {
+  if (loadTrackingControlPrefs().trackingControlsUnlocked) return;
+  if (sessions.some(sessionQualifiesForTrackingUnlock)) {
+    markTrackingControlsUnlocked();
+  }
+}
+
+type TrackingControlPrefsListener = () => void;
+
+const listeners = new Set<TrackingControlPrefsListener>();
+
+function onStorageEvent(e: StorageEvent): void {
+  if (e.key === STORAGE_KEY || e.key === null) notifyTrackingControlPrefsListeners();
+}
+
+function notifyTrackingControlPrefsListeners(): void {
+  for (const listener of [...listeners]) listener();
+}
+
+export function subscribeTrackingControlPrefs(listener: TrackingControlPrefsListener): () => void {
+  if (typeof window !== "undefined" && listeners.size === 0) {
+    window.addEventListener("storage", onStorageEvent);
+  }
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+    if (typeof window !== "undefined" && listeners.size === 0) {
+      window.removeEventListener("storage", onStorageEvent);
+    }
+  };
+}

--- a/src/lib/useTrackingControlPrefs.ts
+++ b/src/lib/useTrackingControlPrefs.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import {
+  loadTrackingControlPrefs,
+  subscribeTrackingControlPrefs,
+} from "./trackingControlPrefs";
+
+export function useHideDistractionHyperfocusControlsPref(): boolean {
+  return useSyncExternalStore(
+    subscribeTrackingControlPrefs,
+    () => loadTrackingControlPrefs().hideDistractionHyperfocusControls,
+    () => false,
+  );
+}
+
+export function useTrackingControlsUnlocked(): boolean {
+  return useSyncExternalStore(
+    subscribeTrackingControlPrefs,
+    () => loadTrackingControlPrefs().trackingControlsUnlocked,
+    () => false,
+  );
+}


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #186, Closes #188

Progressive unlock and optional hide for the SessionView distraction/hyperfocus hold cluster. The core timer, status row, awareness stats, and capture note are unchanged.

### #188 — Progressive unlock
- Hold buttons, keyboard-hint copy, and FlashHint are hidden until the user completes one sit with **planned duration ≥ 300s** (`completed: true`).
- Pre-unlock explainer shown in the tracking layer: *"Distraction and hyperfocus tracking unlock after you complete one sit of five minutes or longer."*
- Unlock persists in `stillpoint_tracking_control_prefs` and backfills from session history on app load.

### #186 — Hide preference
- Settings toggle: **Hide distraction & hyperfocus controls** (device-local `localStorage`).
- When enabled (and unlocked), the hold cluster and keyboard hints are omitted; timer unaffected.
- iOS UserDefaults key names documented in `trackingControlPrefs.ts` for parity follow-up.

## Test plan

- [x] `npm run test:unit -- src/lib/trackingControlPrefs.test.ts` (525 tests pass)
- [x] `npm run build`
- [ ] Manual: new user → Begin → explainer visible, no hold buttons; timer runs normally
- [ ] Manual: complete a 5+ min sit → next session shows hold cluster
- [ ] Manual: Settings → hide toggle → hold cluster hidden on next sit; timer unchanged
- [ ] E2E: `e2e/session/session-flow.spec.ts` (locked-state test + seeded unlock for existing interaction tests)

## Gate

- Sole SessionView thread this wave — no overlapping SessionView PRs expected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69eb2744-aad8-4dad-b3dd-d23ca31f8822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69eb2744-aad8-4dad-b3dd-d23ca31f8822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Hide distraction and hyperfocus controls until they unlock**

### What Changed
- Distraction and hyperfocus hold buttons stay hidden until the user completes one 5-minute sit
- Before unlock, Session view shows a short explainer instead of the tracking controls
- Settings now includes a toggle to hide the tracking controls and keyboard hints during sessions, without affecting the timer
- Unlock status is cleared on logout and can be restored from past session history after sign-in

### Impact
`✅ Fewer distracting controls for new users`
`✅ Cleaner session screen for people who prefer a simpler view`
`✅ Unlock state stays tied to the signed-in account`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
