### PR TITLE
feat(ios): weekday checkmark row on habit widget (#84 follow-up)

### DIFF
--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -288,6 +288,10 @@ final class AppViewModel {
         currentView = .auth
         // Drop the cached suppress opt-in so it can't leak into the next account.
         SessionNotificationSuppressionController.clearSuppressPreference()
+        // Cancel any in-flight backfill and clear the throttle so the next login
+        // (even the same account, same day) re-fetches fresh widget history.
+        widgetHistoryTask?.cancel()
+        widgetHistoryRefreshKey = nil
         syncWidgetData()
     }
 
@@ -558,23 +562,49 @@ final class AppViewModel {
         WidgetTimelineReloader.reloadHabitWidget()
     }
 
+    /// In-flight widget history backfill, cancelled before a new one starts so a
+    /// slow earlier fetch can't overwrite a newer snapshot out of order.
+    private var widgetHistoryTask: Task<Void, Never>?
+    /// `"userId|localDay"` of the last successful backfill; throttles the fetch to
+    /// once per account per local day (past days don't change intra-day, and
+    /// today's completion is handled synchronously by `syncWidgetData()`).
+    private var widgetHistoryRefreshKey: String?
+
     /// #84 follow-up: backfill the widget's 7-day completion row from real
     /// session history so the weekday checkmarks reflect actual practice (not
-    /// just days seen since install). Runs as a detached task off the auth/home
+    /// just days seen since install). Runs as a cancellable task off the auth/home
     /// path so it never blocks cold-start; a fetch failure keeps the
     /// locally-accumulated week that `syncWidgetData()` already wrote.
     private func refreshWidgetWeekHistory() {
         guard ProcessInfo.processInfo.environment["SP_UI_TEST_MODE"] != "1",
               let user = currentUser else { return }
-        Task {
-            guard let result = try? await APIClient.shared.getSessions() else { return }
-            // Guard against an account switch or logout during the await.
-            guard let current = currentUser, current.id == user.id else { return }
+        // Throttle: `/api/sessions` returns the full history, so skip the re-fetch
+        // when we've already backfilled for this account today.
+        let refreshKey = "\(user.id)|\(WidgetDataStore.localDayString(Date()))"
+        guard widgetHistoryRefreshKey != refreshKey else { return }
+        widgetHistoryRefreshKey = refreshKey
+
+        widgetHistoryTask?.cancel()
+        widgetHistoryTask = Task {
+            guard let result = try? await APIClient.shared.getSessions() else {
+                // Allow a later attempt to retry this account+day.
+                if widgetHistoryRefreshKey == refreshKey { widgetHistoryRefreshKey = nil }
+                return
+            }
+            // Drop if superseded, or the account changed during the await.
+            guard !Task.isCancelled,
+                  let current = currentUser, current.id == user.id else { return }
+            let now = Date()
+            let completed = WidgetDataStore.recentCompletedPrimaryDates(from: result.sessions, now: now)
+            // Derive today's completion from the fetched sessions (consistent with
+            // `now`) rather than the in-memory flag, which could be stale past midnight.
+            let doneToday = completed.contains(WidgetDataStore.localDayString(now))
             let snapshot = WidgetDataStore.makeSnapshot(
                 user: current,
-                primaryDoneToday: primaryDoneToday,
+                primaryDoneToday: doneToday,
                 secondDoneToday: secondDoneToday,
-                completedPrimaryDates: WidgetDataStore.recentCompletedPrimaryDates(from: result.sessions)
+                now: now,
+                completedPrimaryDates: completed
             )
             WidgetDataStore.save(snapshot)
             WidgetTimelineReloader.reloadHabitWidget()

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -330,6 +330,7 @@ final class AppViewModel {
             secondDoneToday = false
         }
         syncWidgetData()
+        refreshWidgetWeekHistory()
     }
 
     func beginBreathCounting() {
@@ -555,5 +556,28 @@ final class AppViewModel {
             WidgetDataStore.clear()
         }
         WidgetTimelineReloader.reloadHabitWidget()
+    }
+
+    /// #84 follow-up: backfill the widget's 7-day completion row from real
+    /// session history so the weekday checkmarks reflect actual practice (not
+    /// just days seen since install). Runs as a detached task off the auth/home
+    /// path so it never blocks cold-start; a fetch failure keeps the
+    /// locally-accumulated week that `syncWidgetData()` already wrote.
+    private func refreshWidgetWeekHistory() {
+        guard ProcessInfo.processInfo.environment["SP_UI_TEST_MODE"] != "1",
+              let user = currentUser else { return }
+        Task {
+            guard let result = try? await APIClient.shared.getSessions() else { return }
+            // Guard against an account switch or logout during the await.
+            guard let current = currentUser, current.id == user.id else { return }
+            let snapshot = WidgetDataStore.makeSnapshot(
+                user: current,
+                primaryDoneToday: primaryDoneToday,
+                secondDoneToday: secondDoneToday,
+                completedPrimaryDates: WidgetDataStore.recentCompletedPrimaryDates(from: result.sessions)
+            )
+            WidgetDataStore.save(snapshot)
+            WidgetTimelineReloader.reloadHabitWidget()
+        }
     }
 }

--- a/ios/StillPointShared/Sources/StillPointShared/WidgetData.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/WidgetData.swift
@@ -6,6 +6,28 @@ public enum WidgetAppGroup {
     public static let dataKey = "widget.habitData.v1"
 }
 
+/// One column in the widget's Duolingo-style weekday row: a single-letter
+/// weekday label plus whether the primary standard sit was completed that day.
+public struct WidgetDayMark: Sendable, Equatable, Identifiable {
+    /// ISO local-day string (`yyyy-MM-dd`) this column represents.
+    public let iso: String
+    /// Narrow weekday initial (e.g. `M`, `T`, `W`) for the caller's locale.
+    public let letter: String
+    /// True when the primary standard sit was completed on `iso`.
+    public let done: Bool
+    /// True for the trailing column (the caller's local "today").
+    public let isToday: Bool
+
+    public var id: String { iso }
+
+    public init(iso: String, letter: String, done: Bool, isToday: Bool) {
+        self.iso = iso
+        self.letter = letter
+        self.done = done
+        self.isToday = isToday
+    }
+}
+
 /// Lightweight snapshot the home-screen widget reads from shared `UserDefaults`.
 public struct WidgetData: Codable, Sendable, Equatable {
     public var isLoggedIn: Bool
@@ -16,6 +38,11 @@ public struct WidgetData: Codable, Sendable, Equatable {
     public var primaryDoneToday: Bool
     public var secondDoneToday: Bool
     public var streak: Int
+    /// #84 follow-up: ISO local-day strings (`yyyy-MM-dd`) within the trailing
+    /// 7-day window on which the primary standard sit was completed. Drives the
+    /// Duolingo-style weekday checkmark row. Decoded permissively so snapshots
+    /// written before this field shipped (build 15) still load.
+    public var completedDates: [String]
     public var lastUpdated: Date
 
     public init(
@@ -27,6 +54,7 @@ public struct WidgetData: Codable, Sendable, Equatable {
         primaryDoneToday: Bool,
         secondDoneToday: Bool,
         streak: Int,
+        completedDates: [String] = [],
         lastUpdated: Date
     ) {
         self.isLoggedIn = isLoggedIn
@@ -37,7 +65,29 @@ public struct WidgetData: Codable, Sendable, Equatable {
         self.primaryDoneToday = primaryDoneToday
         self.secondDoneToday = secondDoneToday
         self.streak = streak
+        self.completedDates = completedDates
         self.lastUpdated = lastUpdated
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case isLoggedIn, userId, currentDay, secondTrackDay, dualTrackEnabled
+        case primaryDoneToday, secondDoneToday, streak, completedDates, lastUpdated
+    }
+
+    /// Custom decoder so blobs persisted before `completedDates` existed still
+    /// load (the synthesized decoder would throw on the missing key).
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        isLoggedIn = try c.decode(Bool.self, forKey: .isLoggedIn)
+        userId = try c.decodeIfPresent(String.self, forKey: .userId)
+        currentDay = try c.decode(Int.self, forKey: .currentDay)
+        secondTrackDay = try c.decode(Int.self, forKey: .secondTrackDay)
+        dualTrackEnabled = try c.decode(Bool.self, forKey: .dualTrackEnabled)
+        primaryDoneToday = try c.decode(Bool.self, forKey: .primaryDoneToday)
+        secondDoneToday = try c.decode(Bool.self, forKey: .secondDoneToday)
+        streak = try c.decode(Int.self, forKey: .streak)
+        completedDates = try c.decodeIfPresent([String].self, forKey: .completedDates) ?? []
+        lastUpdated = try c.decode(Date.self, forKey: .lastUpdated)
     }
 
     public static let loggedOut = WidgetData(
@@ -49,6 +99,7 @@ public struct WidgetData: Codable, Sendable, Equatable {
         primaryDoneToday: false,
         secondDoneToday: false,
         streak: 0,
+        completedDates: [],
         lastUpdated: .distantPast
     )
 
@@ -62,6 +113,34 @@ public struct WidgetData: Codable, Sendable, Equatable {
         primaryDoneToday && WidgetDataStore.isSameLocalDay(lastUpdated, now)
     }
 
+    /// Trailing 7-day window (oldest → newest, ending on the caller's local
+    /// "today") of weekday marks for the Duolingo-style row. `now`'s column is
+    /// checked when either `completedDates` records it or the primary sit is
+    /// already complete today.
+    public func weekMarks(now: Date = Date(), calendar: Calendar = .current) -> [WidgetDayMark] {
+        let completed = Set(completedDates)
+        let start = calendar.startOfDay(for: now)
+        let symbols = WidgetData.narrowWeekdaySymbols(calendar: calendar)
+        return (0..<7).reversed().compactMap { offset -> WidgetDayMark? in
+            guard let date = calendar.date(byAdding: .day, value: -offset, to: start) else { return nil }
+            let iso = WidgetDataStore.localDayString(date, calendar: calendar)
+            let isToday = offset == 0
+            let done = completed.contains(iso) || (isToday && isPrimaryCompleteForToday(at: now))
+            let weekday = calendar.component(.weekday, from: date)
+            let letter = symbols.isEmpty ? "" : symbols[(weekday - 1) % symbols.count]
+            return WidgetDayMark(iso: iso, letter: letter, done: done, isToday: isToday)
+        }
+    }
+
+    /// Narrow standalone weekday initials indexed by `weekday - 1` (1 = Sunday).
+    static func narrowWeekdaySymbols(calendar: Calendar) -> [String] {
+        let df = DateFormatter()
+        df.calendar = calendar
+        df.locale = calendar.locale ?? Locale(identifier: "en_US")
+        let symbols: [String]? = df.veryShortStandaloneWeekdaySymbols
+        return symbols ?? ["S", "M", "T", "W", "T", "F", "S"]
+    }
+
     /// Widget gallery / Xcode preview fixture.
     public static let preview = WidgetData(
         isLoggedIn: true,
@@ -72,6 +151,7 @@ public struct WidgetData: Codable, Sendable, Equatable {
         primaryDoneToday: false,
         secondDoneToday: false,
         streak: 12,
+        completedDates: WidgetDataStore.previewCompletedDates(),
         lastUpdated: Date()
     )
 }
@@ -105,12 +185,19 @@ public enum WidgetDataStore {
 
     /// Build a widget snapshot from in-memory app state, adjusting streak without
     /// extra network calls by comparing against the last persisted snapshot.
+    ///
+    /// `completedPrimaryDates`, when supplied (from a real `getSessions()` fetch),
+    /// becomes the authoritative 7-day completion set. When omitted, the prior
+    /// snapshot's dates are carried forward so the fast, network-free sync path
+    /// never wipes history it can't recompute. Today is always folded in when the
+    /// primary sit is done, so completing a sit checks today's box immediately.
     public static func makeSnapshot(
         user: UserDTO?,
         primaryDoneToday: Bool,
         secondDoneToday: Bool,
         now: Date = Date(),
-        previous: WidgetData? = nil
+        previous: WidgetData? = nil,
+        completedPrimaryDates: Set<String>? = nil
     ) -> WidgetData {
         guard let user else {
             return .loggedOut
@@ -124,6 +211,20 @@ public enum WidgetDataStore {
             now: now
         )
 
+        let window = Set(localDayStrings(lastN: 7, endingAt: now))
+        var dates: Set<String>
+        if let completedPrimaryDates {
+            dates = completedPrimaryDates.intersection(window)
+        } else if let prior, prior.isLoggedIn, prior.userId == user.id {
+            // Carry forward what we already knew; drop the other account's history.
+            dates = Set(prior.completedDates).intersection(window)
+        } else {
+            dates = []
+        }
+        if primaryDoneToday {
+            dates.insert(localDayString(now))
+        }
+
         return WidgetData(
             isLoggedIn: true,
             userId: user.id,
@@ -133,8 +234,31 @@ public enum WidgetDataStore {
             primaryDoneToday: primaryDoneToday,
             secondDoneToday: secondDoneToday,
             streak: streak,
+            completedDates: dates.sorted(),
             lastUpdated: now
         )
+    }
+
+    /// The set of local days in the trailing 7-day window on which a completed
+    /// primary standard sit was recorded. Quick and breath sits are excluded
+    /// (they don't advance the daily practice), matching `SessionStatistics`.
+    /// Pure and network-free so it's unit-testable; the caller supplies sessions.
+    public static func recentCompletedPrimaryDates(
+        from sessions: [SessionDTO],
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> Set<String> {
+        let window = Set(localDayStrings(lastN: 7, endingAt: now, calendar: calendar))
+        var result = Set<String>()
+        for session in sessions
+        where session.completed
+            && session.sessionType == .standard
+            && (session.track ?? .primary) == .primary {
+            if window.contains(session.sessionDate) {
+                result.insert(session.sessionDate)
+            }
+        }
+        return result
     }
 
     /// Normalize persisted data for widget display, clearing stale "done today"
@@ -151,6 +275,9 @@ public enum WidgetDataStore {
         } else {
             copy.streak = 0
         }
+        // Keep completion history bounded to the window the row can render.
+        let window = Set(localDayStrings(lastN: 7, endingAt: now))
+        copy.completedDates = data.completedDates.filter { window.contains($0) }
         return copy
     }
 
@@ -188,5 +315,32 @@ public enum WidgetDataStore {
 
     static func isSameLocalDay(_ lhs: Date, _ rhs: Date) -> Bool {
         Calendar.current.isDate(lhs, inSameDayAs: rhs)
+    }
+
+    /// Local-calendar `yyyy-MM-dd` for `date`, matching how the app stamps
+    /// `sessionDate` (local day, POSIX locale) so string equality lines up.
+    public static func localDayString(_ date: Date, calendar: Calendar = .current) -> String {
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.calendar = calendar
+        df.timeZone = calendar.timeZone
+        df.dateFormat = "yyyy-MM-dd"
+        return df.string(from: date)
+    }
+
+    /// The last `n` local-day strings, oldest → newest, ending on `now`'s day.
+    public static func localDayStrings(lastN n: Int, endingAt now: Date = Date(), calendar: Calendar = .current) -> [String] {
+        guard n > 0 else { return [] }
+        let start = calendar.startOfDay(for: now)
+        return (0..<n).reversed().compactMap { offset in
+            calendar.date(byAdding: .day, value: -offset, to: start)
+                .map { localDayString($0, calendar: calendar) }
+        }
+    }
+
+    /// Four of the six prior days marked complete, for gallery/Xcode previews.
+    public static func previewCompletedDates(now: Date = Date()) -> [String] {
+        let recent = localDayStrings(lastN: 7, endingAt: now)
+        return Array(recent.dropLast().suffix(4))
     }
 }

--- a/ios/StillPointShared/Sources/StillPointShared/WidgetData.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/WidgetData.swift
@@ -13,6 +13,8 @@ public struct WidgetDayMark: Sendable, Equatable, Identifiable {
     public let iso: String
     /// Narrow weekday initial (e.g. `M`, `T`, `W`) for the caller's locale.
     public let letter: String
+    /// Full weekday name (e.g. `Monday`) for the VoiceOver label.
+    public let weekdayName: String
     /// True when the primary standard sit was completed on `iso`.
     public let done: Bool
     /// True for the trailing column (the caller's local "today").
@@ -20,9 +22,10 @@ public struct WidgetDayMark: Sendable, Equatable, Identifiable {
 
     public var id: String { iso }
 
-    public init(iso: String, letter: String, done: Bool, isToday: Bool) {
+    public init(iso: String, letter: String, weekdayName: String, done: Bool, isToday: Bool) {
         self.iso = iso
         self.letter = letter
+        self.weekdayName = weekdayName
         self.done = done
         self.isToday = isToday
     }
@@ -120,15 +123,17 @@ public struct WidgetData: Codable, Sendable, Equatable {
     public func weekMarks(now: Date = Date(), calendar: Calendar = .current) -> [WidgetDayMark] {
         let completed = Set(completedDates)
         let start = calendar.startOfDay(for: now)
-        let symbols = WidgetData.narrowWeekdaySymbols(calendar: calendar)
+        let letters = WidgetData.narrowWeekdaySymbols(calendar: calendar)
+        let names = WidgetData.fullWeekdaySymbols(calendar: calendar)
         return (0..<7).reversed().compactMap { offset -> WidgetDayMark? in
             guard let date = calendar.date(byAdding: .day, value: -offset, to: start) else { return nil }
             let iso = WidgetDataStore.localDayString(date, calendar: calendar)
             let isToday = offset == 0
             let done = completed.contains(iso) || (isToday && isPrimaryCompleteForToday(at: now))
             let weekday = calendar.component(.weekday, from: date)
-            let letter = symbols.isEmpty ? "" : symbols[(weekday - 1) % symbols.count]
-            return WidgetDayMark(iso: iso, letter: letter, done: done, isToday: isToday)
+            let letter = letters.isEmpty ? "" : letters[(weekday - 1) % letters.count]
+            let name = names.isEmpty ? "" : names[(weekday - 1) % names.count]
+            return WidgetDayMark(iso: iso, letter: letter, weekdayName: name, done: done, isToday: isToday)
         }
     }
 
@@ -139,6 +144,15 @@ public struct WidgetData: Codable, Sendable, Equatable {
         df.locale = calendar.locale ?? Locale(identifier: "en_US")
         let symbols: [String]? = df.veryShortStandaloneWeekdaySymbols
         return symbols ?? ["S", "M", "T", "W", "T", "F", "S"]
+    }
+
+    /// Full standalone weekday names indexed by `weekday - 1` (1 = Sunday).
+    static func fullWeekdaySymbols(calendar: Calendar) -> [String] {
+        let df = DateFormatter()
+        df.calendar = calendar
+        df.locale = calendar.locale ?? Locale(identifier: "en_US")
+        let symbols: [String]? = df.standaloneWeekdaySymbols
+        return symbols ?? ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
     }
 
     /// Widget gallery / Xcode preview fixture.
@@ -221,7 +235,12 @@ public enum WidgetDataStore {
         } else {
             dates = []
         }
-        if primaryDoneToday {
+        // Fold today in only on the synchronous fast path (no session set), where
+        // `primaryDoneToday` is always same-day fresh. The authoritative path
+        // already carries today's real completion in `completedPrimaryDates`, so
+        // trusting a possibly-stale flag there could wrongly check a new day if the
+        // async fetch crossed local midnight.
+        if completedPrimaryDates == nil, primaryDoneToday {
             dates.insert(localDayString(now))
         }
 
@@ -317,12 +336,16 @@ public enum WidgetDataStore {
         Calendar.current.isDate(lhs, inSameDayAs: rhs)
     }
 
-    /// Local-calendar `yyyy-MM-dd` for `date`, matching how the app stamps
-    /// `sessionDate` (local day, POSIX locale) so string equality lines up.
+    /// Local-day `yyyy-MM-dd` for `date`, matching exactly how the app stamps
+    /// `sessionDate` (`SessionViewModel.saveSession`): POSIX locale + an explicit
+    /// **Gregorian** calendar, in the caller's timezone. Forcing Gregorian (rather
+    /// than `Calendar.current`) keeps the digits aligned on devices whose preferred
+    /// calendar is non-Gregorian (e.g. Buddhist/Japanese), so string equality with
+    /// `sessionDate` still holds and real completions aren't dropped from the row.
     public static func localDayString(_ date: Date, calendar: Calendar = .current) -> String {
         let df = DateFormatter()
         df.locale = Locale(identifier: "en_US_POSIX")
-        df.calendar = calendar
+        df.calendar = Calendar(identifier: .gregorian)
         df.timeZone = calendar.timeZone
         df.dateFormat = "yyyy-MM-dd"
         return df.string(from: date)

--- a/ios/StillPointShared/Tests/StillPointSharedTests/WidgetDataTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/WidgetDataTests.swift
@@ -430,4 +430,50 @@ final class WidgetDataTests: XCTestCase {
         let normalized = WidgetDataStore.normalizedForDisplay(data, now: now)
         XCTAssertEqual(normalized.completedDates, [inWindow])
     }
+
+    /// Authoritative (session-derived) path must not inject today from a possibly
+    /// stale `primaryDoneToday` flag — it trusts the fetched completion set.
+    func testMakeSnapshotDoesNotFoldTodayWhenSessionsAuthoritative() {
+        let now = Date()
+        let today = localDay(0, from: now)
+        let threeDaysAgo = localDay(-3, from: now)
+        let snapshot = WidgetDataStore.makeSnapshot(
+            user: makeUser(id: "u1"),
+            primaryDoneToday: true, // stale flag; sessions say today is not complete
+            secondDoneToday: false,
+            now: now,
+            previous: nil,
+            completedPrimaryDates: [threeDaysAgo]
+        )
+        XCTAssertFalse(snapshot.completedDates.contains(today))
+        XCTAssertEqual(snapshot.completedDates, [threeDaysAgo])
+    }
+
+    /// `localDayString` must emit Gregorian digits even when the supplied calendar
+    /// is non-Gregorian, so keys match `sessionDate` (stamped Gregorian).
+    func testLocalDayStringForcesGregorianDigits() {
+        let date = Date(timeIntervalSince1970: 1_784_000_000) // ~2026
+        var buddhist = Calendar(identifier: .buddhist)
+        buddhist.timeZone = TimeZone(identifier: "UTC")!
+        let iso = WidgetDataStore.localDayString(date, calendar: buddhist)
+        XCTAssertEqual(iso.count, 10)
+        XCTAssertTrue(iso.hasPrefix("20"), "expected Gregorian year, got \(iso)")
+    }
+
+    func testWeekMarksPopulateWeekdayName() {
+        let now = Date()
+        let data = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 5,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            streak: 3,
+            completedDates: [],
+            lastUpdated: now
+        )
+        XCTAssertFalse(data.weekMarks(now: now).last?.weekdayName.isEmpty ?? true)
+    }
 }

--- a/ios/StillPointShared/Tests/StillPointSharedTests/WidgetDataTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/WidgetDataTests.swift
@@ -213,4 +213,221 @@ final class WidgetDataTests: XCTestCase {
         )
         XCTAssertEqual(snapshot.streak, 9)
     }
+
+    // MARK: - #84 follow-up: weekday checkmark row
+
+    private func session(
+        date: String,
+        type: SessionType = .standard,
+        completed: Bool = true,
+        track: Track? = .primary
+    ) -> SessionDTO {
+        SessionDTO(
+            id: "\(date)-\(type.rawValue)-\(completed)-\(track?.rawValue ?? "nil")",
+            dayNumber: 1,
+            sessionType: type,
+            duration: 60,
+            completed: completed,
+            actualTime: 60,
+            clearPercent: 0,
+            thoughtCount: 0,
+            mindStateLog: nil,
+            sessionDate: date,
+            buddySessionId: nil,
+            track: track
+        )
+    }
+
+    private func localDay(_ offset: Int, from now: Date = Date()) -> String {
+        let date = Calendar.current.date(byAdding: .day, value: offset, to: now)!
+        return WidgetDataStore.localDayString(date)
+    }
+
+    /// Snapshots written before `completedDates` shipped must still decode.
+    func testDecodesLegacyBlobWithoutCompletedDates() throws {
+        let ref = Date(timeIntervalSince1970: 1_700_000_000)
+        let legacy: [String: Any] = [
+            "isLoggedIn": true,
+            "userId": "u1",
+            "currentDay": 10,
+            "secondTrackDay": 2,
+            "dualTrackEnabled": false,
+            "primaryDoneToday": true,
+            "secondDoneToday": false,
+            "streak": 7,
+            "lastUpdated": ref.timeIntervalSinceReferenceDate
+        ]
+        let data = try JSONSerialization.data(withJSONObject: legacy)
+        let decoded = try JSONDecoder().decode(WidgetData.self, from: data)
+        XCTAssertEqual(decoded.completedDates, [])
+        XCTAssertEqual(decoded.streak, 7)
+        XCTAssertTrue(decoded.primaryDoneToday)
+    }
+
+    func testRecentCompletedPrimaryDatesFiltersTypeTrackAndWindow() {
+        let now = Date()
+        let today = localDay(0, from: now)
+        let twoDaysAgo = localDay(-2, from: now)
+        let tenDaysAgo = localDay(-10, from: now)
+
+        let sessions = [
+            session(date: today, type: .standard, completed: true, track: .primary),
+            session(date: twoDaysAgo, type: .standard, completed: true, track: nil), // nil treated as primary
+            session(date: tenDaysAgo, type: .standard, completed: true, track: .primary), // outside 7-day window
+            session(date: today, type: .quick, completed: true, track: .primary), // quick excluded
+            session(date: today, type: .standard, completed: false, track: .primary), // incomplete excluded
+            session(date: today, type: .standard, completed: true, track: .second) // second track excluded
+        ]
+
+        let result = WidgetDataStore.recentCompletedPrimaryDates(from: sessions, now: now)
+        XCTAssertEqual(result, [today, twoDaysAgo])
+    }
+
+    func testWeekMarksHasSevenDaysEndingToday() {
+        let now = Date()
+        let today = localDay(0, from: now)
+        let data = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 5,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            streak: 3,
+            completedDates: [today],
+            lastUpdated: now
+        )
+        let marks = data.weekMarks(now: now)
+        XCTAssertEqual(marks.count, 7)
+        XCTAssertEqual(marks.last?.iso, today)
+        XCTAssertEqual(marks.last?.isToday, true)
+        XCTAssertEqual(marks.last?.done, true)
+        XCTAssertEqual(marks.first?.isToday, false)
+    }
+
+    func testWeekMarksChecksTodayViaPrimaryFlagWithoutCompletedDate() {
+        let now = Date()
+        let data = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 5,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: true,
+            secondDoneToday: false,
+            streak: 3,
+            completedDates: [],
+            lastUpdated: now
+        )
+        XCTAssertEqual(data.weekMarks(now: now).last?.done, true)
+    }
+
+    func testMakeSnapshotCarriesForwardHistoryWhenNoSessionsProvided() {
+        let now = Date()
+        let twoDaysAgo = localDay(-2, from: now)
+        let previous = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 12,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            streak: 4,
+            completedDates: [twoDaysAgo],
+            lastUpdated: now
+        )
+        let snapshot = WidgetDataStore.makeSnapshot(
+            user: makeUser(id: "u1"),
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            now: now,
+            previous: previous
+        )
+        XCTAssertEqual(snapshot.completedDates, [twoDaysAgo])
+    }
+
+    func testMakeSnapshotFoldsTodayWhenPrimaryDone() {
+        let now = Date()
+        let snapshot = WidgetDataStore.makeSnapshot(
+            user: makeUser(id: "u1"),
+            primaryDoneToday: true,
+            secondDoneToday: false,
+            now: now,
+            previous: nil
+        )
+        XCTAssertTrue(snapshot.completedDates.contains(localDay(0, from: now)))
+    }
+
+    func testMakeSnapshotUsesProvidedSessionsAsAuthoritative() {
+        let now = Date()
+        let today = localDay(0, from: now)
+        let threeDaysAgo = localDay(-3, from: now)
+        let previous = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 12,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            streak: 4,
+            completedDates: ["1999-01-01"], // stale; must be discarded
+            lastUpdated: now
+        )
+        let snapshot = WidgetDataStore.makeSnapshot(
+            user: makeUser(id: "u1"),
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            now: now,
+            previous: previous,
+            completedPrimaryDates: [today, threeDaysAgo]
+        )
+        XCTAssertEqual(Set(snapshot.completedDates), [today, threeDaysAgo])
+    }
+
+    func testMakeSnapshotDropsHistoryOnAccountSwitch() {
+        let now = Date()
+        let previous = WidgetData(
+            isLoggedIn: true,
+            userId: "old-user",
+            currentDay: 12,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            streak: 4,
+            completedDates: [localDay(-2, from: now)],
+            lastUpdated: now
+        )
+        let snapshot = WidgetDataStore.makeSnapshot(
+            user: makeUser(id: "new-user"),
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            now: now,
+            previous: previous
+        )
+        XCTAssertEqual(snapshot.completedDates, [])
+    }
+
+    func testNormalizedForDisplayPrunesHistoryOutsideWindow() {
+        let now = Date()
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: now)!
+        let inWindow = localDay(-2, from: now)
+        let data = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 4,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: true,
+            secondDoneToday: false,
+            streak: 6,
+            completedDates: ["2000-01-01", inWindow],
+            lastUpdated: yesterday
+        )
+        let normalized = WidgetDataStore.normalizedForDisplay(data, now: now)
+        XCTAssertEqual(normalized.completedDates, [inWindow])
+    }
 }

--- a/ios/StillPointWidget/HabitWidgetEntryView.swift
+++ b/ios/StillPointWidget/HabitWidgetEntryView.swift
@@ -20,7 +20,7 @@ struct HabitWidgetEntryView: View {
             if entry.data.isLoggedIn {
                 Label {
                     Text("\(entry.data.streak)")
-                        .font(.system(size: 34, weight: .light, design: .serif))
+                        .font(.system(size: 30, weight: .light, design: .serif))
                         .foregroundStyle(WidgetPalette.foreground)
                 } icon: {
                     Image(systemName: "flame.fill")
@@ -33,13 +33,9 @@ struct HabitWidgetEntryView: View {
                     .foregroundStyle(WidgetPalette.foregroundMuted)
                     .tracking(1)
 
-                if entry.data.isPrimaryCompleteForToday(at: entry.date) {
-                    doneBadge
-                } else {
-                    Text("\(entry.data.primaryDurationSeconds)s sit")
-                        .font(.system(size: 11, weight: .regular, design: .monospaced))
-                        .foregroundStyle(WidgetPalette.foregroundFaint)
-                }
+                Spacer(minLength: 0)
+
+                weekRow(entry.data.weekMarks(now: entry.date), dotSize: 13, spacing: 3)
             } else {
                 Text("Still Point")
                     .font(.system(size: 16, weight: .medium, design: .serif))
@@ -47,67 +43,104 @@ struct HabitWidgetEntryView: View {
                 Text("Sign in to track your streak")
                     .font(.system(size: 12, weight: .regular))
                     .foregroundStyle(WidgetPalette.foregroundMuted)
+                Spacer(minLength: 0)
             }
-            Spacer(minLength: 0)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .padding(14)
     }
 
     private var mediumLayout: some View {
-        HStack(spacing: 16) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("STREAK")
-                    .font(.system(size: 10, weight: .medium, design: .monospaced))
-                    .foregroundStyle(WidgetPalette.foregroundFaint)
-                    .tracking(2)
-                HStack(alignment: .firstTextBaseline, spacing: 6) {
-                    Image(systemName: "flame.fill")
-                        .foregroundStyle(WidgetPalette.accent)
-                    Text(entry.data.isLoggedIn ? "\(entry.data.streak)" : "—")
-                        .font(.system(size: 40, weight: .light, design: .serif))
-                        .foregroundStyle(WidgetPalette.foreground)
-                }
-            }
-
-            Spacer(minLength: 0)
-
-            if entry.data.isLoggedIn {
-                VStack(alignment: .trailing, spacing: 4) {
-                    Text("DAY")
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 16) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("STREAK")
                         .font(.system(size: 10, weight: .medium, design: .monospaced))
                         .foregroundStyle(WidgetPalette.foregroundFaint)
                         .tracking(2)
-                    Text("\(entry.data.currentDay)")
-                        .font(.system(size: 40, weight: .light, design: .serif))
-                        .foregroundStyle(WidgetPalette.foreground)
-                    if entry.data.dualTrackEnabled {
-                        Text("track 2 · day \(entry.data.secondTrackDay)")
-                            .font(.system(size: 11, weight: .regular, design: .monospaced))
-                            .foregroundStyle(WidgetPalette.foregroundMuted)
-                    } else {
-                        Text("\(entry.data.primaryDurationSeconds)s · \(StillPoint.blockCount(forDuration: entry.data.primaryDurationSeconds)) blocks")
-                            .font(.system(size: 11, weight: .regular, design: .monospaced))
-                            .foregroundStyle(WidgetPalette.foregroundMuted)
-                    }
-                    if entry.data.isPrimaryCompleteForToday(at: entry.date) {
-                        doneBadge
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Image(systemName: "flame.fill")
+                            .foregroundStyle(WidgetPalette.accent)
+                        Text(entry.data.isLoggedIn ? "\(entry.data.streak)" : "—")
+                            .font(.system(size: 40, weight: .light, design: .serif))
+                            .foregroundStyle(WidgetPalette.foreground)
                     }
                 }
-            } else {
-                Text("Sign in")
-                    .font(.system(size: 14, weight: .medium, design: .serif))
-                    .foregroundStyle(WidgetPalette.foregroundMuted)
+
+                Spacer(minLength: 0)
+
+                if entry.data.isLoggedIn {
+                    VStack(alignment: .trailing, spacing: 4) {
+                        Text("DAY")
+                            .font(.system(size: 10, weight: .medium, design: .monospaced))
+                            .foregroundStyle(WidgetPalette.foregroundFaint)
+                            .tracking(2)
+                        Text("\(entry.data.currentDay)")
+                            .font(.system(size: 40, weight: .light, design: .serif))
+                            .foregroundStyle(WidgetPalette.foreground)
+                        if entry.data.dualTrackEnabled {
+                            Text("track 2 · day \(entry.data.secondTrackDay)")
+                                .font(.system(size: 11, weight: .regular, design: .monospaced))
+                                .foregroundStyle(WidgetPalette.foregroundMuted)
+                        } else {
+                            Text("\(entry.data.primaryDurationSeconds)s · \(StillPoint.blockCount(forDuration: entry.data.primaryDurationSeconds)) blocks")
+                                .font(.system(size: 11, weight: .regular, design: .monospaced))
+                                .foregroundStyle(WidgetPalette.foregroundMuted)
+                        }
+                    }
+                } else {
+                    Text("Sign in")
+                        .font(.system(size: 14, weight: .medium, design: .serif))
+                        .foregroundStyle(WidgetPalette.foregroundMuted)
+                }
+            }
+
+            if entry.data.isLoggedIn {
+                Spacer(minLength: 0)
+                weekRow(entry.data.weekMarks(now: entry.date), dotSize: 20, spacing: 10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .padding(16)
     }
 
-    private var doneBadge: some View {
-        Label("Done today", systemImage: "checkmark.circle.fill")
-            .font(.system(size: 11, weight: .medium, design: .monospaced))
-            .foregroundStyle(WidgetPalette.success)
+    /// Duolingo-style weekday row: single-letter labels over per-day marks —
+    /// a filled check for completed sits, a hollow ring for missed days, and a
+    /// dotted ring for today when it's still pending.
+    private func weekRow(_ marks: [WidgetDayMark], dotSize: CGFloat, spacing: CGFloat) -> some View {
+        HStack(spacing: spacing) {
+            ForEach(marks) { mark in
+                VStack(spacing: 4) {
+                    Text(mark.letter)
+                        .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(mark.isToday ? WidgetPalette.foreground : WidgetPalette.foregroundFaint)
+                    dayMark(mark, size: dotSize)
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func dayMark(_ mark: WidgetDayMark, size: CGFloat) -> some View {
+        ZStack {
+            if mark.done {
+                Circle().fill(WidgetPalette.accent)
+                Image(systemName: "checkmark")
+                    .font(.system(size: size * 0.5, weight: .bold))
+                    .foregroundStyle(WidgetPalette.onAccent)
+            } else if mark.isToday {
+                Circle()
+                    .strokeBorder(
+                        WidgetPalette.foregroundMuted,
+                        style: StrokeStyle(lineWidth: 1.4, dash: [2, 2])
+                    )
+            } else {
+                Circle().strokeBorder(WidgetPalette.foregroundFaint.opacity(0.5), lineWidth: 1.2)
+            }
+        }
+        .frame(width: size, height: size)
     }
 }
 
@@ -117,6 +150,7 @@ enum WidgetPalette {
     static let foregroundMuted = Color(red: 232/255, green: 228/255, blue: 222/255).opacity(0.52)
     static let foregroundFaint = Color(red: 232/255, green: 228/255, blue: 222/255).opacity(0.45)
     static let accent = Color(red: 251/255, green: 191/255, blue: 36/255)
+    static let onAccent = Color(red: 26/255, green: 24/255, blue: 22/255)
     static let success = Color(red: 74/255, green: 222/255, blue: 128/255)
 }
 
@@ -131,6 +165,7 @@ struct HabitWidget_Previews: PreviewProvider {
         primaryDoneToday: false,
         secondDoneToday: false,
         streak: 12,
+        completedDates: WidgetDataStore.previewCompletedDates(),
         lastUpdated: Date()
     )
 

--- a/ios/StillPointWidget/HabitWidgetEntryView.swift
+++ b/ios/StillPointWidget/HabitWidgetEntryView.swift
@@ -118,8 +118,17 @@ struct HabitWidgetEntryView: View {
                     dayMark(mark, size: dotSize)
                 }
                 .frame(maxWidth: .infinity)
+                // Collapse the decorative letter + circle into one VoiceOver element.
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(mark.weekdayName)
+                .accessibilityValue(Self.accessibilityState(for: mark))
             }
         }
+    }
+
+    private static func accessibilityState(for mark: WidgetDayMark) -> String {
+        if mark.done { return "Completed" }
+        return mark.isToday ? "Not done yet" : "Missed"
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

Follow-up to the shipped habit widget (#84 / #501). Adds the one Duolingo-style element the original widget was missing: a **trailing 7-day weekday row** with per-day checkmarks, on both the small and medium home-screen sizes. The original widget showed only a single streak number; this shows the days-in-a-row visually the way the reference Duolingo widget does.

Sample (day 24, 12-day streak): `T F S S M` with checks on the completed days and a dashed ring on today while it's still pending.

## What changed

**`StillPointShared/WidgetData.swift`**
- New `completedDates: [String]` field — ISO **local-day** strings within the trailing 7-day window on which the **primary standard** sit was completed. Local-day formatting matches how the app stamps `sessionDate`, so string equality lines up.
- New `weekMarks(now:calendar:)` → `[WidgetDayMark]` builds the 7-column row (oldest → newest, ending today); today's column is checked when either `completedDates` records it or the primary sit is already done today.
- Custom `Codable` init decodes `completedDates` permissively (`decodeIfPresent ?? []`) so snapshots persisted by **build 15**, which predate the field, still load instead of failing to decode.
- `WidgetDataStore.recentCompletedPrimaryDates(from:)` derives the completion set from real session history — completed `.standard` primary-track sits only; quick and breath sits excluded, matching `SessionStatistics`. Pure/network-free so it's unit-testable.
- `makeSnapshot` takes an optional `completedPrimaryDates`: authoritative when provided, otherwise carries the prior snapshot's history forward (dropped on account switch), always folding in today when the primary sit is done. `normalizedForDisplay` prunes to the window after midnight.

**`StillPointApp/AppViewModel.swift`**
- `refreshWidgetWeekHistory()` backfills the week from `getSessions()` off the auth/home path as a **non-blocking** task so cold-start isn't slowed; skipped under `SP_UI_TEST_MODE`. A fetch failure keeps the locally-accumulated week the existing sync path already wrote — no new blocking calls on the critical path.

**`StillPointWidget/HabitWidgetEntryView.swift`**
- Renders the row on both layouts: filled amber check (done), hollow ring (missed), dashed ring (today, pending), on the existing app palette. Small layout drops the old duration line to make room; medium pins the row along the bottom.

## Test plan

- [x] `cd ios/StillPointShared && swift test` — extends `WidgetDataTests`: legacy-blob decode (no `completedDates`), completion-set filtering (type/track/window), week-mark shape + today-via-flag, carry-forward vs authoritative, account-switch reset, window pruning. *(Runs on the `iOS Shared Unit Tests` CI job; not runnable in this Linux session — no Swift toolchain.)*
- [ ] Simulator: sign in → add widget → verify the row reflects the last 7 days of real sits
- [ ] Complete today's sit → return home → today's column flips to a check
- [ ] Cross local midnight → window rolls, stale "done today" clears, prior days stay checked
- [ ] Log out → placeholder; log into a different account → previous account's week does not leak

## Notes

- No server/API changes and no new endpoints — reuses the existing `/api/sessions` fetch that History already uses.
- No new build-signing work: this rides the existing `StillPointWidget` target that shipped in build 15.


---
_Generated by [Claude Code](https://claude.ai/code/session_013KSWVxKyVbr7ya9oUGnBD1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a seven-day completion history to the habit widget.
  * Widgets now display weekday progress with completed, missed, and pending day indicators.
  * Widget history refreshes from recent completed sessions and stays current after app updates.
  * Added support for carrying forward valid history while removing outdated or account-specific data.

* **Bug Fixes**
  * Preserved compatibility with existing widget data that lacks completion history.
  * Improved widget display accuracy by limiting history to the visible seven-day window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->