### PR TITLE
fix(ios): enforce app-block shields in background (#549)

### DIFF
--- a/ios/AppBlockingShared/AppBlockingShared.swift
+++ b/ios/AppBlockingShared/AppBlockingShared.swift
@@ -171,6 +171,32 @@ extension AppBlockingShared {
         return !calendar.isDate(unlockedFor, inSameDayAs: now)
     }
 
+    /// Whether a background refresh should be requeued after a BG task run.
+    static func shouldScheduleBackgroundShieldRefresh() -> Bool {
+        guard let selection = decodeStoredSelection() else { return false }
+        return !(selection.applicationTokens.isEmpty
+            && selection.categoryTokens.isEmpty
+            && selection.webDomainTokens.isEmpty)
+    }
+
+    /// Next preferred BG refresh time: soon when shields should be active, otherwise
+    /// the next local midnight when the user is unlocked for today.
+    static func preferredBackgroundRefreshDate(
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> Date {
+        if shouldApplyShield(now: now, calendar: calendar) {
+            return now.addingTimeInterval(15 * 60)
+        }
+        var midnight = DateComponents(hour: 0, minute: 0, second: 0)
+        midnight.calendar = calendar
+        return calendar.nextDate(
+            after: now,
+            matching: midnight,
+            matchingPolicy: .nextTime
+        ) ?? now.addingTimeInterval(15 * 60)
+    }
+
     /// Background refresh entry point — constructs a store and syncs shields.
     static func syncShieldStateFromSharedDefaults() {
         syncShieldState(to: ManagedSettingsStore())

--- a/ios/AppBlockingShared/AppBlockingShared.swift
+++ b/ios/AppBlockingShared/AppBlockingShared.swift
@@ -18,11 +18,48 @@ enum AppBlockingShared {
     /// Matches the historical app-only key so a migration can copy it forward.
     static let selectionKey = "appBlocking.selection.v1"
 
+    /// Key for the calendar day the user last earned an unlock. Stored in the App
+    /// Group so the monitor extension and background refresh can decide whether
+    /// shields should be applied without launching the main app (#549).
+    static let unlockedForDateKey = "appBlocking.unlockedForDate.v1"
+
     /// Identifier for the repeating daily monitoring interval.
     static let activityName = "dailyLock"
 
+    /// Hourly heartbeat so a missed midnight callback still re-locks within ~1h.
+    static let heartbeatActivityName = "shieldHeartbeat"
+
     /// Shared defaults suite the app writes the selection to and the extension reads.
     static var sharedDefaults: UserDefaults? { UserDefaults(suiteName: appGroupID) }
+
+    /// Read the unlock date from the App Group, falling back to standard defaults
+    /// for older installs that have not migrated yet.
+    static func loadUnlockedForDate(from standardDefaults: UserDefaults? = nil) -> Date? {
+        if let shared = sharedDefaults?.object(forKey: unlockedForDateKey) as? Date {
+            return shared
+        }
+        return standardDefaults?.object(forKey: unlockedForDateKey) as? Date
+    }
+
+    /// Persist the unlock date to the App Group (for the extension) and standard
+    /// defaults (for in-app reads on older code paths).
+    static func saveUnlockedForDate(_ date: Date?, standardDefaults: UserDefaults? = nil) {
+        if let date {
+            sharedDefaults?.set(date, forKey: unlockedForDateKey)
+            standardDefaults?.set(date, forKey: unlockedForDateKey)
+        } else {
+            sharedDefaults?.removeObject(forKey: unlockedForDateKey)
+            standardDefaults?.removeObject(forKey: unlockedForDateKey)
+        }
+    }
+
+    /// One-time migration of the unlock date from standard `UserDefaults` into the
+    /// App Group suite so the monitor extension can read it.
+    static func migrateLegacyUnlockDateIfNeeded(from standardDefaults: UserDefaults) {
+        guard sharedDefaults?.object(forKey: unlockedForDateKey) == nil,
+              let legacy = standardDefaults.object(forKey: unlockedForDateKey) as? Date else { return }
+        sharedDefaults?.set(legacy, forKey: unlockedForDateKey)
+    }
 }
 
 #if !targetEnvironment(simulator)
@@ -32,6 +69,7 @@ import DeviceActivity
 
 extension AppBlockingShared {
     static var deviceActivityName: DeviceActivityName { DeviceActivityName(activityName) }
+    static var heartbeatDeviceActivityName: DeviceActivityName { DeviceActivityName(heartbeatActivityName) }
 
     /// Repeating daily schedule whose interval starts at local midnight. The
     /// monitor extension's `intervalDidStart` fires at the start of each day,
@@ -40,6 +78,17 @@ extension AppBlockingShared {
         DeviceActivitySchedule(
             intervalStart: DateComponents(hour: 0, minute: 0),
             intervalEnd: DateComponents(hour: 23, minute: 59, second: 59),
+            repeats: true
+        )
+    }
+
+    /// Hourly 15-minute window (DeviceActivity minimum). Gives the monitor
+    /// extension additional chances to re-apply shields when the midnight
+    /// callback is delayed or dropped (#549).
+    static func hourlyHeartbeatSchedule() -> DeviceActivitySchedule {
+        DeviceActivitySchedule(
+            intervalStart: DateComponents(minute: 0),
+            intervalEnd: DateComponents(minute: 14),
             repeats: true
         )
     }
@@ -98,6 +147,33 @@ extension AppBlockingShared {
         store.shield.webDomains = selection.webDomainTokens.isEmpty
             ? nil
             : selection.webDomainTokens
+    }
+
+    /// Reconcile ManagedSettings shields with the shared unlock + selection state.
+    /// Used by the monitor extension and background refresh so gated apps re-lock
+    /// even when Still Point has not been opened (#549).
+    static func syncShieldState(
+        to store: ManagedSettingsStore,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) {
+        if !shouldApplyShield(now: now, calendar: calendar) {
+            store.clearAllSettings()
+            return
+        }
+        applySavedShield(to: store)
+    }
+
+    /// `true` when shields should be active: no unlock stored, or the stored
+    /// unlock is from a prior local calendar day. Mirrors `AppBlockGate` (#348).
+    static func shouldApplyShield(now: Date = Date(), calendar: Calendar = .current) -> Bool {
+        guard let unlockedFor = loadUnlockedForDate() else { return true }
+        return !calendar.isDate(unlockedFor, inSameDayAs: now)
+    }
+
+    /// Background refresh entry point — constructs a store and syncs shields.
+    static func syncShieldStateFromSharedDefaults() {
+        syncShieldState(to: ManagedSettingsStore())
     }
 }
 #endif

--- a/ios/AppBlockingShared/AppBlockingShared.swift
+++ b/ios/AppBlockingShared/AppBlockingShared.swift
@@ -173,6 +173,7 @@ extension AppBlockingShared {
 
     /// Whether a background refresh should be requeued after a BG task run.
     static func shouldScheduleBackgroundShieldRefresh() -> Bool {
+        guard AuthorizationCenter.shared.authorizationStatus == .approved else { return false }
         guard let selection = decodeStoredSelection() else { return false }
         return !(selection.applicationTokens.isEmpty
             && selection.categoryTokens.isEmpty

--- a/ios/StillPoint.xcodeproj/project.pbxproj
+++ b/ios/StillPoint.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		5EA3E8C9B84298DE1F37251F /* AuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00D7B1EDF2C56A1B6EB4C28 /* AuthView.swift */; };
 		6760DF427777049973A0D182 /* AppleSignInController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8807A08DBDE8A121951350FD /* AppleSignInController.swift */; };
 		6B6572152FB23B94F990D66B /* AppBlockingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F0B6135A30B315B9962460 /* AppBlockingManager.swift */; };
+		6C7683263FC34CA1A007E771 /* AppBlockingBackgroundScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3F1C7246B41C426B1072571 /* AppBlockingBackgroundScheduler.swift */; };
 		6E8830D16FED5FBB78B6DF34 /* XCUIElement+TapAndType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E69E315D37F87410DBE4B8C /* XCUIElement+TapAndType.swift */; };
 		A7B8C9D0E1F2031425364758 /* XCUIDevice+Portrait.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B8C9D0E1F2031425364759 /* XCUIDevice+Portrait.swift */; };
 		74AE784447C3D50E1E6980E9 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7766937C968433C205A250C /* HistoryView.swift */; };
