### PR TITLE
Guided exercises during active session (#47, #48, #49)

### DIFF
--- a/src/components/GuidedExerciseOverlay.tsx
+++ b/src/components/GuidedExerciseOverlay.tsx
@@ -33,6 +33,11 @@ export function GuidedExerciseOverlay({ open, onClose }: GuidedExerciseOverlayPr
   const [elapsedInStepMs, setElapsedInStepMs] = useState(0);
   const [paused, setPaused] = useState(false);
   const reduceMotionRef = useRef(false);
+  const stepIndexRef = useRef(stepIndex);
+  const elapsedRef = useRef(elapsedInStepMs);
+
+  stepIndexRef.current = stepIndex;
+  elapsedRef.current = elapsedInStepMs;
 
   const exercise = exerciseId ? guidedExerciseById(exerciseId) : null;
   const steps = exercise?.steps ?? [];
@@ -62,22 +67,28 @@ export function GuidedExerciseOverlay({ open, onClose }: GuidedExerciseOverlayPr
 
   const advanceStep = useCallback(() => {
     if (!exercise) return;
-    if (isLastStep(stepIndex, exercise.steps.length)) {
-      setPhase("complete");
-      return;
-    }
-    setStepIndex(i => nextStepIndex(i, exercise.steps.length));
-    setElapsedInStepMs(0);
-  }, [exercise, stepIndex]);
+    setStepIndex(i => {
+      if (isLastStep(i, exercise.steps.length)) {
+        setPhase("complete");
+        return i;
+      }
+      elapsedRef.current = 0;
+      setElapsedInStepMs(0);
+      return nextStepIndex(i, exercise.steps.length);
+    });
+  }, [exercise]);
 
   const goBack = useCallback(() => {
-    if (stepIndex === 0) {
-      resetState();
-      return;
-    }
-    setStepIndex(previousStepIndex);
-    setElapsedInStepMs(0);
-  }, [resetState, stepIndex]);
+    setStepIndex(i => {
+      if (i === 0) {
+        resetState();
+        return 0;
+      }
+      elapsedRef.current = 0;
+      setElapsedInStepMs(0);
+      return previousStepIndex(i);
+    });
+  }, [resetState]);
 
   useEffect(() => {
     if (!open) {
@@ -93,21 +104,35 @@ export function GuidedExerciseOverlay({ open, onClose }: GuidedExerciseOverlayPr
   }, []);
 
   useEffect(() => {
-    if (!open || phase !== "running" || paused || !currentStep) return;
+    if (!open || phase !== "running" || paused || !exercise) return;
 
     const id = window.setInterval(() => {
-      setElapsedInStepMs(prev => prev + TICK_MS);
+      const idx = stepIndexRef.current;
+      const step = exercise.steps[idx];
+      if (!step) return;
+
+      const nextElapsed = elapsedRef.current + TICK_MS;
+      if (nextElapsed < step.durationMs) {
+        elapsedRef.current = nextElapsed;
+        setElapsedInStepMs(nextElapsed);
+        return;
+      }
+
+      elapsedRef.current = 0;
+      if (isLastStep(idx, exercise.steps.length)) {
+        setPhase("complete");
+        setElapsedInStepMs(0);
+        return;
+      }
+
+      const nextIdx = nextStepIndex(idx, exercise.steps.length);
+      stepIndexRef.current = nextIdx;
+      setStepIndex(nextIdx);
+      setElapsedInStepMs(0);
     }, TICK_MS);
 
     return () => window.clearInterval(id);
-  }, [open, phase, paused, currentStep, stepIndex]);
-
-  useEffect(() => {
-    if (!open || phase !== "running" || paused || !currentStep) return;
-    if (elapsedInStepMs >= currentStep.durationMs) {
-      advanceStep();
-    }
-  }, [open, phase, paused, currentStep, elapsedInStepMs, advanceStep]);
+  }, [open, phase, paused, exercise]);
 
   useEffect(() => {
     if (!open) return;
@@ -192,6 +217,7 @@ export function GuidedExerciseOverlay({ open, onClose }: GuidedExerciseOverlayPr
       aria-modal="true"
       aria-label="Guided exercise"
       data-testid="guided-exercise-overlay"
+      data-no-space-distraction
       style={overlayStyle}
     >
       <button type="button" onClick={handleClose} aria-label="Close guided exercise" style={closeButtonStyle}>

--- a/src/components/GuidedExerciseOverlay.tsx
+++ b/src/components/GuidedExerciseOverlay.tsx
@@ -1,0 +1,410 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
+import {
+  isLastStep,
+  nextStepIndex,
+  previousStepIndex,
+  stepProgressFraction,
+} from "@/lib/guidedExercise";
+import {
+  GUIDED_EXERCISES,
+  guidedExerciseById,
+  type GuidedExerciseId,
+} from "@/lib/guidedExerciseContent";
+
+type GuidedExerciseOverlayProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+type Phase = "picker" | "running" | "complete";
+
+const mono: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+};
+
+const TICK_MS = 250;
+
+export function GuidedExerciseOverlay({ open, onClose }: GuidedExerciseOverlayProps) {
+  const [phase, setPhase] = useState<Phase>("picker");
+  const [exerciseId, setExerciseId] = useState<GuidedExerciseId | null>(null);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [elapsedInStepMs, setElapsedInStepMs] = useState(0);
+  const [paused, setPaused] = useState(false);
+  const reduceMotionRef = useRef(false);
+
+  const exercise = exerciseId ? guidedExerciseById(exerciseId) : null;
+  const steps = exercise?.steps ?? [];
+  const currentStep = steps[stepIndex];
+  const progress = currentStep ? stepProgressFraction(stepIndex, elapsedInStepMs, currentStep) : 0;
+
+  const resetState = useCallback(() => {
+    setPhase("picker");
+    setExerciseId(null);
+    setStepIndex(0);
+    setElapsedInStepMs(0);
+    setPaused(false);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    resetState();
+    onClose();
+  }, [onClose, resetState]);
+
+  const startExercise = useCallback((id: GuidedExerciseId) => {
+    setExerciseId(id);
+    setStepIndex(0);
+    setElapsedInStepMs(0);
+    setPaused(false);
+    setPhase("running");
+  }, []);
+
+  const advanceStep = useCallback(() => {
+    if (!exercise) return;
+    if (isLastStep(stepIndex, exercise.steps.length)) {
+      setPhase("complete");
+      return;
+    }
+    setStepIndex(i => nextStepIndex(i, exercise.steps.length));
+    setElapsedInStepMs(0);
+  }, [exercise, stepIndex]);
+
+  const goBack = useCallback(() => {
+    if (stepIndex === 0) {
+      resetState();
+      return;
+    }
+    setStepIndex(previousStepIndex);
+    setElapsedInStepMs(0);
+  }, [resetState, stepIndex]);
+
+  useEffect(() => {
+    if (!open) {
+      resetState();
+    }
+  }, [open, resetState]);
+
+  useEffect(() => {
+    reduceMotionRef.current =
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  }, []);
+
+  useEffect(() => {
+    if (!open || phase !== "running" || paused || !currentStep) return;
+
+    const id = window.setInterval(() => {
+      setElapsedInStepMs(prev => prev + TICK_MS);
+    }, TICK_MS);
+
+    return () => window.clearInterval(id);
+  }, [open, phase, paused, currentStep, stepIndex]);
+
+  useEffect(() => {
+    if (!open || phase !== "running" || paused || !currentStep) return;
+    if (elapsedInStepMs >= currentStep.durationMs) {
+      advanceStep();
+    }
+  }, [open, phase, paused, currentStep, elapsedInStepMs, advanceStep]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        handleClose();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, handleClose]);
+
+  if (!open) return null;
+
+  const overlayStyle: CSSProperties = {
+    position: "fixed",
+    inset: 0,
+    zIndex: 210,
+    background: "rgba(var(--bg-rgb), 0.94)",
+    backdropFilter: "blur(6px)",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "max(24px, env(safe-area-inset-top)) 20px max(24px, env(safe-area-inset-bottom))",
+    animation: reduceMotionRef.current ? undefined : "fadeIn 0.5s ease",
+    ...mono,
+  };
+
+  const cardStyle: CSSProperties = {
+    width: "100%",
+    maxWidth: "min(440px, calc(100vw - 40px))",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: "20px",
+  };
+
+  const buttonRowStyle: CSSProperties = {
+    display: "flex",
+    flexWrap: "wrap",
+    justifyContent: "center",
+    gap: "10px",
+    width: "100%",
+  };
+
+  const secondaryButtonStyle: CSSProperties = {
+    background: "var(--surface-1)",
+    border: "1px solid var(--border-2)",
+    color: "var(--fg-2)",
+    ...mono,
+    fontSize: "11px",
+    letterSpacing: "0.12em",
+    textTransform: "uppercase",
+    padding: "12px 18px",
+    minHeight: "44px",
+    borderRadius: "16px",
+    cursor: "pointer",
+  };
+
+  const closeButtonStyle: CSSProperties = {
+    position: "absolute",
+    top: "max(16px, env(safe-area-inset-top))",
+    right: "max(16px, env(safe-area-inset-right))",
+    background: "none",
+    border: "1px solid var(--border-2)",
+    color: "var(--fg-3)",
+    ...mono,
+    fontSize: "10px",
+    letterSpacing: "0.14em",
+    textTransform: "uppercase",
+    padding: "10px 16px",
+    minHeight: "44px",
+    borderRadius: "999px",
+    cursor: "pointer",
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Guided exercise"
+      data-testid="guided-exercise-overlay"
+      style={overlayStyle}
+    >
+      <button type="button" onClick={handleClose} aria-label="Close guided exercise" style={closeButtonStyle}>
+        close
+      </button>
+
+      <div style={cardStyle}>
+        {phase === "picker" && (
+          <>
+            <div style={{ textAlign: "center" }}>
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: "10px",
+                  letterSpacing: "0.18em",
+                  textTransform: "uppercase",
+                  color: "var(--fg-4)",
+                }}
+              >
+                Guided exercise
+              </p>
+              <h2
+                style={{
+                  margin: "10px 0 0",
+                  fontSize: "18px",
+                  fontWeight: 400,
+                  letterSpacing: "0.06em",
+                  color: "var(--fg-2)",
+                }}
+              >
+                Choose a focus
+              </h2>
+              <p style={{ margin: "12px 0 0", fontSize: "12px", lineHeight: 1.55, color: "var(--fg-4)" }}>
+                Your sit keeps running. Each prompt advances gently on its own — tap next anytime.
+              </p>
+            </div>
+
+            <div style={{ display: "flex", flexDirection: "column", gap: "10px", width: "100%" }}>
+              {GUIDED_EXERCISES.map(item => (
+                <button
+                  key={item.id}
+                  type="button"
+                  data-testid={`guided-exercise-option-${item.id}`}
+                  onClick={() => startExercise(item.id)}
+                  style={{
+                    textAlign: "left",
+                    background: "var(--surface-1)",
+                    border: "1px solid var(--accent-green-border-subtle)",
+                    borderRadius: "16px",
+                    padding: "16px 18px",
+                    cursor: "pointer",
+                    color: "var(--fg-2)",
+                    ...mono,
+                  }}
+                >
+                  <div
+                    style={{
+                      fontSize: "12px",
+                      letterSpacing: "0.12em",
+                      textTransform: "uppercase",
+                      color: "var(--accent-green-dim)",
+                    }}
+                  >
+                    {item.shortLabel}
+                  </div>
+                  <div style={{ marginTop: "6px", fontSize: "13px", letterSpacing: "0.04em" }}>{item.label}</div>
+                  <div style={{ marginTop: "8px", fontSize: "11px", lineHeight: 1.5, color: "var(--fg-4)" }}>
+                    {item.description}
+                  </div>
+                  <div style={{ marginTop: "8px", fontSize: "10px", color: "var(--fg-4)", letterSpacing: "0.08em" }}>
+                    {item.steps.length} prompts
+                  </div>
+                </button>
+              ))}
+            </div>
+          </>
+        )}
+
+        {phase === "running" && exercise && currentStep && (
+          <>
+            <div style={{ width: "100%", textAlign: "center" }}>
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: "10px",
+                  letterSpacing: "0.16em",
+                  textTransform: "uppercase",
+                  color: "var(--fg-4)",
+                }}
+              >
+                {exercise.shortLabel} · {stepIndex + 1} / {steps.length}
+              </p>
+              <h2
+                data-testid="guided-exercise-step-title"
+                style={{
+                  margin: "12px 0 0",
+                  fontSize: "22px",
+                  fontWeight: 300,
+                  letterSpacing: "0.08em",
+                  color: "var(--accent-green-text)",
+                }}
+              >
+                {currentStep.title}
+              </h2>
+            </div>
+
+            <div
+              aria-hidden
+              style={{
+                width: "100%",
+                height: "3px",
+                borderRadius: "999px",
+                background: "var(--border-2)",
+                overflow: "hidden",
+              }}
+            >
+              <div
+                data-testid="guided-exercise-step-progress"
+                style={{
+                  height: "100%",
+                  width: `${progress * 100}%`,
+                  background: "var(--accent-green)",
+                  transition: reduceMotionRef.current ? undefined : "width 0.25s linear",
+                }}
+              />
+            </div>
+
+            <p
+              data-testid="guided-exercise-step-prompt"
+              style={{
+                margin: 0,
+                textAlign: "center",
+                fontSize: "14px",
+                lineHeight: 1.65,
+                color: "var(--fg-2)",
+                letterSpacing: "0.02em",
+                maxWidth: "36ch",
+              }}
+            >
+              {currentStep.prompt}
+            </p>
+
+            <div style={buttonRowStyle}>
+              <button type="button" onClick={goBack} style={secondaryButtonStyle}>
+                back
+              </button>
+              <button
+                type="button"
+                onClick={() => setPaused(p => !p)}
+                aria-pressed={paused}
+                style={secondaryButtonStyle}
+              >
+                {paused ? "resume" : "pause"}
+              </button>
+              <button type="button" onClick={advanceStep} style={secondaryButtonStyle}>
+                {isLastStep(stepIndex, steps.length) ? "finish" : "next"}
+              </button>
+            </div>
+          </>
+        )}
+
+        {phase === "complete" && exercise && (
+          <>
+            <div style={{ textAlign: "center" }}>
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: "10px",
+                  letterSpacing: "0.16em",
+                  textTransform: "uppercase",
+                  color: "var(--fg-4)",
+                }}
+              >
+                {exercise.shortLabel} complete
+              </p>
+              <h2
+                style={{
+                  margin: "12px 0 0",
+                  fontSize: "20px",
+                  fontWeight: 300,
+                  letterSpacing: "0.06em",
+                  color: "var(--fg-2)",
+                }}
+              >
+                Return to your sit
+              </h2>
+              <p style={{ margin: "14px 0 0", fontSize: "13px", lineHeight: 1.55, color: "var(--fg-4)" }}>
+                Let the exercise dissolve. Your timer and tracking continue as before.
+              </p>
+            </div>
+
+            <div style={buttonRowStyle}>
+              <button type="button" onClick={() => startExercise(exercise.id)} style={secondaryButtonStyle}>
+                repeat
+              </button>
+              <button type="button" onClick={resetState} style={secondaryButtonStyle}>
+                choose another
+              </button>
+              <button
+                type="button"
+                onClick={handleClose}
+                style={{
+                  ...secondaryButtonStyle,
+                  borderColor: "var(--accent-green-border)",
+                  color: "var(--accent-green-dim)",
+                }}
+              >
+                back to sit
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/GuidedExerciseOverlay.tsx
+++ b/src/components/GuidedExerciseOverlay.tsx
@@ -32,7 +32,12 @@ export function GuidedExerciseOverlay({ open, onClose }: GuidedExerciseOverlayPr
   const [stepIndex, setStepIndex] = useState(0);
   const [elapsedInStepMs, setElapsedInStepMs] = useState(0);
   const [paused, setPaused] = useState(false);
-  const reduceMotionRef = useRef(false);
+  const [reduceMotion] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
   const stepIndexRef = useRef(stepIndex);
   const elapsedRef = useRef(elapsedInStepMs);
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -97,13 +102,6 @@ export function GuidedExerciseOverlay({ open, onClose }: GuidedExerciseOverlayPr
       resetState();
     }
   }, [open, resetState]);
