### PR TITLE
test(e2e): coverage audit matrix + journey gap-fill (#497)

### DIFF
--- a/docs/testing/e2e-coverage-matrix.md
+++ b/docs/testing/e2e-coverage-matrix.md
@@ -20,10 +20,18 @@ Lane wiring and retry policy: [`e2e-policy.md`](./e2e-policy.md). Spec layout: [
 
 | Journey | Risk | Web | iOS | Spec / test reference |
 |---------|:----:|:---:|:---:|------------------------|
-| **Public** |
+
+### Public
+
+| Journey | Risk | Web | iOS | Spec / test reference |
+|---------|:----:|:---:|:---:|------------------------|
 | Landing page CTAs | P0 | ✅ | ➖ | `e2e/web/smoke.spec.ts` `@smoke` |
 | Privacy / delete-account pages | P2 | ❌ | ➖ | Manual / unit |
-| **Auth (email/password)** |
+
+### Auth (email/password)
+
+| Journey | Risk | Web | iOS | Spec / test reference |
+|---------|:----:|:---:|:---:|------------------------|
 | Auth shell visible (`/app`) | P0 | ✅ | ✅ | `e2e/web/critical.spec.ts`; iOS auth cold-start tests |
 | Signup → authenticated home | P0 | ✅ | ⚠️ | `e2e/auth/signup.spec.ts` `@critical`; iOS uses fixture login in smoke |
 | Login → home shell | P0 | ✅ | ✅ | `e2e/auth/login.spec.ts` `@critical`; `testLaunchLoginCompleteSessionAndHistoryPersistence` |
@@ -35,15 +43,27 @@ Lane wiring and retry policy: [`e2e-policy.md`](./e2e-policy.md). Spec layout: [
 | Auth network failure + Retry | P1 | ✅ | ✅ | `e2e/auth/login.spec.ts`; `testLaunchOfflineShowsUserVisibleMessage` |
 | Deleted account (410) message | P2 | ✅ | ❌ | `e2e/auth/login.spec.ts` |
 | Username uniqueness / race (DB) | P1 | ✅ | ❌ | `e2e/auth/username-uniqueness.integration.spec.ts` (`@authDbIntegration`) |
-| **OAuth (excluded)** |
-| Google / Apple OAuth (web) | — | ❌ | ➖ | **Excluded** — see [Exclusions](#exclusions) |
+
+### OAuth (excluded)
+
+| Journey | Risk | Web | iOS | Spec / test reference |
+|---------|:----:|:---:|:---:|------------------------|
+| Google / Apple OAuth (web) | — | ❌ | ➖ | **Excluded** — see [Exclusions](#exclusions-justified) |
 | Google / Apple native (iOS) | — | ➖ | ❌ | **Excluded** |
-| **Tab routing & deep links** |
+
+### Tab routing & deep links
+
+| Journey | Risk | Web | iOS | Spec / test reference |
+|---------|:----:|:---:|:---:|------------------------|
 | Default `/app` → home/progress | P0 | ✅ | ✅ | `e2e/routing/tab-routing.spec.ts` `@smoke`; iOS smoke |
 | Per-tab URLs + deep links | P1 | ✅ | ⚠️ | `e2e/routing/tab-routing.spec.ts`; iOS history/settings smoke only |
 | Buddy invite deep link | P1 | ✅ | ❌ | `e2e/routing/tab-routing.spec.ts` (mocked join) |
 | Browser back clears session overlay | P1 | ✅ | ➖ | `e2e/routing/tab-routing.spec.ts` |
-| **Home & sessions** |
+
+### Home & sessions
+
+| Journey | Risk | Web | iOS | Spec / test reference |
+|---------|:----:|:---:|:---:|------------------------|
 | Standard session begin → complete → return | P0 | ✅ | ✅ | `e2e/session/session-flow.spec.ts` `@critical`; iOS smoke golden path |
 | Session history persistence after relaunch | P0 | ⚠️ | ✅ | Web mocked POST only; iOS smoke |
 | Quick minute (no day advance) | P1 | ✅ | ✅ | `e2e/session/session-flow.spec.ts`; `testQuickMinuteCompletesWithoutDayAdvance` |
@@ -52,25 +72,45 @@ Lane wiring and retry policy: [`e2e-policy.md`](./e2e-policy.md). Spec layout: [
 | Pause / abandon / thought capture | P2 | ❌ | ❌ | QA manual; snapshot lane only |
 | Landscape session usability | P1 | ✅ | ✅ | `e2e/session/session-flow.spec.ts`; `testRotationDecisionSessionRemainsUsableInLandscape` (non-critical lane) |
 | Pull-to-refresh during session | P2 | ✅ | ➖ | `e2e/session/session-flow.spec.ts` |
-| **Breath counting (excluded)** |
-| Full breath-counting UX | — | ⚠️ | ❌ | **Excluded** — see [Exclusions](#exclusions) |
-| **History / journal / board** |
+
+### Breath counting (excluded)
+
+| Journey | Risk | Web | iOS | Spec / test reference |
+|---------|:----:|:---:|:---:|------------------------|
+| Full breath-counting UX | — | ⚠️ | ❌ | **Excluded** — see [Exclusions](#exclusions-justified) |
+
+### History / journal / board
+
+| Journey | Risk | Web | iOS | Spec / test reference |
+|---------|:----:|:---:|:---:|------------------------|
 | History list + scroll | P1 | ✅ | ✅ | `e2e/layout/overflow.spec.ts`; iOS smoke + `testSessionsFailureShowsVisibleRetryMessage` |
 | Calendar / journey view modes | P2 | ❌ | ❌ | Unit tests (`historyJourney.test.ts`, `HistoryJourneyTests.swift`) |
 | Thought journal tab | P2 | ⚠️ | ✅ | Web layout FlashHint; `testJournalAndBoardTabsReachable` |
 | Public board tab | P2 | ✅ | ✅ | `e2e/layout/issue-473-mobile-web-layout.spec.ts`; `testJournalAndBoardTabsReachable` |
-| **Friends / buddy** |
+
+### Friends / buddy
+
+| Journey | Risk | Web | iOS | Spec / test reference |
+|---------|:----:|:---:|:---:|------------------------|
 | Friends search & requests (web) | P2 | ❌ | ➖ | Web-only surface |
 | Buddy room UI (video, lobby) | P2 | ❌ | ❌ | QA manual; Daily.co third-party |
 | Buddy duration normalization (API) | P1 | ✅ | ❌ | `e2e/buddy/buddy-session-length.integration.spec.ts` |
-| **Settings & account** |
+
+### Settings & account
+
+| Journey | Risk | Web | iOS | Spec / test reference |
+|---------|:----:|:---:|:---:|------------------------|
 | Settings navigation | P1 | ✅ | ✅ | `e2e/auth/login.spec.ts`; `testHistoryAndSettingsNavigationSmoke` |
 | Username inline edit / validation / conflict | P1 | ❌ | ✅ | iOS `testSettingsUsernameInlineEditSucceeds` et al. |
 | Public board / aphorisms toggles | P2 | ❌ | ❌ | QA manual |
 | Notifications subpage | P2 | ❌ | ⚠️ | Link exists; no E2E |
 | App blocking / Screen Time gate | P2 | ➖ | ⚠️ | `testCompletedSessionUnlocksConfiguredAppGate` (settings smoke; no shield E2E) |
 | Delete account flow | P2 | ❌ | ❌ | QA manual |
-| **Layout / a11y (cross-cutting)** |
+
+### Layout / a11y (cross-cutting)
+
+| Journey | Risk | Web | iOS | Spec / test reference |
+|---------|:----:|:---:|:---:|------------------------|
 | Safe area / bottom nav overlap | P1 | ✅ | ✅ | `e2e/layout/safe-area.spec.ts`; `testPrimaryControlsVisibleAboveHomeIndicator` |
 | Horizontal overflow / tap targets | P1 | ✅ | ⚠️ | `e2e/layout/overflow.spec.ts`, `login.spec.ts` |
 | Mobile web 320–375px layout (#473) | P1 | ✅ | ➖ | `e2e/layout/issue-473-mobile-web-layout.spec.ts` |
@@ -83,7 +123,7 @@ Lane wiring and retry policy: [`e2e-policy.md`](./e2e-policy.md). Spec layout: [
 
 ### OAuth (Google / Apple, web + native)
 
-Automated OAuth E2E requires live provider credentials, consent screens, redirect URI wiring, and simulator Keychain state. Policy defers real-provider auth to manual checklists (`docs/mobile-oauth-integration.md`, `ios/QA_CHECKLIST.md`). Route handlers remain covered by unit/integration tests; matrix marks OAuth as **out of scope** until a headless or stub-provider lane exists.
+Automated OAuth E2E requires live provider credentials, consent screens, redirect URI wiring, and simulator Keychain state. Policy defers real-provider auth to manual checklists ([`docs/mobile-oauth-integration.md`](../mobile-oauth-integration.md), [`ios/QA_CHECKLIST.md`](../../ios/QA_CHECKLIST.md)). Route handlers remain covered by unit/integration tests; matrix marks OAuth as **out of scope** until a headless or stub-provider lane exists.
 
 ### Breath counting (full journey)
 
@@ -95,7 +135,7 @@ Breath counting is timing-sensitive (sub-second taps, phase animation, keyboard 
 - **Push notification delivery** — cron/APNs; settings PATCH round-trip still TODO  
 - **Screen Time shield enforcement** — settings gate smoke only (`348-phase2-spec`)  
 - **Full-page visual snapshot gating** — `@visual` / Fastlane only (`e2e-policy.md` §9)  
-- **iOS Friends tab** — web-only; parity gap (`ios/PARITY_CHECKLIST.md`)
+- **iOS Friends tab** — web-only; parity gap ([`ios/PARITY_CHECKLIST.md`](../../ios/PARITY_CHECKLIST.md))
 
 ---
 

--- a/docs/testing/e2e-coverage-matrix.md
+++ b/docs/testing/e2e-coverage-matrix.md
@@ -1,0 +1,121 @@
+# E2E Journey Coverage Matrix (Issue #497)
+
+Published audit of user journeys across **web** (Playwright mobile web) and **iOS** (XCUITest). Supersedes the ad-hoc coverage notes in [#190](https://github.com/auerbachb/still-point/issues/190) and locator-contract tracking in [#152](https://github.com/auerbachb/still-point/issues/152).
+
+**Risk tiers**
+
+| Tier | Meaning | CI lane |
+|------|---------|---------|
+| **P0** | Core retention path; regression blocks merge | `@smoke` / `@critical` (web PR lanes); iOS smoke/critical |
+| **P1** | High-value adjacent flows; covered in release or platform lanes | Full mobile web suite (`e2e-mobile.yml`); iOS critical where noted |
+| **P2** | Lower blast radius, manual QA, or unit/integration only | Tracked; no merge gate in v1 |
+
+**Coverage symbols:** ✅ automated E2E · ⚠️ partial (edge case or API-only) · ❌ not automated · ➖ N/A (platform lacks surface)
+
+Lane wiring and retry policy: [`e2e-policy.md`](./e2e-policy.md). Spec layout: [`e2e/README.md`](../../e2e/README.md), [`ios/StillPointAppUITests/README.md`](../../ios/StillPointAppUITests/README.md).
+
+---
+
+## Matrix
+
+| Journey | Risk | Web | iOS | Spec / test reference |
+|---------|:----:|:---:|:---:|------------------------|
+| **Public** |
+| Landing page CTAs | P0 | ✅ | ➖ | `e2e/web/smoke.spec.ts` `@smoke` |
+| Privacy / delete-account pages | P2 | ❌ | ➖ | Manual / unit |
+| **Auth (email/password)** |
+| Auth shell visible (`/app`) | P0 | ✅ | ✅ | `e2e/web/critical.spec.ts`; iOS auth cold-start tests |
+| Signup → authenticated home | P0 | ✅ | ⚠️ | `e2e/auth/signup.spec.ts` `@critical`; iOS uses fixture login in smoke |
+| Login → home shell | P0 | ✅ | ✅ | `e2e/auth/login.spec.ts` `@critical`; `testLaunchLoginCompleteSessionAndHistoryPersistence` |
+| Logout → auth screen | P0 | ✅ | ✅ | `e2e/settings/logout.spec.ts` `@critical`; `testLogoutReturnsToAuthScreen` |
+| Password reset — request | P1 | ✅ | ✅ | `e2e/auth/password-reset.spec.ts`; `testPasswordResetEntryIsDiscoverable` |
+| Password reset — confirm + re-login | P1 | ✅ | ❌ | `e2e/auth/password-reset.spec.ts` `@critical`; iOS request-only |
+| Password reset — no enumeration | P1 | ✅ | ❌ | `e2e/auth/password-reset.spec.ts` |
+| Auth 401 / token expiry → login | P1 | ✅ | ✅ | `e2e/auth/login.spec.ts`; `testTokenExpiryRoutesToReauthMessage` |
+| Auth network failure + Retry | P1 | ✅ | ✅ | `e2e/auth/login.spec.ts`; `testLaunchOfflineShowsUserVisibleMessage` |
+| Deleted account (410) message | P2 | ✅ | ❌ | `e2e/auth/login.spec.ts` |
+| Username uniqueness / race (DB) | P1 | ✅ | ❌ | `e2e/auth/username-uniqueness.integration.spec.ts` (`@authDbIntegration`) |
+| **OAuth (excluded)** |
+| Google / Apple OAuth (web) | — | ❌ | ➖ | **Excluded** — see [Exclusions](#exclusions) |
+| Google / Apple native (iOS) | — | ➖ | ❌ | **Excluded** |
+| **Tab routing & deep links** |
+| Default `/app` → home/progress | P0 | ✅ | ✅ | `e2e/routing/tab-routing.spec.ts` `@smoke`; iOS smoke |
+| Per-tab URLs + deep links | P1 | ✅ | ⚠️ | `e2e/routing/tab-routing.spec.ts`; iOS history/settings smoke only |
+| Buddy invite deep link | P1 | ✅ | ❌ | `e2e/routing/tab-routing.spec.ts` (mocked join) |
+| Browser back clears session overlay | P1 | ✅ | ➖ | `e2e/routing/tab-routing.spec.ts` |
+| **Home & sessions** |
+| Standard session begin → complete → return | P0 | ✅ | ✅ | `e2e/session/session-flow.spec.ts` `@critical`; iOS smoke golden path |
+| Session history persistence after relaunch | P0 | ⚠️ | ✅ | Web mocked POST only; iOS smoke |
+| Quick minute (no day advance) | P1 | ✅ | ✅ | `e2e/session/session-flow.spec.ts`; `testQuickMinuteCompletesWithoutDayAdvance` |
+| Mind-state holds (light / hyperfocus) | P1 | ✅ | ✅ | `e2e/session/session-flow.spec.ts`; iOS smoke |
+| End early / completion stats | P0 | ✅ | ✅ | `e2e/session/session-flow.spec.ts` `@critical`; iOS smoke |
+| Pause / abandon / thought capture | P2 | ❌ | ❌ | QA manual; snapshot lane only |
+| Landscape session usability | P1 | ✅ | ✅ | `e2e/session/session-flow.spec.ts`; `testRotationDecisionSessionRemainsUsableInLandscape` (non-critical lane) |
+| Pull-to-refresh during session | P2 | ✅ | ➖ | `e2e/session/session-flow.spec.ts` |
+| **Breath counting (excluded)** |
+| Full breath-counting UX | — | ⚠️ | ❌ | **Excluded** — see [Exclusions](#exclusions) |
+| **History / journal / board** |
+| History list + scroll | P1 | ✅ | ✅ | `e2e/layout/overflow.spec.ts`; iOS smoke + `testSessionsFailureShowsVisibleRetryMessage` |
+| Calendar / journey view modes | P2 | ❌ | ❌ | Unit tests (`historyJourney.test.ts`, `HistoryJourneyTests.swift`) |
+| Thought journal tab | P2 | ⚠️ | ✅ | Web layout FlashHint; `testJournalAndBoardTabsReachable` |
+| Public board tab | P2 | ✅ | ✅ | `e2e/layout/issue-473-mobile-web-layout.spec.ts`; `testJournalAndBoardTabsReachable` |
+| **Friends / buddy** |
+| Friends search & requests (web) | P2 | ❌ | ➖ | Web-only surface |
+| Buddy room UI (video, lobby) | P2 | ❌ | ❌ | QA manual; Daily.co third-party |
+| Buddy duration normalization (API) | P1 | ✅ | ❌ | `e2e/buddy/buddy-session-length.integration.spec.ts` |
+| **Settings & account** |
+| Settings navigation | P1 | ✅ | ✅ | `e2e/auth/login.spec.ts`; `testHistoryAndSettingsNavigationSmoke` |
+| Username inline edit / validation / conflict | P1 | ❌ | ✅ | iOS `testSettingsUsernameInlineEditSucceeds` et al. |
+| Public board / aphorisms toggles | P2 | ❌ | ❌ | QA manual |
+| Notifications subpage | P2 | ❌ | ⚠️ | Link exists; no E2E |
+| App blocking / Screen Time gate | P2 | ➖ | ⚠️ | `testCompletedSessionUnlocksConfiguredAppGate` (settings smoke; no shield E2E) |
+| Delete account flow | P2 | ❌ | ❌ | QA manual |
+| **Layout / a11y (cross-cutting)** |
+| Safe area / bottom nav overlap | P1 | ✅ | ✅ | `e2e/layout/safe-area.spec.ts`; `testPrimaryControlsVisibleAboveHomeIndicator` |
+| Horizontal overflow / tap targets | P1 | ✅ | ⚠️ | `e2e/layout/overflow.spec.ts`, `login.spec.ts` |
+| Mobile web 320–375px layout (#473) | P1 | ✅ | ➖ | `e2e/layout/issue-473-mobile-web-layout.spec.ts` |
+| VoiceOver timer + primary button | P1 | ❌ | ✅ | `testVoiceOverLabelsForTimerAndPrimaryButton` |
+| Cold-start auth latency bound | P1 | ❌ | ✅ | iOS smoke (`coldStartAuthCheckMs` ≤ 8000 ms) |
+
+---
+
+## Exclusions (justified)
+
+### OAuth (Google / Apple, web + native)
+
+Automated OAuth E2E requires live provider credentials, consent screens, redirect URI wiring, and simulator Keychain state. Policy defers real-provider auth to manual checklists (`docs/mobile-oauth-integration.md`, `ios/QA_CHECKLIST.md`). Route handlers remain covered by unit/integration tests; matrix marks OAuth as **out of scope** until a headless or stub-provider lane exists.
+
+### Breath counting (full journey)
+
+Breath counting is timing-sensitive (sub-second taps, phase animation, keyboard binding) and already covered by shared logic tests (`src/lib/breathCounting.test.ts`, `BreathCountingLogicTests.swift`). Web retains one **regression-only** edge case (`e2e/session/session-flow.spec.ts`: single-tap persist within first second); it is **not** tagged `@critical` and does not gate merge. iOS has no UI breath E2E by design.
+
+### Other deferred areas (P2, no v1 gate)
+
+- **Buddy room video** (Daily.co WebRTC) — manual QA only  
+- **Push notification delivery** — cron/APNs; settings PATCH round-trip still TODO  
+- **Screen Time shield enforcement** — settings gate smoke only (`348-phase2-spec`)  
+- **Full-page visual snapshot gating** — `@visual` / Fastlane only (`e2e-policy.md` §9)  
+- **iOS Friends tab** — web-only; parity gap (`ios/PARITY_CHECKLIST.md`)
+
+---
+
+## Gap-fill status (this issue)
+
+| Gap | Action |
+|-----|--------|
+| PR `@smoke`/`@critical` covered only landing + auth shell | Tagged golden-path specs; added `signup` + `logout` area specs |
+| Web logout untested | `e2e/settings/logout.spec.ts` |
+| iOS quick minute / logout / journal+board tabs | New XCUITest methods + tab accessibility identifiers |
+| Published matrix missing | This document |
+| Locator contract (#152) | iOS `tab.journal`, `tab.board`, `journal.title`, `board.title` identifiers |
+
+---
+
+## Maintenance
+
+When adding a user-facing journey:
+
+1. Add a row here with risk tier and platform coverage.  
+2. Tag web merge-blocking specs `@smoke` or `@critical` per [`e2e-policy.md`](./e2e-policy.md) §8.  
+3. Wire new iOS tests into `scripts/e2e/run-ios-tests.sh` smoke or critical lanes.  
+4. Prefer `auth.fixture.ts` + role/accessibility contracts over naked sleeps.

--- a/docs/testing/e2e-policy.md
+++ b/docs/testing/e2e-policy.md
@@ -7,6 +7,9 @@ It applies to Issue #194 and is inherited by child issues:
 - [#191](https://github.com/auerbachb/still-point/issues/191)
 - [#192](https://github.com/auerbachb/still-point/issues/192)
 - [#193](https://github.com/auerbachb/still-point/issues/193)
+- [#497](https://github.com/auerbachb/still-point/issues/497) — journey coverage matrix and gap-fill (supersedes [#190](https://github.com/auerbachb/still-point/issues/190) / [#152](https://github.com/auerbachb/still-point/issues/152) tracking)
+
+Journey × platform coverage, P0/P1/P2 tiers, and justified exclusions (OAuth, breath counting): [`e2e-coverage-matrix.md`](./e2e-coverage-matrix.md).
 
 ## 1) Retry policy and non-retriable failures
 
@@ -77,7 +80,7 @@ Enforcement:
 - Playwright tests must rely on role/locator contracts and assertion-driven waits
 - iOS tests must use XCTest expectations/predicate waits and accessibility identifiers
 
-Role/locator contract source of truth remains [#152](https://github.com/auerbachb/still-point/issues/152).
+Role/locator contract source of truth: [`e2e-coverage-matrix.md`](./e2e-coverage-matrix.md) (Issue #497); historical tracking in [#152](https://github.com/auerbachb/still-point/issues/152).
 
 ## 4) Secrets and credentials policy
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,5 +1,7 @@
 # End-to-end and integration tests
 
+Journey coverage audit (P0/P1/P2 matrix, exclusions): [`docs/testing/e2e-coverage-matrix.md`](../docs/testing/e2e-coverage-matrix.md).
+
 Most Playwright specs under `e2e/` hit the dev server with **mocked** API routes (see `e2e/fixtures/auth.fixture.ts`). The **auth DB integration** lane is different: it exercises the real `/api/auth/signup` and `/api/settings` handlers against **live Postgres** (no API mocks).
 
 ## Mobile web E2E (Playwright)

--- a/e2e/auth/login.spec.ts
+++ b/e2e/auth/login.spec.ts
@@ -8,7 +8,7 @@ import {
 } from "../utils/mobile-helpers";
 
 test.describe("mobile auth and shell", () => {
-  test("login to session shell with touch and mobile nav", async ({ page, ensureLoggedIn, mockApiState }) => {
+  test("@critical login to session shell with touch and mobile nav", async ({ page, ensureLoggedIn, mockApiState }) => {
     const auth = await ensureLoggedIn();
     mockApiState.authenticated = false;
     await page.goto("/app");

--- a/e2e/auth/password-reset.spec.ts
+++ b/e2e/auth/password-reset.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "../fixtures/auth.fixture";
 
 test.describe("password reset", () => {
-  test("request link and set new password from token", async ({ page, mockApiState }) => {
+  test("@critical request link and set new password from token", async ({ page, mockApiState }) => {
     let resetRequestedFor: string | null = null;
     let submittedNewPassword: string | null = null;
 

--- a/e2e/auth/signup.spec.ts
+++ b/e2e/auth/signup.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "../fixtures/auth.fixture";
+import { expectMinimumTapTarget, expectNoHorizontalOverflow, tap } from "../utils/mobile-helpers";
+
+test.describe("signup @critical", () => {
+  test("@critical signup reaches authenticated home with Begin CTA", async ({ page, mockApiState }) => {
+    await page.goto("/app");
+    await tap(page.getByRole("button", { name: "sign up" }));
+
+    await page.getByPlaceholder("email").fill(mockApiState.credentials.email);
+    await page.getByPlaceholder("username").fill(mockApiState.credentials.username);
+    await page.getByPlaceholder("password").fill(mockApiState.credentials.password);
+
+    const beginJourney = page.getByRole("button", { name: "Begin the journey" });
+    await expectMinimumTapTarget(beginJourney, "signup submit button");
+    await tap(beginJourney);
+
+    const beginButton = page.getByRole("button", { name: "Begin" });
+    await expect(beginButton).toBeVisible();
+    expect(mockApiState.authenticated, "mock API should mark session authenticated after signup").toBe(true);
+    await expectNoHorizontalOverflow(page);
+  });
+});

--- a/e2e/routing/tab-routing.spec.ts
+++ b/e2e/routing/tab-routing.spec.ts
@@ -7,7 +7,7 @@ import { tap } from "../utils/mobile-helpers";
 // query-param flow still works from any tab URL.
 
 test.describe("tab routing reflects in URL (#292)", () => {
-  test("/app resolves to the Progress tab", async ({ page, ensureLoggedIn }) => {
+  test("@smoke /app resolves to the Progress tab", async ({ page, ensureLoggedIn }) => {
     await ensureLoggedIn();
     await page.goto("/app");
     await expect(page.getByRole("button", { name: "Begin" })).toBeVisible();

--- a/e2e/session/session-flow.spec.ts
+++ b/e2e/session/session-flow.spec.ts
@@ -4,6 +4,7 @@ import {
   expectNoHorizontalOverflow,
   expectVisibleInViewport,
   seedTrackingControlsUnlocked,
+  applyTrackingControlsUnlocked,
   simulatePullToRefreshGesture,
   tap,
   tapWithControlReveal,
@@ -13,6 +14,7 @@ test.describe("mobile session flow", () => {
   test("tracking controls remain interactive when secondary chrome dims", async ({ page, ensureLoggedIn }) => {
     await seedTrackingControlsUnlocked(page);
     await ensureLoggedIn();
+    await applyTrackingControlsUnlocked(page);
     await tap(page.getByRole("button", { name: "Begin" }));
 
     const trackingLayer = page.locator('[data-session-tracking-layer="persistent"]');
@@ -39,6 +41,7 @@ test.describe("mobile session flow", () => {
   test("@critical touch-only session complete flow has no hover dependency", async ({ page, ensureLoggedIn, mockApiState }) => {
     await seedTrackingControlsUnlocked(page);
     await ensureLoggedIn();
+    await applyTrackingControlsUnlocked(page);
 
     const beginButton = page.getByRole("button", { name: "Begin" });
     await expectMinimumTapTarget(beginButton, "begin session button");
@@ -121,6 +124,7 @@ test.describe("mobile session flow", () => {
   test("pull-to-refresh style overscroll does not break active session", async ({ page, ensureLoggedIn }) => {
     await seedTrackingControlsUnlocked(page);
     await ensureLoggedIn();
+    await applyTrackingControlsUnlocked(page);
     await tap(page.getByRole("button", { name: "Begin" }));
 
     const pauseButton = page.getByRole("button", { name: "pause" });

--- a/e2e/session/session-flow.spec.ts
+++ b/e2e/session/session-flow.spec.ts
@@ -36,7 +36,7 @@ test.describe("mobile session flow", () => {
     await expect(hyperfocus).toContainText("Hold");
   });
 
-  test("touch-only session complete flow has no hover dependency", async ({ page, ensureLoggedIn, mockApiState }) => {
+  test("@critical touch-only session complete flow has no hover dependency", async ({ page, ensureLoggedIn, mockApiState }) => {
     await seedTrackingControlsUnlocked(page);
     await ensureLoggedIn();
 

--- a/e2e/settings/logout.spec.ts
+++ b/e2e/settings/logout.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from "../fixtures/auth.fixture";
+import { tap } from "../utils/mobile-helpers";
+
+test.describe("settings logout @critical", () => {
+  test("@critical logout returns to auth screen", async ({ page, ensureLoggedIn, mockApiState }) => {
+    await ensureLoggedIn();
+    await tap(page.getByRole("button", { name: /^settings$/i }));
+
+    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+    await tap(page.getByRole("button", { name: /log out/i }));
+
+    await expect(page.getByPlaceholder("email")).toBeVisible();
+    await expect(page.getByPlaceholder("password")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Enter" })).toBeVisible();
+    expect(mockApiState.authenticated, "mock API should clear auth after logout").toBe(false);
+  });
+});

--- a/e2e/utils/mobile-helpers.ts
+++ b/e2e/utils/mobile-helpers.ts
@@ -3,13 +3,8 @@ import { expect, type Locator, type Page } from "@playwright/test";
 /** #188: unlock distraction/hyperfocus controls for E2E — call before first navigation. */
 export async function seedTrackingControlsUnlocked(page: Page) {
   await page.addInitScript(() => {
-    localStorage.setItem(
-      "stillpoint_tracking_control_prefs",
-      JSON.stringify({
-        hideDistractionHyperfocusControls: false,
-        trackingControlsUnlocked: true,
-      }),
-    );
+    localStorage.setItem("stillpoint_hide_distraction_hyperfocus_controls", "false");
+    localStorage.setItem("stillpoint_tracking_controls_unlocked", "true");
   });
 }
 

--- a/e2e/utils/mobile-helpers.ts
+++ b/e2e/utils/mobile-helpers.ts
@@ -2,10 +2,17 @@ import { expect, type Locator, type Page } from "@playwright/test";
 
 /** #188: unlock distraction/hyperfocus controls for E2E — call before first navigation. */
 export async function seedTrackingControlsUnlocked(page: Page) {
-  await page.addInitScript(() => {
-    localStorage.setItem("stillpoint_hide_distraction_hyperfocus_controls", "false");
-    localStorage.setItem("stillpoint_tracking_controls_unlocked", "true");
-  });
+  await page.addInitScript(applyTrackingControlsUnlockedInPage);
+}
+
+/** Re-apply after auth bootstrap clears account-scoped unlock on initial 401. */
+export async function applyTrackingControlsUnlocked(page: Page) {
+  await page.evaluate(applyTrackingControlsUnlockedInPage);
+}
+
+function applyTrackingControlsUnlockedInPage() {
+  localStorage.setItem("stillpoint_hide_distraction_hyperfocus_controls", "false");
+  localStorage.setItem("stillpoint_tracking_controls_unlocked", "true");
 }
 
 export const MOBILE_SAFE_AREA_TOLERANCE_PX = 6;

--- a/ios/StillPointApp/Navigation/MainTabView.swift
+++ b/ios/StillPointApp/Navigation/MainTabView.swift
@@ -22,12 +22,14 @@ struct MainTabView: View {
             ThoughtJournalView()
                 .tabItem {
                     Label("JOURNAL", systemImage: "book")
+                        .accessibilityIdentifier("tab.journal")
                 }
                 .tag(2)
 
             PublicBoardView(currentUsername: appVM.currentUser?.username)
                 .tabItem {
                     Label("BOARD", systemImage: "person.3")
+                        .accessibilityIdentifier("tab.board")
                 }
                 .tag(3)
 

--- a/ios/StillPointApp/Views/PublicBoardView.swift
+++ b/ios/StillPointApp/Views/PublicBoardView.swift
@@ -12,6 +12,7 @@ struct PublicBoardView: View {
                     .font(SPFont.serifItalic(28, weight: .light))
                     .foregroundStyle(Color(SPColor.fg))
                     .padding(.top, SPSpacing.s4)
+                    .accessibilityIdentifier("board.title")
 
                 Text("Not a competition — a community of people training attention together.")
                     .font(SPFont.serifItalic(15, weight: .light))

--- a/ios/StillPointApp/Views/ThoughtJournalView.swift
+++ b/ios/StillPointApp/Views/ThoughtJournalView.swift
@@ -11,6 +11,7 @@ struct ThoughtJournalView: View {
                     .font(SPFont.serifItalic(28, weight: .light))
                     .foregroundStyle(Color(SPColor.fg))
                     .padding(.top, SPSpacing.s4)
+                    .accessibilityIdentifier("journal.title")
 
                 if vm.totalCount > 0 {
                     Text("\(vm.totalCount) thoughts captured")

--- a/ios/StillPointAppUITests/README.md
+++ b/ios/StillPointAppUITests/README.md
@@ -8,11 +8,14 @@ This directory contains native iOS UI smoke tests for Issue #193 ("journeys beyo
 - **OS:** iOS 17.0+
 - **Cold-start auth bound (documented):** auth check should complete within **5,000 ms** on this simulator class.
 
-## Test coverage map (Issue #193)
+## Test coverage map (Issue #193 / #497)
 
 - Launch → login (fixture) → main session surface + cold-start bound (`testLaunchLoginCompleteSessionAndHistoryPersistence`)
 - Start session → complete → stats visible + relaunch history persistence (`testLaunchLoginCompleteSessionAndHistoryPersistence`)
 - Thought/distraction hold controls do not stick (`testLaunchLoginCompleteSessionAndHistoryPersistence`)
+- Quick minute completes without advancing day (`testQuickMinuteCompletesWithoutDayAdvance`)
+- Logout returns to auth screen (`testLogoutReturnsToAuthScreen`)
+- Journal and board tabs reachable (`testJournalAndBoardTabsReachable`)
 - History/Settings smoke navigation path (`testHistoryAndSettingsNavigationSmoke`)
 - Layout on reference device safe areas (`testPrimaryControlsVisibleAboveHomeIndicator`)
 - Rotation policy assertion (product decision: supported and still usable) (`testRotationDecisionSessionRemainsUsableInLandscape`)
@@ -55,14 +58,9 @@ xcodebuild test \
   -only-testing:StillPointAppUITests
 ```
 
-## CI lane plan (stub until #152 merges)
+## CI lane plan
 
-Planned lane: `ios-ui-smoke`
-
-1. Boot simulator `iPhone 15 Pro` on iOS 17.x.
-2. Run the command above (or equivalent lane wrapper).
-3. Upload XCTest result bundle artifact.
-4. Publish summarized pass/fail output back to PR checks.
+Coverage matrix: [`docs/testing/e2e-coverage-matrix.md`](../../docs/testing/e2e-coverage-matrix.md). Lanes are wired in `scripts/e2e/run-ios-tests.sh` (`smoke` = golden path; `critical` = resilience + settings + quick minute + logout + journal/board).
 
 ## CI setup de-duplication notes
 

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -368,6 +368,7 @@ final class StillPointAppUITests: XCTestCase {
 
         let logoutButton = app.buttons["settings.logoutButton"]
         XCTAssertTrue(logoutButton.waitForExistence(timeout: 5))
+        scrollElementIntoVisibleFrame(logoutButton, in: app)
         tapByStableCenter(logoutButton, in: app)
 
         XCTAssertTrue(
@@ -604,6 +605,27 @@ final class StillPointAppUITests: XCTestCase {
         }
         element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
         return true
+    }
+
+    private func isElementInVisibleFrame(_ element: XCUIElement, in app: XCUIApplication) -> Bool {
+        let frame = element.frame
+        let center = CGPoint(x: frame.midX, y: frame.midY)
+        return !frame.isEmpty
+            && frame.width > 1
+            && frame.height > 1
+            && app.frame.insetBy(dx: -1, dy: -1).contains(center)
+    }
+
+    private func scrollElementIntoVisibleFrame(
+        _ element: XCUIElement,
+        in app: XCUIApplication,
+        maxSwipes: Int = 4
+    ) {
+        for _ in 0..<maxSwipes {
+            if isElementInVisibleFrame(element, in: app) { return }
+            app.swipeUp()
+            RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+        }
     }
 
     private func stableFrame(

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -324,6 +324,74 @@ final class StillPointAppUITests: XCTestCase {
     }
 
     @MainActor
+    func testQuickMinuteCompletesWithoutDayAdvance() throws {
+        let app = makeApp(
+            seedAuthenticated: true,
+            resetStore: true,
+            sessionSeconds: 60,
+            timerMultiplier: 2.0
+        )
+        app.launch()
+
+        waitForRoot("home", in: app, failureMessage: "Home screen did not appear", assertColdStart: false)
+
+        let dayLabel = app.staticTexts.matching(
+            NSPredicate(format: "label == %@ AND identifier != %@", "1", "history.title")
+        ).firstMatch
+        XCTAssertTrue(dayLabel.waitForExistence(timeout: 5), "Expected day 1 on home before quick minute")
+
+        let quickMinuteButton = app.buttons["home.quickMinuteButton"]
+        XCTAssertTrue(quickMinuteButton.waitForExistence(timeout: 5))
+        tapByStableCenter(quickMinuteButton, in: app)
+        XCTAssertTrue(
+            app.otherElements["root.currentView.session"].waitForExistence(timeout: 20),
+            "Quick minute session did not open"
+        )
+
+        tapByStableCenter(app.buttons["session.endEarlyButton"], in: app)
+        let completionTitle = app.staticTexts["completion.dayTitle"]
+        XCTAssertTrue(completionTitle.waitForExistence(timeout: 25))
+        XCTAssertTrue(completionTitle.label.localizedCaseInsensitiveContains("quick minute"))
+
+        tapByStableCenter(app.buttons["completion.returnButton"], in: app)
+        XCTAssertTrue(app.otherElements["root.currentView.home"].waitForExistence(timeout: 8))
+        XCTAssertTrue(dayLabel.waitForExistence(timeout: 5), "Day counter should remain 1 after quick minute")
+    }
+
+    @MainActor
+    func testLogoutReturnsToAuthScreen() throws {
+        let app = makeApp(seedAuthenticated: true, resetStore: true)
+        app.launch()
+
+        waitForRoot("home", in: app, failureMessage: "Home screen did not appear", assertColdStart: false)
+        openTab(identifier: "tab.settings", in: app, waitingFor: app.staticTexts["settings.title"])
+
+        let logoutButton = app.buttons["settings.logoutButton"]
+        XCTAssertTrue(logoutButton.waitForExistence(timeout: 5))
+        tapByStableCenter(logoutButton, in: app)
+
+        XCTAssertTrue(
+            app.otherElements["root.currentView.auth"].waitForExistence(timeout: 15),
+            "Auth screen should appear after logout"
+        )
+        XCTAssertTrue(app.textFields["auth.emailField"].waitForExistence(timeout: 5))
+    }
+
+    @MainActor
+    func testJournalAndBoardTabsReachable() throws {
+        let app = makeApp(seedAuthenticated: true, resetStore: true)
+        app.launch()
+
+        waitForRoot("home", in: app, failureMessage: "Home screen did not appear", assertColdStart: false)
+
+        openTab(identifier: "tab.journal", in: app, waitingFor: app.staticTexts["journal.title"])
+        XCTAssertTrue(app.staticTexts["journal.title"].exists)
+
+        openTab(identifier: "tab.board", in: app, waitingFor: app.staticTexts["board.title"])
+        XCTAssertTrue(app.staticTexts["board.title"].exists)
+    }
+
+    @MainActor
     func testRotationDecisionSessionRemainsUsableInLandscape() throws {
         let app = makeApp(seedAuthenticated: true, resetStore: true, sessionSeconds: 60, timerMultiplier: 1.0)
         app.launch()
@@ -490,6 +558,10 @@ final class StillPointAppUITests: XCTestCase {
         switch identifier {
         case "tab.progress":
             return 1
+        case "tab.journal":
+            return 2
+        case "tab.board":
+            return 3
         case "tab.settings":
             return 4
         default:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,8 +41,9 @@ export default defineConfig({
         {
           name: "chromium",
           use: {
-            ...devices["Desktop Chrome"],
+            ...devices["iPhone 13"],
             browserName: "chromium",
+            hasTouch: true,
           },
         },
       ]

--- a/scripts/e2e/run-ios-tests.sh
+++ b/scripts/e2e/run-ios-tests.sh
@@ -103,9 +103,12 @@ resolve_test_target() {
       ;;
     critical)
       echo "StillPointAppUITests/StillPointAppUITests/testHistoryAndSettingsNavigationSmoke"
+      echo "StillPointAppUITests/StillPointAppUITests/testJournalAndBoardTabsReachable"
       echo "StillPointAppUITests/StillPointAppUITests/testLaunchOfflineShowsUserVisibleMessage"
+      echo "StillPointAppUITests/StillPointAppUITests/testLogoutReturnsToAuthScreen"
       echo "StillPointAppUITests/StillPointAppUITests/testPasswordResetEntryIsDiscoverable"
       echo "StillPointAppUITests/StillPointAppUITests/testPrimaryControlsVisibleAboveHomeIndicator"
+      echo "StillPointAppUITests/StillPointAppUITests/testQuickMinuteCompletesWithoutDayAdvance"
       echo "StillPointAppUITests/StillPointAppUITests/testSessionsFailureShowsVisibleRetryMessage"
       echo "StillPointAppUITests/StillPointAppUITests/testTokenExpiryRoutesToReauthMessage"
       echo "StillPointAppUITests/StillPointAppUITests/testVoiceOverLabelsForTimerAndPrimaryButton"


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #497

Supersedes #190 / #152 E2E tracking with a published audit and targeted gap-fill.

## Audit (delivered first)

- **`docs/testing/e2e-coverage-matrix.md`** — journey × {web, iOS} matrix with P0/P1/P2 risk tiers, spec references, and justified exclusions (**OAuth**, **breath counting**, buddy video, push delivery, Screen Time shields).
- Cross-refs added to `docs/testing/e2e-policy.md` and `e2e/README.md` (locator contract now points at the matrix). **Did not edit** the iOS flake classifier section — leaves room for #496 merge.

## Web gap-fill

| Area | Change |
|------|--------|
| Auth | `e2e/auth/signup.spec.ts` `@critical`; tagged login + password-reset golden paths |
| Session | `@critical` on touch-only complete flow |
| Settings | `e2e/settings/logout.spec.ts` `@critical` |
| Routing | `@smoke` on `/app` → home shell |
| Lanes | PR smoke/critical projects now use **iPhone 13 viewport + hasTouch** so `auth.fixture` / `mobile-helpers` tap contracts work in merge gates |

## iOS gap-fill (XCUITest)

- `testQuickMinuteCompletesWithoutDayAdvance`
- `testLogoutReturnsToAuthScreen`
- `testJournalAndBoardTabsReachable`
- Accessibility identifiers: `tab.journal`, `tab.board`, `journal.title`, `board.title`
- Wired into `scripts/e2e/run-ios-tests.sh` critical lane

## Test plan

- [x] `npm run e2e:policy`
- [x] `npm run e2e:web:smoke` — 2 tests (`@smoke`)
- [x] `npm run e2e:web:critical` — 8 tests (`@critical`, includes landing dual-tag)
- [ ] `npm run e2e:ios:critical` — requires macOS simulator (new tests in lane list)
- [ ] Full mobile web matrix (`e2e-mobile.yml`) on release path

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9026ca51-961e-4df0-97e1-cf2c18854218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9026ca51-961e-4df0-97e1-cf2c18854218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Publish a journey coverage matrix and fill key mobile test gaps**

### What Changed
- Added a published web and iOS coverage matrix that shows which user journeys are covered, which are missing, and which are intentionally out of scope
- Marked key web flows as merge-critical, including signup, login, password reset, logout, tab routing, and session completion
- Added new iOS checks for quick minute completion, logout back to the auth screen, and reaching the journal and board tabs
- Wired the new iOS checks into the critical test lane and added accessibility labels needed to reach the new screens
- Updated the testing docs to point to the new coverage matrix as the source of truth

### Impact
`✅ Clearer test coverage for core user journeys`
`✅ Fewer missed regressions in signup, logout, and session flows`
`✅ Safer iOS navigation checks for journal and board tabs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new signup end-to-end test and a logout flow test.
  * Expanded mobile and iOS test coverage for session, journal, and board journeys.
  * Added a journey coverage matrix documenting coverage status, risk tiers, and gaps.

* **Bug Fixes**
  * Improved test setup so tracking controls are consistently unlocked before mobile session interactions.
  * Updated mobile browser settings for more realistic touch-based coverage.

* **Documentation**
  * Clarified end-to-end testing policy, coverage references, and CI lane guidance.
  * Updated iOS UI test docs to reflect current coverage and lane mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->