### PR TITLE
fix: advance currentDay on final recovery step to unblock standard-sit progression (#559)

### DIFF
--- a/ios/StillPointShared/Tests/StillPointSharedTests/SharedFixtures.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/SharedFixtures.swift
@@ -135,6 +135,28 @@ struct BuddyCalendarColorsFixture: Decodable {
     let cases: [Case]
 }
 
+struct DurationForDayFixture: Decodable {
+    struct Constants: Decodable {
+        let baseDuration: Int
+        let increment: Int
+        let maxDuration: Int
+        let forkDay: Int
+        let recoveryMaxSteps: Int
+        let missedDayGapThreshold: Int
+    }
+    struct DurationCase: Decodable {
+        let day: Int
+        let expected: Int
+    }
+    struct EligibilityCase: Decodable {
+        let currentDay: Int
+        let expected: Bool
+    }
+    let constants: Constants
+    let durationForDay: [DurationCase]
+    let isDualTrackEligible: [EligibilityCase]
+}
+
 // MARK: - Fixture -> SessionDTO helpers
 
 extension HistoryJourneyFixture.Session {

--- a/ios/StillPointShared/Tests/StillPointSharedTests/StillPointDurationTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/StillPointDurationTests.swift
@@ -58,6 +58,31 @@ final class StillPointDurationTests: XCTestCase {
         XCTAssertEqual(StillPoint.advanceSecondTrackDay(sessionType: .standard, completed: false, secondTrackDay: 3), 3)
     }
 
+    // MARK: - Shared fixtures (#540/#421)
+
+    func testDurationForDaySharedFixture() throws {
+        let fixture = try SharedFixtures.load("durationForDay.json", as: DurationForDayFixture.self)
+
+        XCTAssertEqual(fixture.constants.forkDay, StillPoint.forkDay)
+        XCTAssertEqual(fixture.constants.maxDuration, StillPoint.maxDuration)
+
+        for testCase in fixture.durationForDay {
+            XCTAssertEqual(
+                StillPoint.duration(forDay: testCase.day),
+                testCase.expected,
+                "durationForDay day \(testCase.day)"
+            )
+        }
+
+        for testCase in fixture.isDualTrackEligible {
+            XCTAssertEqual(
+                StillPoint.isDualTrackEligible(currentDay: testCase.currentDay),
+                testCase.expected,
+                "isDualTrackEligible currentDay \(testCase.currentDay)"
+            )
+        }
+    }
+
     // Note: invalid days (`< 1`) are tested via `clampedCurrentDay(for:)` below.
     // Calling `duration(forDay:)` with `< 1` traps the debug `assert` in the
     // test runner (intended dev behavior); production builds survive via the

--- a/shared/test-fixtures/README.md
+++ b/shared/test-fixtures/README.md
@@ -15,6 +15,7 @@ implementations breaks CI on at least one platform.
 | `breathCounting.json` | `breathCountForTaps` / `phaseForTaps` / `elapsedDisplay` (`src/lib/breathCounting.ts`) | `BreathCounting.breathCount` / `phase` / `elapsedDisplay` (`BreathCountingLogic.swift`) |
 | `aphorisms.json` | `aphorismForDay` (`src/lib/aphorisms.ts`) | `Aphorisms.forDay` (`Aphorisms.swift`) |
 | `buddyCalendarColors.json` | `buddyColorFromUserId` (`src/lib/buddyCalendarColors.ts`) | `buddyColorIndexFromUserId` (`BuddyCalendarColors.swift`) |
+| `durationForDay.json` | `durationForDay` / `isDualTrackEligible` (`src/lib/constants.ts`, `src/lib/duration.ts`) | `StillPoint.duration(forDay:)` / `isDualTrackEligible` (`Constants.swift`). `advanceProgression` and `detectMissedDayGap` cases are web-only until iOS recovery parity (#524). |
 
 ## How each suite loads them
 

--- a/shared/test-fixtures/durationForDay.json
+++ b/shared/test-fixtures/durationForDay.json
@@ -1,0 +1,83 @@
+{
+  "algorithm": "durationAndProgression",
+  "description": "Golden values for durationForDay, advanceProgression, and detectMissedDayGap. Web src/lib/duration.ts + src/lib/constants.ts and iOS StillPointShared/Constants.swift share durationForDay; advanceProgression and detectMissedDayGap are web-only until iOS recovery parity (#524). Includes cap/fork-day (#240) and missed-day recovery cases (#238/#559).",
+  "constants": {
+    "baseDuration": 60,
+    "increment": 10,
+    "maxDuration": 600,
+    "forkDay": 55,
+    "recoveryMaxSteps": 5,
+    "missedDayGapThreshold": 2
+  },
+  "durationForDay": [
+    { "day": 1, "expected": 60 },
+    { "day": 2, "expected": 70 },
+    { "day": 45, "expected": 500 },
+    { "day": 46, "expected": 510 },
+    { "day": 54, "expected": 590 },
+    { "day": 55, "expected": 600 },
+    { "day": 56, "expected": 600 },
+    { "day": 200, "expected": 600 }
+  ],
+  "isDualTrackEligible": [
+    { "currentDay": 1, "expected": false },
+    { "currentDay": 55, "expected": false },
+    { "currentDay": 56, "expected": true }
+  ],
+  "advanceProgression": [
+    {
+      "name": "completed standard sit outside recovery bumps currentDay",
+      "sessionType": "standard",
+      "completed": true,
+      "state": { "currentDay": 45, "recoveryTargetDay": null, "recoveryCurrentStep": null, "recoveryTotalSteps": null },
+      "expected": { "currentDay": 46, "recoveryTargetDay": null, "recoveryCurrentStep": null, "recoveryTotalSteps": null }
+    },
+    {
+      "name": "mid-recovery step leaves currentDay frozen",
+      "sessionType": "standard",
+      "completed": true,
+      "state": { "currentDay": 45, "recoveryTargetDay": 45, "recoveryCurrentStep": 2, "recoveryTotalSteps": 5 },
+      "expected": { "currentDay": 45, "recoveryTargetDay": 45, "recoveryCurrentStep": 3, "recoveryTotalSteps": 5 }
+    },
+    {
+      "name": "final recovery step clears recovery and advances currentDay (#559)",
+      "sessionType": "standard",
+      "completed": true,
+      "state": { "currentDay": 45, "recoveryTargetDay": 45, "recoveryCurrentStep": 5, "recoveryTotalSteps": 5 },
+      "expected": { "currentDay": 46, "recoveryTargetDay": null, "recoveryCurrentStep": null, "recoveryTotalSteps": null }
+    },
+    {
+      "name": "quick sit never advances",
+      "sessionType": "quick",
+      "completed": true,
+      "state": { "currentDay": 45, "recoveryTargetDay": null, "recoveryCurrentStep": null, "recoveryTotalSteps": null },
+      "expected": { "currentDay": 45, "recoveryTargetDay": null, "recoveryCurrentStep": null, "recoveryTotalSteps": null }
+    }
+  ],
+  "detectMissedDayGap": [
+    {
+      "name": "no gap with one calendar day between sits",
+      "lastCompletedSessionDate": "2026-06-10",
+      "todayIso": "2026-06-11",
+      "currentDay": 45,
+      "recovery": { "recoveryTargetDay": null, "recoveryCurrentStep": null, "recoveryTotalSteps": null },
+      "expected": null
+    },
+    {
+      "name": "2+ day gap starts recovery at currentDay",
+      "lastCompletedSessionDate": "2026-06-09",
+      "todayIso": "2026-06-11",
+      "currentDay": 45,
+      "recovery": { "recoveryTargetDay": null, "recoveryCurrentStep": null, "recoveryTotalSteps": null },
+      "expected": { "recoveryTargetDay": 45, "recoveryCurrentStep": 1, "recoveryTotalSteps": 5 }
+    },
+    {
+      "name": "already recovering does not restart ramp",
+      "lastCompletedSessionDate": "2026-05-01",
+      "todayIso": "2026-06-11",
+      "currentDay": 45,
+      "recovery": { "recoveryTargetDay": 45, "recoveryCurrentStep": 3, "recoveryTotalSteps": 5 },
+      "expected": null
+    }
+  ]
+}

--- a/src/app/api/sessions/route.recovery.integration.test.ts
+++ b/src/app/api/sessions/route.recovery.integration.test.ts
@@ -127,7 +127,7 @@ describe("POST /api/sessions — miss-a-day recovery progression (#238)", () => 
     expect(row!.recoveryTotalSteps).toBe(5);
   });
 
-  test("completing the final recovery step clears recovery and leaves currentDay at the prior level", async () => {
+  test("completing the final recovery step clears recovery and advances currentDay (#559)", async () => {
     const user = await makeUser({
       currentDay: 11,
       recoveryTargetDay: 11,
@@ -140,10 +140,39 @@ describe("POST /api/sessions — miss-a-day recovery progression (#238)", () => 
     expect(res.status).toBe(200);
 
     const [row] = await db.select().from(users).where(eq(users.id, user.id));
-    expect(row!.currentDay).toBe(11);
+    expect(row!.currentDay).toBe(12);
     expect(row!.recoveryTargetDay).toBeNull();
     expect(row!.recoveryCurrentStep).toBeNull();
     expect(row!.recoveryTotalSteps).toBeNull();
+  });
+
+  test("repeated gap cycles advance past day 45 instead of livelocking at 500s (#559)", async () => {
+    const user = await makeUser({ currentDay: 45 });
+    getCurrentUser.mockResolvedValue({ userId: user.id, email: user.email });
+
+    for (let step = 1; step <= 5; step++) {
+      await db.update(users).set({
+        recoveryTargetDay: 45,
+        recoveryCurrentStep: step,
+        recoveryTotalSteps: 5,
+      }).where(eq(users.id, user.id));
+
+      const res = await POST(sessionRequest(baseSessionBody({
+        dayNumber: 45,
+        sessionDate: `2026-06-${String(step).padStart(2, "0")}`,
+      })));
+      expect(res.status).toBe(200);
+    }
+
+    const [afterRecovery] = await db.select().from(users).where(eq(users.id, user.id));
+    expect(afterRecovery!.currentDay).toBe(46);
+    expect(afterRecovery!.recoveryTargetDay).toBeNull();
+
+    const res = await POST(sessionRequest(baseSessionBody({ dayNumber: 46, sessionDate: "2026-06-10" })));
+    expect(res.status).toBe(200);
+
+    const [afterNormal] = await db.select().from(users).where(eq(users.id, user.id));
+    expect(afterNormal!.currentDay).toBe(47);
   });
 
   test("the session immediately after recovery clears resumes normal +1 progression", async () => {

--- a/src/db/atomic.ts
+++ b/src/db/atomic.ts
@@ -536,7 +536,9 @@ function progressionUpdateSql(shouldAdvance: boolean, track: Track) {
   return sql`
     current_day = case
       when not ${shouldAdvance} or ${track} <> 'primary' then u.current_day
-      when ${activeRecoverySql} then u.current_day
+      when ${activeRecoverySql}
+        and u.recovery_current_step + 1 <= u.recovery_total_steps
+      then u.current_day
       else u.current_day + 1
     end,
     recovery_target_day = case

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -38,8 +38,8 @@ export const users = pgTable("users", {
   /** #238: miss-a-day recovery ramp. Nullable trio — all three are set together when a
    *  2+ day gap is detected (`/api/auth/me`) and cleared together once the ramp finishes.
    *  `recoveryTargetDay` freezes the pre-miss `currentDay` (the level to ramp back to);
-   *  `currentDay` itself is left untouched during recovery so the first fully-recovered
-   *  session naturally lands back on that level via `durationForDay(currentDay)`. */
+   *  `currentDay` is frozen mid-ramp but advances by one when the final recovery step
+   *  completes (#559), preventing sparse sitters from livelocking below the cap. */
   recoveryTargetDay: integer("recovery_target_day"),
   recoveryCurrentStep: integer("recovery_current_step"),
   recoveryTotalSteps: integer("recovery_total_steps"),

--- a/src/lib/duration.test.ts
+++ b/src/lib/duration.test.ts
@@ -10,7 +10,9 @@ import {
   recoveryTotalStepsFor,
   sessionDurationForUser,
   startRecovery,
+  type ProgressionState,
 } from "./duration";
+import { loadSharedFixture, type DurationForDayFixture } from "./testing/sharedFixtures";
 
 const NO_RECOVERY = { recoveryTargetDay: null, recoveryCurrentStep: null, recoveryTotalSteps: null };
 
@@ -263,10 +265,10 @@ describe("advanceProgression", () => {
     });
   });
 
-  test("completing the final recovery step clears recovery and leaves currentDay at the prior level", () => {
+  test("completing the final recovery step clears recovery and advances currentDay (#559)", () => {
     const state = { currentDay: 11, recoveryTargetDay: 11, recoveryCurrentStep: 5, recoveryTotalSteps: 5 };
     expect(advanceProgression("standard", true, state)).toEqual({
-      currentDay: 11,
+      currentDay: 12,
       recoveryTargetDay: null,
       recoveryCurrentStep: null,
       recoveryTotalSteps: null,
@@ -279,12 +281,88 @@ describe("advanceProgression", () => {
   });
 
   test("after recovery clears, the next completed session resumes normal progression", () => {
-    const cleared = { currentDay: 11, recoveryTargetDay: null, recoveryCurrentStep: null, recoveryTotalSteps: null };
+    const cleared = { currentDay: 12, recoveryTargetDay: null, recoveryCurrentStep: null, recoveryTotalSteps: null };
     expect(advanceProgression("standard", true, cleared)).toEqual({
-      currentDay: 12,
+      currentDay: 13,
       recoveryTargetDay: null,
       recoveryCurrentStep: null,
       recoveryTotalSteps: null,
     });
+  });
+
+  test("repeated miss gaps after recovery no longer stall progression (#559)", () => {
+    let state: ProgressionState = { currentDay: 45, ...NO_RECOVERY };
+
+    const completeRecoveryCycle = () => {
+      state = {
+        ...state,
+        recoveryTargetDay: state.currentDay,
+        recoveryCurrentStep: 1,
+        recoveryTotalSteps: 5,
+      };
+      for (let step = 1; step <= 5; step++) {
+        state = { ...state, recoveryCurrentStep: step };
+        state = advanceProgression("standard", true, state);
+      }
+    };
+
+    completeRecoveryCycle();
+    expect(state.currentDay).toBe(46);
+    expect(activeRecovery(state)).toBeNull();
+
+    const gapRecovery = detectMissedDayGap({
+      lastCompletedSessionDate: "2026-06-01",
+      todayIso: "2026-06-04",
+      currentDay: state.currentDay,
+      recovery: state,
+    });
+    expect(gapRecovery).toEqual({
+      recoveryTargetDay: 46,
+      recoveryCurrentStep: 1,
+      recoveryTotalSteps: 5,
+    });
+
+    state = { ...state, ...gapRecovery! };
+    completeRecoveryCycle();
+    expect(state.currentDay).toBe(47);
+    expect(durationForDay(state.currentDay)).toBe(520);
+  });
+
+  test("cap-boundary progression climbs past 500s toward 600s after recovery", () => {
+    let state: ProgressionState = { currentDay: 54, ...NO_RECOVERY };
+    expect(durationForDay(state.currentDay)).toBe(590);
+
+    state = advanceProgression("standard", true, state);
+    expect(state.currentDay).toBe(55);
+    expect(durationForDay(state.currentDay)).toBe(MAX_DURATION);
+
+    state = advanceProgression("standard", true, state);
+    expect(state.currentDay).toBe(56);
+    expect(durationForDay(state.currentDay)).toBe(MAX_DURATION);
+  });
+});
+
+describe("duration + progression — shared fixtures (#540/#421)", () => {
+  const fixture = loadSharedFixture<DurationForDayFixture>("durationForDay.json");
+
+  test("constants match implementation", () => {
+    expect(fixture.constants.forkDay).toBe(FORK_DAY);
+    expect(fixture.constants.maxDuration).toBe(MAX_DURATION);
+  });
+
+  test.each(fixture.durationForDay)("durationForDay day $day", ({ day, expected }) => {
+    expect(durationForDay(day)).toBe(expected);
+  });
+
+  test.each(fixture.isDualTrackEligible)("isDualTrackEligible currentDay $currentDay", ({ currentDay, expected }) => {
+    expect(isDualTrackEligible(currentDay)).toBe(expected);
+  });
+
+  test.each(fixture.advanceProgression)("$name", ({ sessionType, completed, state, expected }) => {
+    expect(advanceProgression(sessionType, completed, state)).toEqual(expected);
+  });
+
+  test.each(fixture.detectMissedDayGap)("$name", ({ lastCompletedSessionDate, todayIso, currentDay, recovery, expected }) => {
+    expect(detectMissedDayGap({ lastCompletedSessionDate, todayIso, currentDay, recovery })).toEqual(expected);
   });
 });

--- a/src/lib/duration.ts
+++ b/src/lib/duration.ts
@@ -6,9 +6,9 @@
  *
  * Recovery model: missing 2+ calendar days freezes `recoveryTargetDay` at the
  * pre-miss `currentDay` (the level to ramp back to) and starts a step counter.
- * `currentDay` itself is left untouched for the whole ramp, so once the final
- * recovery step completes and the recovery columns clear, the very next session
- * naturally lands back on `durationForDay(currentDay)` — the prior level.
+ * `currentDay` is frozen mid-ramp but advances by one when the final recovery
+ * step completes (#559), so sparse sitters are not stuck re-entering recovery at
+ * the same day forever before they can climb toward the 10-minute cap.
  */
 import { BASE_DURATION, FORK_DAY, QUICK_DURATION, durationForDay, shouldAdvanceDay, type SessionType } from "./constants";
 import { daysBetweenIsoDatesInclusive } from "./sessionCalendar";
@@ -62,10 +62,9 @@ export function recoveryTotalStepsFor(targetDay: number): number {
 /**
  * Duration (seconds) for a given recovery step (1-indexed). Step 1 is always exactly
  * `BASE_DURATION` (the "reset to 1 minute" session immediately after the miss); later
- * steps ramp linearly by `difference / totalSteps` seconds. The session that follows
- * the final recovery step is no longer "in recovery" — it uses the normal
- * `durationForDay(targetDay)` via `activeRecovery` returning `null`, landing exactly
- * back on the prior duration.
+ * steps ramp linearly by `difference / totalSteps` seconds. Completing the final
+ * recovery step clears recovery and advances `currentDay` by one (#559), so the
+ * next standard sit uses `durationForDay(currentDay)` at the newly earned level.
  */
 export function recoveryStepDuration(targetDay: number, totalSteps: number, step: number): number {
   if (totalSteps <= 0) return BASE_DURATION;
@@ -124,8 +123,8 @@ export function detectMissedDayGap(params: {
  * Advances progression after a session save — the shared replacement for the old
  * "always bump currentDay" rule. Non-advancing sessions (quick sits, incomplete
  * standard sits) return `state` unchanged. A completed standard sit either steps
- * the recovery ramp forward (clearing it once the final step is done, leaving
- * `currentDay` untouched) or, outside recovery, bumps `currentDay` by one as before.
+ * the recovery ramp forward (clearing it and bumping `currentDay` once the final
+ * step is done) or, outside recovery, bumps `currentDay` by one as before.
  */
 export function advanceProgression(
   sessionType: SessionType,
@@ -139,7 +138,7 @@ export function advanceProgression(
     const nextStep = active.recoveryCurrentStep + 1;
     const stillRecovering = nextStep <= active.recoveryTotalSteps;
     return {
-      currentDay: state.currentDay,
+      currentDay: stillRecovering ? state.currentDay : state.currentDay + 1,
       recoveryTargetDay: stillRecovering ? active.recoveryTargetDay : null,
       recoveryCurrentStep: stillRecovering ? nextStep : null,
       recoveryTotalSteps: stillRecovering ? active.recoveryTotalSteps : null,

--- a/src/lib/testing/sharedFixtures.ts
+++ b/src/lib/testing/sharedFixtures.ts
@@ -94,3 +94,49 @@ export type BuddyCalendarColorsFixture = {
   palette: string[];
   cases: Array<{ userId: string; expectedIndex: number; expectedHex: string }>;
 };
+
+export type DurationForDayFixture = {
+  constants: {
+    baseDuration: number;
+    increment: number;
+    maxDuration: number;
+    forkDay: number;
+    recoveryMaxSteps: number;
+    missedDayGapThreshold: number;
+  };
+  durationForDay: Array<{ day: number; expected: number }>;
+  isDualTrackEligible: Array<{ currentDay: number; expected: boolean }>;
+  advanceProgression: Array<{
+    name: string;
+    sessionType: "standard" | "quick" | "breath";
+    completed: boolean;
+    state: {
+      currentDay: number;
+      recoveryTargetDay: number | null;
+      recoveryCurrentStep: number | null;
+      recoveryTotalSteps: number | null;
+    };
+    expected: {
+      currentDay: number;
+      recoveryTargetDay: number | null;
+      recoveryCurrentStep: number | null;
+      recoveryTotalSteps: number | null;
+    };
+  }>;
+  detectMissedDayGap: Array<{
+    name: string;
+    lastCompletedSessionDate: string | null;
+    todayIso: string;
+    currentDay: number;
+    recovery: {
+      recoveryTargetDay: number | null;
+      recoveryCurrentStep: number | null;
+      recoveryTotalSteps: number | null;
+    };
+    expected: {
+      recoveryTargetDay: number;
+      recoveryCurrentStep: number;
+      recoveryTotalSteps: number;
+    } | null;
+  }>;
+};


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #559 — standard-sit progression stuck at 500s (day 45) instead of climbing toward the 600s cap.

**Root cause:** Miss-a-day recovery (#238) left `currentDay` unchanged when the final recovery step completed. Sparse sitters who hit another 2+ day gap before their post-ramp landing sit re-entered recovery at the same day forever — a livelock at 500s.

**Fix:** Completing the final recovery step now increments `currentDay` by one in both:
- `advanceProgression()` (`src/lib/duration.ts`) — shared web client preview logic
- `progressionUpdateSql()` (`src/db/atomic.ts`) — authoritative server session-create path (web + iOS)

Dual-track (#240) is unaffected: second-track advancement remains independent of primary `currentDay`.

## Tests

- Updated recovery integration tests (`route.recovery.integration.test.ts`)
- Added livelock regression + cap-boundary unit tests (`duration.test.ts`)
- Added `shared/test-fixtures/durationForDay.json` with duration, fork-day, missed-day gap, and advancement golden cases (#540/#81)
- Wired web vitest + iOS XCTest parity for `durationForDay` / `isDualTrackEligible` cases

## Verification

- `npm ci`
- `npm run test:unit` — 579 passed
- `npm run typecheck` — clean

## Notes

- iOS still does not decode recovery fields or show recovery ramp durations (#524) — separate follow-up; this PR fixes the server-side livelock that affects both platforms.
- **Please review before merge** — do not merge without explicit approval.

Closes #559
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b75d2507-b7b1-4163-9278-a6ae623961e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b75d2507-b7b1-4163-9278-a6ae623961e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Let the final recovery step advance to the next day**

### What Changed
- Finishing the last miss-a-day recovery step now moves `currentDay` forward instead of leaving it unchanged
- This prevents sparse sit schedules from getting stuck repeating recovery at the same day before reaching the 10-minute cap
- Added regression coverage for the recovery livelock, the cap boundary, and shared duration/progression fixtures used by web and iOS tests

### Impact
`✅ Fewer recovery dead-ends`
`✅ Progress past day 45 toward the 10-minute cap`
`✅ Stronger web and iOS progression checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