-
-  useEffect(() => {
-    reduceMotionRef.current =
-      typeof window !== "undefined" &&
-      typeof window.matchMedia === "function" &&
-      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-  }, []);
 
   useEffect(() => {
     if (!open || phase !== "running" || paused || !exercise) return;
@@ -197,7 +195,7 @@ export function GuidedExerciseOverlay({ open, onClose }: GuidedExerciseOverlayPr
     alignItems: "center",
     justifyContent: "center",
     padding: "max(24px, env(safe-area-inset-top)) 20px max(24px, env(safe-area-inset-bottom))",
-    animation: reduceMotionRef.current ? undefined : "fadeIn 0.5s ease",
+    animation: reduceMotion ? undefined : "fadeIn 0.5s ease",
     ...mono,
   };
 
@@ -385,7 +383,7 @@ export function GuidedExerciseOverlay({ open, onClose }: GuidedExerciseOverlayPr
                   height: "100%",
                   width: `${progress * 100}%`,
                   background: "var(--accent-green)",
-                  transition: reduceMotionRef.current ? undefined : "width 0.25s linear",
+                  transition: reduceMotion ? undefined : "width 0.25s linear",
                 }}
               />
             </div>

--- a/src/components/GuidedExerciseOverlay.tsx
+++ b/src/components/GuidedExerciseOverlay.tsx
@@ -35,6 +35,8 @@ export function GuidedExerciseOverlay({ open, onClose }: GuidedExerciseOverlayPr
   const reduceMotionRef = useRef(false);
   const stepIndexRef = useRef(stepIndex);
   const elapsedRef = useRef(elapsedInStepMs);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   stepIndexRef.current = stepIndex;
   elapsedRef.current = elapsedInStepMs;
@@ -136,15 +138,51 @@ export function GuidedExerciseOverlay({ open, onClose }: GuidedExerciseOverlayPr
 
   useEffect(() => {
     if (!open) return;
+
+    closeButtonRef.current?.focus();
+
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const getFocusableElements = () =>
+      Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        )
+      ).filter(element => !element.hasAttribute("disabled"));
+
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
         handleClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const focusable = getFocusableElements();
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (event.shiftKey) {
+        if (active === first || !dialog.contains(active)) {
+          event.preventDefault();
+          last.focus();
+        }
+        return;
+      }
+
+      if (active === last || !dialog.contains(active)) {
+        event.preventDefault();
+        first.focus();
       }
     };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [open, handleClose]);
+
+    dialog.addEventListener("keydown", onKeyDown);
+    return () => dialog.removeEventListener("keydown", onKeyDown);
+  }, [open, phase, handleClose]);
 
   if (!open) return null;
 
