### PR TITLE
fix(ci): unblock release:ios auto-build (optional e2e-mobile secrets)

### DIFF
--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -18,17 +18,24 @@ on:
         description: "Commit ref (SHA, branch, or tag) to check out and test"
         type: string
         required: true
+    # These MUST stay `required: false`. The only caller (ios-testflight-auto.yml)
+    # passes `secrets: inherit`, and the repo does not define POSTGRES_URL /
+    # E2E_WEB_EMAIL / E2E_WEB_PASSWORD — marking a secret the caller can't supply
+    # as `required: true` fails the whole workflow_call at startup (no runner,
+    # ~2s), which silently blocked every release:ios auto-build. e2e/global-setup.ts
+    # already skips DB provisioning and runs the mobile suite in mock mode when
+    # these are empty, so absent secrets are expected, not an error.
     secrets:
       POSTGRES_URL:
-        required: true
+        required: false
       E2E_WEB_EMAIL:
-        required: true
+        required: false
       E2E_WEB_PASSWORD:
-        required: true
+        required: false
       E2E_TEST_USER_EMAIL:
-        required: true
+        required: false
       E2E_TEST_USER_PASSWORD:
-        required: true
+        required: false
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
## Problem

The **"Auto TestFlight on merge"** workflow (`ios-testflight-auto.yml`) — the `release:ios` label path — has never successfully produced a build. When #555 exercised it for the first time, its mobile-web e2e gate failed in **~2 seconds with no runner assigned** (a `workflow_call` startup failure), which cascaded to skip the bump/tag/build steps. Every real TestFlight build (14, 15, 16) has gone out via the manual `ios-v*-build*` tag path instead.

## Root cause

`ios-testflight-auto.yml` calls the reusable `e2e-mobile.yml` with `secrets: inherit`. `e2e-mobile.yml` declared five secrets as **`required: true`**:

```
POSTGRES_URL, E2E_WEB_EMAIL, E2E_WEB_PASSWORD, E2E_TEST_USER_EMAIL, E2E_TEST_USER_PASSWORD
```

The repo doesn't define `POSTGRES_URL` / `E2E_WEB_EMAIL` / `E2E_WEB_PASSWORD` (the passing web lanes run secret-free; the DB secret that *does* exist is `E2E_AUTH_DB_POSTGRES_URL`, and it's treated as optional). With `secrets: inherit`, a `required: true` secret the caller can't supply **fails the whole `workflow_call` at startup** — before any runner — which is the 2-second failure.

Critically, `e2e/global-setup.ts` is already written to handle these being empty: it *"skips DB provisioning … mock API tests will still run"*. So the secrets were **never actually required** — the `required: true` was the bug.

## Fix

Flip all five to `required: false` (one file), with a comment explaining why they must stay optional so this doesn't regress. No behavior change when secrets *are* present; when absent, the suite runs in mock mode exactly as `global-setup.ts` intends.

## Validation

This can't be exercised by the PR's own CI (`e2e-mobile.yml` only runs via `workflow_call`/`workflow_dispatch`, not on PRs). After merge, confirm end-to-end by either:
- running **`e2e-mobile.yml` via `workflow_dispatch`** against `main`, or
- merging any PR carrying the **`release:ios`** label and watching **Auto TestFlight on merge** complete.

Until it's validated once, keep using the manual tag path for releases.


---
_Generated by [Claude Code](https://claude.ai/code/session_013KSWVxKyVbr7ya9oUGnBD1)_