@@ -134,6 +135,7 @@
 		85EAF998E3470CBB4056699F /* BlockGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockGridView.swift; sourceTree = "<group>"; };
 		8807A08DBDE8A121951350FD /* AppleSignInController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInController.swift; sourceTree = "<group>"; };
 		92F0B6135A30B315B9962460 /* AppBlockingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBlockingManager.swift; sourceTree = "<group>"; };
+		A3F1C7246B41C426B1072571 /* AppBlockingBackgroundScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBlockingBackgroundScheduler.swift; sourceTree = "<group>"; };
 		9311B0CBDED4DF207E799ACC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A00D7B1EDF2C56A1B6EB4C28 /* AuthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthView.swift; sourceTree = "<group>"; };
 		A34376705757DF9CD77D013A /* NotificationsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsSettingsView.swift; sourceTree = "<group>"; };
@@ -293,6 +295,7 @@
 		6F81A1DEB3C67EC2415E179A /* Managers */ = {
 			isa = PBXGroup;
 			children = (
+				A3F1C7246B41C426B1072571 /* AppBlockingBackgroundScheduler.swift */,
 				92F0B6135A30B315B9962460 /* AppBlockingManager.swift */,
 				1F3B170D19689EEF2E14436A /* SessionIdleTimerController.swift */,
 			);
@@ -539,6 +542,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6C7683263FC34CA1A007E771 /* AppBlockingBackgroundScheduler.swift in Sources */,
 				6B6572152FB23B94F990D66B /* AppBlockingManager.swift in Sources */,
 				B6A3805810E44935E75EEC11 /* AppBlockingSettingsView.swift in Sources */,
 				A1636CD509D32399A02C45B3 /* AppBlockingShared.swift in Sources */,

--- a/ios/StillPointApp/Info.plist
+++ b/ios/StillPointApp/Info.plist
@@ -53,6 +53,10 @@
 	<array>
 		<string>audio</string>
 	</array>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.brettonauerbach.stillpoint.app-block-refresh</string>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UISupportedInterfaceOrientations</key>

--- a/ios/StillPointApp/Info.plist
+++ b/ios/StillPointApp/Info.plist
@@ -52,6 +52,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
+		<string>fetch</string>
 	</array>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>

--- a/ios/StillPointApp/Managers/AppBlockingBackgroundScheduler.swift
+++ b/ios/StillPointApp/Managers/AppBlockingBackgroundScheduler.swift
@@ -39,10 +39,17 @@ enum AppBlockingBackgroundScheduler {
         #endif
     }
 
+    static func cancelRefresh() {
+        guard ProcessInfo.processInfo.environment["SP_UI_TEST_MODE"] != "1" else { return }
+        #if targetEnvironment(simulator)
+        return
+        #else
+        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: taskIdentifier)
+        #endif
+    }
+
     #if !targetEnvironment(simulator)
     private static func handleRefresh(_ task: BGTask) {
-        scheduleRefresh()
-
         guard let refreshTask = task as? BGAppRefreshTask else {
             task.setTaskCompleted(success: false)
             return
@@ -50,6 +57,10 @@ enum AppBlockingBackgroundScheduler {
         refreshTask.expirationHandler = {}
 
         AppBlockingShared.syncShieldStateFromSharedDefaults()
+
+        if AppBlockingShared.shouldScheduleBackgroundShieldRefresh() {
+            scheduleRefresh(preferring: AppBlockingShared.preferredBackgroundRefreshDate())
+        }
         refreshTask.setTaskCompleted(success: true)
     }
     #endif

--- a/ios/StillPointApp/Managers/AppBlockingBackgroundScheduler.swift
+++ b/ios/StillPointApp/Managers/AppBlockingBackgroundScheduler.swift
@@ -54,13 +54,20 @@ enum AppBlockingBackgroundScheduler {
             task.setTaskCompleted(success: false)
             return
         }
-        refreshTask.expirationHandler = {}
+        var didComplete = false
+        refreshTask.expirationHandler = {
+            guard !didComplete else { return }
+            didComplete = true
+            refreshTask.setTaskCompleted(success: false)
+        }
 
         AppBlockingShared.syncShieldStateFromSharedDefaults()
 
         if AppBlockingShared.shouldScheduleBackgroundShieldRefresh() {
             scheduleRefresh(preferring: AppBlockingShared.preferredBackgroundRefreshDate())
         }
+        guard !didComplete else { return }
+        didComplete = true
         refreshTask.setTaskCompleted(success: true)
     }
     #endif

--- a/ios/StillPointApp/Managers/AppBlockingBackgroundScheduler.swift
+++ b/ios/StillPointApp/Managers/AppBlockingBackgroundScheduler.swift
@@ -1,0 +1,56 @@
+import BackgroundTasks
+import Foundation
+
+/// Schedules opportunistic background refresh so app-block shields are
+/// reconciled even when DeviceActivity callbacks are delayed (#549).
+enum AppBlockingBackgroundScheduler {
+    static let taskIdentifier = "com.brettonauerbach.stillpoint.app-block-refresh"
+
+    /// Earliest time before the system may run the next refresh.
+    private static let minimumLeadTime: TimeInterval = 15 * 60
+
+    static func registerIfNeeded() {
+        guard ProcessInfo.processInfo.environment["SP_UI_TEST_MODE"] != "1" else { return }
+        #if targetEnvironment(simulator)
+        return
+        #else
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: taskIdentifier,
+            using: nil
+        ) { task in
+            handleRefresh(task)
+        }
+        #endif
+    }
+
+    static func scheduleRefresh(preferring earliestBeginDate: Date? = nil) {
+        guard ProcessInfo.processInfo.environment["SP_UI_TEST_MODE"] != "1" else { return }
+        #if targetEnvironment(simulator)
+        return
+        #else
+        let request = BGAppRefreshTaskRequest(identifier: taskIdentifier)
+        request.earliestBeginDate = earliestBeginDate ?? Date(timeIntervalSinceNow: minimumLeadTime)
+        do {
+            try BGTaskScheduler.shared.submit(request)
+        } catch {
+            // The system coalesces duplicate submissions; a failure here just
+            // means this particular request was not queued.
+        }
+        #endif
+    }
+
+    #if !targetEnvironment(simulator)
+    private static func handleRefresh(_ task: BGTask) {
+        scheduleRefresh()
+
+        guard let refreshTask = task as? BGAppRefreshTask else {
+            task.setTaskCompleted(success: false)
+            return
+        }
+        refreshTask.expirationHandler = {}
+
+        AppBlockingShared.syncShieldStateFromSharedDefaults()
+        refreshTask.setTaskCompleted(success: true)
+    }
+    #endif
+}

