### PR TITLE
feat(ios): ARKit gaze attention tracking with opt-in settings (#113)

### DIFF
--- a/drizzle/sessions_attention_log_113_incremental.sql
+++ b/drizzle/sessions_attention_log_113_incremental.sql
@@ -1,0 +1,4 @@
+-- iOS ARKit gaze attention log (issue #113). mindStateLog-style JSONB array of
+-- { time: number, state: string } entries where state is "attentive" | "away".
+
+ALTER TABLE "sessions" ADD COLUMN IF NOT EXISTS "attention_log" jsonb;

--- a/drizzle/users_attention_tracking_113_incremental.sql
+++ b/drizzle/users_attention_tracking_113_incremental.sql
@@ -1,0 +1,4 @@
+-- iOS ARKit gaze attention tracking opt-in (issue #113). Off by default, same
+-- boolean-preference pattern as users.aphorisms_enabled.
+
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "attention_tracking_enabled" boolean DEFAULT false NOT NULL;

--- a/ios/StillPointApp/Info.plist
+++ b/ios/StillPointApp/Info.plist
@@ -46,7 +46,7 @@
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSCameraUsageDescription</key>
-	<string>Still Point needs camera access for partner video sessions.</string>
+	<string>Still Point uses the camera for partner video sessions and, when you opt in, gaze attention tracking during sits.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Still Point needs microphone access for partner video sessions.</string>
 	<key>UIBackgroundModes</key>

--- a/ios/StillPointApp/Managers/AttentionTrackingManager.swift
+++ b/ios/StillPointApp/Managers/AttentionTrackingManager.swift
@@ -77,13 +77,7 @@ final class AttentionTrackingManager: NSObject {
 
     func stop() {
         guard isRunning else { return }
-        session.pause()
-        isRunning = false
-        isPaused = false
-        elapsedProvider = nil
-        pendingLookAt = nil
-        frameDispatchScheduled = false
-        clearPendingDebounce()
+        resetRunningState()
     }
 
     func pause() {
@@ -106,6 +100,16 @@ final class AttentionTrackingManager: NSObject {
     private func clearPendingDebounce() {
         sustained.pendingState = nil
         sustained.pendingSince = nil
+    }
+
+    private func resetRunningState() {
+        session.pause()
+        isRunning = false
+        isPaused = false
+        elapsedProvider = nil
+        pendingLookAt = nil
+        frameDispatchScheduled = false
+        clearPendingDebounce()
     }
 
     fileprivate func handleLookAtPoint(_ lookAtPoint: SIMD3<Float>) {
@@ -148,6 +152,13 @@ final class AttentionTrackingManager: NSObject {
 }
 
 extension AttentionTrackingManager: ARSessionDelegate {
+    nonisolated func session(_ session: ARSession, didFailWithError error: Error) {
+        Task { @MainActor in
+            guard self.isRunning else { return }
+            self.resetRunningState()
+        }
+    }
+
     nonisolated func session(_ session: ARSession, didUpdate anchors: [ARAnchor]) {
         guard let faceAnchor = anchors.compactMap({ $0 as? ARFaceAnchor }).first else { return }
         let lookAtPoint = faceAnchor.lookAtPoint

--- a/ios/StillPointApp/Managers/AttentionTrackingManager.swift
+++ b/ios/StillPointApp/Managers/AttentionTrackingManager.swift
@@ -1,0 +1,124 @@
+#if targetEnvironment(simulator)
+
+import Foundation
+import StillPointShared
+
+/// Simulator stub — ARKit face tracking requires a TrueDepth device.
+@Observable
+@MainActor
+final class AttentionTrackingManager {
+    private(set) var isSupported = false
+    private(set) var isRunning = false
+    private(set) var currentAttentionState = "attentive"
+    private(set) var attentionLog: [AttentionEntry] = [AttentionEntry(time: 0, state: "attentive")]
+
+    func start(elapsedProvider: @escaping () -> Double) {
+        _ = elapsedProvider
+        isRunning = false
+    }
+
+    func stop() {
+        isRunning = false
+    }
+
+    func pause() {}
+
+    func resume() {}
+}
+
+#else
+
+import ARKit
+import Foundation
+import StillPointShared
+
+/// ARKit face-tracking gaze attention sampler (#113). Uses `ARFaceAnchor.lookAtPoint`
+/// — the only public API for gaze direction — with a 0.5s sustained-gaze debounce.
+@Observable
+@MainActor
+final class AttentionTrackingManager: NSObject {
+    private(set) var isSupported: Bool
+    private(set) var isRunning = false
+    private(set) var currentAttentionState = "attentive"
+    private(set) var attentionLog: [AttentionEntry] = [AttentionEntry(time: 0, state: "attentive")]
+
+    private let session = ARSession()
+    private var elapsedProvider: (() -> Double)?
+    private var sustained = AttentionTrackingLogic.SustainedState()
+    private var isPaused = false
+
+    override init() {
+        isSupported = ARFaceTrackingConfiguration.isSupported
+        super.init()
+        session.delegate = self
+    }
+
+    func start(elapsedProvider: @escaping () -> Double) {
+        guard isSupported, !isRunning else { return }
+        self.elapsedProvider = elapsedProvider
+        sustained = AttentionTrackingLogic.SustainedState()
+        currentAttentionState = sustained.loggedState
+        attentionLog = sustained.log
+        isPaused = false
+
+        let configuration = ARFaceTrackingConfiguration()
+        configuration.isLightEstimationEnabled = false
+        session.run(configuration, options: [.resetTracking, .removeExistingAnchors])
+        isRunning = true
+    }
+
+    func stop() {
+        guard isRunning else { return }
+        session.pause()
+        isRunning = false
+        isPaused = false
+        elapsedProvider = nil
+    }
+
+    func pause() {
+        guard isRunning, !isPaused else { return }
+        session.pause()
+        isPaused = true
+    }
+
+    func resume() {
+        guard isRunning, isPaused, isSupported else { return }
+        let configuration = ARFaceTrackingConfiguration()
+        configuration.isLightEstimationEnabled = false
+        session.run(configuration)
+        isPaused = false
+    }
+
+    fileprivate func handleLookAtPoint(_ lookAtPoint: SIMD3<Float>) {
+        guard isRunning, !isPaused, let elapsedProvider else { return }
+
+        let rawState = AttentionTrackingLogic.classifyGaze(
+            lookAtX: lookAtPoint.x,
+            lookAtY: lookAtPoint.y,
+            lookAtZ: lookAtPoint.z
+        )
+        let now = ProcessInfo.processInfo.systemUptime
+        let elapsed = elapsedProvider()
+
+        sustained = AttentionTrackingLogic.applyRawSample(
+            rawState,
+            elapsed: elapsed,
+            now: now,
+            state: sustained
+        )
+        currentAttentionState = sustained.loggedState
+        attentionLog = sustained.log
+    }
+}
+
+extension AttentionTrackingManager: ARSessionDelegate {
+    nonisolated func session(_ session: ARSession, didUpdate anchors: [ARAnchor]) {
+        guard let faceAnchor = anchors.compactMap({ $0 as? ARFaceAnchor }).first else { return }
+        let lookAtPoint = faceAnchor.lookAtPoint
+        Task { @MainActor in
+            self.handleLookAtPoint(lookAtPoint)
+        }
+    }
+}
+
+#endif

--- a/ios/StillPointApp/Managers/AttentionTrackingManager.swift
+++ b/ios/StillPointApp/Managers/AttentionTrackingManager.swift
@@ -9,12 +9,14 @@ import StillPointShared
 final class AttentionTrackingManager {
     private(set) var isSupported = false
     private(set) var isRunning = false
+    private(set) var didReceiveSample = false
     private(set) var currentAttentionState = "attentive"
-    private(set) var attentionLog: [AttentionEntry] = [AttentionEntry(time: 0, state: "attentive")]
+    private(set) var attentionLog: [AttentionEntry] = []
 
     func start(elapsedProvider: @escaping () -> Double) {
         _ = elapsedProvider
         isRunning = false
+        didReceiveSample = false
     }
 
     func stop() {
@@ -39,13 +41,16 @@ import StillPointShared
 final class AttentionTrackingManager: NSObject {
     private(set) var isSupported: Bool
     private(set) var isRunning = false
+    private(set) var didReceiveSample = false
     private(set) var currentAttentionState = "attentive"
-    private(set) var attentionLog: [AttentionEntry] = [AttentionEntry(time: 0, state: "attentive")]
+    private(set) var attentionLog: [AttentionEntry] = []
 
     private let session = ARSession()
     private var elapsedProvider: (() -> Double)?
     private var sustained = AttentionTrackingLogic.SustainedState()
     private var isPaused = false
+    private var pendingLookAt: SIMD3<Float>?
+    private var frameDispatchScheduled = false
 
     override init() {
         isSupported = ARFaceTrackingConfiguration.isSupported
@@ -59,7 +64,10 @@ final class AttentionTrackingManager: NSObject {
         sustained = AttentionTrackingLogic.SustainedState()
         currentAttentionState = sustained.loggedState
         attentionLog = sustained.log
+        didReceiveSample = false
         isPaused = false
+        pendingLookAt = nil
+        frameDispatchScheduled = false
 
         let configuration = ARFaceTrackingConfiguration()
         configuration.isLightEstimationEnabled = false
@@ -73,12 +81,18 @@ final class AttentionTrackingManager: NSObject {
         isRunning = false
         isPaused = false
         elapsedProvider = nil
+        pendingLookAt = nil
+        frameDispatchScheduled = false
+        clearPendingDebounce()
     }
 
     func pause() {
         guard isRunning, !isPaused else { return }
         session.pause()
         isPaused = true
+        pendingLookAt = nil
+        frameDispatchScheduled = false
+        clearPendingDebounce()
     }
 
     func resume() {
@@ -89,9 +103,15 @@ final class AttentionTrackingManager: NSObject {
         isPaused = false
     }
 
+    private func clearPendingDebounce() {
+        sustained.pendingState = nil
+        sustained.pendingSince = nil
+    }
+
     fileprivate func handleLookAtPoint(_ lookAtPoint: SIMD3<Float>) {
         guard isRunning, !isPaused, let elapsedProvider else { return }
 
+        didReceiveSample = true
         let rawState = AttentionTrackingLogic.classifyGaze(
             lookAtX: lookAtPoint.x,
             lookAtY: lookAtPoint.y,
@@ -109,6 +129,22 @@ final class AttentionTrackingManager: NSObject {
         currentAttentionState = sustained.loggedState
         attentionLog = sustained.log
     }
+
+    fileprivate func dispatchLatestLookAtPoint() {
+        guard let lookAtPoint = pendingLookAt else { return }
+        pendingLookAt = nil
+        handleLookAtPoint(lookAtPoint)
+    }
+
+    fileprivate func scheduleLookAtDispatch(_ lookAtPoint: SIMD3<Float>) {
+        pendingLookAt = lookAtPoint
+        guard !frameDispatchScheduled else { return }
+        frameDispatchScheduled = true
+        Task { @MainActor in
+            defer { self.frameDispatchScheduled = false }
+            self.dispatchLatestLookAtPoint()
+        }
+    }
 }
 
 extension AttentionTrackingManager: ARSessionDelegate {
@@ -116,7 +152,7 @@ extension AttentionTrackingManager: ARSessionDelegate {
         guard let faceAnchor = anchors.compactMap({ $0 as? ARFaceAnchor }).first else { return }
         let lookAtPoint = faceAnchor.lookAtPoint
         Task { @MainActor in
-            self.handleLookAtPoint(lookAtPoint)
+            self.scheduleLookAtDispatch(lookAtPoint)
         }
     }
 }

--- a/ios/StillPointApp/ViewModels/SessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/SessionViewModel.swift
@@ -29,6 +29,8 @@ final class SessionViewModel {
     // Mind state
     var mindState: String = "clear"
     var mindStateLog: [MindStateEntry] = []
+    /// #113: ARKit gaze attention log when opt-in tracking is enabled.
+    var attentionLog: [AttentionEntry]?
     /// Distraction segments started this sit (for in-session badge); API `thoughtCount` uses captured notes only.
     var distractionSegmentCount = 0
     var capturedThoughts: [CapturedThought] = []
@@ -244,6 +246,7 @@ final class SessionViewModel {
             clearPercent: clearPercent,
             thoughtCount: thoughtCount,
             mindStateLog: mindStateLog,
+            attentionLog: attentionLog,
             sessionDate: dateFormatter.string(from: Date()),
             track: track
         )

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -117,7 +117,6 @@ struct SessionView: View {
         .onAppear {
             vm.start()
             if appVM.currentUser?.attentionTrackingEnabled == true {
-                vm.attentionLog = [AttentionEntry(time: 0, state: "attentive")]
                 attentionManager.start { vm.elapsed }
             }
             SessionIdleTimerController.syncLocalSession(
@@ -186,7 +185,8 @@ struct SessionView: View {
         .onChange(of: vm.isComplete) { _, isComplete in
             if isComplete {
                 attentionManager.stop()
-                if appVM.currentUser?.attentionTrackingEnabled == true {
+                if appVM.currentUser?.attentionTrackingEnabled == true,
+                   attentionManager.didReceiveSample {
                     vm.attentionLog = attentionManager.attentionLog
                 }
             }

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -11,6 +11,7 @@ struct SessionView: View {
     let appVM: AppViewModel
     @State private var vm: SessionViewModel
     @State private var showSaveError = false
+    @State private var attentionManager = AttentionTrackingManager()
 
     init(appVM: AppViewModel, sessionType: SessionType = .standard, track: Track = .primary) {
         self.appVM = appVM
@@ -115,6 +116,10 @@ struct SessionView: View {
         }
         .onAppear {
             vm.start()
+            if appVM.currentUser?.attentionTrackingEnabled == true {
+                vm.attentionLog = [AttentionEntry(time: 0, state: "attentive")]
+                attentionManager.start { vm.elapsed }
+            }
             SessionIdleTimerController.syncLocalSession(
                 appVM: appVM,
                 isRunning: sessionTimerRunning
@@ -125,6 +130,7 @@ struct SessionView: View {
             )
         }
         .onDisappear {
+            attentionManager.stop()
             SessionIdleTimerController.syncLocalSession(
                 appVM: appVM,
                 isRunning: false
@@ -150,7 +156,14 @@ struct SessionView: View {
                 inProgress: sessionInProgress
             )
         }
-        .onChange(of: vm.isPaused) { _, _ in
+        .onChange(of: vm.isPaused) { _, isPaused in
+            if appVM.currentUser?.attentionTrackingEnabled == true {
+                if isPaused {
+                    attentionManager.pause()
+                } else {
+                    attentionManager.resume()
+                }
+            }
             SessionIdleTimerController.syncLocalSession(
                 appVM: appVM,
                 isRunning: sessionTimerRunning
@@ -171,6 +184,12 @@ struct SessionView: View {
             )
         }
         .onChange(of: vm.isComplete) { _, isComplete in
+            if isComplete {
+                attentionManager.stop()
+                if appVM.currentUser?.attentionTrackingEnabled == true {
+                    vm.attentionLog = attentionManager.attentionLog
+                }
+            }
             SessionIdleTimerController.syncLocalSession(
                 appVM: appVM,
                 isRunning: sessionTimerRunning

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -6,8 +6,10 @@ struct SettingsView: View {
     @State private var notificationPrefs = NotificationPreferencesViewModel()
     @State private var isPublic: Bool = false
     @State private var aphorismsEnabled: Bool = false
+    @State private var attentionTrackingEnabled: Bool = false
     @State private var isUpdating = false
     @State private var isUpdatingAphorisms = false
+    @State private var isUpdatingAttentionTracking = false
     @State private var isSavingUsername = false
     @State private var showDeleteAccountDialog = false
     @State private var showDeleteAccountConfirm = false
@@ -15,7 +17,7 @@ struct SettingsView: View {
     @State private var deleteAccountError = ""
     @State private var showDeleteAccountError = false
 
-    private var isSavingSettings: Bool { isUpdating || isUpdatingAphorisms || isSavingUsername }
+    private var isSavingSettings: Bool { isUpdating || isUpdatingAphorisms || isUpdatingAttentionTracking || isSavingUsername }
 
     var body: some View {
         NavigationStack {
@@ -89,6 +91,34 @@ struct SettingsView: View {
                     }
                     .tint(SPColor.green)
                     .accessibilityIdentifier("settings.keepScreenAwakeDuringSessionToggle")
+
+                    Toggle(isOn: $attentionTrackingEnabled) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Gaze attention tracking")
+                                .font(SPFont.mono(13))
+                                .foregroundStyle(Color(SPColor.fg))
+                            Text("Uses the front camera during sessions to log when your gaze leaves the screen. Off by default.")
+                                .font(SPFont.serif(13, weight: .light))
+                                .foregroundStyle(Color(SPColor.fg4))
+                        }
+                    }
+                    .tint(SPColor.green)
+                    .disabled(isSavingSettings)
+                    .accessibilityIdentifier("settings.attentionTrackingToggle")
+                    .onChange(of: attentionTrackingEnabled) { _, newValue in
+                        guard !isUpdatingAttentionTracking else { return }
+                        guard appVM.currentUser?.attentionTrackingEnabled != newValue else { return }
+                        isUpdatingAttentionTracking = true
+                        Task {
+                            defer { isUpdatingAttentionTracking = false }
+                            do {
+                                let updated = try await APIClient.shared.updateSettings(attentionTrackingEnabled: newValue)
+                                appVM.applySettingsUser(updated)
+                            } catch {
+                                attentionTrackingEnabled = !newValue
+                            }
+                        }
+                    }
                 }
                 .padding(SPSpacing.s3)
                 .background(SPColor.surface1)
@@ -263,6 +293,10 @@ struct SettingsView: View {
             guard appVM.currentUser != nil else { return }
             syncFromCurrentUser()
         }
+        .onChange(of: appVM.currentUser?.attentionTrackingEnabled) { _, _ in
+            guard appVM.currentUser != nil else { return }
+            syncFromCurrentUser()
+        }
     }
 
     private var notificationsLinkSection: some View {
@@ -297,6 +331,7 @@ struct SettingsView: View {
     private func syncFromCurrentUser() {
         isPublic = appVM.currentUser?.isPublic ?? false
         aphorismsEnabled = appVM.currentUser?.aphorismsEnabled ?? false
+        attentionTrackingEnabled = appVM.currentUser?.attentionTrackingEnabled ?? false
     }
 
     private var appVersionFooter: String {

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -275,12 +275,18 @@ public actor APIClient {
         try await updateSettings(body: SettingsPatchBody(aphorismsEnabled: aphorismsEnabled))
     }
 
+    /// #113: opt-in ARKit gaze attention tracking during sessions.
+    public func updateSettings(attentionTrackingEnabled: Bool) async throws -> UserDTO {
+        try await updateSettings(body: SettingsPatchBody(attentionTrackingEnabled: attentionTrackingEnabled))
+    }
+
     private func updateSettings(body: SettingsPatchBody) async throws -> UserDTO {
         if let uiTestAPIStore {
             return try await uiTestAPIStore.updateSettings(
                 isPublic: body.isPublic,
                 username: body.username,
-                aphorismsEnabled: body.aphorismsEnabled
+                aphorismsEnabled: body.aphorismsEnabled,
+                attentionTrackingEnabled: body.attentionTrackingEnabled
             )
         }
         let response: UserResponse = try await patch("/api/settings", body: body)
@@ -504,11 +510,18 @@ private struct SettingsPatchBody: Encodable {
     let isPublic: Bool?
     let username: String?
     let aphorismsEnabled: Bool?
+    let attentionTrackingEnabled: Bool?
 
-    init(isPublic: Bool? = nil, username: String? = nil, aphorismsEnabled: Bool? = nil) {
+    init(
+        isPublic: Bool? = nil,
+        username: String? = nil,
+        aphorismsEnabled: Bool? = nil,
+        attentionTrackingEnabled: Bool? = nil
+    ) {
         self.isPublic = isPublic
         self.username = username
         self.aphorismsEnabled = aphorismsEnabled
+        self.attentionTrackingEnabled = attentionTrackingEnabled
     }
 
     func encode(to encoder: Encoder) throws {
@@ -516,12 +529,14 @@ private struct SettingsPatchBody: Encodable {
         if let isPublic { try c.encode(isPublic, forKey: .isPublic) }
         if let username { try c.encode(username, forKey: .username) }
         if let aphorismsEnabled { try c.encode(aphorismsEnabled, forKey: .aphorismsEnabled) }
+        if let attentionTrackingEnabled { try c.encode(attentionTrackingEnabled, forKey: .attentionTrackingEnabled) }
     }
 
     private enum CodingKeys: String, CodingKey {
         case isPublic
         case username
         case aphorismsEnabled
+        case attentionTrackingEnabled
     }
 }
 

--- a/ios/StillPointShared/Sources/StillPointShared/AttentionTrackingLogic.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AttentionTrackingLogic.swift
@@ -21,7 +21,7 @@ public enum AttentionTrackingLogic {
 
         public init(
             loggedState: String = "attentive",
-            log: [AttentionEntry] = [AttentionEntry(time: 0, state: "attentive")],
+            log: [AttentionEntry] = [],
             pendingState: String? = nil,
             pendingSince: TimeInterval? = nil
         ) {

--- a/ios/StillPointShared/Sources/StillPointShared/AttentionTrackingLogic.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AttentionTrackingLogic.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Pure logic for ARKit gaze attention tracking (#113). Kept in StillPointShared so
+/// the 0.5s sustained-gaze debounce is unit-testable without ARKit.
+public enum AttentionTrackingLogic {
+    public static let sustainedThreshold: TimeInterval = 0.5
+
+    /// Classify a raw `ARFaceAnchor.lookAtPoint` sample as attentive or away.
+    /// `lookAtPoint` is in face-anchor space: negative Z generally means toward the device.
+    public static func classifyGaze(lookAtX: Float, lookAtY: Float, lookAtZ: Float) -> String {
+        let towardDevice = lookAtZ < -0.12
+        let centered = abs(lookAtX) < 0.18 && abs(lookAtY) < 0.18
+        return (towardDevice && centered) ? "attentive" : "away"
+    }
+
+    public struct SustainedState: Equatable, Sendable {
+        public var loggedState: String
+        public var log: [AttentionEntry]
+        public var pendingState: String?
+        public var pendingSince: TimeInterval?
+
+        public init(
+            loggedState: String = "attentive",
+            log: [AttentionEntry] = [AttentionEntry(time: 0, state: "attentive")],
+            pendingState: String? = nil,
+            pendingSince: TimeInterval? = nil
+        ) {
+            self.loggedState = loggedState
+            self.log = log
+            self.pendingState = pendingState
+            self.pendingSince = pendingSince
+        }
+    }
+
+    /// Apply a raw gaze sample with sustained-gaze debouncing. Returns updated state;
+    /// appends to `log` only when the debounced state changes.
+    public static func applyRawSample(
+        _ rawState: String,
+        elapsed: Double,
+        now: TimeInterval,
+        state: SustainedState,
+        threshold: TimeInterval = sustainedThreshold
+    ) -> SustainedState {
+        var next = state
+
+        if rawState == next.loggedState {
+            next.pendingState = nil
+            next.pendingSince = nil
+            return next
+        }
+
+        if next.pendingState != rawState {
+            next.pendingState = rawState
+            next.pendingSince = now
+            return next
+        }
+
+        guard let pendingSince = next.pendingSince, now - pendingSince >= threshold else {
+            return next
+        }
+
+        next.loggedState = rawState
+        next.pendingState = nil
+        next.pendingSince = nil
+        next.log.append(AttentionEntry(time: elapsed, state: rawState))
+        return next
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -12,6 +12,8 @@ public struct UserDTO: Codable, Sendable {
     /// responses from a server that predates this field (or cached fixtures)
     /// still decode, defaulting to off.
     public let aphorismsEnabled: Bool
+    /// #113: opt-in iOS ARKit gaze attention tracking during sessions.
+    public let attentionTrackingEnabled: Bool
     /// #240: dual-track fork. `dualTrackEnabled` gates the opt-in second daily
     /// track; `secondTrackDay` is its independent day counter. Both decoded
     /// permissively so a server that predates #240 defaults to single-track.
@@ -25,6 +27,7 @@ public struct UserDTO: Codable, Sendable {
         isPublic: Bool,
         currentDay: Int,
         aphorismsEnabled: Bool = false,
+        attentionTrackingEnabled: Bool = false,
         dualTrackEnabled: Bool = false,
         secondTrackDay: Int = 1
     ) {
@@ -34,6 +37,7 @@ public struct UserDTO: Codable, Sendable {
         self.isPublic = isPublic
         self.currentDay = currentDay
         self.aphorismsEnabled = aphorismsEnabled
+        self.attentionTrackingEnabled = attentionTrackingEnabled
         self.dualTrackEnabled = dualTrackEnabled
         self.secondTrackDay = secondTrackDay
     }
@@ -46,12 +50,13 @@ public struct UserDTO: Codable, Sendable {
         isPublic = try c.decode(Bool.self, forKey: .isPublic)
         currentDay = try c.decode(Int.self, forKey: .currentDay)
         aphorismsEnabled = try c.decodeIfPresent(Bool.self, forKey: .aphorismsEnabled) ?? false
+        attentionTrackingEnabled = try c.decodeIfPresent(Bool.self, forKey: .attentionTrackingEnabled) ?? false
         dualTrackEnabled = try c.decodeIfPresent(Bool.self, forKey: .dualTrackEnabled) ?? false
         secondTrackDay = try c.decodeIfPresent(Int.self, forKey: .secondTrackDay) ?? 1
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, email, username, isPublic, currentDay, aphorismsEnabled, dualTrackEnabled, secondTrackDay
+        case id, email, username, isPublic, currentDay, aphorismsEnabled, attentionTrackingEnabled, dualTrackEnabled, secondTrackDay
     }
 }
 
@@ -67,6 +72,8 @@ public struct SessionDTO: Codable, Sendable {
     public let clearPercent: Int
     public let thoughtCount: Int
     public let mindStateLog: [MindStateEntry]?
+    /// #113: ARKit gaze attention transitions ("attentive" | "away").
+    public let attentionLog: [AttentionEntry]?
     public let sessionDate: String
     /// ISO-8601 from API when present; used for same-day ordering (matches web `sessionSortKey`).
     public let createdAt: String?
@@ -88,6 +95,7 @@ public struct SessionDTO: Codable, Sendable {
         clearPercent: Int,
         thoughtCount: Int,
         mindStateLog: [MindStateEntry]?,
+        attentionLog: [AttentionEntry]? = nil,
         sessionDate: String,
         createdAt: String? = nil,
         buddySessionId: String?,
@@ -104,6 +112,7 @@ public struct SessionDTO: Codable, Sendable {
         self.clearPercent = clearPercent
         self.thoughtCount = thoughtCount
         self.mindStateLog = mindStateLog
+        self.attentionLog = attentionLog
         self.sessionDate = sessionDate
         self.createdAt = createdAt
         self.buddySessionId = buddySessionId
@@ -170,6 +179,8 @@ public struct CreateSessionRequest: Codable, Sendable {
     public let clearPercent: Int
     public let thoughtCount: Int
     public let mindStateLog: [MindStateEntry]
+    /// #113: ARKit gaze attention log; omitted when tracking is off.
+    public let attentionLog: [AttentionEntry]?
     public let sessionDate: String
     /// Number of full breaths counted. Only sent for `.breath` sessions; nil otherwise.
     public let breathCount: Int?
@@ -186,6 +197,7 @@ public struct CreateSessionRequest: Codable, Sendable {
         clearPercent: Int,
         thoughtCount: Int,
         mindStateLog: [MindStateEntry],
+        attentionLog: [AttentionEntry]? = nil,
         sessionDate: String,
         breathCount: Int? = nil,
         track: Track = .primary
@@ -199,6 +211,7 @@ public struct CreateSessionRequest: Codable, Sendable {
         self.clearPercent = clearPercent
         self.thoughtCount = thoughtCount
         self.mindStateLog = mindStateLog
+        self.attentionLog = attentionLog
         self.sessionDate = sessionDate
         self.breathCount = breathCount
         self.track = track

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -27,7 +27,7 @@ public struct UserDTO: Codable, Sendable {
         isPublic: Bool,
         currentDay: Int,
         aphorismsEnabled: Bool = false,
-        attentionTrackingEnabled: Bool = false,
+        attentionTrackingEnabled: Bool? = nil,
         dualTrackEnabled: Bool = false,
         secondTrackDay: Int = 1
     ) {
@@ -37,7 +37,7 @@ public struct UserDTO: Codable, Sendable {
         self.isPublic = isPublic
         self.currentDay = currentDay
         self.aphorismsEnabled = aphorismsEnabled
-        self.attentionTrackingEnabled = attentionTrackingEnabled
+        self.attentionTrackingEnabled = attentionTrackingEnabled ?? false
         self.dualTrackEnabled = dualTrackEnabled
         self.secondTrackDay = secondTrackDay
     }

--- a/ios/StillPointShared/Sources/StillPointShared/Models/AttentionEntry.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/Models/AttentionEntry.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// A single ARKit gaze attention transition recorded during a session.
+/// Matches the web app's `{ time: number; state: string }` JSONB entries (#113).
+public struct AttentionEntry: Codable, Equatable, Sendable {
+    /// Seconds elapsed when this attention state began
+    public let time: Double
+
+    /// "attentive" (gaze on screen) or "away" (gaze off screen).
+    public let state: String
+
+    public init(time: Double, state: String) {
+        self.time = time
+        self.state = state
+    }
+
+    public var isAttentive: Bool { state == "attentive" }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
@@ -252,6 +252,7 @@ actor UITestAPIStore {
                     isPublic: store.user.isPublic,
                     currentDay: store.user.currentDay,
                     aphorismsEnabled: store.user.aphorismsEnabled,
+                    attentionTrackingEnabled: store.user.attentionTrackingEnabled,
                     dualTrackEnabled: store.user.dualTrackEnabled,
                     secondTrackDay: nextSecond
                 )
@@ -263,6 +264,7 @@ actor UITestAPIStore {
                     isPublic: store.user.isPublic,
                     currentDay: max(store.user.currentDay, data.dayNumber + 1),
                     aphorismsEnabled: store.user.aphorismsEnabled,
+                    attentionTrackingEnabled: store.user.attentionTrackingEnabled,
                     dualTrackEnabled: store.user.dualTrackEnabled,
                     secondTrackDay: store.user.secondTrackDay
                 )
@@ -283,6 +285,7 @@ actor UITestAPIStore {
             isPublic: store.user.isPublic,
             currentDay: store.user.currentDay,
             aphorismsEnabled: store.user.aphorismsEnabled,
+            attentionTrackingEnabled: store.user.attentionTrackingEnabled,
             dualTrackEnabled: true,
             secondTrackDay: store.user.secondTrackDay
         )

--- a/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
@@ -229,6 +229,7 @@ actor UITestAPIStore {
             clearPercent: data.clearPercent,
             thoughtCount: data.thoughtCount,
             mindStateLog: data.mindStateLog,
+            attentionLog: data.attentionLog,
             sessionDate: data.sessionDate,
             createdAt: nil,
             buddySessionId: nil,
@@ -350,12 +351,18 @@ actor UITestAPIStore {
 
     // MARK: - Settings
 
-    func updateSettings(isPublic: Bool?, username: String?, aphorismsEnabled: Bool?) throws -> UserDTO {
+    func updateSettings(
+        isPublic: Bool?,
+        username: String?,
+        aphorismsEnabled: Bool?,
+        attentionTrackingEnabled: Bool?
+    ) throws -> UserDTO {
         try ensureAuthenticated()
 
         var nextUsername = store.user.username
         var nextIsPublic = store.user.isPublic
         var nextAphorismsEnabled = store.user.aphorismsEnabled
+        var nextAttentionTrackingEnabled = store.user.attentionTrackingEnabled
 
         if let username {
             let trimmed = username.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -376,6 +383,10 @@ actor UITestAPIStore {
             nextAphorismsEnabled = aphorismsEnabled
         }
 
+        if let attentionTrackingEnabled {
+            nextAttentionTrackingEnabled = attentionTrackingEnabled
+        }
+
         store.user = UserDTO(
             id: store.user.id,
             email: store.user.email,
@@ -383,6 +394,7 @@ actor UITestAPIStore {
             isPublic: nextIsPublic,
             currentDay: store.user.currentDay,
             aphorismsEnabled: nextAphorismsEnabled,
+            attentionTrackingEnabled: nextAttentionTrackingEnabled,
             dualTrackEnabled: store.user.dualTrackEnabled,
             secondTrackDay: store.user.secondTrackDay
         )

--- a/ios/StillPointShared/Tests/StillPointSharedTests/AttentionTrackingLogicTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/AttentionTrackingLogicTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import StillPointShared
+
+final class AttentionTrackingLogicTests: XCTestCase {
+    func testClassifyGazeAttentiveWhenLookingAtDevice() {
+        XCTAssertEqual(
+            AttentionTrackingLogic.classifyGaze(lookAtX: 0.02, lookAtY: -0.03, lookAtZ: -0.25),
+            "attentive"
+        )
+    }
+
+    func testClassifyGazeAwayWhenLookingOffScreen() {
+        XCTAssertEqual(
+            AttentionTrackingLogic.classifyGaze(lookAtX: 0.4, lookAtY: 0.0, lookAtZ: -0.25),
+            "away"
+        )
+        XCTAssertEqual(
+            AttentionTrackingLogic.classifyGaze(lookAtX: 0.0, lookAtY: 0.0, lookAtZ: 0.1),
+            "away"
+        )
+    }
+
+    func testSustainedThresholdFiltersBriefNoise() {
+        var state = AttentionTrackingLogic.SustainedState()
+
+        state = AttentionTrackingLogic.applyRawSample("away", elapsed: 1.0, now: 0.0, state: state)
+        XCTAssertEqual(state.loggedState, "attentive")
+        XCTAssertEqual(state.pendingState, "away")
+
+        state = AttentionTrackingLogic.applyRawSample("away", elapsed: 1.2, now: 0.3, state: state)
+        XCTAssertEqual(state.loggedState, "attentive")
+        XCTAssertEqual(state.log.count, 1)
+
+        state = AttentionTrackingLogic.applyRawSample("away", elapsed: 1.6, now: 0.55, state: state)
+        XCTAssertEqual(state.loggedState, "away")
+        XCTAssertEqual(state.log.count, 2)
+        XCTAssertEqual(state.log.last?.time, 1.6)
+        XCTAssertEqual(state.log.last?.state, "away")
+    }
+
+    func testSustainedThresholdIsHalfSecond() {
+        XCTAssertEqual(AttentionTrackingLogic.sustainedThreshold, 0.5, accuracy: 0.001)
+    }
+}

--- a/ios/StillPointShared/Tests/StillPointSharedTests/AttentionTrackingLogicTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/AttentionTrackingLogicTests.swift
@@ -29,11 +29,11 @@ final class AttentionTrackingLogicTests: XCTestCase {
 
         state = AttentionTrackingLogic.applyRawSample("away", elapsed: 1.2, now: 0.3, state: state)
         XCTAssertEqual(state.loggedState, "attentive")
-        XCTAssertEqual(state.log.count, 1)
+        XCTAssertEqual(state.log.count, 0)
 
         state = AttentionTrackingLogic.applyRawSample("away", elapsed: 1.6, now: 0.55, state: state)
         XCTAssertEqual(state.loggedState, "away")
-        XCTAssertEqual(state.log.count, 2)
+        XCTAssertEqual(state.log.count, 1)
         XCTAssertEqual(state.log.last?.time, 1.6)
         XCTAssertEqual(state.log.last?.state, "away")
     }

--- a/ios/StillPointShared/Tests/StillPointSharedTests/CreateSessionEncodingTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/CreateSessionEncodingTests.swift
@@ -2,6 +2,30 @@ import XCTest
 @testable import StillPointShared
 
 final class CreateSessionEncodingTests: XCTestCase {
+    func testCreateSessionRequestIncludesAttentionLogWhenPresent() throws {
+        let request = CreateSessionRequest(
+            dayNumber: 3,
+            duration: 180,
+            completed: true,
+            actualTime: 180,
+            clearPercent: 90,
+            thoughtCount: 0,
+            mindStateLog: [MindStateEntry(time: 0, state: "clear")],
+            attentionLog: [
+                AttentionEntry(time: 0, state: "attentive"),
+                AttentionEntry(time: 42.5, state: "away"),
+            ],
+            sessionDate: "2026-07-02"
+        )
+
+        let data = try JSONEncoder().encode(request)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let attentionLog = try XCTUnwrap(object["attentionLog"] as? [[String: Any]])
+
+        XCTAssertEqual(attentionLog.count, 2)
+        XCTAssertEqual(attentionLog[1]["state"] as? String, "away")
+    }
+
     func testCreateSessionRequestIncludesQuickSessionType() throws {
         let request = CreateSessionRequest(
             dayNumber: 7,

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -29,6 +29,7 @@ targets:
         product: GoogleSignIn
       - target: StillPointMonitor
       - target: StillPointWidget
+      - sdk: ARKit.framework
     info:
       path: StillPointApp/Info.plist
       properties:
@@ -57,7 +58,7 @@ targets:
         # Privacy purpose strings — REQUIRED by iOS for the buddy video web view
         # (BuddyVideoWebView: WKWebView -> Daily.co getUserMedia). A missing key is a
         # hard crash the moment camera/mic is requested, not a graceful denial.
-        NSCameraUsageDescription: Still Point needs camera access for partner video sessions.
+        NSCameraUsageDescription: Still Point uses the camera for partner video sessions and, when you opt in, gaze attention tracking during sits.
         NSMicrophoneUsageDescription: Still Point needs microphone access for partner video sessions.
         # NSFamilyControlsUsageDescription is intentionally NOT declared: it is not a
         # recognized iOS key. FamilyControls / Screen Time authorization is gated by the

--- a/src/app/api/auth/apple-native/route.ts
+++ b/src/app/api/auth/apple-native/route.ts
@@ -106,6 +106,7 @@ export const POST = withApiHandler("apple-native", async (request: NextRequest) 
       isPublic: user.isPublic,
       currentDay: user.currentDay,
       aphorismsEnabled: user.aphorismsEnabled,
+      attentionTrackingEnabled: user.attentionTrackingEnabled,
     },
     token,
   });

--- a/src/app/api/auth/google-native/route.ts
+++ b/src/app/api/auth/google-native/route.ts
@@ -114,6 +114,7 @@ export const POST = withApiHandler("google-native", async (request: NextRequest)
       isPublic: user.isPublic,
       currentDay: user.currentDay,
       aphorismsEnabled: user.aphorismsEnabled,
+      attentionTrackingEnabled: user.attentionTrackingEnabled,
     },
     token,
   });

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -61,6 +61,7 @@ export const POST = withApiHandler("Login", async (request: NextRequest) => {
       isPublic: user.isPublic,
       currentDay: user.currentDay,
       aphorismsEnabled: user.aphorismsEnabled,
+      attentionTrackingEnabled: user.attentionTrackingEnabled,
       recoveryTargetDay: user.recoveryTargetDay,
       recoveryCurrentStep: user.recoveryCurrentStep,
       recoveryTotalSteps: user.recoveryTotalSteps,

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -22,6 +22,7 @@ export const GET = withApiHandler("Auth me", async (request: NextRequest) => {
     isPublic: users.isPublic,
     currentDay: users.currentDay,
     aphorismsEnabled: users.aphorismsEnabled,
+    attentionTrackingEnabled: users.attentionTrackingEnabled,
     recoveryTargetDay: users.recoveryTargetDay,
     recoveryCurrentStep: users.recoveryCurrentStep,
     recoveryTotalSteps: users.recoveryTotalSteps,

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -91,6 +91,7 @@ export const POST = withApiHandler("Signup", async (request: NextRequest) => {
       isPublic: newUser.isPublic,
       currentDay: newUser.currentDay,
       aphorismsEnabled: newUser.aphorismsEnabled,
+      attentionTrackingEnabled: newUser.attentionTrackingEnabled,
       recoveryTargetDay: newUser.recoveryTargetDay,
       recoveryCurrentStep: newUser.recoveryCurrentStep,
       recoveryTotalSteps: newUser.recoveryTotalSteps,

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -51,7 +51,7 @@ export const POST = withApiHandler("Create session", async (request: NextRequest
   if (body === null || typeof body !== "object" || Array.isArray(body)) {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
-  const { dayNumber, duration, actualTime, clearPercent, thoughtCount, mindStateLog, sessionDate } = body;
+  const { dayNumber, duration, actualTime, clearPercent, thoughtCount, mindStateLog, attentionLog, sessionDate } = body;
   const completed = parseCompleted(body.completed);
   const sessionType = parseOptionalSessionType(body.sessionType);
   const track = parseOptionalTrack(body.track);
@@ -97,6 +97,7 @@ export const POST = withApiHandler("Create session", async (request: NextRequest
       thoughtCount: thoughtCount ?? 0,
       breathCount,
       mindStateLog: mindStateLog ?? [],
+      attentionLog: Array.isArray(attentionLog) ? attentionLog : null,
       sessionDate,
     },
   });

--- a/src/app/api/settings/route.test.ts
+++ b/src/app/api/settings/route.test.ts
@@ -20,6 +20,9 @@ vi.mock("@/db/schema", () => ({
     isPublic: "isPublic",
     currentDay: "currentDay",
     aphorismsEnabled: "aphorismsEnabled",
+    attentionTrackingEnabled: "attentionTrackingEnabled",
+    dualTrackEnabled: "dualTrackEnabled",
+    secondTrackDay: "secondTrackDay",
   },
 }));
 
@@ -168,6 +171,32 @@ describe("PATCH /api/settings", () => {
     expect(dbUpdate).toHaveBeenCalledTimes(1);
     const updates = dbUpdateSet.mock.calls[0]![0];
     expect(updates.isPublic).toBe(true);
+    expect(updates).not.toHaveProperty("username");
+  });
+
+  test("attentionTrackingEnabled-only updates skip username atomic path and use the HTTP driver", async () => {
+    dbUpdateReturning.mockResolvedValue([
+      {
+        id: userId,
+        email: "user@example.com",
+        username: "existing",
+        isPublic: true,
+        currentDay: 1,
+        aphorismsEnabled: false,
+        attentionTrackingEnabled: true,
+        dualTrackEnabled: false,
+        secondTrackDay: 1,
+      },
+    ]);
+    const { PATCH } = await import("./route");
+
+    const res = await PATCH(buildRequest({ attentionTrackingEnabled: true }));
+
+    expect(res.status).toBe(200);
+    expect(atomicUpdateUsername).not.toHaveBeenCalled();
+    expect(dbUpdate).toHaveBeenCalledTimes(1);
+    const updates = dbUpdateSet.mock.calls[0]![0];
+    expect(updates.attentionTrackingEnabled).toBe(true);
     expect(updates).not.toHaveProperty("username");
   });
 

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -17,6 +17,7 @@ const RETURN_FIELDS = {
   isPublic: users.isPublic,
   currentDay: users.currentDay,
   aphorismsEnabled: users.aphorismsEnabled,
+  attentionTrackingEnabled: users.attentionTrackingEnabled,
   dualTrackEnabled: users.dualTrackEnabled,
   secondTrackDay: users.secondTrackDay,
 };
@@ -38,6 +39,11 @@ export const PATCH = withApiHandler(
 
     if (typeof body.aphorismsEnabled === "boolean") {
       updates.aphorismsEnabled = body.aphorismsEnabled;
+      hasSupportedUpdate = true;
+    }
+
+    if (typeof body.attentionTrackingEnabled === "boolean") {
+      updates.attentionTrackingEnabled = body.attentionTrackingEnabled;
       hasSupportedUpdate = true;
     }
 

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -12,6 +12,7 @@ const RETURN_FIELDS = {
   isPublic: users.isPublic,
   currentDay: users.currentDay,
   aphorismsEnabled: users.aphorismsEnabled,
+  attentionTrackingEnabled: users.attentionTrackingEnabled,
   recoveryTargetDay: users.recoveryTargetDay,
   recoveryCurrentStep: users.recoveryCurrentStep,
   recoveryTotalSteps: users.recoveryTotalSteps,

--- a/src/db/atomic.ts
+++ b/src/db/atomic.ts
@@ -515,6 +515,7 @@ function mapSessionRow(row: Record<string, unknown>): typeof sessions.$inferSele
     thoughtCount: Number(row.thought_count),
     breathCount: row.breath_count == null ? null : Number(row.breath_count),
     mindStateLog: row.mind_state_log as typeof sessions.$inferSelect["mindStateLog"],
+    attentionLog: row.attention_log as typeof sessions.$inferSelect["attentionLog"],
     sessionDate: String(row.session_date),
     focusRating: row.focus_rating == null ? null : Number(row.focus_rating),
     happinessRating: row.happiness_rating == null ? null : Number(row.happiness_rating),
@@ -589,7 +590,7 @@ export async function atomicCreateSessionWithProgression(params: {
       insert into sessions (
         user_id, buddy_session_id, day_number, session_type, track, duration,
         bonus_seconds, completed, actual_time, clear_percent, thought_count,
-        breath_count, mind_state_log, session_date
+        breath_count, mind_state_log, attention_log, session_date
       )
       values (
         ${userId}::uuid,
@@ -605,6 +606,7 @@ export async function atomicCreateSessionWithProgression(params: {
         ${session.thoughtCount ?? 0},
         ${session.breathCount ?? null},
         ${JSON.stringify(session.mindStateLog ?? [])}::jsonb,
+        ${session.attentionLog ? JSON.stringify(session.attentionLog) : null}::jsonb,
         ${session.sessionDate}
       )
       returning *

--- a/src/db/atomic.ts
+++ b/src/db/atomic.ts
@@ -25,6 +25,7 @@ type UsernameUpdateResult =
         isPublic: boolean;
         currentDay: number;
         aphorismsEnabled: boolean;
+        attentionTrackingEnabled: boolean;
         dualTrackEnabled: boolean;
         secondTrackDay: number;
       };
@@ -59,6 +60,7 @@ export async function atomicUpdateUsername(params: {
         isPublic: users.isPublic,
         currentDay: users.currentDay,
         aphorismsEnabled: users.aphorismsEnabled,
+        attentionTrackingEnabled: users.attentionTrackingEnabled,
         dualTrackEnabled: users.dualTrackEnabled,
         secondTrackDay: users.secondTrackDay,
       });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -31,6 +31,9 @@ export const users = pgTable("users", {
   /** #88: opt-in for a short meditation / digital-minimalism aphorism shown as
    *  pre-session inspiration on the Home view. Defaults off. */
   aphorismsEnabled: boolean("aphorisms_enabled").default(false).notNull(),
+  /** #113: opt-in iOS ARKit gaze attention tracking during sessions. Defaults off
+   *  so the camera is never requested without explicit user consent. */
+  attentionTrackingEnabled: boolean("attention_tracking_enabled").default(false).notNull(),
   currentDay: integer("current_day").default(1).notNull(),
   /** #238: miss-a-day recovery ramp. Nullable trio — all three are set together when a
    *  2+ day gap is detected (`/api/auth/me`) and cleared together once the ramp finishes.
@@ -366,6 +369,8 @@ export const sessions = pgTable("sessions", {
   /** #374: taps-per-breath count for breath-counting sessions; null for other types. */
   breathCount: integer("breath_count"),
   mindStateLog: jsonb("mind_state_log").$type<Array<{ time: number; state: string }>>(),
+  /** #113: ARKit gaze attention transitions ({ time, state: "attentive" | "away" }). */
+  attentionLog: jsonb("attention_log").$type<Array<{ time: number; state: string }>>(),
   sessionDate: date("session_date").notNull(),
   /** #109: post-session self-report ratings (1-10), null until set via the
    *  by-session PATCH route from the CompletionScreen sliders. */

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -29,6 +29,8 @@ export type User = {
   currentDay: number;
   /** #88: opt-in pre-session aphorism shown on Home. */
   aphorismsEnabled: boolean;
+  /** #113: opt-in iOS ARKit gaze attention tracking during sessions. */
+  attentionTrackingEnabled?: boolean;
   /** #238: miss-a-day recovery ramp state, nullable trio (see src/lib/duration.ts). */
   recoveryTargetDay?: number | null;
   recoveryCurrentStep?: number | null;
@@ -54,6 +56,8 @@ export type Session = {
   clearPercent: number;
   thoughtCount: number;
   mindStateLog: Array<{ time: number; state: string }> | null;
+  /** #113: ARKit gaze attention transitions ("attentive" | "away"). */
+  attentionLog?: Array<{ time: number; state: string }> | null;
   sessionDate: string;
   createdAt: string;
   /** Present when this row was created from a completed buddy sit (#119). */
@@ -250,7 +254,7 @@ export const api = {
   getBoard: () =>
     request<{ board: BoardEntry[] }>("/api/board"),
 
-  updateSettings: (data: { isPublic?: boolean; aphorismsEnabled?: boolean }) =>
+  updateSettings: (data: { isPublic?: boolean; aphorismsEnabled?: boolean; attentionTrackingEnabled?: boolean }) =>
     request<{ user: User }>("/api/settings", { method: "PATCH", body: JSON.stringify(data) }),
 
   getFriends: () => request<{ friends: FriendPublicUser[] }>("/api/friends"),


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #113

## Summary

Adds opt-in iOS gaze attention tracking during meditation sessions using ARKit `ARFaceAnchor.lookAtPoint` (the only viable public gaze API). Tracking is **off by default** and gated behind a Settings toggle so the front camera is never requested without explicit user consent.

## Changes

### Backend
- `users.attention_tracking_enabled` boolean (default `false`)
- `sessions.attention_log` JSONB array of `{ time, state }` entries (`"attentive"` | `"away"`), mirroring `mindStateLog`
- Drizzle schema + incremental migrations
- Settings PATCH, auth/me, and session create routes extended

### iOS
- **`AttentionTrackingManager`** — ARKit face-tracking session on TrueDepth devices; simulator stub when unsupported
- **`AttentionTrackingLogic`** (StillPointShared) — gaze classification + **0.5s sustained-gaze debounce** to filter noise
- **Settings → Session → "Gaze attention tracking"** toggle (server-backed, revert-on-failure)
- **`SessionView`** — starts/stops/pauses tracking when opt-in; persists `attentionLog` on session save
- Updated **`NSCameraUsageDescription`** to cover both buddy video and opt-in gaze tracking
- Linked **ARKit.framework** via `project.yml`

## Privacy / camera flow

- Camera is only activated when the user enables the toggle **and** starts a session
- No surprise prompts — toggle defaults off and copy explains front-camera use
- `NSCameraUsageDescription` updated in both `Info.plist` and `project.yml`

## Test plan

- [ ] **Settings toggle**: Enable "Gaze attention tracking" → verify PATCH succeeds and persists after relaunch
- [ ] **Opt-out default**: Fresh install / new user → toggle off, no camera prompt during session
- [ ] **Session with tracking on** (TrueDepth device): Start a sit → front camera activates → complete session → verify `attention_log` saved via API/DB
- [ ] **0.5s debounce**: Brief gaze flickers should not spam log entries (unit tests cover this in `AttentionTrackingLogicTests`)
- [ ] **Pause/resume**: Pausing session pauses ARKit; resuming continues sampling
- [ ] **Simulator / non-TrueDepth**: App compiles and runs; tracking gracefully no-ops (`isSupported = false`)
- [ ] **CI compile**: `xcodegen generate` + iOS e2e/shared test workflows pass
- [ ] **Buddy video unaffected**: Existing camera usage for Daily.co sessions still works with updated usage string

## Notes

- Feeds **build 15** (`CURRENT_PROJECT_VERSION: 15` already set in `project.yml`)
- Web parity for the settings toggle is deferred — this is iOS-only (ARKit)
- Gaze thresholds in `AttentionTrackingLogic.classifyGaze` are heuristic and may need tuning on real devices

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0883feb3-b604-44d1-848e-d0ba2ba4fe74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0883feb3-b604-44d1-848e-d0ba2ba4fe74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Add opt-in gaze attention tracking for iOS sessions**

### What Changed
- Added a new settings toggle that lets users turn gaze attention tracking on or off, with the setting saved to their account
- During a session, the app can now use the front camera on supported devices to log when gaze stays on the screen or moves away, and it pauses tracking when the session is paused
- Session saves now include the attention log, and account/session responses now return the new tracking data
- Updated camera permission text so users are told it may be used for opt-in gaze tracking as well as partner video sessions

### Impact
`✅ Opt-in session camera tracking`
`✅ Saved attention history after each sit`
`✅ Clearer camera permission prompt`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
