### PR TITLE
Wire StillPointWidget export signing for TestFlight (build 15)

### DIFF
--- a/.github/workflows/ios-testflight-build.yml
+++ b/.github/workflows/ios-testflight-build.yml
@@ -27,6 +27,8 @@ on:
         required: true
       BUILD_PROVISION_PROFILE_EXTENSION_BASE64:
         required: true
+      BUILD_PROVISION_PROFILE_WIDGET_BASE64:
+        required: true
       P12_PASSWORD:
         required: true
       APPSTORE_API_KEY_ID:
@@ -171,18 +173,21 @@ jobs:
           P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
           BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
           BUILD_PROVISION_PROFILE_EXTENSION_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_EXTENSION_BASE64 }}
+          BUILD_PROVISION_PROFILE_WIDGET_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_WIDGET_BASE64 }}
         run: |
           # Create variables
           CERTIFICATE_PATH="$RUNNER_TEMP/build_certificate.p12"
           PP_PATH="$RUNNER_TEMP/build_pp.mobileprovision"
           EXT_PP_PATH="$RUNNER_TEMP/build_pp_ext.mobileprovision"
+          WIDGET_PP_PATH="$RUNNER_TEMP/build_pp_widget.mobileprovision"
           KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
           KEYCHAIN_PASSWORD=$(openssl rand -hex 16)
 
-          # Import certificate and both provisioning profiles (app + monitor extension)
+          # Import certificate and all three provisioning profiles (app + monitor + widget extensions)
           echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o "$CERTIFICATE_PATH"
           echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o "$PP_PATH"
           echo -n "$BUILD_PROVISION_PROFILE_EXTENSION_BASE64" | base64 --decode -o "$EXT_PP_PATH"
+          echo -n "$BUILD_PROVISION_PROFILE_WIDGET_BASE64" | base64 --decode -o "$WIDGET_PP_PATH"
 
           # Create temporary keychain
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
@@ -198,18 +203,21 @@ jobs:
           # shellcheck disable=SC2046
           security list-keychain -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
 
-          # Install BOTH provisioning profiles by UUID. The app and the embedded
-          # StillPointMonitor extension each sign with their own profile, selected
-          # per-target via PROVISIONING_PROFILE_SPECIFIER in ios/project.yml.
+          # Install all three provisioning profiles by UUID. The app and the embedded
+          # StillPointMonitor and StillPointWidget extensions each sign with their own
+          # profile, selected per-target via PROVISIONING_PROFILE_SPECIFIER in ios/project.yml.
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
           PP_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< "$(/usr/bin/security cms -D -i "$PP_PATH")")
           cp "$PP_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/"${PP_UUID}".mobileprovision
           EXT_PP_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< "$(/usr/bin/security cms -D -i "$EXT_PP_PATH")")
           cp "$EXT_PP_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/"${EXT_PP_UUID}".mobileprovision
+          WIDGET_PP_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< "$(/usr/bin/security cms -D -i "$WIDGET_PP_PATH")")
+          cp "$WIDGET_PP_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/"${WIDGET_PP_UUID}".mobileprovision
           # Export the installed UUIDs so the always()-cleanup step removes the
           # actual UUID-named files (not the raw build_pp names).
           echo "PP_UUID=${PP_UUID}" >> "$GITHUB_ENV"
           echo "EXT_PP_UUID=${EXT_PP_UUID}" >> "$GITHUB_ENV"
+          echo "WIDGET_PP_UUID=${WIDGET_PP_UUID}" >> "$GITHUB_ENV"
 
       - name: Build archive
         working-directory: ios
@@ -232,11 +240,12 @@ jobs:
             exit 1
           fi
 
-          # The app and the embedded StillPointMonitor extension each sign manually
-          # with their own profile, selected per-target via PROVISIONING_PROFILE_SPECIFIER
-          # in project.yml; both profiles were installed in the previous step. We do NOT
-          # pass a single global PROVISIONING_PROFILE_SPECIFIER here — that would force the
-          # app's profile onto the extension and fail signing (bundle-id mismatch).
+          # The app and the embedded StillPointMonitor and StillPointWidget extensions each
+          # sign manually with their own profile, selected per-target via
+          # PROVISIONING_PROFILE_SPECIFIER in project.yml; all three profiles were installed
+          # in the previous step. We do NOT pass a single global PROVISIONING_PROFILE_SPECIFIER
+          # here — that would force the app's profile onto an extension and fail signing
+          # (bundle-id mismatch).
           #
           # GID_* are passed as build settings so xcodebuild substitutes them into the
           # Info.plist's $(GID_…) placeholders at build time, overriding project.yml's
@@ -283,10 +292,14 @@ jobs:
           rm -f "$RUNNER_TEMP/build_certificate.p12" 2>/dev/null || true
           rm -f "$RUNNER_TEMP/build_pp.mobileprovision" 2>/dev/null || true
           rm -f "$RUNNER_TEMP/build_pp_ext.mobileprovision" 2>/dev/null || true