@@ -213,6 +251,7 @@ export function GuidedExerciseOverlay({ open, onClose }: GuidedExerciseOverlayPr
 
   return (
     <div
+      ref={dialogRef}
       role="dialog"
       aria-modal="true"
       aria-label="Guided exercise"
@@ -220,7 +259,13 @@ export function GuidedExerciseOverlay({ open, onClose }: GuidedExerciseOverlayPr
       data-no-space-distraction
       style={overlayStyle}
     >
-      <button type="button" onClick={handleClose} aria-label="Close guided exercise" style={closeButtonStyle}>
+      <button
+        ref={closeButtonRef}
+        type="button"
+        onClick={handleClose}
+        aria-label="Close guided exercise"
+        style={closeButtonStyle}
+      >
         close
       </button>
 

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -107,6 +107,12 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
   useSessionSuppressionRelay(!sessionFinished);
 
   useEffect(() => {
+    if (sessionFinished) {
+      setShowGuidedExercise(false);
+    }
+  }, [sessionFinished]);
+
+  useEffect(() => {
     const resetTimer = () => {
       setControlsVisible(true);
       if (hideTimerRef.current) clearTimeout(hideTimerRef.current);

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -17,6 +17,7 @@ import {
   useTrackingControlsUnlocked,
 } from "@/lib/useTrackingControlPrefs";
 import { useSessionSuppressionRelay } from "@/lib/useSessionSuppression";
+import { GuidedExerciseOverlay } from "./GuidedExerciseOverlay";
 
 type MindState = "clear" | "thinking" | "hyperfocus";
 
@@ -92,6 +93,7 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   /** True after user pauses once this sit — keeps tracking UI (and ThoughtCapture) mounted while paused. */
   const [wasPausedInSession, setWasPausedInSession] = useState(false);
+  const [showGuidedExercise, setShowGuidedExercise] = useState(false);
   /** Live opt-in Settings pref; pause/complete/abandon drop `isActive` and toggle-off releases too. */
   const keepScreenAwakePref = useKeepScreenAwakePref();
   const trackingControlsUnlocked = useTrackingControlsUnlocked();
@@ -367,6 +369,7 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
 
   return (
     <div style={{ animation: "fadeIn 0.8s ease", display: "flex", flexDirection: "column", alignItems: "center" }}>
+      <GuidedExerciseOverlay open={showGuidedExercise} onClose={() => setShowGuidedExercise(false)} />
       <BlockTimer
         totalSeconds={totalSeconds}
         isActive={isActive}
@@ -570,7 +573,32 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
           </div>
 
           {!showPostDistractionCapture && (
-            <div style={{ marginTop: isMobile ? "12px" : "18px", display: "flex", justifyContent: "center", width: "100%" }}>
+            <div
+              style={{
+                marginTop: isMobile ? "12px" : "18px",
+                display: "flex",
+                justifyContent: "center",
+                gap: "10px",
+                flexWrap: "wrap",
+                width: "100%",
+              }}
+            >
+              {isActive && (
+                <button
+                  type="button"
+                  onClick={() => setShowGuidedExercise(true)}
+                  aria-label="Open guided exercise"
+                  data-testid="guided-exercise-open"
+                  style={{
+                    ...captureNoteButtonStyle,
+                    borderColor: "var(--accent-green-border-subtle)",
+                    color: "var(--accent-green-dim)",
+                    opacity: sessionChromeDimmed ? 0.48 : 0.88,
+                  }}
+                >
+                  guided exercise
+                </button>
+              )}
               <button
                 type="button"
                 onClick={handleOpenThoughtCapture}

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -166,7 +166,7 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
   }, [finalizeActiveHold]);
 
   const { holdKindRef, resetHoldTracking } = useMindStateHold({
-    enabled: isActive && showDistractionHyperfocusCluster,
+    enabled: isActive && showDistractionHyperfocusCluster && !showGuidedExercise,
     beginDistraction,
     beginHyperfocus,
     endHoldFromKeyboard,

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -94,6 +94,7 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
   /** True after user pauses once this sit — keeps tracking UI (and ThoughtCapture) mounted while paused. */
   const [wasPausedInSession, setWasPausedInSession] = useState(false);
   const [showGuidedExercise, setShowGuidedExercise] = useState(false);
+  const guidedExerciseTriggerRef = useRef<HTMLButtonElement>(null);
   /** Live opt-in Settings pref; pause/complete/abandon drop `isActive` and toggle-off releases too. */
   const keepScreenAwakePref = useKeepScreenAwakePref();
   const trackingControlsUnlocked = useTrackingControlsUnlocked();
@@ -177,6 +178,11 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
     beginHyperfocus,
     endHoldFromKeyboard,
   });
+
+  const closeGuidedExercise = useCallback(() => {
+    setShowGuidedExercise(false);
+    requestAnimationFrame(() => guidedExerciseTriggerRef.current?.focus());
+  }, []);
 
   const openGuidedExercise = useCallback(() => {
     finalizeActiveHold(elapsedRef.current);
@@ -381,7 +387,7 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
 
   return (
     <div style={{ animation: "fadeIn 0.8s ease", display: "flex", flexDirection: "column", alignItems: "center" }}>
-      <GuidedExerciseOverlay open={showGuidedExercise} onClose={() => setShowGuidedExercise(false)} />
+      <GuidedExerciseOverlay open={showGuidedExercise} onClose={closeGuidedExercise} />
       <BlockTimer
         totalSeconds={totalSeconds}
         isActive={isActive}
@@ -597,6 +603,7 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
             >
               {isActive && (
                 <button
+                  ref={guidedExerciseTriggerRef}
                   type="button"
                   onClick={openGuidedExercise}
                   aria-label="Open guided exercise"

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -178,6 +178,12 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
     endHoldFromKeyboard,
   });
 
+  const openGuidedExercise = useCallback(() => {
+    finalizeActiveHold(elapsedRef.current);
+    resetHoldTracking();
+    setShowGuidedExercise(true);
+  }, [finalizeActiveHold, resetHoldTracking]);
+
   const calcClearPercent = useCallback(() => {
     const endTime = elapsedRef.current || totalSeconds;
     return computeClearPercentFromLog(mindStateLog, endTime);
@@ -592,7 +598,7 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
               {isActive && (
                 <button
                   type="button"
-                  onClick={() => setShowGuidedExercise(true)}
+                  onClick={openGuidedExercise}
                   aria-label="Open guided exercise"
                   data-testid="guided-exercise-open"
                   style={{

--- a/src/lib/guidedExercise.test.ts
+++ b/src/lib/guidedExercise.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampStepIndex,
+  exerciseSummary,
+  isLastStep,
+  nextStepIndex,
+  previousStepIndex,
+  stepProgressFraction,
+  totalDurationMs,
+} from "./guidedExercise";
+import { GUIDED_EXERCISES, guidedExerciseById } from "./guidedExerciseContent";
+
+describe("guidedExerciseContent", () => {
+  it("defines all three exercise modes", () => {
+    const ids = GUIDED_EXERCISES.map(e => e.id);
+    expect(ids).toEqual(["progressive-sensory", "breathing-awareness", "body-scan"]);
+  });
+
+  it("progressive sensory has five sense steps", () => {
+    const exercise = guidedExerciseById("progressive-sensory");
+    expect(exercise.steps).toHaveLength(5);
+    expect(exercise.steps.map(s => s.id)).toEqual(["sight", "sound", "smell", "taste", "touch"]);
+  });
+
+  it("body scan walks through body regions", () => {
+    const exercise = guidedExerciseById("body-scan");
+    expect(exercise.steps.length).toBeGreaterThanOrEqual(8);
+    expect(exercise.steps[0]?.title).toBe("Feet");
+    expect(exercise.steps.at(-1)?.title).toBe("Whole body");
+  });
+
+  it("every step has positive duration for gentle pacing", () => {
+    for (const exercise of GUIDED_EXERCISES) {
+      for (const step of exercise.steps) {
+        expect(step.durationMs).toBeGreaterThan(0);
+        expect(step.prompt.length).toBeGreaterThan(10);
+      }
+    }
+  });
+});
+
+describe("guidedExercise helpers", () => {
+  const steps = guidedExerciseById("progressive-sensory").steps;
+
+  it("totalDurationMs sums step durations", () => {
+    expect(totalDurationMs(steps)).toBe(steps.reduce((n, s) => n + s.durationMs, 0));
+  });
+
+  it("clampStepIndex keeps index in range", () => {
+    expect(clampStepIndex(-2, steps.length)).toBe(0);
+    expect(clampStepIndex(2, steps.length)).toBe(2);
+    expect(clampStepIndex(99, steps.length)).toBe(steps.length - 1);
+  });
+
+  it("next and previous step indices", () => {
+    expect(nextStepIndex(0, steps.length)).toBe(1);
+    expect(nextStepIndex(steps.length - 1, steps.length)).toBe(steps.length - 1);
+    expect(previousStepIndex(0)).toBe(0);
+    expect(previousStepIndex(2)).toBe(1);
+  });
+
+  it("isLastStep identifies the final prompt", () => {
+    expect(isLastStep(steps.length - 2, steps.length)).toBe(false);
+    expect(isLastStep(steps.length - 1, steps.length)).toBe(true);
+  });
+
+  it("stepProgressFraction tracks elapsed time within a step", () => {
+    const step = steps[0]!;
+    expect(stepProgressFraction(0, 0, step)).toBe(0);
+    expect(stepProgressFraction(0, step.durationMs / 2, step)).toBe(0.5);
+    expect(stepProgressFraction(0, step.durationMs, step)).toBe(1);
+    expect(stepProgressFraction(0, step.durationMs * 2, step)).toBe(1);
+  });
+
+  it("exerciseSummary reports step count and total duration", () => {
+    const summary = exerciseSummary("breathing-awareness");
+    expect(summary.stepCount).toBe(5);
+    expect(summary.totalDurationMs).toBe(totalDurationMs(guidedExerciseById("breathing-awareness").steps));
+  });
+});

--- a/src/lib/guidedExercise.ts
+++ b/src/lib/guidedExercise.ts
@@ -1,0 +1,47 @@
+import {
+  type GuidedExerciseDefinition,
+  type GuidedExerciseStep,
+  guidedExerciseById,
+  type GuidedExerciseId,
+} from "./guidedExerciseContent";
+
+export function totalDurationMs(steps: GuidedExerciseStep[]): number {
+  return steps.reduce((sum, step) => sum + step.durationMs, 0);
+}
+
+export function clampStepIndex(index: number, stepCount: number): number {
+  if (stepCount <= 0) return 0;
+  return Math.min(Math.max(0, index), stepCount - 1);
+}
+
+export function isLastStep(index: number, stepCount: number): boolean {
+  return stepCount > 0 && index >= stepCount - 1;
+}
+
+export function nextStepIndex(index: number, stepCount: number): number {
+  return clampStepIndex(index + 1, stepCount);
+}
+
+export function previousStepIndex(index: number): number {
+  return Math.max(0, index - 1);
+}
+
+export function stepProgressFraction(index: number, elapsedInStepMs: number, step: GuidedExerciseStep): number {
+  if (step.durationMs <= 0) return 1;
+  return Math.min(1, Math.max(0, elapsedInStepMs / step.durationMs));
+}
+
+export function exerciseSummary(id: GuidedExerciseId): Pick<GuidedExerciseDefinition, "id" | "label" | "shortLabel" | "description"> & {
+  stepCount: number;
+  totalDurationMs: number;
+} {
+  const exercise = guidedExerciseById(id);
+  return {
+    id: exercise.id,
+    label: exercise.label,
+    shortLabel: exercise.shortLabel,
+    description: exercise.description,
+    stepCount: exercise.steps.length,
+    totalDurationMs: totalDurationMs(exercise.steps),
+  };
+}

--- a/src/lib/guidedExerciseContent.ts
+++ b/src/lib/guidedExerciseContent.ts
@@ -1,0 +1,183 @@
+export type GuidedExerciseId = "progressive-sensory" | "breathing-awareness" | "body-scan";
+
+export type GuidedExerciseStep = {
+  id: string;
+  title: string;
+  prompt: string;
+  /** How long this prompt stays before auto-advancing (ms). */
+  durationMs: number;
+};
+
+export type GuidedExerciseDefinition = {
+  id: GuidedExerciseId;
+  label: string;
+  shortLabel: string;
+  description: string;
+  steps: GuidedExerciseStep[];
+};
+
+/** Default pacing between auto-advances — gentle enough to settle into each prompt. */
+export const GUIDED_STEP_DURATION_MS = 45_000;
+
+const SENSORY_STEP_MS = 40_000;
+const BREATH_STEP_MS = 50_000;
+const BODY_SCAN_STEP_MS = 35_000;
+
+export const GUIDED_EXERCISES: GuidedExerciseDefinition[] = [
+  {
+    id: "progressive-sensory",
+    label: "Progressive sensory",
+    shortLabel: "Five senses",
+    description: "Notice each sense one at a time, without searching for anything special.",
+    steps: [
+      {
+        id: "sight",
+        title: "Sight",
+        prompt:
+          "Let your eyes rest softly. Notice colors, shapes, and light — whatever is present, without fixing on any one thing.",
+        durationMs: SENSORY_STEP_MS,
+      },
+      {
+        id: "sound",
+        title: "Sound",
+        prompt:
+          "Bring attention to hearing. Notice near and far sounds, silence between them, and the texture of what you hear.",
+        durationMs: SENSORY_STEP_MS,
+      },
+      {
+        id: "smell",
+        title: "Smell",
+        prompt:
+          "Notice scents in the air — subtle or strong. If nothing stands out, rest with the neutral quality of breathing.",
+        durationMs: SENSORY_STEP_MS,
+      },
+      {
+        id: "taste",
+        title: "Taste",
+        prompt:
+          "Notice taste in the mouth — lingering flavors or plainness. Let the sensation be as it is.",
+        durationMs: SENSORY_STEP_MS,
+      },
+      {
+        id: "touch",
+        title: "Touch",
+        prompt:
+          "Feel contact points: seat, floor, clothing, air on skin. Notice temperature and pressure without adjusting.",
+        durationMs: SENSORY_STEP_MS,
+      },
+    ],
+  },
+  {
+    id: "breathing-awareness",
+    label: "Breathing awareness",
+    shortLabel: "Breath",
+    description: "Rest attention on the physical sensation of breathing.",
+    steps: [
+      {
+        id: "settle",
+        title: "Settle",
+        prompt:
+          "Allow the body to be still. You do not need to change the breath — simply notice that breathing is happening.",
+        durationMs: 25_000,
+      },
+      {
+        id: "sensation",
+        title: "Sensation",
+        prompt:
+          "Find where breath is most vivid: nostrils, chest, or belly. Stay with the raw sensation of each inhale and exhale.",
+        durationMs: BREATH_STEP_MS,
+      },
+      {
+        id: "rhythm",
+        title: "Rhythm",
+        prompt:
+          "Follow the natural rhythm. When the mind wanders, gently return to the feeling of air moving in and out.",
+        durationMs: BREATH_STEP_MS,
+      },
+      {
+        id: "full-cycle",
+        title: "Full cycle",
+        prompt:
+          "Notice the beginning, middle, and end of each breath. Rest in the pause between exhale and the next inhale.",
+        durationMs: BREATH_STEP_MS,
+      },
+      {
+        id: "open",
+        title: "Open awareness",
+        prompt:
+          "Let breath stay in the background while awareness widens. The body continues breathing on its own.",
+        durationMs: 30_000,
+      },
+    ],
+  },
+  {
+    id: "body-scan",
+    label: "Body scan",
+    shortLabel: "Body scan",
+    description: "Move attention slowly through regions of the body.",
+    steps: [
+      {
+        id: "feet",
+        title: "Feet",
+        prompt: "Bring attention to the feet — toes, soles, heels. Notice sensation or the absence of sensation.",
+        durationMs: BODY_SCAN_STEP_MS,
+      },
+      {
+        id: "legs",
+        title: "Legs",
+        prompt: "Include calves, knees, and thighs. Feel weight, warmth, tingling, or stillness.",
+        durationMs: BODY_SCAN_STEP_MS,
+      },
+      {
+        id: "hips",
+        title: "Hips & pelvis",
+        prompt: "Notice the pelvis and lower back where they meet the seat or floor.",
+        durationMs: BODY_SCAN_STEP_MS,
+      },
+      {
+        id: "abdomen",
+        title: "Abdomen",
+        prompt: "Feel the belly rise and fall with breath. Soften any holding in the core.",
+        durationMs: BODY_SCAN_STEP_MS,
+      },
+      {
+        id: "chest",
+        title: "Chest",
+        prompt: "Notice the chest and upper back — heartbeat, breath, contact with clothing.",
+        durationMs: BODY_SCAN_STEP_MS,
+      },
+      {
+        id: "hands-arms",
+        title: "Hands & arms",
+        prompt: "Scan through fingers, palms, forearms, and upper arms. Let them be heavy or light.",
+        durationMs: BODY_SCAN_STEP_MS,
+      },
+      {
+        id: "shoulders-neck",
+        title: "Shoulders & neck",
+        prompt: "Include shoulders, neck, and throat. Release unnecessary tension if you find it.",
+        durationMs: BODY_SCAN_STEP_MS,
+      },
+      {
+        id: "face-head",
+        title: "Face & head",
+        prompt: "Notice jaw, cheeks, eyes, forehead, and scalp. Let the face be neutral.",
+        durationMs: BODY_SCAN_STEP_MS,
+      },
+      {
+        id: "whole-body",
+        title: "Whole body",
+        prompt: "Feel the entire body at once — a single field of sensation from head to toe.",
+        durationMs: BODY_SCAN_STEP_MS,
+      },
+    ],
+  },
+];
+
+export function guidedExerciseById(id: GuidedExerciseId): GuidedExerciseDefinition {
+  const exercise = GUIDED_EXERCISES.find(e => e.id === id);
+  if (!exercise) {
+    throw new Error(`Unknown guided exercise: ${id}`);
+  }
+  return exercise;
+}

--- a/src/lib/guidedExerciseContent.ts
+++ b/src/lib/guidedExerciseContent.ts
@@ -19,10 +19,6 @@ export type GuidedExerciseDefinition = {
 /** Default pacing between auto-advances — gentle enough to settle into each prompt. */
 export const GUIDED_STEP_DURATION_MS = 45_000;
 
-const SENSORY_STEP_MS = GUIDED_STEP_DURATION_MS - 5_000;
-const BREATH_STEP_MS = GUIDED_STEP_DURATION_MS + 5_000;
-const BODY_SCAN_STEP_MS = GUIDED_STEP_DURATION_MS - 10_000;
-
 export const GUIDED_EXERCISES: GuidedExerciseDefinition[] = [
   {
     id: "progressive-sensory",
@@ -35,35 +31,35 @@ export const GUIDED_EXERCISES: GuidedExerciseDefinition[] = [
         title: "Sight",
         prompt:
           "Let your eyes rest softly. Notice colors, shapes, and light — whatever is present, without fixing on any one thing.",
-        durationMs: SENSORY_STEP_MS,
+        durationMs: GUIDED_STEP_DURATION_MS - 5_000,
       },
       {
         id: "sound",
         title: "Sound",
         prompt:
           "Bring attention to hearing. Notice near and far sounds, silence between them, and the texture of what you hear.",
-        durationMs: SENSORY_STEP_MS,
+        durationMs: GUIDED_STEP_DURATION_MS - 5_000,
       },
       {
         id: "smell",
         title: "Smell",
         prompt:
           "Notice scents in the air — subtle or strong. If nothing stands out, rest with the neutral quality of breathing.",
-        durationMs: SENSORY_STEP_MS,
+        durationMs: GUIDED_STEP_DURATION_MS - 5_000,
       },
       {
         id: "taste",
         title: "Taste",
         prompt:
           "Notice taste in the mouth — lingering flavors or plainness. Let the sensation be as it is.",
-        durationMs: SENSORY_STEP_MS,
+        durationMs: GUIDED_STEP_DURATION_MS - 5_000,
       },
       {
         id: "touch",
         title: "Touch",
         prompt:
           "Feel contact points: seat, floor, clothing, air on skin. Notice temperature and pressure without adjusting.",
-        durationMs: SENSORY_STEP_MS,
+        durationMs: GUIDED_STEP_DURATION_MS - 5_000,
       },
     ],
   },
@@ -78,35 +74,35 @@ export const GUIDED_EXERCISES: GuidedExerciseDefinition[] = [
         title: "Settle",
         prompt:
           "Allow the body to be still. You do not need to change the breath — simply notice that breathing is happening.",
-        durationMs: 25_000,
+        durationMs: GUIDED_STEP_DURATION_MS - 20_000,
       },
       {
         id: "sensation",
         title: "Sensation",
         prompt:
           "Find where breath is most vivid: nostrils, chest, or belly. Stay with the raw sensation of each inhale and exhale.",
-        durationMs: BREATH_STEP_MS,
+        durationMs: GUIDED_STEP_DURATION_MS + 5_000,
       },
       {
         id: "rhythm",
         title: "Rhythm",
         prompt:
           "Follow the natural rhythm. When the mind wanders, gently return to the feeling of air moving in and out.",
-        durationMs: BREATH_STEP_MS,
+        durationMs: GUIDED_STEP_DURATION_MS + 5_000,
       },
       {
         id: "full-cycle",
         title: "Full cycle",
         prompt:
           "Notice the beginning, middle, and end of each breath. Rest in the pause between exhale and the next inhale.",
-        durationMs: BREATH_STEP_MS,
+        durationMs: GUIDED_STEP_DURATION_MS + 5_000,
       },
       {
         id: "open",
         title: "Open awareness",
         prompt:
           "Let breath stay in the background while awareness widens. The body continues breathing on its own.",
-        durationMs: 30_000,
+        durationMs: GUIDED_STEP_DURATION_MS - 15_000,
       },
     ],
   },
@@ -120,55 +116,55 @@ export const GUIDED_EXERCISES: GuidedExerciseDefinition[] = [
         id: "feet",
         title: "Feet",
         prompt: "Bring attention to the feet — toes, soles, heels. Notice sensation or the absence of sensation.",
-        durationMs: BODY_SCAN_STEP_MS,
+        durationMs: GUIDED_STEP_DURATION_MS - 10_000,
       },
       {
         id: "legs",
         title: "Legs",
         prompt: "Include calves, knees, and thighs. Feel weight, warmth, tingling, or stillness.",
-        durationMs: BODY_SCAN_STEP_MS,
+        durationMs: GUIDED_STEP_DURATION_MS - 10_000,
       },
       {
         id: "hips",
         title: "Hips & pelvis",
         prompt: "Notice the pelvis and lower back where they meet the seat or floor.",
-        durationMs: BODY_SCAN_STEP_MS,
+        durationMs: GUIDED_STEP_DURATION_MS - 10_000,
       },
       {
         id: "abdomen",
         title: "Abdomen",
         prompt: "Feel the belly rise and fall with breath. Soften any holding in the core.",
-        durationMs: BODY_SCAN_STEP_MS,
+        durationMs: GUIDED_STEP_DURATION_MS - 10_000,
       },
       {
         id: "chest",
         title: "Chest",
         prompt: "Notice the chest and upper back — heartbeat, breath, contact with clothing.",
-        durationMs: BODY_SCAN_STEP_MS,
+        durationMs: GUIDED_STEP_DURATION_MS - 10_000,
       },
       {
         id: "hands-arms",
         title: "Hands & arms",
         prompt: "Scan through fingers, palms, forearms, and upper arms. Let them be heavy or light.",
-        durationMs: BODY_SCAN_STEP_MS,
+        durationMs: GUIDED_STEP_DURATION_MS - 10_000,
       },
       {
         id: "shoulders-neck",
         title: "Shoulders & neck",
         prompt: "Include shoulders, neck, and throat. Release unnecessary tension if you find it.",
-        durationMs: BODY_SCAN_STEP_MS,
+        durationMs: GUIDED_STEP_DURATION_MS - 10_000,
       },
       {
         id: "face-head",
         title: "Face & head",
         prompt: "Notice jaw, cheeks, eyes, forehead, and scalp. Let the face be neutral.",
-        durationMs: BODY_SCAN_STEP_MS,
+        durationMs: GUIDED_STEP_DURATION_MS - 10_000,
       },
       {
         id: "whole-body",
         title: "Whole body",
         prompt: "Feel the entire body at once — a single field of sensation from head to toe.",
-        durationMs: BODY_SCAN_STEP_MS,
+        durationMs: GUIDED_STEP_DURATION_MS - 10_000,
       },
     ],
   },

--- a/src/lib/guidedExerciseContent.ts
+++ b/src/lib/guidedExerciseContent.ts
@@ -19,9 +19,9 @@ export type GuidedExerciseDefinition = {
 /** Default pacing between auto-advances — gentle enough to settle into each prompt. */
 export const GUIDED_STEP_DURATION_MS = 45_000;
 
-const SENSORY_STEP_MS = 40_000;
-const BREATH_STEP_MS = 50_000;
-const BODY_SCAN_STEP_MS = 35_000;
+const SENSORY_STEP_MS = GUIDED_STEP_DURATION_MS - 5_000;
+const BREATH_STEP_MS = GUIDED_STEP_DURATION_MS + 5_000;
+const BODY_SCAN_STEP_MS = GUIDED_STEP_DURATION_MS - 10_000;
 
 export const GUIDED_EXERCISES: GuidedExerciseDefinition[] = [
   {


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a shared **guided-exercise framework** to the web session view. During an active sit, a **guided exercise** button opens a full-screen overlay with three modes:

- **#47 Progressive sensory** — five senses, one at a time (sight → sound → smell → taste → touch)
- **#48 Breathing awareness** — attention on breath sensation through settling, rhythm, and open awareness
- **#49 Body scan** — attention through body regions from feet to whole body

The sit timer and tracking continue underneath. Each mode uses sequenced prompts with gentle auto-advance pacing (~35–50s per step), plus manual back / pause / next controls and a completion screen.

Closes #47
Closes #48
Closes #49

## Changes

- `src/lib/guidedExerciseContent.ts` — prompt content for all three modes
- `src/lib/guidedExercise.ts` — step/pacing helpers
- `src/lib/guidedExercise.test.ts` — unit tests for content structure and helpers
- `src/components/GuidedExerciseOverlay.tsx` — shared overlay (mode picker → running → complete)
- `src/components/SessionView.tsx` — **guided exercise** button during active session

## Test plan

- [x] `npm run test:unit` — 545 tests pass (includes new `guidedExercise.test.ts`)
- [x] `npm run typecheck` — clean
- [ ] Manual: start a sit → tap **guided exercise** → verify mode picker shows three options
- [ ] Manual: run **Progressive sensory** → confirm five sense prompts in order with auto-advance
- [ ] Manual: run **Breathing awareness** → confirm breath-focused prompts
- [ ] Manual: run **Body scan** → confirm body-region progression
- [ ] Manual: verify pause / next / back / close (Escape) work; timer keeps running throughout
- [ ] Manual: confirm button hidden when session is paused

## Notes

- Web-first; iOS parity is a follow-up.
- Sole SessionView-UI thread — no other session chrome changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-237f6661-c68f-4cdf-99f5-672246989f42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-237f6661-c68f-4cdf-99f5-672246989f42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Add guided exercises during an active session**

### What Changed
- Adds a guided exercise button during an active sit that opens a full-screen overlay without stopping the session timer or tracking
- Lets users choose between three guided modes: five senses, breathing awareness, and body scan
- Each mode steps through prompts one by one with gentle auto-advance, plus back, pause/resume, next/finish, repeat, and close controls
- The overlay now supports keyboard focus trapping, Escape to close, and focus returning to the launch button after close; it also closes when the sit ends
- Guided exercise pauses the usual in-session hold controls while it is open

### Impact
`✅ Guided exercises during active sits`
`✅ Fewer accidental session interruptions`
`✅ Clearer keyboard and screen reader navigation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
