### PR TITLE
feat(auth): log cause of google-native identity-token verification failures

### DIFF
--- a/src/app/api/auth/google-native/route.test.ts
+++ b/src/app/api/auth/google-native/route.test.ts
@@ -1,5 +1,5 @@
 import type { NextRequest } from "next/server";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const jwtVerify = vi.fn();
 
@@ -68,6 +68,12 @@ describe("POST /api/auth/google-native", () => {
       },
     ]);
     createToken.mockResolvedValue("jwt-from-createToken");
+  });
+
+  afterEach(() => {
+    // Restores console.error spies even when an assertion throws mid-test;
+    // in Vitest 4 this only affects vi.spyOn spies, not the module vi.fn mocks.
+    vi.restoreAllMocks();
   });
 
   test("returns user + token and sets sp_token cookie on valid id token", async () => {
@@ -180,7 +186,6 @@ describe("POST /api/auth/google-native", () => {
     expect(logged).not.toContain("person@gmail.com");
     expect(logged).not.toContain("google-sub-1");
     expect(logged).not.toContain('unexpected "aud" claim value');
-    consoleError.mockRestore();
   });
 
   test("logs a signature failure distinctly from an aud mismatch", async () => {
@@ -205,7 +210,6 @@ describe("POST /api/auth/google-native", () => {
     expect(logged).toContain("code=ERR_JWS_SIGNATURE_VERIFICATION_FAILED");
     expect(logged).not.toContain("claim=");
     expect(logged).not.toContain("configuredAudiences=");
-    consoleError.mockRestore();
   });
 
   test("returns 401 when email is present but not verified", async () => {

--- a/src/app/api/auth/google-native/route.test.ts
+++ b/src/app/api/auth/google-native/route.test.ts
@@ -146,6 +146,68 @@ describe("POST /api/auth/google-native", () => {
     expect(res.cookies.get("sp_token")).toBeUndefined();
   });
 
+  test("logs an aud-mismatch diagnostic with the configured audience count, never token contents", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const audError = Object.assign(new Error('unexpected "aud" claim value'), {
+      code: "ERR_JWT_CLAIM_VALIDATION_FAILED",
+      claim: "aud",
+      reason: "check_failed",
+      // jose attaches the decoded Claims Set to claim-validation errors; none
+      // of it may reach the log.
+      payload: {
+        aud: "999-rogue.apps.googleusercontent.com",
+        email: "person@gmail.com",
+        sub: "google-sub-1",
+      },
+    });
+    jwtVerify.mockRejectedValueOnce(audError);
+
+    const { POST } = await import("./route");
+    const req = {
+      json: async () => ({ idToken: "header.payload.sig" }),
+    } as unknown as NextRequest;
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toBe("Invalid identity token");
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    const logged = consoleError.mock.calls[0].map(String).join(" ");
+    expect(logged).toContain("claim=aud");
+    expect(logged).toContain("configuredAudiences=2");
+    expect(logged).not.toContain("999-rogue.apps.googleusercontent.com");
+    expect(logged).not.toContain("person@gmail.com");
+    expect(logged).not.toContain("google-sub-1");
+    expect(logged).not.toContain('unexpected "aud" claim value');
+    consoleError.mockRestore();
+  });
+
+  test("logs a signature failure distinctly from an aud mismatch", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const sigError = Object.assign(new Error("signature verification failed"), {
+      code: "ERR_JWS_SIGNATURE_VERIFICATION_FAILED",
+    });
+    jwtVerify.mockRejectedValueOnce(sigError);
+
+    const { POST } = await import("./route");
+    const req = {
+      json: async () => ({ idToken: "header.payload.sig" }),
+    } as unknown as NextRequest;
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toBe("Invalid identity token");
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    const logged = consoleError.mock.calls[0].map(String).join(" ");
+    expect(logged).toContain("code=ERR_JWS_SIGNATURE_VERIFICATION_FAILED");
+    expect(logged).not.toContain("claim=");
+    expect(logged).not.toContain("configuredAudiences=");
+    consoleError.mockRestore();
+  });
+
   test("returns 401 when email is present but not verified", async () => {
     jwtVerify.mockResolvedValue({
       payload: {

--- a/src/app/api/auth/google-native/route.ts
+++ b/src/app/api/auth/google-native/route.ts
@@ -24,6 +24,30 @@ function googleAudiences(): string[] {
     .filter((value): value is string => Boolean(value));
 }
 
+/**
+ * Log why `jwtVerify` rejected an identity token using only jose's stable error
+ * metadata: class name, error `code`, and the failed `claim` when present.
+ * Never log `error.message` or `error.payload` — jose attaches the decoded JWT
+ * Claims Set (aud, email, sub, name) to claim-validation errors, and token
+ * contents must stay out of server logs. For `aud` failures, include how many
+ * audiences the server accepts so a missing/mismatched client-ID env var
+ * (#546) is diagnosable from logs alone — never the token's actual `aud`.
+ */
+function logTokenVerificationFailure(error: unknown): void {
+  const { code, claim } = (error ?? {}) as { code?: unknown; claim?: unknown };
+  const parts = [`error=${error instanceof Error ? error.name : typeof error}`];
+  if (typeof code === "string" && code) {
+    parts.push(`code=${code}`);
+  }
+  if (typeof claim === "string" && claim) {
+    parts.push(`claim=${claim}`);
+    if (claim === "aud") {
+      parts.push(`configuredAudiences=${googleAudiences().length}`);
+    }
+  }
+  console.error(`google-native: identity token verification failed (${parts.join(", ")})`);
+}
+
 type RequestBody = {
   idToken?: string;
   // Optional; included for parity with Google's API and future server-side token
@@ -77,7 +101,8 @@ export const POST = withApiHandler("google-native", async (request: NextRequest)
     if (typeof payload.name === "string" && payload.name.trim()) {
       nameFromToken = payload.name.trim();
     }
-  } catch {
+  } catch (error) {
+    logTokenVerificationFailure(error);
     return NextResponse.json({ error: "Invalid identity token" }, { status: 401 });
   }
 


### PR DESCRIPTION
## **User description**
## Summary

`jwtVerify` failures in `POST /api/auth/google-native` previously vanished into a bare `catch {}` returning a generic `401 "Invalid identity token"` — an audience mismatch (the #546 incident, which took env forensics to diagnose), an expired token, and a bad signature were indistinguishable server-side.

This adds a `console.error` in the verification catch that logs **only jose's stable error metadata**:

- error class name and `code` (`ERR_JWT_CLAIM_VALIDATION_FAILED`, `ERR_JWT_EXPIRED`, `ERR_JWS_SIGNATURE_VERIFICATION_FAILED`, …)
- the failed `claim` when present (`aud` / `iss` / `exp` / …)
- for `aud` failures, the **count** of configured audiences from `googleAudiences()` — so a missing/mismatched `AUTH_GOOGLE_IOS_CLIENT_ID` / `AUTH_GOOGLE_ID` is visible at a glance

It deliberately never logs `error.message` or `error.payload`: jose v6 attaches the decoded JWT Claims Set (`aud`, `email`, `sub`, `name`) to claim-validation errors, so narrow field extraction is what keeps token contents and PII out of logs. Detection duck-types on `code`/`claim` rather than `instanceof` because jose v6's `JWTExpired` implements-but-does-not-extend `JWTClaimValidationFailed`, and the test suite mocks the whole `jose` module. The client-facing 401 response is byte-identical; `withApiHandler` is unaffected (these errors never escape the handler).

Example log lines:

```
google-native: identity token verification failed (error=JWTClaimValidationFailed, code=ERR_JWT_CLAIM_VALIDATION_FAILED, claim=aud, configuredAudiences=2)
google-native: identity token verification failed (error=JWSSignatureVerificationFailed, code=ERR_JWS_SIGNATURE_VERIFICATION_FAILED)
```

Closes #569
Refs #546 (optional hardening item; #546 stays open for on-device verification)

## Test plan

- [x] Aud-mismatch failure logs `claim=aud` + `configuredAudiences=<n>` and is asserted to exclude the token's `aud` value, email, `sub`, and `error.message` — even when the error carries jose's decoded `payload` (new unit test, `console.error` spy)
- [x] Signature failure logs `code=ERR_JWS_SIGNATURE_VERIFICATION_FAILED` with no `claim=`/`configuredAudiences=` fields, distinguishing it from an aud mismatch (new unit test, `console.error` spy)
- [x] Client-facing response unchanged: `401 {"error":"Invalid identity token"}` asserted in both new tests; pre-existing aud-mismatch 401 test untouched and passing
- [x] All 9 `route.test.ts` tests pass (`npx vitest run src/app/api/auth/google-native/route.test.ts`)
- [x] Full unit suite passes: `npm run test:unit` — 566/566 (not in CI; the single unhandled `jsdom` resolution error is pre-existing from #503, tracked separately)
- [x] `npm run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Log why Google identity token verification failed without exposing token contents**

### What Changed
- When Google identity token verification fails, the server now logs the failure reason before returning the same 401 response as before.
- Audience mismatches include how many configured Google audiences were found, making missing or wrong client IDs easier to spot from logs.
- Signature failures are logged separately from claim failures.
- The logs avoid token contents and decoded claim data, so email, subject, and audience values do not appear in server output.
- Test cleanup now restores console error spies after each test, preventing one failing test from affecting later ones.

### Impact
`✅ Faster diagnosis of invalid Google sign-in tokens`
`✅ Easier detection of missing or mismatched Google client IDs`
`✅ Fewer repeated auth investigations after signature failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