--- a/ios/StillPointApp/Managers/AppBlockingManager.swift
+++ b/ios/StillPointApp/Managers/AppBlockingManager.swift
@@ -12,12 +12,12 @@ final class AppBlockingManager {
     private(set) var didUnlockFromLastCompletedSession = false
 
     private let defaults: UserDefaults
-    private let unlockedForDateKey = "appBlocking.unlockedForDate.v1"
     private let uiTestSelectionEnabled: Bool
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
-        self.unlockedForDate = defaults.object(forKey: unlockedForDateKey) as? Date
+        AppBlockingShared.migrateLegacyUnlockDateIfNeeded(from: defaults)
+        self.unlockedForDate = AppBlockingShared.loadUnlockedForDate(from: defaults)
         self.uiTestSelectionEnabled = ProcessInfo.processInfo.environment["SP_UI_TEST_APP_BLOCKING_SELECTED"] == "1"
         refreshShielding()
     }
@@ -58,13 +58,13 @@ final class AppBlockingManager {
         guard hasSelection else { return }
         unlockedForDate = Date()
         didUnlockFromLastCompletedSession = true
-        defaults.set(unlockedForDate, forKey: unlockedForDateKey)
+        AppBlockingShared.saveUnlockedForDate(unlockedForDate, standardDefaults: defaults)
     }
 
     func lockNow() {
         didUnlockFromLastCompletedSession = false
         unlockedForDate = nil
-        defaults.removeObject(forKey: unlockedForDateKey)
+        AppBlockingShared.saveUnlockedForDate(nil, standardDefaults: defaults)
     }
 
     func refreshShielding() {
@@ -73,13 +73,13 @@ final class AppBlockingManager {
         if unlockedForDate != nil, AppBlockGate.isUnlockExpired(unlockedFor: unlockedForDate) {
             unlockedForDate = nil
             didUnlockFromLastCompletedSession = false
-            defaults.removeObject(forKey: unlockedForDateKey)
+            AppBlockingShared.saveUnlockedForDate(nil, standardDefaults: defaults)
         }
 
         if !hasSelection {
             unlockedForDate = nil
             didUnlockFromLastCompletedSession = false
-            defaults.removeObject(forKey: unlockedForDateKey)
+            AppBlockingShared.saveUnlockedForDate(nil, standardDefaults: defaults)
         }
     }
 }
