### PR TITLE
feat(history): mind-state sit-time trends for light/heavy/hyperfocus (#182)

### DIFF
--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -5,6 +5,7 @@ import { requireAuth } from "@/lib/api/requireAuth";
 import { withApiHandler } from "@/lib/api/withApiHandler";
 import { calculateSessionStats, parseCompleted, parseOptionalSessionType, parseOptionalTrack } from "@/lib/constants";
 import { calculateHistoryPeriodStats } from "@/lib/historyStats";
+import { calculateMindStateTrendStats } from "@/lib/historyMindStateTrends";
 import { isValidSessionCalendarDate, todayLocalIsoDate } from "@/lib/sessionCalendar";
 import { eq, desc } from "drizzle-orm";
 import { sessions } from "@/db/schema";
@@ -24,6 +25,7 @@ export const GET = withApiHandler("Get sessions", async (request: NextRequest) =
     ? todayParam
     : todayLocalIsoDate();
   const periodStats = calculateHistoryPeriodStats(userSessions, todayIso);
+  const mindStateTrends = calculateMindStateTrendStats(userSessions, todayIso);
 
   return NextResponse.json({
     sessions: userSessions,
@@ -31,6 +33,7 @@ export const GET = withApiHandler("Get sessions", async (request: NextRequest) =
       ...stats,
       bonusMinutesTotal: Math.round(stats.bonusSecondsTotal / 60),
       ...periodStats,
+      mindStateTrends,
     },
   });
 });

