### PR TITLE
feat(ios): surface visible gaze tracking feedback (#562)

### DIFF
--- a/ios/StillPointApp/Managers/AttentionTrackingManager.swift
+++ b/ios/StillPointApp/Managers/AttentionTrackingManager.swift
@@ -128,6 +128,7 @@ final class AttentionTrackingManager: NSObject {
     private var isPaused = false
     private var pendingLookAt: SIMD3<Float>?
     private var frameDispatchScheduled = false
+    private var startGeneration = 0
 
     override init() {
         isSupported = ARFaceTrackingConfiguration.isSupported
@@ -143,7 +144,11 @@ final class AttentionTrackingManager: NSObject {
         }
         guard !isRunning else { return }
 
+        startGeneration += 1
+        let generation = startGeneration
+
         guard await ensureCameraAuthorized() else { return }
+        guard generation == startGeneration else { return }
 
         self.elapsedProvider = elapsedProvider
         sustained = AttentionTrackingLogic.SustainedState()
@@ -163,7 +168,12 @@ final class AttentionTrackingManager: NSObject {
     }
 
     func stop() {
-        guard isRunning else { return }
+        startGeneration += 1
+        guard isRunning else {
+            status = .idle
+            lastFailureMessage = nil
+            return
+        }
         resetRunningState()
         status = .idle
         lastFailureMessage = nil

--- a/ios/StillPointApp/Managers/AttentionTrackingManager.swift
+++ b/ios/StillPointApp/Managers/AttentionTrackingManager.swift
@@ -9,6 +9,7 @@ enum AttentionTrackingStatus: Equatable {
     case permissionDenied
     case idle
     case running
+    case paused
     case failed
 }
 
@@ -51,9 +52,15 @@ final class AttentionTrackingManager {
         status = .unsupported
     }
 
-    func pause() {}
+    func pause() {
+        guard status == .running else { return }
+        status = .paused
+    }
 
-    func resume() {}
+    func resume() {
+        guard status == .paused else { return }
+        status = .running
+    }
 }
 
 #else
@@ -69,6 +76,7 @@ enum AttentionTrackingStatus: Equatable {
     case permissionDenied
     case idle
     case running
+    case paused
     case failed
 }
 
@@ -165,6 +173,7 @@ final class AttentionTrackingManager: NSObject {
         guard isRunning, !isPaused else { return }
         session.pause()
         isPaused = true
+        status = .paused
         pendingLookAt = nil
         frameDispatchScheduled = false
         clearPendingDebounce()
@@ -176,6 +185,7 @@ final class AttentionTrackingManager: NSObject {
         configuration.isLightEstimationEnabled = false
         session.run(configuration)
         isPaused = false
+        status = .running
     }
 
     private func ensureCameraAuthorized() async -> Bool {

--- a/ios/StillPointApp/Managers/AttentionTrackingManager.swift
+++ b/ios/StillPointApp/Managers/AttentionTrackingManager.swift
@@ -3,6 +3,26 @@
 import Foundation
 import StillPointShared
 
+/// Observable status for ARKit gaze tracking (#562).
+enum AttentionTrackingStatus: Equatable {
+    case unsupported
+    case permissionDenied
+    case idle
+    case running
+    case failed
+}
+
+/// Preflight camera capability without starting an ARSession.
+enum AttentionTrackingCapability {
+    static func preflight() -> AttentionTrackingStatus {
+        .unsupported
+    }
+
+    static func requestCameraAccessIfNeeded() async -> AttentionTrackingStatus {
+        .unsupported
+    }
+}
+
 /// Simulator stub — ARKit face tracking requires a TrueDepth device.
 @Observable
 @MainActor
@@ -12,15 +32,23 @@ final class AttentionTrackingManager {
     private(set) var didReceiveSample = false
     private(set) var currentAttentionState = "attentive"
     private(set) var attentionLog: [AttentionEntry] = []
+    private(set) var status: AttentionTrackingStatus = .unsupported
+    private(set) var lastFailureMessage: String?
 
-    func start(elapsedProvider: @escaping () -> Double) {
+    init() {
+        status = .unsupported
+    }
+
+    func start(elapsedProvider: @escaping () -> Double) async {
         _ = elapsedProvider
         isRunning = false
         didReceiveSample = false
+        status = .unsupported
     }
 
     func stop() {
         isRunning = false
+        status = .unsupported
     }
 
     func pause() {}
@@ -31,8 +59,47 @@ final class AttentionTrackingManager {
 #else
 
 import ARKit
+import AVFoundation
 import Foundation
 import StillPointShared
+
+/// Observable status for ARKit gaze tracking (#562).
+enum AttentionTrackingStatus: Equatable {
+    case unsupported
+    case permissionDenied
+    case idle
+    case running
+    case failed
+}
+
+/// Preflight camera capability without starting an ARSession.
+enum AttentionTrackingCapability {
+    static func preflight() -> AttentionTrackingStatus {
+        guard ARFaceTrackingConfiguration.isSupported else { return .unsupported }
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .denied, .restricted:
+            return .permissionDenied
+        default:
+            return .idle
+        }
+    }
+
+    static func requestCameraAccessIfNeeded() async -> AttentionTrackingStatus {
+        guard ARFaceTrackingConfiguration.isSupported else { return .unsupported }
+
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            return .idle
+        case .denied, .restricted:
+            return .permissionDenied
+        case .notDetermined:
+            let granted = await AVCaptureDevice.requestAccess(for: .video)
+            return granted ? .idle : .permissionDenied
+        @unknown default:
+            return .permissionDenied
+        }
+    }
+}
 
 /// ARKit face-tracking gaze attention sampler (#113). Uses `ARFaceAnchor.lookAtPoint`
 /// — the only public API for gaze direction — with a 0.5s sustained-gaze debounce.
@@ -44,6 +111,8 @@ final class AttentionTrackingManager: NSObject {
     private(set) var didReceiveSample = false
     private(set) var currentAttentionState = "attentive"
     private(set) var attentionLog: [AttentionEntry] = []
+    private(set) var status: AttentionTrackingStatus
+    private(set) var lastFailureMessage: String?
 
     private let session = ARSession()
     private var elapsedProvider: (() -> Double)?
@@ -54,12 +123,20 @@ final class AttentionTrackingManager: NSObject {
 
     override init() {
         isSupported = ARFaceTrackingConfiguration.isSupported
+        status = isSupported ? .idle : .unsupported
         super.init()
         session.delegate = self
     }
 
-    func start(elapsedProvider: @escaping () -> Double) {
-        guard isSupported, !isRunning else { return }
+    func start(elapsedProvider: @escaping () -> Double) async {
+        guard isSupported else {
+            status = .unsupported
+            return
+        }
+        guard !isRunning else { return }
+
+        guard await ensureCameraAuthorized() else { return }
+
         self.elapsedProvider = elapsedProvider
         sustained = AttentionTrackingLogic.SustainedState()
         currentAttentionState = sustained.loggedState
@@ -68,16 +145,20 @@ final class AttentionTrackingManager: NSObject {
         isPaused = false
         pendingLookAt = nil
         frameDispatchScheduled = false
+        lastFailureMessage = nil
 
         let configuration = ARFaceTrackingConfiguration()
         configuration.isLightEstimationEnabled = false
         session.run(configuration, options: [.resetTracking, .removeExistingAnchors])
         isRunning = true
+        status = .running
     }
 
     func stop() {
         guard isRunning else { return }
         resetRunningState()
+        status = .idle
+        lastFailureMessage = nil
     }
 
     func pause() {
@@ -95,6 +176,26 @@ final class AttentionTrackingManager: NSObject {
         configuration.isLightEstimationEnabled = false
         session.run(configuration)
         isPaused = false
+    }
+
+    private func ensureCameraAuthorized() async -> Bool {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            return true
+        case .notDetermined:
+            let granted = await AVCaptureDevice.requestAccess(for: .video)
+            if !granted {
+                status = .permissionDenied
+                return false
+            }
+            return true
+        case .denied, .restricted:
+            status = .permissionDenied
+            return false
+        @unknown default:
+            status = .permissionDenied
+            return false
+        }
     }
 
     private func clearPendingDebounce() {
@@ -155,6 +256,12 @@ extension AttentionTrackingManager: ARSessionDelegate {
     nonisolated func session(_ session: ARSession, didFailWithError error: Error) {
         Task { @MainActor in
             guard self.isRunning else { return }
+            if let arError = error as? ARError, arError.errorCode == .cameraUnauthorized {
+                self.status = .permissionDenied
+            } else {
+                self.status = .failed
+                self.lastFailureMessage = error.localizedDescription
+            }
             self.resetRunningState()
         }
     }

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -19,7 +19,9 @@ enum AppView: Equatable {
         dayNumber: Int,
         sessionType: SessionType,
         duration: Int,
-        bonusSeconds: Int
+        bonusSeconds: Int,
+        attentionLog: [AttentionEntry]?,
+        attentionElapsed: Double?
     )
     case breathCounting
     case logReason(date: String)
@@ -488,7 +490,9 @@ final class AppViewModel {
         sessionType: SessionType = .standard,
         duration: Int,
         bonusSeconds: Int = 0,
-        unlockAppGate: Bool
+        unlockAppGate: Bool,
+        attentionLog: [AttentionEntry]? = nil,
+        attentionElapsed: Double? = nil
     ) {
         // Daily-lock model (#348): any naturally-completed session — quick-minute
         // or standard — unlocks the gated apps for the rest of the day.
@@ -505,7 +509,9 @@ final class AppViewModel {
             dayNumber: dayNumber,
             sessionType: sessionType,
             duration: duration,
-            bonusSeconds: bonusSeconds
+            bonusSeconds: bonusSeconds,
+            attentionLog: attentionLog,
+            attentionElapsed: attentionElapsed
         )
     }
 

--- a/ios/StillPointApp/Views/CompletionView.swift
+++ b/ios/StillPointApp/Views/CompletionView.swift
@@ -14,6 +14,8 @@ struct CompletionView: View {
     let sessionType: SessionType
     let duration: Int
     let bonusSeconds: Int
+    let attentionLog: [AttentionEntry]?
+    let attentionElapsed: Double?
 
     @State private var endNote = ""
     @State private var noteSaved = false
@@ -27,6 +29,14 @@ struct CompletionView: View {
     private var isSaveDisabled: Bool { endNote.isEmpty || noteSaved || isSaving || sessionId.isEmpty }
     private var isQuickSession: Bool { sessionType == .quick }
     private var hasUnlockedApps: Bool { appVM.appBlockingManager.didUnlockFromLastCompletedSession }
+
+    private var attentionSummary: AttentionTrackingLogic.AttentionSummary? {
+        guard let attentionLog, let attentionElapsed, attentionElapsed > 0 else { return nil }
+        return AttentionTrackingLogic.calculateAttentionSummary(
+            log: attentionLog,
+            totalElapsed: attentionElapsed
+        )
+    }
 
     private var durationSubtitle: String {
         guard bonusSeconds > 0 else {
@@ -82,6 +92,27 @@ struct CompletionView: View {
                         bgColor: SPColor.amberBgFaint,
                         borderColor: SPColor.amberBorderSubtle
                     )
+
+                    if let attentionSummary {
+                        HStack(spacing: SPSpacing.s3) {
+                            statCard(
+                                value: "\(attentionSummary.attentivePercent)%",
+                                label: "GAZE ON SCREEN",
+                                color: SPColor.green,
+                                bgColor: SPColor.greenBgFaint,
+                                borderColor: SPColor.greenBorderSubtle
+                            )
+
+                            statCard(
+                                value: "\(attentionSummary.awayPercent)%",
+                                label: "GAZE AWAY",
+                                color: SPColor.amber,
+                                bgColor: SPColor.amberBgFaint,
+                                borderColor: SPColor.amberBorderSubtle
+                            )
+                        }
+                        .accessibilityIdentifier("completion.attentionSummary")
+                    }
                 }
 
                 // Captured thoughts

--- a/ios/StillPointApp/Views/RootView.swift
+++ b/ios/StillPointApp/Views/RootView.swift
@@ -44,7 +44,7 @@ struct RootView: View {
                     .id(sessionId)
                     .transition(.opacity)
 
-            case .completion(let sessionId, let clearPercent, let thoughtCount, let thoughts, let dayNumber, let sessionType, let duration, let bonusSeconds):
+            case .completion(let sessionId, let clearPercent, let thoughtCount, let thoughts, let dayNumber, let sessionType, let duration, let bonusSeconds, let attentionLog, let attentionElapsed):
                 CompletionView(
                     appVM: appVM,
                     sessionId: sessionId,
@@ -54,7 +54,9 @@ struct RootView: View {
                     dayNumber: dayNumber,
                     sessionType: sessionType,
                     duration: duration,
-                    bonusSeconds: bonusSeconds
+                    bonusSeconds: bonusSeconds,
+                    attentionLog: attentionLog,
+                    attentionElapsed: attentionElapsed
                 )
                 .transition(.opacity)
 

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -18,6 +18,7 @@ struct SessionView: View {
     @State private var showAttentionPermissionAlert = false
     @State private var showAttentionFailedAlert = false
     @State private var attentionManager = AttentionTrackingManager()
+    @State private var attentionStartGeneration = 0
 
     init(appVM: AppViewModel, sessionType: SessionType = .standard, track: Track = .primary) {
         self.appVM = appVM
@@ -147,6 +148,7 @@ struct SessionView: View {
             )
         }
         .onDisappear {
+            attentionStartGeneration += 1
             attentionManager.stop()
             SessionIdleTimerController.syncLocalSession(
                 appVM: appVM,
@@ -159,10 +161,16 @@ struct SessionView: View {
         }
         .onChange(of: vm.showIntroOverlay) { _, showIntro in
             if showIntro {
+                attentionStartGeneration += 1
                 attentionManager.stop()
             } else {
                 syncAttentionTracking()
             }
+        }
+        .onChange(of: attentionManager.status) { _, status in
+            guard appVM.currentUser?.attentionTrackingEnabled == true else { return }
+            guard sessionTimerRunning, !vm.showIntroOverlay else { return }
+            presentAttentionStatusAlert(for: status)
         }
         .onChange(of: appVM.keepScreenAwakeDuringSession) { _, _ in
             SessionIdleTimerController.syncLocalSession(
@@ -307,18 +315,29 @@ struct SessionView: View {
     private func syncAttentionTracking() {
         guard appVM.currentUser?.attentionTrackingEnabled == true else { return }
         guard !vm.showIntroOverlay, sessionTimerRunning else { return }
+        attentionStartGeneration += 1
+        let generation = attentionStartGeneration
         Task {
             await attentionManager.start { vm.elapsed }
-            switch attentionManager.status {
-            case .unsupported:
-                showAttentionUnsupportedAlert = true
-            case .permissionDenied:
-                showAttentionPermissionAlert = true
-            case .failed:
-                showAttentionFailedAlert = true
-            default:
-                break
+            guard generation == attentionStartGeneration else { return }
+            guard !vm.showIntroOverlay, sessionTimerRunning else {
+                attentionManager.stop()
+                return
             }
+            presentAttentionStatusAlert(for: attentionManager.status)
+        }
+    }
+
+    private func presentAttentionStatusAlert(for status: AttentionTrackingStatus) {
+        switch status {
+        case .unsupported:
+            showAttentionUnsupportedAlert = true
+        case .permissionDenied:
+            showAttentionPermissionAlert = true
+        case .failed:
+            showAttentionFailedAlert = true
+        case .idle, .running, .paused:
+            break
         }
     }
 

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -14,6 +14,9 @@ struct SessionView: View {
     @State private var vm: SessionViewModel
     @State private var showSaveError = false
     @State private var showCaptureHelper = false
+    @State private var showAttentionUnsupportedAlert = false
+    @State private var showAttentionPermissionAlert = false
+    @State private var showAttentionFailedAlert = false
     @State private var attentionManager = AttentionTrackingManager()
 
     init(appVM: AppViewModel, sessionType: SessionType = .standard, track: Track = .primary) {
@@ -242,6 +245,26 @@ struct SessionView: View {
         } message: {
             Text("Your session data couldn't be saved. You can retry or continue without saving.")
         }
+        .alert("Gaze tracking unavailable", isPresented: $showAttentionUnsupportedAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("This device does not support TrueDepth face tracking. Gaze attention tracking requires an iPhone or iPad with a front-facing TrueDepth camera.")
+        }
+        .alert("Camera access required", isPresented: $showAttentionPermissionAlert) {
+            Button("Open Settings") {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
+            }
+            Button("Continue without gaze tracking", role: .cancel) {}
+        } message: {
+            Text("Gaze attention tracking needs front camera access. Allow camera access in Settings to use this feature during sessions.")
+        }
+        .alert("Gaze tracking failed", isPresented: $showAttentionFailedAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(attentionManager.lastFailureMessage ?? "The ARKit session stopped unexpectedly. Your sit continues without gaze tracking.")
+        }
     }
 
     // MARK: - Progress Bar
@@ -284,7 +307,25 @@ struct SessionView: View {
     private func syncAttentionTracking() {
         guard appVM.currentUser?.attentionTrackingEnabled == true else { return }
         guard !vm.showIntroOverlay, sessionTimerRunning else { return }
-        attentionManager.start { vm.elapsed }
+        Task {
+            await attentionManager.start { vm.elapsed }
+            switch attentionManager.status {
+            case .unsupported:
+                showAttentionUnsupportedAlert = true
+            case .permissionDenied:
+                showAttentionPermissionAlert = true
+            case .failed:
+                showAttentionFailedAlert = true
+            default:
+                break
+            }
+        }
+    }
+
+    private var showsLiveGazeIndicator: Bool {
+        appVM.currentUser?.attentionTrackingEnabled == true
+            && attentionManager.status == .running
+            && (attentionManager.isRunning || attentionManager.didReceiveSample)
     }
 
     private var bottomOverlayReserve: CGFloat {
@@ -345,6 +386,32 @@ struct SessionView: View {
                 }
             }
             .padding(.horizontal, SPSpacing.s3)
+
+            if showsLiveGazeIndicator {
+                HStack(spacing: SPSpacing.s2) {
+                    Circle()
+                        .fill(
+                            attentionManager.currentAttentionState == "attentive"
+                                ? SPColor.green
+                                : SPColor.amber
+                        )
+                        .frame(width: 8, height: 8)
+
+                    Text(
+                        attentionManager.currentAttentionState == "attentive"
+                            ? "Gaze on screen"
+                            : "Gaze away"
+                    )
+                    .font(SPFont.mono(10, weight: .medium))
+                    .foregroundStyle(Color(SPColor.fg3))
+                    .tracking(1)
+
+                    Spacer(minLength: 0)
+                }
+                .padding(.horizontal, SPSpacing.s3)
+                .accessibilityIdentifier("session.gazeIndicator")
+                .accessibilityValue(attentionManager.currentAttentionState)
+            }
 
             if !vm.showPostDistractionCapture, vm.isActive || vm.isPaused {
                 HStack(spacing: SPSpacing.s1) {
@@ -614,7 +681,9 @@ struct SessionView: View {
                 sessionType: session.sessionType,
                 duration: vm.plannedSeconds,
                 bonusSeconds: vm.bonusSeconds,
-                unlockAppGate: vm.completedNaturally
+                unlockAppGate: vm.completedNaturally,
+                attentionLog: vm.attentionLog,
+                attentionElapsed: vm.attentionLog != nil ? vm.elapsed : nil
             )
         }
     }

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -19,6 +19,7 @@ struct SessionView: View {
     @State private var showAttentionFailedAlert = false
     @State private var attentionManager = AttentionTrackingManager()
     @State private var attentionStartGeneration = 0
+    @State private var gazeTrackingRanThisSession = false
 
     init(appVM: AppViewModel, sessionType: SessionType = .standard, track: Track = .primary) {
         self.appVM = appVM
@@ -168,6 +169,9 @@ struct SessionView: View {
             }
         }
         .onChange(of: attentionManager.status) { _, status in
+            if status == .running {
+                gazeTrackingRanThisSession = true
+            }
             guard appVM.currentUser?.attentionTrackingEnabled == true else { return }
             guard sessionInProgress, !vm.showIntroOverlay else { return }
             presentAttentionStatusAlert(for: status)
@@ -217,11 +221,16 @@ struct SessionView: View {
         }
         .onChange(of: vm.isComplete) { _, isComplete in
             if isComplete {
+                let shouldIncludeGazeSummary = appVM.currentUser?.attentionTrackingEnabled == true
+                    && gazeTrackingRanThisSession
+                let gazeLog = shouldIncludeGazeSummary ? attentionManager.attentionLog : nil
                 attentionManager.stop()
-                if appVM.currentUser?.attentionTrackingEnabled == true,
-                   attentionManager.didReceiveSample {
-                    vm.attentionLog = attentionManager.attentionLog
+                if shouldIncludeGazeSummary {
+                    vm.attentionLog = gazeLog
                 }
+                gazeTrackingRanThisSession = false
+            } else {
+                attentionManager.stop()
             }
             SessionIdleTimerController.syncLocalSession(
                 appVM: appVM,

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -169,7 +169,7 @@ struct SessionView: View {
         }
         .onChange(of: attentionManager.status) { _, status in
             guard appVM.currentUser?.attentionTrackingEnabled == true else { return }
-            guard sessionTimerRunning, !vm.showIntroOverlay else { return }
+            guard sessionInProgress, !vm.showIntroOverlay else { return }
             presentAttentionStatusAlert(for: status)
         }
         .onChange(of: appVM.keepScreenAwakeDuringSession) { _, _ in
@@ -344,7 +344,8 @@ struct SessionView: View {
     private var showsLiveGazeIndicator: Bool {
         appVM.currentUser?.attentionTrackingEnabled == true
             && attentionManager.status == .running
-            && (attentionManager.isRunning || attentionManager.didReceiveSample)
+            && !vm.isPaused
+            && attentionManager.didReceiveSample
     }
 
     private var bottomOverlayReserve: CGFloat {

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import StillPointShared
+import UIKit
 
 struct SettingsView: View {
     let appVM: AppViewModel
@@ -17,6 +18,8 @@ struct SettingsView: View {
     @State private var isDeletingAccount = false
     @State private var deleteAccountError = ""
     @State private var showDeleteAccountError = false
+    @State private var showAttentionUnsupportedAlert = false
+    @State private var showAttentionPermissionDeniedAlert = false
 
     private var isSavingSettings: Bool { isUpdating || isUpdatingAphorisms || isUpdatingAttentionTracking || isSavingUsername }
 
@@ -128,6 +131,21 @@ struct SettingsView: View {
                         isUpdatingAttentionTracking = true
                         Task {
                             defer { isUpdatingAttentionTracking = false }
+                            if newValue {
+                                let capability = await AttentionTrackingCapability.requestCameraAccessIfNeeded()
+                                switch capability {
+                                case .unsupported:
+                                    attentionTrackingEnabled = false
+                                    showAttentionUnsupportedAlert = true
+                                    return
+                                case .permissionDenied:
+                                    attentionTrackingEnabled = false
+                                    showAttentionPermissionDeniedAlert = true
+                                    return
+                                default:
+                                    break
+                                }
+                            }
                             do {
                                 let updated = try await APIClient.shared.updateSettings(attentionTrackingEnabled: newValue)
                                 appVM.applySettingsUser(updated)
@@ -313,6 +331,21 @@ struct SettingsView: View {
         .onChange(of: appVM.currentUser?.attentionTrackingEnabled) { _, _ in
             guard appVM.currentUser != nil else { return }
             syncFromCurrentUser()
+        }
+        .alert("Gaze tracking unavailable", isPresented: $showAttentionUnsupportedAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("This device does not support TrueDepth face tracking. Gaze attention tracking requires an iPhone or iPad with a front-facing TrueDepth camera.")
+        }
+        .alert("Camera access required", isPresented: $showAttentionPermissionDeniedAlert) {
+            Button("Open Settings") {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Gaze attention tracking needs front camera access. Allow camera access in Settings to enable this feature.")
         }
     }
 

--- a/ios/StillPointShared/Sources/StillPointShared/AttentionTrackingLogic.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AttentionTrackingLogic.swift
@@ -65,4 +65,56 @@ public enum AttentionTrackingLogic {
         next.log.append(AttentionEntry(time: elapsed, state: rawState))
         return next
     }
+
+    /// Percent attentive vs away derived from a session attention log (#562).
+    public struct AttentionSummary: Equatable, Sendable {
+        public let attentivePercent: Int
+        public let awayPercent: Int
+
+        public init(attentivePercent: Int, awayPercent: Int) {
+            self.attentivePercent = attentivePercent
+            self.awayPercent = awayPercent
+        }
+    }
+
+    /// Compute gaze-on-screen vs gaze-away proportions for completion summaries.
+    /// Assumes the session begins in `initialState` (default `"attentive"`).
+    public static func calculateAttentionSummary(
+        log: [AttentionEntry],
+        totalElapsed: Double,
+        initialState: String = "attentive"
+    ) -> AttentionSummary {
+        guard totalElapsed > 0 else {
+            return AttentionSummary(attentivePercent: 100, awayPercent: 0)
+        }
+
+        guard !log.isEmpty else {
+            let attentive = initialState == "attentive" ? 100 : 0
+            return AttentionSummary(attentivePercent: attentive, awayPercent: 100 - attentive)
+        }
+
+        var effectiveLog = log
+        if effectiveLog[0].time > 0 {
+            effectiveLog.insert(AttentionEntry(time: 0, state: initialState), at: 0)
+        }
+
+        var attentiveTime: Double = 0
+        for (index, entry) in effectiveLog.enumerated() {
+            let endTime: Double
+            if index + 1 < effectiveLog.count {
+                endTime = effectiveLog[index + 1].time
+            } else {
+                endTime = totalElapsed
+            }
+            if entry.isAttentive {
+                attentiveTime += endTime - entry.time
+            }
+        }
+
+        let attentivePercent = Int(round((attentiveTime / totalElapsed) * 100))
+        return AttentionSummary(
+            attentivePercent: attentivePercent,
+            awayPercent: max(0, 100 - attentivePercent)
+        )
+    }
 }

--- a/ios/StillPointShared/Tests/StillPointSharedTests/AttentionSummaryTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/AttentionSummaryTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import StillPointShared
+
+final class AttentionSummaryTests: XCTestCase {
+    func testEmptyLogAssumesInitialAttentiveState() {
+        let summary = AttentionTrackingLogic.calculateAttentionSummary(
+            log: [],
+            totalElapsed: 120
+        )
+        XCTAssertEqual(summary.attentivePercent, 100)
+        XCTAssertEqual(summary.awayPercent, 0)
+    }
+
+    func testSingleAwaySegment() {
+        let summary = AttentionTrackingLogic.calculateAttentionSummary(
+            log: [AttentionEntry(time: 30, state: "away")],
+            totalElapsed: 60
+        )
+        XCTAssertEqual(summary.attentivePercent, 50)
+        XCTAssertEqual(summary.awayPercent, 50)
+    }
+
+    func testMultipleSegments() {
+        let summary = AttentionTrackingLogic.calculateAttentionSummary(
+            log: [
+                AttentionEntry(time: 10, state: "away"),
+                AttentionEntry(time: 40, state: "attentive"),
+            ],
+            totalElapsed: 60
+        )
+        XCTAssertEqual(summary.attentivePercent, 50)
+        XCTAssertEqual(summary.awayPercent, 50)
+    }
+
+    func testZeroElapsedReturnsFullAttentive() {
+        let summary = AttentionTrackingLogic.calculateAttentionSummary(
+            log: [AttentionEntry(time: 0, state: "away")],
+            totalElapsed: 0
+        )
+        XCTAssertEqual(summary.attentivePercent, 100)
+        XCTAssertEqual(summary.awayPercent, 0)
+    }
+}


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #562 — gaze/attention tracking now produces **visible** results during and after a session, and ARKit/camera failures are surfaced loudly instead of silently no-oping.

Closes the post-ship gap from #113 where `attentionLog` was captured and persisted but never shown in the UI.

## Changes

### Foundation (`AttentionTrackingManager`)
- Added `AttentionTrackingStatus` (`unsupported`, `permissionDenied`, `idle`, `running`, `failed`)
- Explicit `AVCaptureDevice` camera authorization preflight before starting ARSession
- Map `ARError.cameraUnauthorized` → `permissionDenied`; other ARKit errors → `failed` with message
- Added `AttentionTrackingCapability` helper for Settings opt-in preflight

### Loud failures
- **Settings**: enabling the toggle checks device support + camera permission; shows alerts with "Open Settings" for denied camera, informative copy for unsupported TrueDepth devices; reverts toggle when tracking cannot run
- **Session**: non-blocking alerts when tracking fails to start (unsupported / denied / ARKit error); sit continues normally

### Visible results (in-session + completion — not history)
- **Live indicator** in `sessionTrackingInfoBar`: green/amber dot + "Gaze on screen" / "Gaze away" when tracking is actively running
- **Completion summary**: GAZE ON SCREEN / GAZE AWAY stat cards computed via new `AttentionTrackingLogic.calculateAttentionSummary`

### Shared logic + tests
- `AttentionTrackingLogic.AttentionSummary` + `calculateAttentionSummary(log:totalElapsed:)`
- New `AttentionSummaryTests` (existing debounce tests unchanged)

## Test plan

- [x] Unit: `AttentionSummaryTests` added; existing `AttentionTrackingLogicTests` unchanged
- [ ] CI: `swift test` in `ios/StillPointShared` (macOS runner)
- [ ] Device: enable tracking → start sit → live gaze indicator updates when looking away
- [ ] Device: completion screen shows GAZE ON SCREEN / GAZE AWAY cards
- [ ] Device: deny camera → clear alert + Open Settings; session continues without tracking
- [ ] Device: unsupported device (no TrueDepth) → clear unsupported alert

## Notes

- History view intentionally **not** updated per issue scope ("NOT history")
- Physical TrueDepth device verification required for full acceptance
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58018f7e-104e-4fc8-8b23-793efaacaa3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58018f7e-104e-4fc8-8b23-793efaacaa3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Show gaze tracking status, failures, and completion results**

### What Changed
- Gaze tracking now shows a live on-screen indicator during sessions when tracking is running, including whether the user is looking at the screen or away
- If gaze tracking cannot run, the app now shows clear alerts for unsupported devices, denied camera access, and ARKit failures; camera permission prompts can open Settings
- Completion screens now include gaze-on-screen and gaze-away percentage cards when tracking ran, including sessions with no gaze samples
- Session completion now carries gaze data forward so the summary can be shown after the session ends
- Added tests for the gaze summary calculation

### Impact
`✅ Clearer gaze tracking feedback during sessions`
`✅ Fewer silent tracking failures`
`✅ More complete session summaries`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