@@ -102,7 +102,6 @@ final class AppBlockingManager {
 
     private let defaults: UserDefaults
     private let store: ManagedSettingsStore?
-    private let unlockedForDateKey = "appBlocking.unlockedForDate.v1"
     private let uiTestMode: Bool
     private let uiTestSelectionEnabled: Bool
     private let deviceActivityCenter = DeviceActivityCenter()
@@ -120,9 +119,10 @@ final class AppBlockingManager {
             // Older builds stored the selection in standard defaults; copy it into
             // the App Group suite so the monitor extension can read it.
             Self.migrateLegacySelectionIfNeeded(from: defaults)
+            AppBlockingShared.migrateLegacyUnlockDateIfNeeded(from: defaults)
         }
         self.selection = AppBlockingShared.loadSelection()
-        self.unlockedForDate = defaults.object(forKey: unlockedForDateKey) as? Date
+        self.unlockedForDate = AppBlockingShared.loadUnlockedForDate(from: defaults)
         self.authorizationStatus = uiTestMode ? .notDetermined : AuthorizationCenter.shared.authorizationStatus
         self.uiTestMode = uiTestMode
         self.uiTestSelectionEnabled = uiTestSelectionEnabled
@@ -197,7 +197,7 @@ final class AppBlockingManager {
         guard hasSelection else { return }
         unlockedForDate = Date()
         didUnlockFromLastCompletedSession = true
-        defaults.set(unlockedForDate, forKey: unlockedForDateKey)
+        AppBlockingShared.saveUnlockedForDate(unlockedForDate, standardDefaults: defaults)
         lastErrorMessage = nil
         clearShielding()
         // Keep the daily schedule (and foreground backup) armed so the apps re-lock
@@ -208,7 +208,7 @@ final class AppBlockingManager {
     func lockNow() {
         didUnlockFromLastCompletedSession = false
         unlockedForDate = nil
-        defaults.removeObject(forKey: unlockedForDateKey)
+        AppBlockingShared.saveUnlockedForDate(nil, standardDefaults: defaults)
         refreshShielding()
     }
 
@@ -224,13 +224,13 @@ final class AppBlockingManager {
         if unlockedForDate != nil, AppBlockGate.isUnlockExpired(unlockedFor: unlockedForDate) {
             unlockedForDate = nil
             didUnlockFromLastCompletedSession = false
-            defaults.removeObject(forKey: unlockedForDateKey)
+            AppBlockingShared.saveUnlockedForDate(nil, standardDefaults: defaults)
         }
 
         if !hasSelection {
             unlockedForDate = nil
             didUnlockFromLastCompletedSession = false
-            defaults.removeObject(forKey: unlockedForDateKey)
+            AppBlockingShared.saveUnlockedForDate(nil, standardDefaults: defaults)
             updateDailyResetScheduling()
             clearShielding()
             return
@@ -294,17 +294,24 @@ final class AppBlockingManager {
     ///   `intervalDidStart` re-applies the shield at local midnight even when the
     ///   app is suspended/terminated — the case the old in-process `Timer` could
     ///   not handle.
+    /// - Heartbeat: an hourly 15-minute window gives the extension extra chances
+    ///   to reconcile shields when the midnight callback is dropped (#549).
     /// - Backup: a foreground-only one-shot `Timer` to the next local midnight, so
     ///   if the app stays open across the day boundary (no `scenePhase` change to
     ///   trigger `refreshShielding`) the in-app state still re-locks promptly even
     ///   if the system schedule is delayed.
+    /// - Background refresh: `BGAppRefreshTask` as a tertiary fallback when the
+    ///   extension does not run (#549).
     ///
     /// When there is no authorized selection both are torn down, so a stale schedule
     /// can never re-shield after the user removes apps or revokes authorization.
     private func updateDailyResetScheduling() {
         guard !uiTestMode else { return }
         guard hasSelection, isAuthorizationApproved else {
-            deviceActivityCenter.stopMonitoring([AppBlockingShared.deviceActivityName])
+            deviceActivityCenter.stopMonitoring([
+                AppBlockingShared.deviceActivityName,
+                AppBlockingShared.heartbeatDeviceActivityName,
+            ])
             midnightTimer?.invalidate()
             midnightTimer = nil
             return
@@ -314,6 +321,10 @@ final class AppBlockingManager {
                 AppBlockingShared.deviceActivityName,
                 during: AppBlockingShared.dailySchedule()
             )
+            try deviceActivityCenter.startMonitoring(
+                AppBlockingShared.heartbeatDeviceActivityName,
+                during: AppBlockingShared.hourlyHeartbeatSchedule()
+            )
         } catch {
             // Re-registering an already-active schedule is benign. Any other
             // failure just means the system schedule isn't armed this run; the
@@ -321,6 +332,20 @@ final class AppBlockingManager {
             // daily-lock guarantee degrades gracefully rather than breaking.
         }
         scheduleForegroundMidnightBackup()
+        AppBlockingBackgroundScheduler.scheduleRefresh(
+            preferring: Self.nextShieldCheckDate(unlockedFor: unlockedForDate)
+        )
+    }
+
+    /// Prefer the next local midnight when the user is unlocked; otherwise ask for
+    /// a sooner opportunistic refresh so a missed extension callback is corrected.
+    private static func nextShieldCheckDate(unlockedFor: Date?) -> Date {
+        if let unlockedFor,
+           !AppBlockGate.isUnlockExpired(unlockedFor: unlockedFor),
+           let nextMidnight = nextLocalMidnight() {
+            return nextMidnight
+        }
+        return Date(timeIntervalSinceNow: 15 * 60)
     }
 
     private func scheduleForegroundMidnightBackup() {

--- a/ios/StillPointApp/Managers/AppBlockingManager.swift
+++ b/ios/StillPointApp/Managers/AppBlockingManager.swift
@@ -314,6 +314,7 @@ final class AppBlockingManager {
             ])
             midnightTimer?.invalidate()
             midnightTimer = nil
+            AppBlockingBackgroundScheduler.cancelRefresh()
             return
         }
         do {
@@ -321,31 +322,21 @@ final class AppBlockingManager {
                 AppBlockingShared.deviceActivityName,
                 during: AppBlockingShared.dailySchedule()
             )
+        } catch {
+            // Re-registering an already-active daily schedule is benign.
+        }
+        do {
             try deviceActivityCenter.startMonitoring(
                 AppBlockingShared.heartbeatDeviceActivityName,
                 during: AppBlockingShared.hourlyHeartbeatSchedule()
             )
         } catch {
-            // Re-registering an already-active schedule is benign. Any other
-            // failure just means the system schedule isn't armed this run; the
-            // foreground backup timer + foreground refresh remain, so the
-            // daily-lock guarantee degrades gracefully rather than breaking.
+            // Re-registering an already-active heartbeat schedule is benign.
         }
         scheduleForegroundMidnightBackup()
         AppBlockingBackgroundScheduler.scheduleRefresh(
-            preferring: Self.nextShieldCheckDate(unlockedFor: unlockedForDate)
+            preferring: AppBlockingShared.preferredBackgroundRefreshDate()
         )
-    }
-
-    /// Prefer the next local midnight when the user is unlocked; otherwise ask for
-    /// a sooner opportunistic refresh so a missed extension callback is corrected.
-    private static func nextShieldCheckDate(unlockedFor: Date?) -> Date {
-        if let unlockedFor,
-           !AppBlockGate.isUnlockExpired(unlockedFor: unlockedFor),
-           let nextMidnight = nextLocalMidnight() {
-            return nextMidnight
-        }
-        return Date(timeIntervalSinceNow: 15 * 60)
     }
 
     private func scheduleForegroundMidnightBackup() {

--- a/ios/StillPointApp/PushNotificationCoordinator.swift
+++ b/ios/StillPointApp/PushNotificationCoordinator.swift
@@ -20,6 +20,7 @@ final class PushNotificationCoordinator: NSObject, UIApplicationDelegate, UNUser
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         UNUserNotificationCenter.current().delegate = self
+        AppBlockingBackgroundScheduler.registerIfNeeded()
         if let userInfo = launchOptions?[.remoteNotification] as? [AnyHashable: Any] {
             queueOrDeliverDeepLink(from: userInfo)
         }

--- a/ios/StillPointApp/Views/RootView.swift
+++ b/ios/StillPointApp/Views/RootView.swift
@@ -128,8 +128,15 @@ struct RootView: View {
                 appVM: appVM,
                 isForegroundActive: phase == .active
             )
-            if phase == .active {
+            switch phase {
+            case .active, .inactive, .background:
+                // Reconcile shields on every lifecycle transition so a stale
+                // unlock cannot survive when the app is backgrounded (#549).
                 appVM.appBlockingManager.refreshShielding()
+            @unknown default:
+                break
+            }
+            if phase == .active {
                 SessionIdleTimerController.applyDesiredIdleTimerState()
             } else if phase == .inactive || phase == .background {
                 // Multi-window: only clear when no scene is foreground-active (issue #87).

--- a/ios/StillPointMonitor/StillPointMonitorExtension.swift
+++ b/ios/StillPointMonitor/StillPointMonitorExtension.swift
@@ -13,9 +13,17 @@ final class StillPointMonitorExtension: DeviceActivityMonitor {
 
     override func intervalDidStart(for activity: DeviceActivityName) {
         super.intervalDidStart(for: activity)
-        // A new calendar day has begun, so the prior day's unlock has expired:
-        // re-apply the shield from the saved selection.
-        AppBlockingShared.applySavedShield(to: store)
+        // Reconcile shields with the shared unlock state. On a new local day the
+        // prior unlock has expired so gated apps re-lock; on the same day a
+        // qualifying unlock keeps them clear (#549).
+        AppBlockingShared.syncShieldState(to: store)
+    }
+
+    override func intervalDidEnd(for activity: DeviceActivityName) {
+        super.intervalDidEnd(for: activity)
+        // Backup path when `intervalDidStart` is delayed or dropped — common on
+        // recent iOS releases per Apple Developer Forums reports (#549).
+        AppBlockingShared.syncShieldState(to: store)
     }
 }
 #else

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -66,8 +66,10 @@ targets:
         # and the authorization dialog text cannot be customized via Info.plist. See #432.
 
         # Keep audio alive when the app is backgrounded mid-session.
+        # fetch: required for BGAppRefreshTask (#549 / CodeAnt).
         UIBackgroundModes:
           - audio
+          - fetch
         BGTaskSchedulerPermittedIdentifiers:
           - com.brettonauerbach.stillpoint.app-block-refresh
         UILaunchScreen: {}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -68,6 +68,8 @@ targets:
         # Keep audio alive when the app is backgrounded mid-session.
         UIBackgroundModes:
           - audio
+        BGTaskSchedulerPermittedIdentifiers:
+          - com.brettonauerbach.stillpoint.app-block-refresh
         UILaunchScreen: {}
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #549

## Problem

Gated apps (e.g. YouTube) could remain **unlocked all day** even when the user had not completed a session. Opening Still Point briefly and closing it would re-apply shields — meaning the foreground `refreshShielding()` path worked, but the background enforcement did not.

The prior fix (#423 / #429) relied on a single `DeviceActivityMonitor` callback at local midnight. That API is known to be unreliable on recent iOS releases: the extension often does not launch until the user opens the app.

## Solution

Defense-in-depth background enforcement:

1. **Shared unlock state in App Group** — `unlockedForDate` is now mirrored to the App Group so the monitor extension and background refresh can decide whether shields should be active without launching the main app.

2. **Unlock-aware monitor extension** — `StillPointMonitorExtension` calls `syncShieldState`, which applies shields only when today's unlock has expired (or is absent). Also handles `intervalDidEnd` as a backup when `intervalDidStart` is dropped.

3. **Hourly DeviceActivity heartbeat** — A second 15-minute-per-hour schedule gives the extension additional chances to reconcile shields when the midnight callback fails.

4. **`BGAppRefreshTask` fallback** — Registers `com.brettonauerbach.stillpoint.app-block-refresh` to opportunistically sync shields in the background.

5. **Lifecycle refresh** — `RootView` now calls `refreshShielding()` on inactive/background transitions as well as active, so shields are reconciled whenever the app is backgrounded.

## Testing

- [ ] Complete a session → gated apps unlock for the rest of the day
- [ ] Without opening Still Point the next morning, verify gated apps are blocked
- [ ] If midnight callback is delayed, verify hourly heartbeat or BG refresh re-locks within ~1 hour
- [ ] Confirm a same-day unlock is not accidentally re-blocked when monitoring is (re)registered mid-day

## Notes

`BGTaskSchedulerPermittedIdentifiers` was added to `Info.plist` / `project.yml`. No new entitlements required beyond the existing Family Controls + App Group setup.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f51af-6b00-7ce2-bd67-575fa94605b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f51af-6b00-7ce2-bd67-575fa94605b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of app-block shielding when daily callbacks are delayed or missed.
  * Shields now automatically reconcile with the current day’s unlock state, including clearing when blocking shouldn’t be active.
  * Added wider refresh coverage across app lifecycle changes and enhanced reconciliation for extension intervals.
* **New Features**
  * Added background refresh scheduling to keep blocking state up to date, including periodic retry behavior.
* **Compatibility**
  * Existing unlock settings are preserved and migrated automatically for older installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Keep app-blocked apps re-locked in the background**

### What Changed
- Gated apps are now re-checked in the background, so a missed midnight callback no longer leaves them unlocked until the app is opened.
- The app now keeps unlock state in shared storage, letting the extension and background refresh decide whether shields should stay off or be restored.
- Shields are re-applied from both the daily schedule and an hourly backup window, and the app also refreshes shielding whenever it moves between active, inactive, and background states.
- If the user is no longer allowed to unblock apps, any stale shield schedule is removed so old unlocks do not carry over.

### Impact
`✅ Fewer apps staying unlocked overnight`
`✅ Faster re-lock after missed midnight callbacks`
`✅ More reliable background app blocking`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