--- a/src/components/HistoryMindStateTrends.tsx
+++ b/src/components/HistoryMindStateTrends.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import type { MindStateTrendStats } from "@/lib/historyMindStateTrends";
+import { formatTotalTime } from "@/lib/historyMonthGrid";
+
+type HistoryMindStateTrendsProps = {
+  trends: MindStateTrendStats;
+  isMobile: boolean;
+};
+
+const SEGMENTS = [
+  { key: "clearPercent" as const, label: "aware", color: "var(--accent-green)" },
+  { key: "lightDistractionPercent" as const, label: "light distraction", color: "var(--accent-amber)" },
+  { key: "heavyDistractionPercent" as const, label: "heavy distraction", color: "var(--accent-danger-muted)" },
+  { key: "hyperfocusPercent" as const, label: "hyperfocus", color: "rgba(96, 165, 250, 0.95)" },
+];
+
+function formatDayLabel(isoDate: string): string {
+  const d = new Date(isoDate + "T12:00:00");
+  return d.toLocaleDateString("en-US", { weekday: "short", month: "numeric", day: "numeric" });
+}
+
+export function HistoryMindStateTrends({ trends, isMobile }: HistoryMindStateTrendsProps) {
+  const mono: CSSProperties = { fontFamily: "var(--font-mono)" };
+  const statCardStyle: CSSProperties = {
+    textAlign: "center",
+    minWidth: isMobile ? "72px" : "88px",
+  };
+
+  const activeDays = trends.dailyTrend.filter(day => day.totalSitSeconds > 0);
+  const summaryCards = [
+    {
+      label: "light distraction",
+      value: `${trends.trailing4Week.lightDistractionPercent}%`,
+      color: "var(--accent-amber)",
+    },
+    {
+      label: "heavy distraction",
+      value: `${trends.trailing4Week.heavyDistractionPercent}%`,
+      color: "var(--accent-danger-muted)",
+    },
+    {
+      label: "hyperfocus",
+      value: `${trends.trailing4Week.hyperfocusPercent}%`,
+      color: "rgba(96, 165, 250, 0.95)",
+    },
+    {
+      label: "sit time",
+      value: formatTotalTime(trends.trailing4Week.totalSitSeconds),
+      color: "var(--fg)",
+    },
+  ];
+
+  return (
+    <div style={{ width: "100%", maxWidth: "480px", display: "flex", flexDirection: "column", gap: "16px" }}>
+      <div style={{
+        fontFamily: "var(--font-serif)",
+        fontSize: "14px",
+        color: "var(--fg-2)",
+        letterSpacing: "0.07em",
+        textTransform: "uppercase",
+        textAlign: "center",
+      }}>
+        Sit-time composition
+      </div>
+
+      <div style={{
+        display: "flex",
+        gap: isMobile ? "12px" : "20px",
+        flexWrap: "wrap",
+        justifyContent: "center",
+        ...mono,
+      }}>
+        {summaryCards.map(card => (
+          <div key={card.label} style={statCardStyle}>
+            <div style={{ fontSize: "22px", fontWeight: 200, color: card.color }}>{card.value}</div>
+            <div style={{
+              fontSize: "10px",
+              color: "var(--fg-3)",
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              marginTop: "4px",
+            }}>
+              {card.label}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div style={{
+        ...mono,
+        fontSize: "10px",
+        color: "var(--fg-4)",
+        textAlign: "center",
+        letterSpacing: "0.05em",
+      }}>
+        Trailing 4 weeks · all time {trends.allTime.lightDistractionPercent}% light ·
+        {" "}{trends.allTime.heavyDistractionPercent}% heavy ·
+        {" "}{trends.allTime.hyperfocusPercent}% hyperfocus
+      </div>
+
+      {activeDays.length > 0 ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+          {activeDays.map(day => (
+            <div
+              key={day.date}
+              style={{
+                display: "grid",
+                gridTemplateColumns: isMobile ? "72px 1fr 44px" : "96px 1fr 52px",
+                gap: "8px",
+                alignItems: "center",
+                ...mono,
+                fontSize: "10px",
+                color: "var(--fg-3)",
+              }}
+            >
+              <span style={{ textAlign: "right", whiteSpace: "nowrap" }}>{formatDayLabel(day.date)}</span>
+              <div style={{
+                height: "10px",
+                borderRadius: "3px",
+                overflow: "hidden",
+                display: "flex",
+                background: "var(--surface-1)",
+              }}>
+                {SEGMENTS.map(segment => {
+                  const width = day.composition[segment.key];
+                  if (width <= 0) return null;
+                  return (
+                    <div
+                      key={segment.key}
+                      title={`${segment.label}: ${width}%`}
+                      style={{
+                        width: `${width}%`,
+                        height: "100%",
+                        background: segment.color,
+                        opacity: segment.key === "clearPercent" ? 0.75 : 0.85,
+                      }}
+                    />
+                  );
+                })}
+              </div>
+              <span style={{ color: "var(--fg-4)" }}>{formatTotalTime(day.totalSitSeconds)}</span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div style={{ ...mono, fontSize: "11px", color: "var(--fg-4)", textAlign: "center" }}>
+          No sits in the trailing 4 weeks yet.
+        </div>
+      )}
+
+      <div style={{ display: "flex", gap: "12px", justifyContent: "center", flexWrap: "wrap" }}>
+        {SEGMENTS.map(segment => (
+          <div
+            key={segment.key}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "6px",
+              ...mono,
+              fontSize: "10px",
+              color: "var(--fg-3)",
+            }}
+          >
+            <div style={{
+              width: "10px",
+              height: "10px",
+              borderRadius: "2px",
+              background: segment.color,
+              opacity: 0.8,
+            }} />
+            {segment.label}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -7,6 +7,8 @@ import { buildCurrentMonthGrid, buildPriorMonthSummaries, formatTotalTime } from
 import { buildHistoryJourneyRows } from "@/lib/historyJourney";
 import { useIsMobile } from "@/lib/useIsMobile";
 import { todayLocalIsoDate } from "@/lib/sessionCalendar";
+import type { MindStateTrendStats } from "@/lib/historyMindStateTrends";
+import { HistoryMindStateTrends } from "@/components/HistoryMindStateTrends";
 
 const NO_RECOVERY: RecoveryFields = {
   recoveryTargetDay: null,
@@ -65,6 +67,24 @@ type HistoryViewProps = {
   username: string;
 };
 
+const EMPTY_MIND_STATE_TRENDS: MindStateTrendStats = {
+  trailing4Week: {
+    totalSitSeconds: 0,
+    clearPercent: 0,
+    lightDistractionPercent: 0,
+    heavyDistractionPercent: 0,
+    hyperfocusPercent: 0,
+  },
+  allTime: {
+    totalSitSeconds: 0,
+    clearPercent: 0,
+    lightDistractionPercent: 0,
+    heavyDistractionPercent: 0,
+    hyperfocusPercent: 0,
+  },
+  dailyTrend: [],
+};
+
 export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: HistoryViewProps) {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [stats, setStats] = useState({
@@ -79,6 +99,7 @@ export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: Hi
     trailing4WeekTimePercent: 0,
     totalTimeAllTime: 0,
     progressTo10kHours: 0,
+    mindStateTrends: EMPTY_MIND_STATE_TRENDS,
   });
   const [expandedEntryId, setExpandedEntryId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -114,6 +135,7 @@ export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: Hi
         trailing4WeekTimePercent: sessData.stats?.trailing4WeekTimePercent ?? 0,
         totalTimeAllTime: sessData.stats?.totalTimeAllTime ?? 0,
         progressTo10kHours: sessData.stats?.progressTo10kHours ?? 0,
+        mindStateTrends: sessData.stats?.mindStateTrends ?? EMPTY_MIND_STATE_TRENDS,
       });
       setThoughts(thoughtData.thoughts || []);
       setLoading(false);
@@ -297,6 +319,8 @@ export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: Hi
               </div>
             ))}
           </div>
+
+          <HistoryMindStateTrends trends={stats.mindStateTrends} isMobile={isMobile} />
 
           {/* All-time progress toward 10,000 hours */}
           <div style={{ width: "100%", maxWidth: "480px" }}>

--- a/src/lib/historyMindStateTrends.test.ts
+++ b/src/lib/historyMindStateTrends.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "vitest";
+import {
+  computeMindStateCompositionFromLog,
+  recordHoldSegment,
+} from "./mindStateSession";
+import { calculateMindStateTrendStats } from "./historyMindStateTrends";
+
+describe("computeMindStateCompositionFromLog", () => {
+  test("empty log is fully clear", () => {
+    expect(computeMindStateCompositionFromLog([], 300)).toEqual({
+      clearSeconds: 300,
+      lightDistractionSeconds: 0,
+      heavyDistractionSeconds: 0,
+      hyperfocusSeconds: 0,
+      totalSeconds: 300,
+    });
+  });
+
+  test("splits thinking, hyperfocus, and heavy segments", () => {
+    const composition = computeMindStateCompositionFromLog(
+      [
+        { time: 0, state: "clear" },
+        { time: 60, state: "thinking" },
+        { time: 120, state: "clear" },
+        { time: 180, state: "hyperfocus" },
+        { time: 240, state: "heavy" },
+        { time: 300, state: "clear" },
+      ],
+      300,
+    );
+
+    expect(composition).toEqual({
+      clearSeconds: 120,
+      lightDistractionSeconds: 60,
+      heavyDistractionSeconds: 60,
+      hyperfocusSeconds: 60,
+      totalSeconds: 300,
+    });
+  });
+
+  test("treats time before the first entry as clear", () => {
+    const composition = computeMindStateCompositionFromLog(
+      [{ time: 50, state: "thinking" }],
+      100,
+    );
+    expect(composition.clearSeconds).toBe(50);
+    expect(composition.lightDistractionSeconds).toBe(50);
+  });
+
+  test("hold segments replay the same way as clear-percent math", () => {
+    let log: Array<{ time: number; state: string }> = [];
+    log = recordHoldSegment(log, "hyperfocus", 0, 60);
+    log = recordHoldSegment(log, "thinking", 120, 180);
+    expect(computeMindStateCompositionFromLog(log, 240)).toEqual({
+      clearSeconds: 120,
+      lightDistractionSeconds: 60,
+      heavyDistractionSeconds: 0,
+      hyperfocusSeconds: 60,
+      totalSeconds: 240,
+    });
+  });
+});
+
+describe("calculateMindStateTrendStats", () => {
+  const today = "2026-07-02";
+
+  test("aggregates trailing window and daily buckets by sit seconds", () => {
+    const stats = calculateMindStateTrendStats(
+      [
+        {
+          sessionDate: "2026-07-01",
+          duration: 120,
+          actualTime: 120,
+          mindStateLog: [{ time: 0, state: "thinking" }],
+        },
+        {
+          sessionDate: "2026-07-02",
+          duration: 60,
+          actualTime: 60,
+          mindStateLog: [{ time: 0, state: "hyperfocus" }],
+        },
+        {
+          sessionDate: "2026-05-01",
+          duration: 300,
+          actualTime: 300,
+          mindStateLog: [{ time: 0, state: "clear" }],
+        },
+      ],
+      today,
+    );
+
+    expect(stats.trailing4Week.totalSitSeconds).toBe(180);
+    expect(stats.trailing4Week.lightDistractionPercent).toBeCloseTo(66.7, 1);
+    expect(stats.trailing4Week.hyperfocusPercent).toBeCloseTo(33.3, 1);
+    expect(stats.trailing4Week.heavyDistractionPercent).toBe(0);
+    expect(stats.allTime.totalSitSeconds).toBe(480);
+    expect(stats.allTime.clearPercent).toBeCloseTo(62.5, 1);
+
+    const july1 = stats.dailyTrend.find(bucket => bucket.date === "2026-07-01");
+    const july2 = stats.dailyTrend.find(bucket => bucket.date === "2026-07-02");
+    expect(july1?.composition.lightDistractionPercent).toBe(100);
+    expect(july2?.composition.hyperfocusPercent).toBe(100);
+    expect(stats.dailyTrend).toHaveLength(28);
+  });
+
+  test("returns zeroed stats when there are no sessions", () => {
+    const stats = calculateMindStateTrendStats([], today);
+    expect(stats.trailing4Week).toMatchObject({
+      totalSitSeconds: 0,
+      clearPercent: 0,
+      lightDistractionPercent: 0,
+      heavyDistractionPercent: 0,
+      hyperfocusPercent: 0,
+    });
+    expect(stats.dailyTrend.every(bucket => bucket.totalSitSeconds === 0)).toBe(true);
+  });
+});

--- a/src/lib/historyMindStateTrends.test.ts
+++ b/src/lib/historyMindStateTrends.test.ts
@@ -59,6 +59,15 @@ describe("computeMindStateCompositionFromLog", () => {
       totalSeconds: 240,
     });
   });
+
+  test("skips malformed log entries without throwing", () => {
+    const composition = computeMindStateCompositionFromLog(
+      [null as unknown as { time: number; state: string }, { time: 30, state: "thinking" }],
+      60,
+    );
+    expect(composition.lightDistractionSeconds).toBe(30);
+    expect(composition.clearSeconds).toBe(30);
+  });
 });
 
 describe("calculateMindStateTrendStats", () => {
@@ -113,5 +122,22 @@ describe("calculateMindStateTrendStats", () => {
       hyperfocusPercent: 0,
     });
     expect(stats.dailyTrend.every(bucket => bucket.totalSitSeconds === 0)).toBe(true);
+  });
+
+  test("uses session elapsed timeline instead of wall-clock actualTime when paused", () => {
+    const stats = calculateMindStateTrendStats(
+      [
+        {
+          sessionDate: "2026-07-02",
+          duration: 300,
+          actualTime: 900,
+          mindStateLog: [],
+        },
+      ],
+      today,
+    );
+
+    expect(stats.trailing4Week.totalSitSeconds).toBe(300);
+    expect(stats.trailing4Week.clearPercent).toBe(100);
   });
 });

