### PR TITLE
feat(ios): session screen redesign with intro overlay (#560)

### DIFF
--- a/ios/StillPointApp/Components/SessionIntroOverlayView.swift
+++ b/ios/StillPointApp/Components/SessionIntroOverlayView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+/// Pre-session intro that gates the countdown until dismissed (#560).
+struct SessionIntroOverlayView: View {
+    let onBegin: () -> Void
+    let onDontShowAgain: () -> Void
+
+    var body: some View {
+        ZStack {
+            SPColor.bg.opacity(0.96)
+                .ignoresSafeArea()
+
+            VStack(spacing: SPSpacing.s4) {
+                Spacer()
+
+                Text("Before you begin")
+                    .font(SPFont.serifItalic(24, weight: .light))
+                    .foregroundStyle(Color(SPColor.fg))
+
+                VStack(alignment: .leading, spacing: SPSpacing.s3) {
+                    introRow(
+                        icon: "timer",
+                        text: "Watch the timer count down. When you notice a thought, capture it — then return to watching."
+                    )
+                    introRow(
+                        icon: "hand.tap",
+                        text: "Hold the bottom buttons to log light distraction or hyperfocus segments."
+                    )
+                    introRow(
+                        icon: "speaker.wave.2",
+                        text: "Toggle tick, chime, and end sounds below the transport controls."
+                    )
+                }
+                .padding(.horizontal, SPSpacing.s4)
+
+                Button {
+                    onBegin()
+                } label: {
+                    Text("Begin")
+                        .font(SPFont.mono(14, weight: .medium))
+                        .spCapsuleButtonStyle(.greenGradient, size: .fullWidth, tall: true, minHeight: 44)
+                }
+                .accessibilityIdentifier("session.introBeginButton")
+
+                Button {
+                    onDontShowAgain()
+                } label: {
+                    Text("Don't show again")
+                        .font(SPFont.mono(12, weight: .medium))
+                        .foregroundStyle(Color(SPColor.fg4))
+                        .frame(minHeight: 44)
+                        .frame(maxWidth: .infinity)
+                }
+                .accessibilityIdentifier("session.introDontShowAgainButton")
+
+                Spacer().frame(height: SPSpacing.s4)
+            }
+            .padding(.horizontal, SPSpacing.s4)
+        }
+        .accessibilityIdentifier("session.introOverlay")
+    }
+
+    private func introRow(icon: String, text: String) -> some View {
+        HStack(alignment: .top, spacing: SPSpacing.s2) {
+            Image(systemName: icon)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(SPColor.greenText)
+                .frame(width: 24, alignment: .center)
+            Text(text)
+                .font(SPFont.serif(15, weight: .light))
+                .foregroundStyle(Color(SPColor.fg3))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}

--- a/ios/StillPointApp/ViewModels/SessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/SessionViewModel.swift
@@ -39,6 +39,8 @@ final class SessionViewModel {
 
     // UI state — optional thought prompt after a distraction segment ends
     var showPostDistractionCapture = false
+    /// Pre-session intro overlay; gates `start()` until dismissed (#560).
+    var showIntroOverlay = false
     var controlsVisible = true
     var soundPrefs: AudioEngine.SoundPrefs
 
@@ -99,6 +101,25 @@ final class SessionViewModel {
         self.uiTestTimerMultiplier = Self.resolveUITestTimerMultiplier()
         // Initial mind state log entry
         self.mindStateLog = [MindStateEntry(time: 0, state: "clear")]
+    }
+
+    /// Prepare the session screen. Shows the intro overlay unless permanently hidden or UI-test skip.
+    func prepareSession(introHiddenPermanently: Bool, skipIntroForUITest: Bool) {
+        if skipIntroForUITest || introHiddenPermanently {
+            showIntroOverlay = false
+            start()
+        } else {
+            showIntroOverlay = true
+        }
+    }
+
+    /// Dismiss the intro overlay and begin the countdown.
+    func dismissIntroOverlay(dontShowAgain: Bool) {
+        if dontShowAgain {
+            SessionIntroPrefs.setIntroOverlayHidden(true)
+        }
+        showIntroOverlay = false
+        start()
     }
 
     func start() {

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -76,15 +76,6 @@ struct SessionView: View {
                 }
             }
 
-            // Pre-session intro gates the countdown (#560).
-            if vm.showIntroOverlay {
-                SessionIntroOverlayView(
-                    onBegin: { vm.dismissIntroOverlay(dontShowAgain: false) },
-                    onDontShowAgain: { vm.dismissIntroOverlay(dontShowAgain: true) }
-                )
-                .transition(.opacity)
-            }
-
             // Bottom chrome: secondary controls above; primary hold targets pinned to thumb-reach zone.
             VStack(spacing: 0) {
                 Spacer()
@@ -103,6 +94,7 @@ struct SessionView: View {
                     .accessibilityIdentifier("session.secondaryChromeMarker")
                     .accessibilityValue(secondaryChromeDimmed ? "dimmed" : "visible")
             }
+            .allowsHitTesting(!vm.showIntroOverlay)
             .animation(.easeInOut(duration: 0.3), value: vm.controlsVisible)
 
             // Thought capture after releasing a distraction hold
@@ -122,6 +114,15 @@ struct SessionView: View {
                 }
                 .transition(.opacity)
             }
+
+            // Pre-session intro gates the countdown (#560) — topmost layer blocks chrome interaction.
+            if vm.showIntroOverlay {
+                SessionIntroOverlayView(
+                    onBegin: { vm.dismissIntroOverlay(dontShowAgain: false) },
+                    onDontShowAgain: { vm.dismissIntroOverlay(dontShowAgain: true) }
+                )
+                .transition(.opacity)
+            }
         }
         .onTapGesture {
             vm.userInteracted()
@@ -132,9 +133,7 @@ struct SessionView: View {
                 introHiddenPermanently: SessionIntroPrefs.isIntroOverlayHidden,
                 skipIntroForUITest: skipIntro
             )
-            if appVM.currentUser?.attentionTrackingEnabled == true {
-                attentionManager.start { vm.elapsed }
-            }
+            syncAttentionTracking()
             SessionIdleTimerController.syncLocalSession(
                 appVM: appVM,
                 isRunning: sessionTimerRunning
@@ -154,6 +153,13 @@ struct SessionView: View {
                 appVM: appVM,
                 inProgress: false
             )
+        }
+        .onChange(of: vm.showIntroOverlay) { _, showIntro in
+            if showIntro {
+                attentionManager.stop()
+            } else {
+                syncAttentionTracking()
+            }
         }
         .onChange(of: appVM.keepScreenAwakeDuringSession) { _, _ in
             SessionIdleTimerController.syncLocalSession(
@@ -273,6 +279,12 @@ struct SessionView: View {
     /// Active sit timer only (not paused); idle timer may lock while paused.
     private var sessionTimerRunning: Bool {
         vm.isActive && !vm.isPaused && !vm.isComplete && !vm.isAbandoned
+    }
+
+    private func syncAttentionTracking() {
+        guard appVM.currentUser?.attentionTrackingEnabled == true else { return }
+        guard !vm.showIntroOverlay, sessionTimerRunning else { return }
+        attentionManager.start { vm.elapsed }
     }
 
     private var bottomOverlayReserve: CGFloat {

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -4,13 +4,16 @@ import UIKit
 
 struct SessionView: View {
     /// Space reserved when tracking info, secondary controls, and thumb-reach holds are visible.
-    private static let bottomOverlayReserveWithControls: CGFloat = 348
+    private static let bottomOverlayReserveWithControls: CGFloat = 300
     /// Minimum vertical hit target for hold-to-track controls (Apple HIG ~44pt+).
     private static let thumbReachHoldMinHeight: CGFloat = 56
+    /// Minimum tap target for sound toggles (Apple HIG 44pt).
+    private static let soundToggleMinSize: CGFloat = 44
 
     let appVM: AppViewModel
     @State private var vm: SessionViewModel
     @State private var showSaveError = false
+    @State private var showCaptureHelper = false
     @State private var attentionManager = AttentionTrackingManager()
 
     init(appVM: AppViewModel, sessionType: SessionType = .standard, track: Track = .primary) {
@@ -69,8 +72,17 @@ struct SessionView: View {
                             .tracking(2)
                     }
                     .frame(height: contentHeight)
-                    .padding(.top, SPSpacing.s2)
+                    .padding(.top, SPSpacing.s1)
                 }
+            }
+
+            // Pre-session intro gates the countdown (#560).
+            if vm.showIntroOverlay {
+                SessionIntroOverlayView(
+                    onBegin: { vm.dismissIntroOverlay(dontShowAgain: false) },
+                    onDontShowAgain: { vm.dismissIntroOverlay(dontShowAgain: true) }
+                )
+                .transition(.opacity)
             }
 
             // Bottom chrome: secondary controls above; primary hold targets pinned to thumb-reach zone.
@@ -115,7 +127,11 @@ struct SessionView: View {
             vm.userInteracted()
         }
         .onAppear {
-            vm.start()
+            let skipIntro = ProcessInfo.processInfo.environment["SP_UI_TEST_MODE"] == "1"
+            vm.prepareSession(
+                introHiddenPermanently: SessionIntroPrefs.isIntroOverlayHidden,
+                skipIntroForUITest: skipIntro
+            )
             if appVM.currentUser?.attentionTrackingEnabled == true {
                 attentionManager.start { vm.elapsed }
             }
@@ -275,7 +291,7 @@ struct SessionView: View {
         vm.isActive && !vm.controlsVisible
     }
 
-    /// Status + hints above the thumb zone; hold controls live in `thumbReachHoldControls`.
+    /// Status + capture action above the thumb zone; hold controls live in `thumbReachHoldControls`.
     private var sessionTrackingInfoBar: some View {
         VStack(spacing: SPSpacing.s2) {
             HStack(spacing: SPSpacing.s2) {
@@ -318,42 +334,46 @@ struct SessionView: View {
             }
             .padding(.horizontal, SPSpacing.s3)
 
-            if appVM.appBlockingManager.hasSelection {
-                Text("Complete the timer to open your selected app gate. Ending early keeps those apps held.")
-                    .font(SPFont.mono(10))
-                    .foregroundStyle(Color(SPColor.fg4))
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, SPSpacing.s4)
-            }
-
-            Text("Hold a button, or hold Space (light distraction) or Comma (hyperfocus) on an external keyboard.")
-                .font(SPFont.mono(10))
-                .foregroundStyle(Color(SPColor.fg4))
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, SPSpacing.s4)
-
-            Text("Light distraction holds only log segments. Use explicit capture paths to save notes.")
-                .font(SPFont.mono(10))
-                .foregroundStyle(Color(SPColor.fg4))
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, SPSpacing.s4)
-
             if !vm.showPostDistractionCapture, vm.isActive || vm.isPaused {
-                Button {
-                    vm.openThoughtCapture()
-                } label: {
-                    Text("Capture")
-                        .font(SPFont.mono(12, weight: .medium))
-                        .spCapsuleButtonStyle(.amber, size: .compact, minHeight: 44)
+                HStack(spacing: SPSpacing.s1) {
+                    Button {
+                        vm.openThoughtCapture()
+                    } label: {
+                        Text("Capture intrusive thought")
+                            .font(SPFont.mono(12, weight: .medium))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.75)
+                            .spCapsuleButtonStyle(.amber, size: .fullWidth, minHeight: 44)
+                    }
+                    .accessibilityIdentifier("session.captureButton")
+
+                    Button {
+                        showCaptureHelper = true
+                    } label: {
+                        Image(systemName: "info.circle")
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundStyle(Color(SPColor.fg4))
+                            .frame(width: Self.soundToggleMinSize, height: Self.soundToggleMinSize)
+                            .contentShape(Rectangle())
+                    }
+                    .accessibilityLabel("Capture intrusive thought help")
+                    .accessibilityIdentifier("session.captureHelperButton")
+                    .popover(isPresented: $showCaptureHelper, arrowEdge: .bottom) {
+                        Text("Tap to save a note about what you were thinking. Hold buttons only log awareness segments — they do not save notes.")
+                            .font(SPFont.serif(14, weight: .light))
+                            .foregroundStyle(Color(SPColor.fg2))
+                            .padding(SPSpacing.s3)
+                            .frame(maxWidth: 280)
+                            .presentationCompactAdaptation(.popover)
+                    }
                 }
-                .accessibilityIdentifier("session.captureButton")
                 .opacity(vm.isActive && !vm.controlsVisible ? 0.48 : 0.88)
                 .animation(.easeInOut(duration: 0.3), value: vm.controlsVisible)
-                .padding(.top, SPSpacing.s1)
+                .padding(.horizontal, SPSpacing.s3)
             }
         }
-        .padding(.top, SPSpacing.s3)
-        .padding(.bottom, SPSpacing.s2)
+        .padding(.top, SPSpacing.s2)
+        .padding(.bottom, SPSpacing.s1)
         .background(
             SPColor.bg.opacity(0.92)
                 .background(.ultraThinMaterial)
@@ -366,7 +386,8 @@ struct SessionView: View {
             Text("\(vm.mindState == "thinking" ? "Release" : "Hold") — light distraction")
                 .font(SPFont.serifItalic(15))
                 .foregroundStyle(Color(SPColor.fg))
-                .multilineTextAlignment(.center)
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
                 .spCapsuleButtonStyle(
                     vm.mindState == "thinking" ? .amber : .green,
                     size: .fullWidth,
@@ -392,7 +413,8 @@ struct SessionView: View {
             Text("\(vm.mindState == "hyperfocus" ? "Release" : "Hold") — hyperfocus")
                 .font(SPFont.serifItalic(15))
                 .foregroundStyle(Color(SPColor.fg))
-                .multilineTextAlignment(.center)
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
                 .padding(.horizontal, SPSpacing.s3)
                 .frame(maxWidth: .infinity, minHeight: Self.thumbReachHoldMinHeight)
                 .background(
@@ -449,6 +471,8 @@ struct SessionView: View {
                 } label: {
                     Text(vm.isPaused ? "Resume" : "Pause")
                         .font(SPFont.mono(12, weight: .medium))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
                         .spCapsuleButtonStyle(.neutral, size: .compact)
                 }
                 .accessibilityIdentifier("session.pauseResumeButton")
@@ -459,6 +483,8 @@ struct SessionView: View {
                 } label: {
                     Text("End Early")
                         .font(SPFont.mono(12, weight: .medium))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
                         .spCapsuleButtonStyle(.neutral, size: .compact)
                 }
                 .accessibilityIdentifier("session.endEarlyButton")
@@ -467,8 +493,10 @@ struct SessionView: View {
                     Button {
                         vm.openThoughtCapture()
                     } label: {
-                        Text("Capture")
+                        Text("Capture intrusive thought")
                             .font(SPFont.mono(12, weight: .medium))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.75)
                             .spCapsuleButtonStyle(.amber, size: .compact)
                     }
                     .accessibilityIdentifier("session.captureButton")
@@ -481,6 +509,8 @@ struct SessionView: View {
                 } label: {
                     Text("+1 min")
                         .font(SPFont.mono(12, weight: .medium))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
                         .spCapsuleButtonStyle(.neutral, size: .compact)
                         .foregroundStyle(Color(SPColor.fg2))
                 }
@@ -493,6 +523,8 @@ struct SessionView: View {
                 } label: {
                     Text("+5 min")
                         .font(SPFont.mono(12, weight: .medium))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
                         .spCapsuleButtonStyle(.neutral, size: .compact)
                         .foregroundStyle(Color(SPColor.fg2))
                 }
@@ -507,6 +539,8 @@ struct SessionView: View {
                 } label: {
                     Text("Abandon")
                         .font(SPFont.mono(12, weight: .medium))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
                         .spCapsuleButtonStyle(.danger, size: .compact)
                 }
                 .accessibilityIdentifier("session.abandonButton")
@@ -538,12 +572,16 @@ struct SessionView: View {
         Button(action: action) {
             HStack(spacing: 4) {
                 Image(systemName: isOn ? "speaker.wave.2.fill" : "speaker.slash.fill")
-                    .font(.system(size: 10))
+                    .font(.system(size: 12))
                 Text(label)
-                    .font(SPFont.mono(10))
+                    .font(SPFont.mono(11))
+                    .lineLimit(1)
             }
             .foregroundStyle(isOn ? Color(SPColor.fg3) : Color(SPColor.fg4))
+            .frame(minWidth: Self.soundToggleMinSize, minHeight: Self.soundToggleMinSize)
+            .contentShape(Rectangle())
         }
+        .accessibilityIdentifier("session.soundToggle.\(label)")
     }
 
     // MARK: - Completion Handler

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -6,6 +6,7 @@ struct SettingsView: View {
     @State private var notificationPrefs = NotificationPreferencesViewModel()
     @State private var isPublic: Bool = false
     @State private var aphorismsEnabled: Bool = false
+    @State private var sessionIntroEnabled: Bool = true
     @State private var attentionTrackingEnabled: Bool = false
     @State private var isUpdating = false
     @State private var isUpdatingAphorisms = false
@@ -91,6 +92,22 @@ struct SettingsView: View {
                     }
                     .tint(SPColor.green)
                     .accessibilityIdentifier("settings.keepScreenAwakeDuringSessionToggle")
+
+                    Toggle(isOn: $sessionIntroEnabled) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Session intro overlay")
+                                .font(SPFont.mono(13))
+                                .foregroundStyle(Color(SPColor.fg))
+                            Text("Show a brief intro before each session countdown begins")
+                                .font(SPFont.serif(13, weight: .light))
+                                .foregroundStyle(Color(SPColor.fg4))
+                        }
+                    }
+                    .tint(SPColor.green)
+                    .accessibilityIdentifier("settings.sessionIntroToggle")
+                    .onChange(of: sessionIntroEnabled) { _, newValue in
+                        SessionIntroPrefs.setIntroOverlayHidden(!newValue)
+                    }
 
                     Toggle(isOn: $attentionTrackingEnabled) {
                         VStack(alignment: .leading, spacing: 2) {
@@ -331,6 +348,7 @@ struct SettingsView: View {
     private func syncFromCurrentUser() {
         isPublic = appVM.currentUser?.isPublic ?? false
         aphorismsEnabled = appVM.currentUser?.aphorismsEnabled ?? false
+        sessionIntroEnabled = !SessionIntroPrefs.isIntroOverlayHidden
         attentionTrackingEnabled = appVM.currentUser?.attentionTrackingEnabled ?? false
     }
 

--- a/ios/StillPointShared/Sources/StillPointShared/SessionIntroPrefs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/SessionIntroPrefs.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Persists whether the pre-session intro overlay is permanently hidden (#560).
+///
+/// When hidden, the overlay is skipped on every subsequent session until the user
+/// re-enables it from Settings.
+public enum SessionIntroPrefs {
+    /// iOS UserDefaults key (parity with web localStorage naming style).
+    public static let hideIntroOverlayKey = "sp_hideSessionIntroOverlay"
+
+    /// `true` when the user chose "Don't show again" on the session intro overlay.
+    public static var isIntroOverlayHidden: Bool {
+        UserDefaults.standard.bool(forKey: hideIntroOverlayKey)
+    }
+
+    public static func setIntroOverlayHidden(_ hidden: Bool) {
+        UserDefaults.standard.set(hidden, forKey: hideIntroOverlayKey)
+    }
+
+    /// Wipes the persisted intro preference. Used by UI-test reset paths.
+    public static func resetPersistedPrefs() {
+        UserDefaults.standard.removeObject(forKey: hideIntroOverlayKey)
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
@@ -64,6 +64,7 @@ actor UITestAPIStore {
             // `APIClient` are cleared by the client itself via `resetStore`.
             defaults.removeObject(forKey: defaultsKey)
             AudioEngine.resetPersistedPrefs()
+            SessionIntroPrefs.resetPersistedPrefs()
             // Flush the in-memory cache to cfprefsd so the immediately
             // following read sees the cleared state. Issue #266 follow-up.
             defaults.synchronize()

--- a/ios/StillPointShared/Tests/StillPointSharedTests/SessionIntroPrefsTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/SessionIntroPrefsTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import StillPointShared
+
+final class SessionIntroPrefsTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        SessionIntroPrefs.resetPersistedPrefs()
+    }
+
+    override func tearDown() {
+        SessionIntroPrefs.resetPersistedPrefs()
+        super.tearDown()
+    }
+
+    func testDefaultIsNotHidden() {
+        XCTAssertFalse(SessionIntroPrefs.isIntroOverlayHidden)
+    }
+
+    func testSetHiddenPersists() {
+        SessionIntroPrefs.setIntroOverlayHidden(true)
+        XCTAssertTrue(SessionIntroPrefs.isIntroOverlayHidden)
+    }
+
+    func testResetClearsHiddenFlag() {
+        SessionIntroPrefs.setIntroOverlayHidden(true)
+        SessionIntroPrefs.resetPersistedPrefs()
+        XCTAssertFalse(SessionIntroPrefs.isIntroOverlayHidden)
+    }
+
+    func testReEnableAfterHide() {
+        SessionIntroPrefs.setIntroOverlayHidden(true)
+        SessionIntroPrefs.setIntroOverlayHidden(false)
+        XCTAssertFalse(SessionIntroPrefs.isIntroOverlayHidden)
+    }
+}


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #560

## Summary

iOS-only session screen redesign:

- **Intro overlay** gates the countdown until dismissed on every session
- **"Don't show again"** permanently hides the intro (persisted via `SessionIntroPrefs`)
- **Settings → Session intro overlay** toggle re-enables the intro
- **Wider "Capture intrusive thought" button** with info popover helper text
- **Sound toggles** meet ≥44pt tap targets
- **Single-line transport labels** (`lineLimit(1)` + scale factor)
- **Reclaimed top space** by moving verbose hints into the intro overlay and trimming the info bar

No changes to gaze/mic/photo (#562/#563/#564).

## Test Plan

- [ ] Start a session — intro overlay appears before countdown begins
- [ ] Tap **Begin** — overlay dismisses and timer starts
- [ ] Start another session — intro reappears (not permanently dismissed)
- [ ] Tap **Don't show again** — intro skipped on subsequent sessions
- [ ] Settings → **Session intro overlay** ON — intro returns on next session
- [ ] **Capture intrusive thought** button is full-width with info (ⓘ) popover
- [ ] Sound toggles (tick/chime/end) are easy to tap (≥44pt)
- [ ] Transport labels (Pause, End Early, +1 min, etc.) stay on one line
- [ ] Timer/block grid has more vertical room vs. before
- [ ] `swift test` in `ios/StillPointShared` passes locally
- [ ] Existing UI tests pass (intro auto-skipped in `SP_UI_TEST_MODE`)

## Notes

- Intro overlay is auto-skipped when `SP_UI_TEST_MODE=1` so existing E2E tests are unaffected.
- App-target build remains CI-only (local xcodebuild can't parse the project).

**Please review before merge.**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-467860c4-c6b2-427f-a1b9-ffc36567d5bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-467860c4-c6b2-427f-a1b9-ffc36567d5bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Add a pre-session intro overlay and tighten the session screen layout**

### What Changed
- A brief intro now appears before a session starts, and the countdown does not begin until it is dismissed.
- Users can permanently hide the intro with “Don’t show again,” and turn it back on from Settings.
- The session screen now gives more room to the timer area by trimming extra text and reducing chrome spacing.
- The “Capture intrusive thought” action is more prominent and includes a help popover that explains when to use it.
- Sound toggles and several session buttons now have larger tap targets and shorter labels fit on one line.

### Impact
`✅ Fewer accidental session starts`
`✅ Quicker access to capture notes during a session`
`✅ Easier-to-tap sound and control buttons`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