+          rm -f "$RUNNER_TEMP/build_pp_widget.mobileprovision" 2>/dev/null || true
           if [[ -n "${PP_UUID:-}" ]]; then
             rm -f ~/Library/MobileDevice/Provisioning\ Profiles/"${PP_UUID}".mobileprovision 2>/dev/null || true
           fi
           if [[ -n "${EXT_PP_UUID:-}" ]]; then
             rm -f ~/Library/MobileDevice/Provisioning\ Profiles/"${EXT_PP_UUID}".mobileprovision 2>/dev/null || true
+          fi
+          if [[ -n "${WIDGET_PP_UUID:-}" ]]; then
+            rm -f ~/Library/MobileDevice/Provisioning\ Profiles/"${WIDGET_PP_UUID}".mobileprovision 2>/dev/null || true
           fi
           rm -rf ~/.private_keys 2>/dev/null || true

--- a/ios/ExportOptions.plist
+++ b/ios/ExportOptions.plist
@@ -16,6 +16,8 @@
 		<string>StillPoint App Store</string>
 		<key>com.brettonauerbach.stillpoint.monitor</key>
 		<string>StillPoint Monitor App Store</string>
+		<key>com.brettonauerbach.stillpoint.widget</key>
+		<string>StillPoint Widget App Store</string>
 	</dict>
 	<key>uploadSymbols</key>
 	<true/>


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #544

## Summary

Completes the **export-signing** path for the `StillPointWidget` app extension so build 15 can upload to TestFlight without failing at the export step (same class of failure the Monitor extension hit in #442/#446/#451).

Archive signing was already wired in `ios/project.yml` (`PROVISIONING_PROFILE_SPECIFIER: "StillPoint Widget App Store"`). This PR adds the missing export + CI pieces:

- **`ios/ExportOptions.plist`**: maps `com.brettonauerbach.stillpoint.widget` → `StillPoint Widget App Store`
- **`.github/workflows/ios-testflight-build.yml`**: third profile import/embed mirroring the monitor extension, keyed on new secret `BUILD_PROVISION_PROFILE_WIDGET_BASE64`

## Verified (no code changes needed)

- `CURRENT_PROJECT_VERSION` is **15** consistently across app, monitor, and widget targets in `ios/project.yml`
- `StillPointWidget.entitlements` App Group (`group.com.brettonauerbach.stillpoint`) matches the main app and monitor extension
- Widget `Info.plist` already uses `$(MARKETING_VERSION)` / `$(CURRENT_PROJECT_VERSION)`

## Human prerequisites — Bretton must complete before cutting build 15

**Do not trigger the release until these are done:**

1. In [Apple Developer](https://developer.apple.com/account/resources/identifiers/list): create App ID **`com.brettonauerbach.stillpoint.widget`** with the **App Group** capability enabled (must include `group.com.brettonauerbach.stillpoint`, matching the main app per #84).
2. Generate an **App Store distribution** provisioning profile named **`StillPoint Widget App Store`** for that App ID.
3. Base64-encode the profile and add it as a GitHub repo secret: **`BUILD_PROVISION_PROFILE_WIDGET_BASE64`**.

Only after the secret exists should the release fire (`release:ios` label on a merged PR, or tag `ios-v1.0.3-build15`).

## Test plan

- [ ] `ios-app-store-dry-run` passes on this PR (A4 tag trigger + B2 secret refs intact)
- [ ] After `BUILD_PROVISION_PROFILE_WIDGET_BASE64` is set: TestFlight workflow export step logs show all **three** profiles (app + monitor + widget) imported and matched
- [ ] TestFlight build 15 uploads without export/signing failure
- [ ] On-device: Google sign-in (#471), home-screen widget (#84), aphorisms/fonts/thumb-reach/attention-tracking, #438 buddy QA

## Not in scope (intentionally deferred)

- **Cutting build 15** — blocked on the Apple Developer console steps above
- On-device verification checklist — runs after TestFlight build is available
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26c93840-4e55-45ef-b8cf-1a13b48b4ab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26c93840-4e55-45ef-b8cf-1a13b48b4ab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
Complete TestFlight signing for the StillPoint widget extension

### What Changed
- Added the widget app’s distribution profile to export settings so TestFlight uploads can sign it correctly
- Updated the iOS build workflow to install, use, and clean up a third provisioning profile for the widget extension
- Kept the app, monitor extension, and widget extension signed with their own profiles during export

### Impact
`✅ Fewer TestFlight export failures`
`✅ Successful uploads for builds that include the widget extension`
`✅ Clearer release path for build 15`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added signing support for the app’s widget extension in the iOS TestFlight build workflow.
  * Updated export settings so the widget is included with its own provisioning profile.

* **Bug Fixes**
  * Improved provisioning profile installation and cleanup during build steps to handle the widget profile correctly.
  * Clarified build signing behavior for multiple targets so each target uses its own profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->