--- a/src/lib/historyMindStateTrends.ts
+++ b/src/lib/historyMindStateTrends.ts
@@ -67,7 +67,8 @@ function compositionPercents(composition: MindStateCompositionSeconds): MindStat
 
 function compositionForSession(session: MindStateTrendSessionInput): MindStateCompositionSeconds {
   const endTime = sessionEndTime(session);
-  return computeMindStateCompositionFromLog(session.mindStateLog ?? [], endTime);
+  const log = Array.isArray(session.mindStateLog) ? session.mindStateLog : [];
+  return computeMindStateCompositionFromLog(log, endTime);
 }
 
 /**

--- a/src/lib/historyMindStateTrends.ts
+++ b/src/lib/historyMindStateTrends.ts
@@ -32,8 +32,30 @@ export type MindStateTrendStats = {
   dailyTrend: MindStateDailyTrendBucket[];
 };
 
+function isValidMindStateLogEntry(
+  entry: unknown,
+): entry is { time: number; state: string } {
+  return (
+    entry != null
+    && typeof entry === "object"
+    && typeof (entry as { time?: unknown }).time === "number"
+    && Number.isFinite((entry as { time: number }).time)
+    && typeof (entry as { state?: unknown }).state === "string"
+  );
+}
+
+/** Session-elapsed seconds for trend replay (same axis as clear-percent endT, not wall-clock actualTime). */
 function sessionEndTime(session: MindStateTrendSessionInput): number {
-  return Math.max(session.actualTime ?? session.duration, 0);
+  const duration = Math.max(session.duration, 0);
+  const log = Array.isArray(session.mindStateLog) ? session.mindStateLog : [];
+  let elapsedEnd = 0;
+  for (const entry of log) {
+    if (isValidMindStateLogEntry(entry)) {
+      elapsedEnd = Math.max(elapsedEnd, Math.max(entry.time, 0));
+    }
+  }
+  if (elapsedEnd > 0) return elapsedEnd;
+  return duration;
 }
 
 function emptyComposition(): MindStateCompositionSeconds {

--- a/src/lib/historyMindStateTrends.ts
+++ b/src/lib/historyMindStateTrends.ts
@@ -1,0 +1,125 @@
+import { addDaysToIsoDate, isValidSessionCalendarDate } from "./sessionCalendar";
+import { TRAILING_4_WEEK_DAYS } from "./historyStats";
+import {
+  computeMindStateCompositionFromLog,
+  type MindStateCompositionSeconds,
+} from "./mindStateSession";
+
+export type MindStateTrendSessionInput = {
+  sessionDate?: string;
+  actualTime?: number | null;
+  duration: number;
+  mindStateLog?: Array<{ time: number; state: string }> | null;
+};
+
+export type MindStateCompositionPercents = {
+  clearPercent: number;
+  lightDistractionPercent: number;
+  heavyDistractionPercent: number;
+  hyperfocusPercent: number;
+};
+
+export type MindStateDailyTrendBucket = {
+  date: string;
+  totalSitSeconds: number;
+  composition: MindStateCompositionPercents;
+};
+
+export type MindStateTrendStats = {
+  trailing4Week: MindStateCompositionPercents & { totalSitSeconds: number };
+  allTime: MindStateCompositionPercents & { totalSitSeconds: number };
+  /** One bucket per calendar day in the trailing window (oldest first). */
+  dailyTrend: MindStateDailyTrendBucket[];
+};
+
+function sessionEndTime(session: MindStateTrendSessionInput): number {
+  return Math.max(session.actualTime ?? session.duration, 0);
+}
+
+function emptyComposition(): MindStateCompositionSeconds {
+  return {
+    clearSeconds: 0,
+    lightDistractionSeconds: 0,
+    heavyDistractionSeconds: 0,
+    hyperfocusSeconds: 0,
+    totalSeconds: 0,
+  };
+}
+
+function addComposition(target: MindStateCompositionSeconds, next: MindStateCompositionSeconds): void {
+  target.clearSeconds += next.clearSeconds;
+  target.lightDistractionSeconds += next.lightDistractionSeconds;
+  target.heavyDistractionSeconds += next.heavyDistractionSeconds;
+  target.hyperfocusSeconds += next.hyperfocusSeconds;
+  target.totalSeconds += next.totalSeconds;
+}
+
+function compositionPercents(composition: MindStateCompositionSeconds): MindStateCompositionPercents {
+  const denom = Math.max(composition.totalSeconds, 1);
+  const toPercent = (seconds: number) => parseFloat(((seconds / denom) * 100).toFixed(1));
+  return {
+    clearPercent: toPercent(composition.clearSeconds),
+    lightDistractionPercent: toPercent(composition.lightDistractionSeconds),
+    heavyDistractionPercent: toPercent(composition.heavyDistractionSeconds),
+    hyperfocusPercent: toPercent(composition.hyperfocusSeconds),
+  };
+}
+
+function compositionForSession(session: MindStateTrendSessionInput): MindStateCompositionSeconds {
+  const endTime = sessionEndTime(session);
+  return computeMindStateCompositionFromLog(session.mindStateLog ?? [], endTime);
+}
+
+/**
+ * Aggregates sit-time composition from persisted `mindStateLog` rows for History trends (#182).
+ */
+export function calculateMindStateTrendStats(
+  sessions: MindStateTrendSessionInput[],
+  todayIso: string,
+): MindStateTrendStats {
+  const periodStart = addDaysToIsoDate(todayIso, -(TRAILING_4_WEEK_DAYS - 1));
+  const trailingTotals = emptyComposition();
+  const allTimeTotals = emptyComposition();
+  const dailyTotals = new Map<string, MindStateCompositionSeconds>();
+
+  for (let i = 0; i < TRAILING_4_WEEK_DAYS; i++) {
+    dailyTotals.set(addDaysToIsoDate(periodStart, i), emptyComposition());
+  }
+
+  for (const session of sessions) {
+    if (!isValidSessionCalendarDate(session.sessionDate)) continue;
+    const composition = compositionForSession(session);
+    if (composition.totalSeconds <= 0) continue;
+
+    addComposition(allTimeTotals, composition);
+
+    if (session.sessionDate! >= periodStart && session.sessionDate! <= todayIso) {
+      addComposition(trailingTotals, composition);
+      const dayBucket = dailyTotals.get(session.sessionDate!);
+      if (dayBucket) addComposition(dayBucket, composition);
+    }
+  }
+
+  const dailyTrend: MindStateDailyTrendBucket[] = [];
+  for (let i = 0; i < TRAILING_4_WEEK_DAYS; i++) {
+    const date = addDaysToIsoDate(periodStart, i);
+    const totals = dailyTotals.get(date) ?? emptyComposition();
+    dailyTrend.push({
+      date,
+      totalSitSeconds: totals.totalSeconds,
+      composition: compositionPercents(totals),
+    });
+  }
+
+  return {
+    trailing4Week: {
+      totalSitSeconds: trailingTotals.totalSeconds,
+      ...compositionPercents(trailingTotals),
+    },
+    allTime: {
+      totalSitSeconds: allTimeTotals.totalSeconds,
+      ...compositionPercents(allTimeTotals),
+    },
+    dailyTrend,
+  };
+}

--- a/src/lib/mindStateSession.ts
+++ b/src/lib/mindStateSession.ts
@@ -186,12 +186,24 @@ export function computeMindStateCompositionFromLog(
   };
   if (totalSeconds === 0) return out;
 
+  const safeLog = [...log]
+    .map((entry) => ({
+      time: Math.min(Math.max(entry.time, 0), totalSeconds),
+      state: entry.state,
+    }))
+    .sort((a, b) => a.time - b.time);
+
   let lastTime = 0;
   let lastState = "clear";
-  const full = log.length === 0 ? [{ time: totalSeconds, state: "clear" }] : [...log, { time: totalSeconds, state: "clear" }];
+  const full = safeLog.length === 0
+    ? [{ time: totalSeconds, state: "clear" }]
+    : [...safeLog, { time: totalSeconds, state: "clear" }];
   for (const entry of full) {
-    bucketMindStateSeconds(lastState, entry.time - lastTime, out);
-    lastTime = entry.time;
+    const clampedTime = Math.min(Math.max(entry.time, lastTime), totalSeconds);
+    if (clampedTime > lastTime) {
+      bucketMindStateSeconds(lastState, clampedTime - lastTime, out);
+    }
+    lastTime = clampedTime;
     lastState = entry.state;
   }
 

--- a/src/lib/mindStateSession.ts
+++ b/src/lib/mindStateSession.ts
@@ -141,6 +141,63 @@ function isAwareLikeState(state: string): boolean {
   return state === "clear" || state === "hyperfocus";
 }
 
+export type MindStateCompositionSeconds = {
+  clearSeconds: number;
+  lightDistractionSeconds: number;
+  heavyDistractionSeconds: number;
+  hyperfocusSeconds: number;
+  totalSeconds: number;
+};
+
+function bucketMindStateSeconds(state: string, seconds: number, out: MindStateCompositionSeconds): void {
+  if (seconds <= 0) return;
+  switch (state) {
+    case "thinking":
+      out.lightDistractionSeconds += seconds;
+      break;
+    case "heavy":
+      out.heavyDistractionSeconds += seconds;
+      break;
+    case "hyperfocus":
+      out.hyperfocusSeconds += seconds;
+      break;
+    default:
+      out.clearSeconds += seconds;
+      break;
+  }
+}
+
+/**
+ * Replays `mindStateLog` into sit-time seconds for clear, light distraction,
+ * heavy distraction, and hyperfocus. Uses the same segment boundaries as
+ * `computeClearPercentFromLog`.
+ */
+export function computeMindStateCompositionFromLog(
+  log: Array<{ time: number; state: string }>,
+  endTime: number,
+): MindStateCompositionSeconds {
+  const totalSeconds = Math.max(endTime, 0);
+  const out: MindStateCompositionSeconds = {
+    clearSeconds: 0,
+    lightDistractionSeconds: 0,
+    heavyDistractionSeconds: 0,
+    hyperfocusSeconds: 0,
+    totalSeconds,
+  };
+  if (totalSeconds === 0) return out;
+
+  let lastTime = 0;
+  let lastState = "clear";
+  const full = log.length === 0 ? [{ time: totalSeconds, state: "clear" }] : [...log, { time: totalSeconds, state: "clear" }];
+  for (const entry of full) {
+    bucketMindStateSeconds(lastState, entry.time - lastTime, out);
+    lastTime = entry.time;
+    lastState = entry.state;
+  }
+
+  return out;
+}
+
 export function computeClearPercentFromLog(
   log: Array<{ time: number; state: string }>,
   endTime: number,

--- a/src/lib/mindStateSession.ts
+++ b/src/lib/mindStateSession.ts
@@ -167,6 +167,18 @@ function bucketMindStateSeconds(state: string, seconds: number, out: MindStateCo
   }
 }
 
+function isValidMindStateLogEntry(
+  entry: unknown,
+): entry is { time: number; state: string } {
+  return (
+    entry != null
+    && typeof entry === "object"
+    && typeof (entry as { time?: unknown }).time === "number"
+    && Number.isFinite((entry as { time: number }).time)
+    && typeof (entry as { state?: unknown }).state === "string"
+  );
+}
+
 /**
  * Replays `mindStateLog` into sit-time seconds for clear, light distraction,
  * heavy distraction, and hyperfocus. Uses the same segment boundaries as
@@ -187,10 +199,13 @@ export function computeMindStateCompositionFromLog(
   if (totalSeconds === 0) return out;
 
   const safeLog = [...log]
-    .map((entry) => ({
-      time: Math.min(Math.max(entry.time, 0), totalSeconds),
-      state: entry.state,
-    }))
+    .flatMap((entry) => {
+      if (!isValidMindStateLogEntry(entry)) return [];
+      return [{
+        time: Math.min(Math.max(entry.time, 0), totalSeconds),
+        state: entry.state,
+      }];
+    })
     .sort((a, b) => a.time - b.time);
 
   let lastTime = 0;


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #182

## Summary

Adds History trend views for how sit time composes beyond overall `clearPercent`: **light distraction** (`thinking`), **heavy distraction** (`heavy`), and **hyperfocus**, replayed from persisted `mindStateLog` segments.

## Changes

- **`computeMindStateCompositionFromLog`** — replays log segments into clear / light / heavy / hyperfocus seconds using the same boundary rules as clear-percent math.
- **`calculateMindStateTrendStats`** — aggregates trailing 4-week and all-time composition plus per-day buckets for the chart.
- **`GET /api/sessions`** — returns `stats.mindStateTrends` (read-only aggregation).
- **`HistoryMindStateTrends`** — calendar-mode stacked bars + summary cards in `HistoryView`.

## Notes

- Hyperfocus and light distraction use existing log states from #72 / #184.
- Heavy distraction reads `state: "heavy"` when present; legacy sessions without that state show 0% heavy until capture-range logging lands.

## Test plan

- [x] `npm run test:unit -- src/lib/historyMindStateTrends.test.ts src/lib/mindStateSession.test.ts`
- [x] Full unit suite (`npm run test:unit`) — 522 tests pass
- [ ] Manual: open `/app/history` → Calendar → confirm **Sit-time composition** cards and daily stacked bars reflect sessions with `thinking` / `hyperfocus` holds
- [ ] Manual: verify `GET /api/sessions?today=YYYY-MM-DD` includes `stats.mindStateTrends` with expected percentages

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cafae241-02fe-46a7-b1e6-e86b67bd8ecb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cafae241-02fe-46a7-b1e6-e86b67bd8ecb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Show sit-time composition trends in History**

### What Changed
- History now shows how sit time is split across aware, light distraction, heavy distraction, and hyperfocus.
- The History page adds trailing 4-week summary cards and a daily stacked bar view, with an empty-state message when there are no sits.
- Session history responses now include these trend totals for both the trailing window and all time.
- Trend calculations ignore invalid session dates and safely handle missing or malformed saved logs.

### Impact
`✅ Clearer sit-time breakdowns`
`✅ Faster review of distraction patterns`
`✅ Fewer History errors from bad saved logs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
