### PR TITLE
feat(history): year-in-review 12-month grid sub-view (#380)

### DIFF
--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -418,9 +418,10 @@ export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: Hi
                 onClick={() => setCalendarSubView("yearInReview")}
                 style={{
                   ...mono, fontSize: "10px", letterSpacing: "0.08em", textTransform: "uppercase",
-                  padding: "4px 10px", borderRadius: "4px",
+                  padding: "12px 14px", borderRadius: "4px",
                   border: "1px solid var(--border-1)", background: "transparent",
                   color: "var(--fg-3)", cursor: "pointer",
+                  minHeight: "44px", minWidth: "44px",
                 }}
               >
                 Year in review

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -9,6 +9,7 @@ import { useIsMobile } from "@/lib/useIsMobile";
 import { todayLocalIsoDate } from "@/lib/sessionCalendar";
 import type { MindStateTrendStats } from "@/lib/historyMindStateTrends";
 import { HistoryMindStateTrends } from "@/components/HistoryMindStateTrends";
+import { HistoryYearInReview } from "@/components/HistoryYearInReview";
 
 const NO_RECOVERY: RecoveryFields = {
   recoveryTargetDay: null,
@@ -105,6 +106,7 @@ export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: Hi
   const [loading, setLoading] = useState(true);
   const [thoughts, setThoughts] = useState<Thought[]>([]);
   const [viewMode, setViewMode] = useState<"calendar" | "journey">("calendar");
+  const [calendarSubView, setCalendarSubView] = useState<"default" | "yearInReview">("default");
   const [todayDate, setTodayDate] = useState<string>(() => todayLocalIsoDate());
   const isMobile = useIsMobile();
   const sessionLabelColWidth = isMobile ? "88px" : "100px";
@@ -282,7 +284,10 @@ export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: Hi
           <button
             key={mode}
             type="button"
-            onClick={() => setViewMode(mode)}
+            onClick={() => {
+              setViewMode(mode);
+              if (mode === "journey") setCalendarSubView("default");
+            }}
             style={{
               padding: "6px 14px",
               borderRadius: "4px",
@@ -300,6 +305,14 @@ export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: Hi
       </div>
 
       {viewMode === "calendar" ? (
+        calendarSubView === "yearInReview" ? (
+          <HistoryYearInReview
+            sessions={sessions}
+            todayDate={todayDate}
+            isMobile={isMobile}
+            onBack={() => setCalendarSubView("default")}
+          />
+        ) : (
         <>
           {/* Trailing 4-week stats */}
           <div style={{
@@ -390,12 +403,28 @@ export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: Hi
           {/* Current month grid */}
           <div style={{ width: "100%", maxWidth: "480px" }}>
             <div style={{
-              fontFamily: "var(--font-serif)",
-              fontSize: "14px", color: "var(--fg-2)",
-              marginBottom: "12px", letterSpacing: "0.07em", textTransform: "uppercase",
-              textAlign: "center",
+              display: "flex", justifyContent: "space-between", alignItems: "center",
+              marginBottom: "12px",
             }}>
-              {monthGrid.monthLabel}
+              <div style={{
+                fontFamily: "var(--font-serif)",
+                fontSize: "14px", color: "var(--fg-2)",
+                letterSpacing: "0.07em", textTransform: "uppercase",
+              }}>
+                {monthGrid.monthLabel}
+              </div>
+              <button
+                type="button"
+                onClick={() => setCalendarSubView("yearInReview")}
+                style={{
+                  ...mono, fontSize: "10px", letterSpacing: "0.08em", textTransform: "uppercase",
+                  padding: "4px 10px", borderRadius: "4px",
+                  border: "1px solid var(--border-1)", background: "transparent",
+                  color: "var(--fg-3)", cursor: "pointer",
+                }}
+              >
+                Year in review
+              </button>
             </div>
 
             <div style={{
@@ -498,6 +527,7 @@ export function HistoryView({ currentDay, recovery = NO_RECOVERY, username }: Hi
             </div>
           </div>
         </>
+        )
       ) : (
         /* Journey — relative session buildup (gap-collapse per #421) */
         <div style={{ width: "100%", maxWidth: "660px" }}>

--- a/src/components/HistoryYearInReview.tsx
+++ b/src/components/HistoryYearInReview.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useMemo, type CSSProperties } from "react";
+import type { Session } from "@/lib/api";
+import {
+  buildTrailing12MonthSummaries,
+  formatShortMonthLabel,
+  type MonthlySummary,
+} from "@/lib/historyMonthlyAggregation";
+import { formatTotalTime } from "@/lib/historyMonthGrid";
+
+type HistoryYearInReviewProps = {
+  sessions: Session[];
+  todayDate: string;
+  isMobile: boolean;
+  onBack: () => void;
+};
+
+function activityIntensity(summary: MonthlySummary): number {
+  if (summary.daysInMonth === 0) return 0;
+  return summary.daysActive / summary.daysInMonth;
+}
+
+export function HistoryYearInReview({
+  sessions,
+  todayDate,
+  isMobile,
+  onBack,
+}: HistoryYearInReviewProps) {
+  const months = useMemo(
+    () => buildTrailing12MonthSummaries(sessions, todayDate),
+    [sessions, todayDate],
+  );
+
+  const totals = useMemo(() => {
+    const daysActive = months.reduce((sum, m) => sum + m.daysActive, 0);
+    const totalTimeSeconds = months.reduce((sum, m) => sum + m.totalTimeSeconds, 0);
+    return { daysActive, totalTimeSeconds };
+  }, [months]);
+
+  const mono: CSSProperties = {
+    fontFamily: "var(--font-mono)",
+  };
+
+  const columns = isMobile ? 2 : 3;
+
+  return (
+    <div style={{ width: "100%", maxWidth: "480px" }}>
+      <div style={{
+        display: "flex", justifyContent: "space-between", alignItems: "center",
+        marginBottom: "16px",
+      }}>
+        <button
+          type="button"
+          onClick={onBack}
+          style={{
+            ...mono, fontSize: "11px", letterSpacing: "0.08em", textTransform: "uppercase",
+            padding: "6px 12px", borderRadius: "4px",
+            border: "1px solid var(--border-1)", background: "transparent",
+            color: "var(--fg-3)", cursor: "pointer",
+          }}
+        >
+          &larr; Calendar
+        </button>
+        <div style={{
+          fontFamily: "var(--font-serif)",
+          fontSize: "14px", color: "var(--fg-2)",
+          letterSpacing: "0.07em", textTransform: "uppercase",
+        }}>
+          Year in review
+        </div>
+        <div style={{ width: "88px" }} aria-hidden="true" />
+      </div>
+
+      <div style={{
+        display: "flex", gap: isMobile ? "12px" : "20px", justifyContent: "center",
+        marginBottom: "20px", flexWrap: "wrap", ...mono,
+      }}>
+        {[
+          { label: "days active", value: String(totals.daysActive) },
+          { label: "total time", value: formatTotalTime(totals.totalTimeSeconds) },
+        ].map(s => (
+          <div key={s.label} style={{ textAlign: "center", minWidth: isMobile ? "72px" : "88px" }}>
+            <div style={{ fontSize: "24px", fontWeight: 200, color: "var(--fg)" }}>{s.value}</div>
+            <div style={{
+              fontSize: "10px", color: "var(--fg-3)", letterSpacing: "0.12em",
+              textTransform: "uppercase", marginTop: "4px",
+            }}>
+              {s.label}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div style={{
+        display: "grid",
+        gridTemplateColumns: `repeat(${columns}, 1fr)`,
+        gap: "8px",
+      }}>
+        {months.map(month => {
+          const hasActivity = month.daysActive > 0;
+          const bg = hasActivity ? "var(--accent-green-bg)" : "var(--surface-1)";
+          const border = hasActivity
+            ? "1px solid var(--accent-green-border)"
+            : "1px solid var(--border-1)";
+          const opacity = hasActivity ? 0.45 + activityIntensity(month) * 0.55 : 0.65;
+
+          return (
+            <div
+              key={month.yearMonth}
+              style={{
+                padding: isMobile ? "10px 8px" : "12px 10px",
+                borderRadius: "4px",
+                background: bg,
+                border,
+                opacity,
+                display: "flex",
+                flexDirection: "column",
+                gap: "6px",
+                minHeight: isMobile ? "72px" : "80px",
+              }}
+            >
+              <div style={{
+                ...mono, fontSize: isMobile ? "10px" : "11px",
+                color: hasActivity ? "var(--accent-green-dim)" : "var(--fg-3)",
+                letterSpacing: "0.04em",
+              }}>
+                {formatShortMonthLabel(month.yearMonth)}
+              </div>
+              <div style={{
+                ...mono, fontSize: isMobile ? "13px" : "15px",
+                fontWeight: 200, color: "var(--fg)",
+              }}>
+                {month.daysActive}/{month.daysInMonth}
+              </div>
+              <div style={{
+                ...mono, fontSize: "10px", color: "var(--fg-4)",
+              }}>
+                {formatTotalTime(month.totalTimeSeconds)}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <p style={{
+        ...mono, fontSize: "10px", color: "var(--fg-4)",
+        textAlign: "center", marginTop: "16px",
+      }}>
+        trailing 12 months &middot; days active / days in month
+      </p>
+    </div>
+  );
+}

--- a/src/components/HistoryYearInReview.tsx
+++ b/src/components/HistoryYearInReview.tsx
@@ -55,9 +55,10 @@ export function HistoryYearInReview({
           onClick={onBack}
           style={{
             ...mono, fontSize: "11px", letterSpacing: "0.08em", textTransform: "uppercase",
-            padding: "6px 12px", borderRadius: "4px",
+            padding: "12px 16px", borderRadius: "4px",
             border: "1px solid var(--border-1)", background: "transparent",
             color: "var(--fg-3)", cursor: "pointer",
+            minHeight: "44px", minWidth: "44px",
           }}
         >
           &larr; Calendar

--- a/src/lib/historyMonthGrid.ts
+++ b/src/lib/historyMonthGrid.ts
@@ -1,5 +1,10 @@
 import { isValidSessionCalendarDate } from "./sessionCalendar";
 import { sessionTimeSeconds, type HistorySessionTimeInput } from "./historyStats";
+import {
+  type MonthlySummary,
+} from "./historyMonthlyAggregation";
+
+export { buildPriorMonthSummaries } from "./historyMonthlyAggregation";
 
 export type MonthDayState = "future" | "today" | "meditated" | "missed";
 
@@ -15,13 +20,7 @@ export type MonthGridCell =
   | { kind: "blank" }
   | { kind: "day"; day: MonthGridDay };
 
-export type PriorMonthSummary = {
-  yearMonth: string;
-  label: string;
-  daysActive: number;
-  daysInMonth: number;
-  totalTimeSeconds: number;
-};
+export type PriorMonthSummary = MonthlySummary;
 
 function parseYearMonth(isoDate: string): { year: number; month: number } {
   const [y, m] = isoDate.split("-").map(Number);
@@ -108,68 +107,6 @@ export function buildCurrentMonthGrid(
   }
 
   return { yearMonth: ym, monthLabel: monthLabel(year, month), cells };
-}
-
-/**
- * One compact row per calendar month strictly before the month of `todayIso`.
- * Spans from the earliest session month through the month before current.
- */
-export function buildPriorMonthSummaries(
-  sessions: HistorySessionTimeInput[],
-  todayIso: string,
-): PriorMonthSummary[] {
-  const { year: todayYear, month: todayMonth } = parseYearMonth(todayIso);
-  const currentYm = yearMonthKey(todayYear, todayMonth);
-
-  const validDates = sessions
-    .map(s => s.sessionDate)
-    .filter((d): d is string => isValidSessionCalendarDate(d));
-  if (validDates.length === 0) return [];
-
-  const earliest = validDates.reduce((a, b) => (a < b ? a : b));
-  const { year: startYear, month: startMonth } = parseYearMonth(earliest);
-  const byDate = groupSessionsByDate(sessions);
-
-  const summaries: PriorMonthSummary[] = [];
-  let y = startYear;
-  let m = startMonth;
-
-  while (true) {
-    const ym = yearMonthKey(y, m);
-    if (ym >= currentYm) break;
-
-    const dim = daysInCalendarMonth(y, m);
-    let daysActive = 0;
-    let totalTimeSeconds = 0;
-
-    for (let day = 1; day <= dim; day++) {
-      const dd = String(day).padStart(2, "0");
-      const isoDate = `${ym}-${dd}`;
-      const daySessions = byDate.get(isoDate);
-      if (daySessions && daySessions.length > 0) {
-        daysActive++;
-        for (const s of daySessions) {
-          totalTimeSeconds += sessionTimeSeconds(s);
-        }
-      }
-    }
-
-    summaries.push({
-      yearMonth: ym,
-      label: monthLabel(y, m),
-      daysActive,
-      daysInMonth: dim,
-      totalTimeSeconds,
-    });
-
-    m++;
-    if (m > 12) {
-      m = 1;
-      y++;
-    }
-  }
-
-  return summaries;
 }
 
 /** Human-readable total time for summary rows. */

--- a/src/lib/historyMonthlyAggregation.test.ts
+++ b/src/lib/historyMonthlyAggregation.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "vitest";
+import {
+  aggregateMonthSummary,
+  buildPriorMonthSummaries,
+  buildTrailing12MonthSummaries,
+  formatShortMonthLabel,
+} from "./historyMonthlyAggregation";
+
+const SAMPLE_SESSIONS = [
+  { sessionDate: "2026-05-10", duration: 600, actualTime: 600 },
+  { sessionDate: "2026-05-20", duration: 300, actualTime: 300 },
+  { sessionDate: "2026-06-15", duration: 120, actualTime: 120 },
+  { sessionDate: "2026-07-01", duration: 60, actualTime: 60 },
+];
+
+describe("aggregateMonthSummary", () => {
+  test("counts unique active days and total sit seconds", () => {
+    const summary = aggregateMonthSummary(SAMPLE_SESSIONS, 2026, 5);
+    expect(summary).toMatchObject({
+      yearMonth: "2026-05",
+      daysActive: 2,
+      daysInMonth: 31,
+      totalTimeSeconds: 900,
+    });
+  });
+});
+
+describe("buildTrailing12MonthSummaries", () => {
+  test("returns exactly 12 months ending with the month of today", () => {
+    const summaries = buildTrailing12MonthSummaries(SAMPLE_SESSIONS, "2026-07-02");
+    expect(summaries).toHaveLength(12);
+    expect(summaries[0].yearMonth).toBe("2025-08");
+    expect(summaries[11].yearMonth).toBe("2026-07");
+  });
+
+  test("includes days active and total time per month", () => {
+    const summaries = buildTrailing12MonthSummaries(SAMPLE_SESSIONS, "2026-07-02");
+    const may = summaries.find(s => s.yearMonth === "2026-05")!;
+    const jul = summaries.find(s => s.yearMonth === "2026-07")!;
+
+    expect(may).toMatchObject({ daysActive: 2, totalTimeSeconds: 900 });
+    expect(jul).toMatchObject({ daysActive: 1, totalTimeSeconds: 60 });
+  });
+
+  test("months without sessions show zero activity", () => {
+    const summaries = buildTrailing12MonthSummaries(SAMPLE_SESSIONS, "2026-07-02");
+    const aug2025 = summaries.find(s => s.yearMonth === "2025-08")!;
+    expect(aug2025).toMatchObject({ daysActive: 0, totalTimeSeconds: 0, daysInMonth: 31 });
+  });
+});
+
+describe("buildPriorMonthSummaries", () => {
+  test("aggregates days active and total time for months before current", () => {
+    const summaries = buildPriorMonthSummaries(SAMPLE_SESSIONS, "2026-07-02");
+
+    expect(summaries.map(s => s.yearMonth)).toEqual(["2026-05", "2026-06"]);
+    expect(summaries[0]).toMatchObject({ daysActive: 2, daysInMonth: 31, totalTimeSeconds: 900 });
+    expect(summaries[1]).toMatchObject({ daysActive: 1, daysInMonth: 30, totalTimeSeconds: 120 });
+  });
+
+  test("returns empty when all sessions are in the current month", () => {
+    expect(
+      buildPriorMonthSummaries(
+        [{ sessionDate: "2026-07-01", duration: 60, actualTime: 60 }],
+        "2026-07-02",
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("formatShortMonthLabel", () => {
+  test("formats year-month as short label", () => {
+    expect(formatShortMonthLabel("2026-07")).toBe("Jul 2026");
+  });
+});

--- a/src/lib/historyMonthlyAggregation.ts
+++ b/src/lib/historyMonthlyAggregation.ts
@@ -1,0 +1,155 @@
+import { isValidSessionCalendarDate } from "./sessionCalendar";
+import { sessionTimeSeconds, type HistorySessionTimeInput } from "./historyStats";
+
+export type MonthlySummary = {
+  yearMonth: string;
+  label: string;
+  daysActive: number;
+  daysInMonth: number;
+  totalTimeSeconds: number;
+};
+
+function parseYearMonth(isoDate: string): { year: number; month: number } {
+  const [y, m] = isoDate.split("-").map(Number);
+  return { year: y, month: m };
+}
+
+export function yearMonthKey(year: number, month: number): string {
+  return `${year}-${String(month).padStart(2, "0")}`;
+}
+
+function daysInCalendarMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+function monthLabel(year: number, month: number): string {
+  const d = new Date(Date.UTC(year, month - 1, 1, 12));
+  return d.toLocaleDateString("en-US", { month: "long", year: "numeric", timeZone: "UTC" });
+}
+
+function shortMonthLabel(year: number, month: number): string {
+  const d = new Date(Date.UTC(year, month - 1, 1, 12));
+  return d.toLocaleDateString("en-US", { month: "short", year: "numeric", timeZone: "UTC" });
+}
+
+function groupSessionsByDate(
+  sessions: HistorySessionTimeInput[],
+): Map<string, HistorySessionTimeInput[]> {
+  const map = new Map<string, HistorySessionTimeInput[]>();
+  for (const session of sessions) {
+    if (!isValidSessionCalendarDate(session.sessionDate)) continue;
+    const date = session.sessionDate!;
+    (map.get(date) ?? map.set(date, []).get(date)!).push(session);
+  }
+  return map;
+}
+
+function advanceMonth(year: number, month: number, delta: number): { year: number; month: number } {
+  let y = year;
+  let m = month + delta;
+  while (m < 1) {
+    m += 12;
+    y--;
+  }
+  while (m > 12) {
+    m -= 12;
+    y++;
+  }
+  return { year: y, month: m };
+}
+
+/** Aggregate days-active and total sit time for one calendar month. */
+export function aggregateMonthSummary(
+  sessions: HistorySessionTimeInput[],
+  year: number,
+  month: number,
+): MonthlySummary {
+  const ym = yearMonthKey(year, month);
+  const byDate = groupSessionsByDate(sessions);
+  const dim = daysInCalendarMonth(year, month);
+  let daysActive = 0;
+  let totalTimeSeconds = 0;
+
+  for (let day = 1; day <= dim; day++) {
+    const dd = String(day).padStart(2, "0");
+    const isoDate = `${ym}-${dd}`;
+    const daySessions = byDate.get(isoDate);
+    if (daySessions && daySessions.length > 0) {
+      daysActive++;
+      for (const s of daySessions) {
+        totalTimeSeconds += sessionTimeSeconds(s);
+      }
+    }
+  }
+
+  return {
+    yearMonth: ym,
+    label: monthLabel(year, month),
+    daysActive,
+    daysInMonth: dim,
+    totalTimeSeconds,
+  };
+}
+
+/**
+ * Trailing 12 calendar months ending with the month containing `todayIso`.
+ * Used by the year-in-review grid (#380).
+ */
+export function buildTrailing12MonthSummaries(
+  sessions: HistorySessionTimeInput[],
+  todayIso: string,
+): MonthlySummary[] {
+  const { year: todayYear, month: todayMonth } = parseYearMonth(todayIso);
+  const start = advanceMonth(todayYear, todayMonth, -11);
+
+  const summaries: MonthlySummary[] = [];
+  let y = start.year;
+  let m = start.month;
+
+  for (let i = 0; i < 12; i++) {
+    summaries.push(aggregateMonthSummary(sessions, y, m));
+    ({ year: y, month: m } = advanceMonth(y, m, 1));
+  }
+
+  return summaries;
+}
+
+/** Short month label for compact grid cells (e.g. "Jul 2026"). */
+export function formatShortMonthLabel(yearMonth: string): string {
+  const { year, month } = parseYearMonth(`${yearMonth}-01`);
+  return shortMonthLabel(year, month);
+}
+
+/**
+ * One compact row per calendar month strictly before the month of `todayIso`.
+ * Spans from the earliest session month through the month before current.
+ */
+export function buildPriorMonthSummaries(
+  sessions: HistorySessionTimeInput[],
+  todayIso: string,
+): MonthlySummary[] {
+  const { year: todayYear, month: todayMonth } = parseYearMonth(todayIso);
+  const currentYm = yearMonthKey(todayYear, todayMonth);
+
+  const validDates = sessions
+    .map(s => s.sessionDate)
+    .filter((d): d is string => isValidSessionCalendarDate(d));
+  if (validDates.length === 0) return [];
+
+  const earliest = validDates.reduce((a, b) => (a < b ? a : b));
+  const { year: startYear, month: startMonth } = parseYearMonth(earliest);
+
+  const summaries: MonthlySummary[] = [];
+  let y = startYear;
+  let m = startMonth;
+
+  while (true) {
+    const ym = yearMonthKey(y, m);
+    if (ym >= currentYm) break;
+
+    summaries.push(aggregateMonthSummary(sessions, y, m));
+    ({ year: y, month: m } = advanceMonth(y, m, 1));
+  }
+
+  return summaries;
+}

--- a/src/lib/historyMonthlyAggregation.ts
+++ b/src/lib/historyMonthlyAggregation.ts
@@ -59,13 +59,12 @@ function advanceMonth(year: number, month: number, delta: number): { year: numbe
 }
 
 /** Aggregate days-active and total sit time for one calendar month. */
-export function aggregateMonthSummary(
-  sessions: HistorySessionTimeInput[],
+function aggregateMonthSummaryFromGrouped(
+  byDate: Map<string, HistorySessionTimeInput[]>,
   year: number,
   month: number,
 ): MonthlySummary {
   const ym = yearMonthKey(year, month);
-  const byDate = groupSessionsByDate(sessions);
   const dim = daysInCalendarMonth(year, month);
   let daysActive = 0;
   let totalTimeSeconds = 0;
@@ -91,6 +90,14 @@ export function aggregateMonthSummary(
   };
 }
 
+export function aggregateMonthSummary(
+  sessions: HistorySessionTimeInput[],
+  year: number,
+  month: number,
+): MonthlySummary {
+  return aggregateMonthSummaryFromGrouped(groupSessionsByDate(sessions), year, month);
+}
+
 /**
  * Trailing 12 calendar months ending with the month containing `todayIso`.
  * Used by the year-in-review grid (#380).
@@ -101,13 +108,14 @@ export function buildTrailing12MonthSummaries(
 ): MonthlySummary[] {
   const { year: todayYear, month: todayMonth } = parseYearMonth(todayIso);
   const start = advanceMonth(todayYear, todayMonth, -11);
+  const byDate = groupSessionsByDate(sessions);
 
   const summaries: MonthlySummary[] = [];
   let y = start.year;
   let m = start.month;
 
   for (let i = 0; i < 12; i++) {
-    summaries.push(aggregateMonthSummary(sessions, y, m));
+    summaries.push(aggregateMonthSummaryFromGrouped(byDate, y, m));
     ({ year: y, month: m } = advanceMonth(y, m, 1));
   }
 
@@ -138,6 +146,7 @@ export function buildPriorMonthSummaries(
 
   const earliest = validDates.reduce((a, b) => (a < b ? a : b));
   const { year: startYear, month: startMonth } = parseYearMonth(earliest);
+  const byDate = groupSessionsByDate(sessions);
 
   const summaries: MonthlySummary[] = [];
   let y = startYear;
@@ -147,7 +156,7 @@ export function buildPriorMonthSummaries(
     const ym = yearMonthKey(y, m);
     if (ym >= currentYm) break;
 
-    summaries.push(aggregateMonthSummary(sessions, y, m));
+    summaries.push(aggregateMonthSummaryFromGrouped(byDate, y, m));
     ({ year: y, month: m } = advanceMonth(y, m, 1));
   }
 


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #380

## Summary

Adds a **Year in review** sub-view within the History calendar mode — a trailing 12-month grid showing days active and total sit time per month. Built on #83's month-grid styling and design tokens; no SPA-shell routing changes.

## Changes

- **`src/lib/historyMonthlyAggregation.ts`** — shared monthly aggregation utility
  - `aggregateMonthSummary()` — days active + total time for one calendar month
  - `buildTrailing12MonthSummaries()` — trailing 12 months ending with current month
  - `buildPriorMonthSummaries()` — moved here from `historyMonthGrid.ts` (re-exported for compatibility)
- **`src/components/HistoryYearInReview.tsx`** — 12-month grid sub-view (3×4 desktop, 2×6 mobile)
- **`src/components/HistoryView.tsx`** — local `calendarSubView` state toggles between default calendar and year-in-review; "Year in review" button on current-month header; back link returns to calendar

## Test plan

- [ ] Open Progress → Calendar view
- [ ] Click **Year in review** on the current month header
- [ ] Verify 12-month grid renders (Aug 2025 – Jul 2026 for today)
- [ ] Each cell shows short month label, `daysActive/daysInMonth`, and formatted total time
- [ ] Header totals (days active, total time) match sum of grid cells
- [ ] Click **← Calendar** to return to default calendar view
- [ ] Switch to Session buildup — year-in-review state resets; switch back to Calendar shows default view
- [ ] Unit tests: `npm run test:unit -- src/lib/historyMonthlyAggregation.test.ts src/lib/historyMonthGrid.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41c9a3fb-d4a5-4cc2-9c76-6c7fad77aa57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41c9a3fb-d4a5-4cc2-9c76-6c7fad77aa57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Add a Year in review view to History calendar**

### What Changed
- Added a new "Year in review" option inside the History calendar that shows the last 12 months in a compact grid.
- Each month now shows active days, total time, and a simple visual cue for months with more activity.
- Added a back button to return to the normal calendar view, and switching to Session buildup resets the Year in review state.
- Made the Calendar and Year in review navigation controls easier to tap on mobile.

### Impact
`✅ Faster yearly progress checks`
`✅ Easier month-by-month activity review`
`✅ Fewer missed taps on mobile navigation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
