### PR TITLE
chore(ios): bump build number to 16 for TestFlight

### DIFF
--- a/ios/project.yml
+++ b/ios/project.yml
@@ -87,7 +87,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint
         MARKETING_VERSION: "1.0.3"
-        CURRENT_PROJECT_VERSION: 15
+        CURRENT_PROJECT_VERSION: 16
         # Native Google Sign-In client IDs (#344). Empty by default so no real
         # client ID is committed; override per environment / in CI signing config.
         # GID_CLIENT_ID:           iOS OAuth client ID (xxxxx.apps.googleusercontent.com)
@@ -129,7 +129,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint.monitor
         MARKETING_VERSION: "1.0.3"
-        CURRENT_PROJECT_VERSION: 15
+        CURRENT_PROJECT_VERSION: 16
         DEVELOPMENT_TEAM: T5UU4BP6AV
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]: StillPointMonitor/StillPointMonitor.entitlements
@@ -159,7 +159,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint.widget
         MARKETING_VERSION: "1.0.3"
-        CURRENT_PROJECT_VERSION: 15
+        CURRENT_PROJECT_VERSION: 16
         DEVELOPMENT_TEAM: T5UU4BP6AV
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]: StillPointWidget/StillPointWidget.entitlements


### PR DESCRIPTION
## Summary

Bumps `CURRENT_PROJECT_VERSION` **15 → 16** across the app, monitor, and widget targets so the merged Duolingo-style weekday checkmark row (#551) can be cut to TestFlight. Marketing version stays `1.0.3`.

Each TestFlight upload needs a unique, higher build number, and all embedded binaries must share it — hence all three targets.

## Release step

After this merges, push the tag to trigger **Build & Upload to TestFlight** (`ios-testflight.yml`):

```
git tag ios-v1.0.3-build16 <merge-sha>
git push origin ios-v1.0.3-build16
```

## Notes

- `CFBundleVersion` in each `Info.plist` is `$(CURRENT_PROJECT_VERSION)`, so the "Info.plist in sync with project.yml" check is unaffected.
- No signing/entitlement changes — rides the same three-target signing wired up for build 15.


---
_Generated by [Claude Code](https://claude.ai/code/session_013KSWVxKyVbr7ya9oUGnBD1)_