### PR TITLE
fix(scheduler): defer daily reminders past quiet-hours end (#561)

### DIFF
--- a/src/lib/notification-scheduler.test.ts
+++ b/src/lib/notification-scheduler.test.ts
@@ -395,5 +395,130 @@ describe("notification scheduler", () => {
     expect(sendDailyReminderNotification).toHaveBeenCalledTimes(1);
   });
 
+  describe("quiet-hours boundary (#561)", () => {
+    test("isInQuietHours: overnight end is exclusive at 08:00", async () => {
+      const { isInQuietHours } = await import("./notification-scheduler");
+      const quiet = { start: "22:00", end: "08:00" } as const;
+
+      expect(isInQuietHours(7 * 60 + 59, quiet.start, quiet.end)).toBe(true);
+      expect(isInQuietHours(8 * 60, quiet.start, quiet.end)).toBe(false);
+    });
+
+    test("isInQuietHours: default iOS window 22:00–07:00 treats 07:59 as outside quiet", async () => {
+      const { isInQuietHours } = await import("./notification-scheduler");
+      const quiet = { start: "22:00", end: "07:00" } as const;
+
+      expect(isInQuietHours(6 * 60 + 59, quiet.start, quiet.end)).toBe(true);
+      expect(isInQuietHours(7 * 60, quiet.start, quiet.end)).toBe(false);
+      expect(isInQuietHours(7 * 60 + 59, quiet.start, quiet.end)).toBe(false);
+    });
+
+    test("evaluateReminderDispatchWindow defers a 07:54 reminder until quiet ends at 08:00", async () => {
+      const { evaluateReminderDispatchWindow } = await import("./notification-scheduler");
+      const reminder = 7 * 60 + 54;
+      const quiet = { start: "22:00", end: "08:00" } as const;
+
+      expect(evaluateReminderDispatchWindow(7 * 60 + 54, reminder, quiet.start, quiet.end)).toEqual({
+        due: false,
+        dayOffset: 0,
+      });
+      expect(evaluateReminderDispatchWindow(7 * 60 + 59, reminder, quiet.start, quiet.end)).toEqual({
+        due: false,
+        dayOffset: 0,
+      });
+      expect(evaluateReminderDispatchWindow(8 * 60, reminder, quiet.start, quiet.end)).toEqual({
+        due: true,
+        dayOffset: 0,
+      });
+    });
+
+    test("evaluateReminderDispatchWindow still delivers a 07:59 reminder on the 08:00 tick", async () => {
+      const { evaluateReminderDispatchWindow } = await import("./notification-scheduler");
+      const reminder = 7 * 60 + 59;
+      const quiet = { start: "22:00", end: "08:00" } as const;
+
+      expect(evaluateReminderDispatchWindow(7 * 60 + 59, reminder, quiet.start, quiet.end)).toEqual({
+        due: false,
+        dayOffset: 0,
+      });
+      expect(evaluateReminderDispatchWindow(8 * 60, reminder, quiet.start, quiet.end)).toEqual({
+        due: true,
+        dayOffset: 0,
+      });
+    });
+
+    test("dispatchDueNotifications delivers after quiet hours when the normal window expired (#561)", async () => {
+      preferenceRows = [{
+        ...basePrefs,
+        dailyReminderTime: "07:54",
+        quietHoursStart: "22:00",
+        quietHoursEnd: "08:00",
+      }];
+
+      const { dispatchDueNotifications } = await import("./notification-scheduler");
+
+      const blocked = await dispatchDueNotifications(new Date("2026-05-29T07:59:00.000Z"));
+      expect(blocked.sent).toBe(0);
+      expect(sendDailyReminderNotification).not.toHaveBeenCalled();
+
+      const delivered = await dispatchDueNotifications(new Date("2026-05-29T08:00:00.000Z"));
+      expect(delivered.sent).toBe(1);
+      expect(sendDailyReminderNotification).toHaveBeenCalledTimes(1);
+    });
+
+    test("dispatchDueNotifications does not defer past CRON_WINDOW_MINUTES after quiet end", async () => {
+      preferenceRows = [{
+        ...basePrefs,
+        dailyReminderTime: "07:45",
+        quietHoursStart: "22:00",
+        quietHoursEnd: "08:00",
+      }];
+
+      const { dispatchDueNotifications } = await import("./notification-scheduler");
+      const result = await dispatchDueNotifications(new Date("2026-05-29T08:06:00.000Z"));
+
+      expect(result.sent).toBe(0);
+      expect(sendDailyReminderNotification).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("America/New_York DST (#561)", () => {
+    test("dispatchDueNotifications matches 08:00 local on spring-forward day", async () => {
+      preferenceRows = [{ ...basePrefs, tz: "America/New_York", dailyReminderTime: "08:00" }];
+      const { dispatchDueNotifications } = await import("./notification-scheduler");
+      // 2026-03-08 08:02 EDT (UTC-4 after 2 AM spring-forward) = 12:02 UTC
+      const result = await dispatchDueNotifications(new Date("2026-03-08T12:02:00.000Z"));
+
+      expect(result.sent).toBe(1);
+      expect(sendDailyReminderNotification).toHaveBeenCalledTimes(1);
+    });
+
+    test("dispatchDueNotifications matches 08:00 local on fall-back day", async () => {
+      preferenceRows = [{ ...basePrefs, tz: "America/New_York", dailyReminderTime: "08:00" }];
+      const { dispatchDueNotifications } = await import("./notification-scheduler");
+      // 2026-11-01 08:02 EST (UTC-5 after 2 AM fall-back) = 13:02 UTC
+      const result = await dispatchDueNotifications(new Date("2026-11-01T13:02:00.000Z"));
+
+      expect(result.sent).toBe(1);
+      expect(sendDailyReminderNotification).toHaveBeenCalledTimes(1);
+    });
+
+    test("quiet-hours deferral works in America/New_York across DST", async () => {
+      preferenceRows = [{
+        ...basePrefs,
+        tz: "America/New_York",
+        dailyReminderTime: "07:54",
+        quietHoursStart: "22:00",
+        quietHoursEnd: "08:00",
+      }];
+      const { dispatchDueNotifications } = await import("./notification-scheduler");
+      // 2026-03-08 08:00 EDT = 12:00 UTC
+      const result = await dispatchDueNotifications(new Date("2026-03-08T12:00:00.000Z"));
+
+      expect(result.sent).toBe(1);
+      expect(sendDailyReminderNotification).toHaveBeenCalledTimes(1);
+    });
+  });
+
 
 });

--- a/src/lib/notification-scheduler.ts
+++ b/src/lib/notification-scheduler.ts
@@ -126,7 +126,7 @@ function isWithinCronWindow(
   return { within: true, dayOffset };
 }
 
-function isInQuietHours(
+export function isInQuietHours(
   localMinutes: number,
   quietStart: string | null,
   quietEnd: string | null,
@@ -143,6 +143,46 @@ function isInQuietHours(
     return localMinutes >= start && localMinutes < end;
   }
   return localMinutes >= start || localMinutes < end;
+}
+
+/**
+ * Whether a daily/miss-a-day cron tick should dispatch for the user's reminder time.
+ *
+ * Quiet hours suppress delivery while the run is inside the configured range. When
+ * the reminder itself falls during quiet hours, the window extends to
+ * CRON_WINDOW_MINUTES after quiet ends so a morning reminder blocked at 07:54 is
+ * still delivered at 08:00 rather than permanently dropped once delta exceeds the
+ * normal 5-minute window.
+ */
+export function evaluateReminderDispatchWindow(
+  localMinutes: number,
+  reminderMinutes: number,
+  quietStart: string | null,
+  quietEnd: string | null,
+): { due: boolean; dayOffset: 0 | -1 } {
+  if (isInQuietHours(localMinutes, quietStart, quietEnd)) {
+    return { due: false, dayOffset: 0 };
+  }
+
+  const window = isWithinCronWindow(localMinutes, reminderMinutes);
+  if (window.within) {
+    return { due: true, dayOffset: window.dayOffset };
+  }
+
+  if (!quietStart || !quietEnd || !isInQuietHours(reminderMinutes, quietStart, quietEnd)) {
+    return { due: false, dayOffset: 0 };
+  }
+
+  const quietEndMinutes = parseReminderMinutes(quietEnd);
+  const dayMinutes = 24 * 60;
+  const deltaFromQuietEnd = (localMinutes - quietEndMinutes + dayMinutes) % dayMinutes;
+  if (deltaFromQuietEnd > CRON_WINDOW_MINUTES) {
+    return { due: false, dayOffset: 0 };
+  }
+
+  const delta = (localMinutes - reminderMinutes + dayMinutes) % dayMinutes;
+  const dayOffset: 0 | -1 = delta > 0 && localMinutes < reminderMinutes ? -1 : 0;
+  return { due: true, dayOffset };
 }
 
 function frequencyAllowsSend(
@@ -353,8 +393,13 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
 
       const reminderMinutes = parseReminderMinutes(prefs.dailyReminderTime);
 
-      const { within, dayOffset } = isWithinCronWindow(local.minutesSinceMidnight, reminderMinutes);
-      if (!within) {
+      const { due, dayOffset } = evaluateReminderDispatchWindow(
+        local.minutesSinceMidnight,
+        reminderMinutes,
+        prefs.quietHoursStart,
+        prefs.quietHoursEnd,
+      );
+      if (!due) {
         skipped += 1;
         continue;
       }
@@ -364,11 +409,6 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
       // Using it as the dispatch windowKey anchors deduplication to the reminder's intended
       // date rather than the run's date, preventing duplicate sends at midnight boundaries.
       const intendedDateKey = addCalendarDays(local.dateKey, dayOffset);
-
-      if (isInQuietHours(local.minutesSinceMidnight, prefs.quietHoursStart, prefs.quietHoursEnd)) {
-        skipped += 1;
-        continue;
-      }
 
       if (prefs.missADayEnabled) {
         const yesterday = addCalendarDays(intendedDateKey, -1);


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes daily reminder non-delivery for users whose reminder time falls in the last ~10 minutes before quiet hours end (e.g. `07:54` with quiet hours `22:00`–`08:00`).

**Root cause:** The scheduler checked quiet hours at cron-run time and skipped delivery while inside quiet hours. Once quiet hours ended, the normal 5-minute cron window had already expired (`delta > 5`), so the reminder was permanently dropped — never reaching APNs/device-token delivery.

**Fix:** New `evaluateReminderDispatchWindow()` defers reminders that fall *during* quiet hours until the first cron ticks after quiet ends (up to `CRON_WINDOW_MINUTES` past quiet end), without changing behavior for reminders outside quiet hours.

Closes #561

## End-to-end trace

| Stage | Finding |
|-------|---------|
| **Vercel cron** (`*/5 * * * *` → `/api/cron/dispatch-notifications`) | Working — fires every 5 min with `CRON_SECRET` auth |
| **Window match** (`isWithinCronWindow`) | Working — inclusive 5-min bound (#440) |
| **Quiet-hours boundary** | **Bug** — 07:50–07:54 reminders blocked during quiet, then missed at 08:00 because `delta=6 > 5` |
| **APNs / device token** | Working when scheduler dispatches — no changes needed |

## Changes

- `src/lib/notification-scheduler.ts`
  - Export `isInQuietHours` (unchanged boundary semantics: end exclusive)
  - Add `evaluateReminderDispatchWindow` with quiet-hours deferral
  - Replace separate window + quiet-hours checks in `dispatchDueNotifications`
- `src/lib/notification-scheduler.test.ts`
  - Quiet-hours boundary: `07:59` inside / `08:00` outside for `22:00`–`08:00`
  - Default iOS window `22:00`–`07:00`: `07:59` is outside quiet
  - Deferred delivery: `07:54` reminder delivers at `08:00` tick
  - Deferral cap: `07:45` reminder does **not** deliver at `08:06`
  - America/New_York DST: spring-forward (2026-03-08) and fall-back (2026-11-01) at `08:00` local

## Test Plan

- [x] `npm ci`
- [x] `npm run typecheck` (`tsc --noEmit`) — clean
- [x] `npm run test:unit` — 566 tests pass (vitest excludes `**/.claude/**`)
- [ ] Manual: set reminder `07:54`, quiet hours `22:00`–`08:00`, confirm push arrives ~08:00 local
- [ ] Manual: set reminder `08:00`, quiet hours `22:00`–`08:00`, confirm push arrives at 08:00 local
- [ ] Manual: verify no double-send across 08:00 and 08:05 ticks (idempotency via `claimNotificationDispatch`)

**Please review and confirm before merge.**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb037b5b-4627-4db4-bcbd-33bfe53a8b78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb037b5b-4627-4db4-bcbd-33bfe53a8b78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Keep daily reminders from being dropped at the end of quiet hours**

### What Changed
- Daily reminders that fall during quiet hours are now sent on the first cron run after quiet hours end, instead of being skipped once the normal delivery window expires
- Reminders still stay silent during quiet hours, and delivery still stops after the normal cron window outside that case
- Added coverage for quiet-hours boundaries and DST changes in New York so reminders still go out at the expected local time

### Impact
`✅ Fewer missed morning reminders`
`✅ Clearer quiet-hours behavior`
`✅ Reliable reminder delivery across DST`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
