### PR TITLE
security(auth): Apple S2S jti replay guard (#532)

### DIFF
--- a/.github/workflows/ios-shared-tests.yml
+++ b/.github/workflows/ios-shared-tests.yml
@@ -39,7 +39,7 @@ jobs:
           # Use the paginated files API — `gh pr view --json files` caps the list
           # (~100 files), which on a large PR could miss StillPointShared changes
           # and skip the real test via the no-op. `--paginate` returns every file.
-          files="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].path' 2>/dev/null || true)"
+          files="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename' 2>/dev/null || true)"
           if [ -z "$files" ] || printf '%s\n' "$files" | grep -qE '^(ios/StillPointShared/|\.github/workflows/ios-shared-tests\.yml$)'; then
             echo "shared=true" >> "$GITHUB_OUTPUT"
           else

--- a/drizzle/apple_notification_log_jti_unique_incremental.sql
+++ b/drizzle/apple_notification_log_jti_unique_incremental.sql
@@ -3,10 +3,11 @@
 -- This file is the manual-apply reference for existing databases (prod / preview branches)
 -- and is what `scripts/apply-migrations.ts` runs automatically on every deploy.
 --
--- Invariant: each JWT `jti` is recorded at most once. Replayed notifications with
+-- Invariant: each non-null JWT `jti` is recorded at most once. Replayed notifications with
 -- the same `jti` are deduplicated at insert time and must not re-trigger handlers.
--- A partial unique index is used because `jti` is nullable — legacy/malformed tokens
--- may omit it and must remain insertable without colliding with each other.
+-- Notifications that omit `jti` are out of scope for this guard and rely on idempotent
+-- handler noops on redelivery. A partial unique index is used because `jti` is nullable —
+-- legacy/malformed tokens may omit it and must remain insertable without colliding.
 --
 -- Pre-flight (RUN FIRST against the target DB, read-only; must return 0 rows):
 --   SELECT jti, count(*)

--- a/drizzle/apple_notification_log_jti_unique_incremental.sql
+++ b/drizzle/apple_notification_log_jti_unique_incremental.sql
@@ -3,11 +3,10 @@
 -- This file is the manual-apply reference for existing databases (prod / preview branches)
 -- and is what `scripts/apply-migrations.ts` runs automatically on every deploy.
 --
--- Invariant: each non-null JWT `jti` is recorded at most once. Replayed notifications with
+-- Invariant: each JWT `jti` is recorded at most once. Replayed notifications with
 -- the same `jti` are deduplicated at insert time and must not re-trigger handlers.
--- Notifications that omit `jti` are out of scope for this guard and rely on idempotent
--- handler noops on redelivery. A partial unique index is used because `jti` is nullable —
--- legacy/malformed tokens may omit it and must remain insertable without colliding.
+-- A partial unique index is used because `jti` is nullable — legacy/malformed tokens
+-- may omit it and must remain insertable without colliding with each other.
 --
 -- Pre-flight (RUN FIRST against the target DB, read-only; must return 0 rows):
 --   SELECT jti, count(*)
@@ -21,7 +20,7 @@
 -- This script is idempotent (IF NOT EXISTS) and is wrapped in a transaction by the
 -- migration runner, so a failure mid-flight rolls back cleanly.
 --
--- Lock note: CREATE UNIQUE INDEX (non-CONCURRENTLY) takes SHARE on
+-- Lock note: CREATE UNIQUE INDEX (non-CONCURRENTLY) takes ACCESS EXCLUSIVE on
 -- apple_notification_log for the duration of the build, blocking concurrent writes.
 -- This is fine on the current small table (sub-second build). The runner executes
 -- inside a transaction, so CONCURRENTLY is not an option here.

--- a/drizzle/apple_notification_log_jti_unique_incremental.sql
+++ b/drizzle/apple_notification_log_jti_unique_incremental.sql
@@ -20,7 +20,7 @@
 -- This script is idempotent (IF NOT EXISTS) and is wrapped in a transaction by the
 -- migration runner, so a failure mid-flight rolls back cleanly.
 --
--- Lock note: CREATE UNIQUE INDEX (non-CONCURRENTLY) takes ACCESS EXCLUSIVE on
+-- Lock note: CREATE UNIQUE INDEX (non-CONCURRENTLY) takes SHARE on
 -- apple_notification_log for the duration of the build, blocking concurrent writes.
 -- This is fine on the current small table (sub-second build). The runner executes
 -- inside a transaction, so CONCURRENTLY is not an option here.

--- a/drizzle/apple_notification_log_jti_unique_incremental.sql
+++ b/drizzle/apple_notification_log_jti_unique_incremental.sql
@@ -1,0 +1,30 @@
+-- Issue #532: replay guard for Apple server-to-server notifications.
+-- Preferred: apply schema with `npx drizzle-kit push` (see README).
+-- This file is the manual-apply reference for existing databases (prod / preview branches)
+-- and is what `scripts/apply-migrations.ts` runs automatically on every deploy.
+--
+-- Invariant: each JWT `jti` is recorded at most once. Replayed notifications with
+-- the same `jti` are deduplicated at insert time and must not re-trigger handlers.
+-- A partial unique index is used because `jti` is nullable — legacy/malformed tokens
+-- may omit it and must remain insertable without colliding with each other.
+--
+-- Pre-flight (RUN FIRST against the target DB, read-only; must return 0 rows):
+--   SELECT jti, count(*)
+--   FROM apple_notification_log
+--   WHERE jti IS NOT NULL
+--   GROUP BY 1
+--   HAVING count(*) > 1;
+-- Duplicate `jti` rows MUST be deduped before this migration reaches the branch,
+-- or the unique index build below fails and rolls back the transaction.
+--
+-- This script is idempotent (IF NOT EXISTS) and is wrapped in a transaction by the
+-- migration runner, so a failure mid-flight rolls back cleanly.
+--
+-- Lock note: CREATE UNIQUE INDEX (non-CONCURRENTLY) takes ACCESS EXCLUSIVE on
+-- apple_notification_log for the duration of the build, blocking concurrent writes.
+-- This is fine on the current small table (sub-second build). The runner executes
+-- inside a transaction, so CONCURRENTLY is not an option here.
+
+CREATE UNIQUE INDEX IF NOT EXISTS "apple_notification_log_jti_unique"
+  ON "apple_notification_log" ("jti")
+  WHERE "jti" IS NOT NULL;

--- a/src/app/api/auth/apple/notifications/route.test.ts
+++ b/src/app/api/auth/apple/notifications/route.test.ts
@@ -49,7 +49,7 @@ beforeEach(() => {
     actionTaken: "account_deleted",
     userId: "user-uuid-1",
   });
-  recordAppleNotificationReceipt.mockResolvedValue("log-uuid-1");
+  recordAppleNotificationReceipt.mockResolvedValue({ logId: "log-uuid-1", alreadySeen: false });
   finalizeAppleNotificationLog.mockResolvedValue(undefined);
 });
 
@@ -143,6 +143,21 @@ describe("POST /api/auth/apple/notifications", () => {
       actionTaken: "processing_failed",
       userId: null,
     });
+  });
+
+  test("replayed jti returns 200 without reprocessing", async () => {
+    recordAppleNotificationReceipt.mockResolvedValue({
+      logId: "existing-log-id",
+      alreadySeen: true,
+    });
+    const { POST } = await import("./route");
+
+    const res = await POST(requestWithBody({ payload: "tok" }));
+
+    expect(res.status).toBe(200);
+    expect(recordAppleNotificationReceipt).toHaveBeenCalled();
+    expect(handleAppleNotificationEvent).not.toHaveBeenCalled();
+    expect(finalizeAppleNotificationLog).not.toHaveBeenCalled();
   });
 
   test("duplicate deliveries still return 200 and are audited", async () => {

--- a/src/app/api/auth/apple/notifications/route.test.ts
+++ b/src/app/api/auth/apple/notifications/route.test.ts
@@ -6,11 +6,13 @@ const {
   handleAppleNotificationEvent,
   recordAppleNotificationReceipt,
   finalizeAppleNotificationLog,
+  claimAppleNotificationForProcessing,
 } = vi.hoisted(() => ({
   verifyAppleJwt: vi.fn(),
   handleAppleNotificationEvent: vi.fn(),
   recordAppleNotificationReceipt: vi.fn(),
   finalizeAppleNotificationLog: vi.fn(),
+  claimAppleNotificationForProcessing: vi.fn(),
 }));
 
 vi.mock("@/lib/apple-auth", () => ({
@@ -24,6 +26,7 @@ vi.mock("@/lib/apple-notifications", async (importOriginal) => {
     handleAppleNotificationEvent,
     recordAppleNotificationReceipt,
     finalizeAppleNotificationLog,
+    claimAppleNotificationForProcessing,
   };
 });
 
@@ -50,6 +53,7 @@ beforeEach(() => {
     userId: "user-uuid-1",
   });
   recordAppleNotificationReceipt.mockResolvedValue({ logId: "log-uuid-1", alreadySeen: false });
+  claimAppleNotificationForProcessing.mockResolvedValue(true);
   finalizeAppleNotificationLog.mockResolvedValue(undefined);
 });
 

--- a/src/app/api/auth/apple/notifications/route.ts
+++ b/src/app/api/auth/apple/notifications/route.ts
@@ -64,19 +64,10 @@ export const POST = withApiHandler("apple notifications", async (request: NextRe
     return NextResponse.json({ received: true });
   }
 
+  let result: Awaited<ReturnType<typeof handleAppleNotificationEvent>>;
   try {
-    const result = await handleAppleNotificationEvent(event);
-    try {
-      await finalizeAppleNotificationLog(receipt.logId, result);
-    } catch (finalizeError) {
-      console.error("apple notifications: finalize audit row failed:", finalizeError);
-      return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-    }
-    return NextResponse.json({ received: true });
+    result = await handleAppleNotificationEvent(event);
   } catch (error) {
-    // Apple does not document retry semantics for these notifications, so the
-    // 500 may be final — log loudly for manual follow-up. If Apple (or an
-    // operator) redelivers, the idempotent handlers make that safe.
     console.error("apple notifications: processing failed:", error);
     await finalizeAppleNotificationLog(receipt.logId, {
       actionTaken: "processing_failed",
@@ -86,4 +77,13 @@ export const POST = withApiHandler("apple notifications", async (request: NextRe
     });
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
+
+  try {
+    await finalizeAppleNotificationLog(receipt.logId, result);
+  } catch (finalizeError) {
+    console.error("apple notifications: finalize audit row failed:", finalizeError);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+
+  return NextResponse.json({ received: true });
 });

--- a/src/app/api/auth/apple/notifications/route.ts
+++ b/src/app/api/auth/apple/notifications/route.ts
@@ -43,9 +43,9 @@ export const POST = withApiHandler("apple notifications", async (request: NextRe
 
   // Receipt first: the audit row exists before any side effect runs, so a
   // mid-handling crash can never lose the record of a received notification.
-  let logId: string;
+  let receipt: Awaited<ReturnType<typeof recordAppleNotificationReceipt>>;
   try {
-    logId = await recordAppleNotificationReceipt({
+    receipt = await recordAppleNotificationReceipt({
       eventType: event.type,
       subject: event.sub,
       eventTime: event.event_time,
@@ -57,16 +57,23 @@ export const POST = withApiHandler("apple notifications", async (request: NextRe
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 
+  if (receipt.alreadySeen) {
+    console.info(
+      `apple notifications: duplicate jti replay suppressed (logId=${receipt.logId})`,
+    );
+    return NextResponse.json({ received: true });
+  }
+
   try {
     const result = await handleAppleNotificationEvent(event);
-    await finalizeAppleNotificationLog(logId, result);
+    await finalizeAppleNotificationLog(receipt.logId, result);
     return NextResponse.json({ received: true });
   } catch (error) {
     // Apple does not document retry semantics for these notifications, so the
     // 500 may be final — log loudly for manual follow-up. If Apple (or an
     // operator) redelivers, the idempotent handlers make that safe.
     console.error("apple notifications: processing failed:", error);
-    await finalizeAppleNotificationLog(logId, {
+    await finalizeAppleNotificationLog(receipt.logId, {
       actionTaken: "processing_failed",
       userId: null,
     }).catch((finalizeError) => {

--- a/src/app/api/auth/apple/notifications/route.ts
+++ b/src/app/api/auth/apple/notifications/route.ts
@@ -66,7 +66,12 @@ export const POST = withApiHandler("apple notifications", async (request: NextRe
 
   try {
     const result = await handleAppleNotificationEvent(event);
-    await finalizeAppleNotificationLog(receipt.logId, result);
+    try {
+      await finalizeAppleNotificationLog(receipt.logId, result);
+    } catch (finalizeError) {
+      console.error("apple notifications: finalize audit row failed:", finalizeError);
+      return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
     return NextResponse.json({ received: true });
   } catch (error) {
     // Apple does not document retry semantics for these notifications, so the

--- a/src/app/api/auth/apple/notifications/route.ts
+++ b/src/app/api/auth/apple/notifications/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { withApiHandler } from "@/lib/api/withApiHandler";
 import { verifyAppleJwt } from "@/lib/apple-auth";
 import {
+  claimAppleNotificationForProcessing,
   finalizeAppleNotificationLog,
   handleAppleNotificationEvent,
   parseAppleEventsClaim,
@@ -64,6 +65,14 @@ export const POST = withApiHandler("apple notifications", async (request: NextRe
     return NextResponse.json({ received: true });
   }
 
+  const claimed = await claimAppleNotificationForProcessing(receipt.logId);
+  if (!claimed) {
+    console.info(
+      `apple notifications: concurrent delivery suppressed (logId=${receipt.logId})`,
+    );
+    return NextResponse.json({ received: true });
+  }
+
   let result: Awaited<ReturnType<typeof handleAppleNotificationEvent>>;
   try {
     result = await handleAppleNotificationEvent(event);
@@ -82,7 +91,8 @@ export const POST = withApiHandler("apple notifications", async (request: NextRe
     await finalizeAppleNotificationLog(receipt.logId, result);
   } catch (finalizeError) {
     console.error("apple notifications: finalize audit row failed:", finalizeError);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    // Side effects already applied — acknowledge to avoid duplicate handler runs.
+    return NextResponse.json({ received: true });
   }
 
   return NextResponse.json({ received: true });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -191,7 +191,8 @@ export const accountDeletionLog = pgTable("account_deletion_log", {
 }));
 
 /** #338: Audit log for Sign in with Apple server-to-server notifications.
- *  One row per verified notification received, including repeat deliveries.
+ *  One row per verified notification; duplicate deliveries sharing a `jti` are
+ *  deduplicated (#532) rather than re-logged or re-processed.
  *  `user_id` has no FK so rows survive account deletion (same as account_deletion_log). */
 export const appleNotificationLog = pgTable("apple_notification_log", {
   id: uuid("id").primaryKey().defaultRandom(),
@@ -212,6 +213,9 @@ export const appleNotificationLog = pgTable("apple_notification_log", {
 }, (table) => ({
   subjectIdx: index("idx_apple_notification_log_subject").on(table.subject),
   userIdx: index("idx_apple_notification_log_user").on(table.userId),
+  jtiUnique: uniqueIndex("apple_notification_log_jti_unique")
+    .on(table.jti)
+    .where(sql`"jti" IS NOT NULL`),
 }));
 
 /** OAuth provider identities linked to a user (#136).

--- a/src/lib/apple-notifications.test.ts
+++ b/src/lib/apple-notifications.test.ts
@@ -8,10 +8,11 @@ const {
   updateWhere,
   updateReturning,
   insertValues,
+  insertOnConflict,
   insertReturning,
   deleteUserAccount,
 } = vi.hoisted(() => ({
-  /** select().from().where().limit() — oauth_accounts link lookup */
+  /** select().from().where().limit() — oauth_accounts link lookup and jti replay lookup */
   linkLimit: vi.fn(),
   /** select().from().where().orderBy().limit() — audit-log fallback lookup */
   fallbackLimit: vi.fn(),
@@ -20,6 +21,7 @@ const {
   updateWhere: vi.fn(),
   updateReturning: vi.fn(),
   insertValues: vi.fn(),
+  insertOnConflict: vi.fn(),
   insertReturning: vi.fn(),
   deleteUserAccount: vi.fn(),
 }));
@@ -50,7 +52,13 @@ vi.mock("@/db", () => ({
     insert: () => ({
       values: (values: unknown) => {
         insertValues(values);
-        return { returning: insertReturning };
+        return {
+          onConflictDoNothing: (...args: unknown[]) => {
+            insertOnConflict(...args);
+            return { returning: insertReturning };
+          },
+          returning: insertReturning,
+        };
       },
     }),
   },
@@ -207,15 +215,15 @@ describe("handleAppleNotificationEvent", () => {
 });
 
 describe("recordAppleNotificationReceipt", () => {
-  test("inserts a received row and returns its id", async () => {
-    const id = await recordAppleNotificationReceipt({
+  test("inserts a received row and returns alreadySeen false", async () => {
+    const result = await recordAppleNotificationReceipt({
       eventType: "consent-revoked",
       subject: "apple-sub-1",
       eventTime: 1_718_000_000_000,
       jti: "jti-abc",
     });
 
-    expect(id).toBe("log-uuid-1");
+    expect(result).toEqual({ logId: "log-uuid-1", alreadySeen: false });
     expect(insertValues).toHaveBeenCalledWith({
       eventType: "consent-revoked",
       subject: "apple-sub-1",
@@ -223,19 +231,37 @@ describe("recordAppleNotificationReceipt", () => {
       jti: "jti-abc",
       actionTaken: "received",
     });
+    expect(insertOnConflict).toHaveBeenCalled();
+  });
+
+  test("returns alreadySeen true when the jti insert conflicts", async () => {
+    insertReturning.mockResolvedValueOnce([]);
+    linkLimit.mockResolvedValueOnce([{ id: "existing-log-id" }]);
+
+    const result = await recordAppleNotificationReceipt({
+      eventType: "consent-revoked",
+      subject: "apple-sub-1",
+      eventTime: 1_718_000_000_000,
+      jti: "jti-replay",
+    });
+
+    expect(result).toEqual({ logId: "existing-log-id", alreadySeen: true });
+    expect(linkLimit).toHaveBeenCalled();
   });
 
   test("tolerates missing event_time and jti", async () => {
-    await recordAppleNotificationReceipt({
+    const result = await recordAppleNotificationReceipt({
       eventType: "email-enabled",
       subject: "apple-sub-1",
       eventTime: undefined,
       jti: undefined,
     });
 
+    expect(result).toEqual({ logId: "log-uuid-1", alreadySeen: false });
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({ eventTime: null, jti: null }),
     );
+    expect(insertOnConflict).not.toHaveBeenCalled();
   });
 
   test("truncates an oversized external event type instead of failing the insert", async () => {

--- a/src/lib/apple-notifications.test.ts
+++ b/src/lib/apple-notifications.test.ts
@@ -216,6 +216,8 @@ describe("handleAppleNotificationEvent", () => {
 
 describe("recordAppleNotificationReceipt", () => {
   test("inserts a received row and returns alreadySeen false", async () => {
+    linkLimit.mockResolvedValueOnce([]);
+
     const result = await recordAppleNotificationReceipt({
       eventType: "consent-revoked",
       subject: "apple-sub-1",
@@ -231,11 +233,9 @@ describe("recordAppleNotificationReceipt", () => {
       jti: "jti-abc",
       actionTaken: "received",
     });
-    expect(insertOnConflict).toHaveBeenCalled();
   });
 
   test("returns alreadySeen true when the jti insert conflicts after successful handling", async () => {
-    insertReturning.mockResolvedValueOnce([]);
     linkLimit.mockResolvedValueOnce([{ id: "existing-log-id", actionTaken: "account_deleted" }]);
 
     const result = await recordAppleNotificationReceipt({
@@ -247,10 +247,10 @@ describe("recordAppleNotificationReceipt", () => {
 
     expect(result).toEqual({ logId: "existing-log-id", alreadySeen: true });
     expect(linkLimit).toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
   });
 
   test("returns alreadySeen false when the jti replay is still in-flight or failed", async () => {
-    insertReturning.mockResolvedValueOnce([]);
     linkLimit.mockResolvedValueOnce([{ id: "existing-log-id", actionTaken: "received" }]);
 
     const retryResult = await recordAppleNotificationReceipt({
@@ -262,7 +262,6 @@ describe("recordAppleNotificationReceipt", () => {
 
     expect(retryResult).toEqual({ logId: "existing-log-id", alreadySeen: false });
 
-    insertReturning.mockResolvedValueOnce([]);
     linkLimit.mockResolvedValueOnce([
       { id: "failed-log-id", actionTaken: "processing_failed" },
     ]);
@@ -277,6 +276,22 @@ describe("recordAppleNotificationReceipt", () => {
     expect(failedRetry).toEqual({ logId: "failed-log-id", alreadySeen: false });
   });
 
+  test("hashes oversized jti values before insert", async () => {
+    linkLimit.mockResolvedValueOnce([]);
+    const longJti = "x".repeat(300);
+
+    await recordAppleNotificationReceipt({
+      eventType: "consent-revoked",
+      subject: "apple-sub-1",
+      eventTime: undefined,
+      jti: longJti,
+    });
+
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ jti: expect.stringMatching(/^sha256:[0-9a-f]{64}$/) }),
+    );
+  });
+
   test("tolerates missing event_time and jti", async () => {
     const result = await recordAppleNotificationReceipt({
       eventType: "email-enabled",
@@ -289,7 +304,6 @@ describe("recordAppleNotificationReceipt", () => {
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({ eventTime: null, jti: null }),
     );
-    expect(insertOnConflict).not.toHaveBeenCalled();
   });
 
   test("truncates an oversized external event type instead of failing the insert", async () => {

--- a/src/lib/apple-notifications.test.ts
+++ b/src/lib/apple-notifications.test.ts
@@ -234,9 +234,9 @@ describe("recordAppleNotificationReceipt", () => {
     expect(insertOnConflict).toHaveBeenCalled();
   });
 
-  test("returns alreadySeen true when the jti insert conflicts", async () => {
+  test("returns alreadySeen true when the jti insert conflicts after successful handling", async () => {
     insertReturning.mockResolvedValueOnce([]);
-    linkLimit.mockResolvedValueOnce([{ id: "existing-log-id" }]);
+    linkLimit.mockResolvedValueOnce([{ id: "existing-log-id", actionTaken: "account_deleted" }]);
 
     const result = await recordAppleNotificationReceipt({
       eventType: "consent-revoked",
@@ -247,6 +247,34 @@ describe("recordAppleNotificationReceipt", () => {
 
     expect(result).toEqual({ logId: "existing-log-id", alreadySeen: true });
     expect(linkLimit).toHaveBeenCalled();
+  });
+
+  test("returns alreadySeen false when the jti replay is still in-flight or failed", async () => {
+    insertReturning.mockResolvedValueOnce([]);
+    linkLimit.mockResolvedValueOnce([{ id: "existing-log-id", actionTaken: "received" }]);
+
+    const retryResult = await recordAppleNotificationReceipt({
+      eventType: "consent-revoked",
+      subject: "apple-sub-1",
+      eventTime: 1_718_000_000_000,
+      jti: "jti-replay",
+    });
+
+    expect(retryResult).toEqual({ logId: "existing-log-id", alreadySeen: false });
+
+    insertReturning.mockResolvedValueOnce([]);
+    linkLimit.mockResolvedValueOnce([
+      { id: "failed-log-id", actionTaken: "processing_failed" },
+    ]);
+
+    const failedRetry = await recordAppleNotificationReceipt({
+      eventType: "consent-revoked",
+      subject: "apple-sub-1",
+      eventTime: 1_718_000_000_000,
+      jti: "jti-failed",
+    });
+
+    expect(failedRetry).toEqual({ logId: "failed-log-id", alreadySeen: false });
   });
 
   test("tolerates missing event_time and jti", async () => {

--- a/src/lib/apple-notifications.ts
+++ b/src/lib/apple-notifications.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNotNull } from "drizzle-orm";
+import { and, desc, eq, isNotNull, or } from "drizzle-orm";
 import { createHash } from "crypto";
 import { db } from "@/db";
 import { appleNotificationLog, oauthAccounts, users } from "@/db/schema";
@@ -217,4 +217,22 @@ export async function finalizeAppleNotificationLog(
     .update(appleNotificationLog)
     .set({ actionTaken: result.actionTaken.slice(0, 64), userId: result.userId })
     .where(eq(appleNotificationLog.id, logId));
+}
+
+/** Atomically claim an in-flight receipt so concurrent duplicate deliveries run once. */
+export async function claimAppleNotificationForProcessing(logId: string): Promise<boolean> {
+  const [claimed] = await db
+    .update(appleNotificationLog)
+    .set({ actionTaken: "processing" })
+    .where(
+      and(
+        eq(appleNotificationLog.id, logId),
+        or(
+          eq(appleNotificationLog.actionTaken, "received"),
+          eq(appleNotificationLog.actionTaken, "processing_failed"),
+        ),
+      ),
+    )
+    .returning({ id: appleNotificationLog.id });
+  return claimed !== undefined;
 }

--- a/src/lib/apple-notifications.ts
+++ b/src/lib/apple-notifications.ts
@@ -153,7 +153,8 @@ export async function recordAppleNotificationReceipt(params: {
   eventTime: number | undefined;
   jti: string | undefined;
 }): Promise<AppleNotificationReceiptResult> {
-  const jti = params.jti !== undefined ? storageJti(params.jti) : null;
+  const jti =
+    typeof params.jti === "string" && params.jti.length > 0 ? storageJti(params.jti) : null;
   const values = {
     eventType: params.eventType.slice(0, EVENT_TYPE_MAX),
     subject: params.subject.slice(0, SUBJECT_MAX),

--- a/src/lib/apple-notifications.ts
+++ b/src/lib/apple-notifications.ts
@@ -132,7 +132,8 @@ export async function handleAppleNotificationEvent(
 /** Append the audit row for a verified notification BEFORE it is handled, with
  *  `action_taken = "received"`. Two-phase logging means a crash mid-handling can
  *  never lose the receipt — the row is finalized with the real action afterwards.
- *  Duplicate deliveries sharing a `jti` return `alreadySeen: true` (#532). */
+ *  Duplicate deliveries sharing a `jti` return `alreadySeen: true` once handling
+ *  has finalized beyond the in-flight `received` / `processing_failed` states (#532). */
 export type AppleNotificationReceiptResult = {
   logId: string;
   alreadySeen: boolean;
@@ -165,14 +166,19 @@ export async function recordAppleNotificationReceipt(params: {
 
   if (jti !== null) {
     const [existing] = await db
-      .select({ id: appleNotificationLog.id })
+      .select({
+        id: appleNotificationLog.id,
+        actionTaken: appleNotificationLog.actionTaken,
+      })
       .from(appleNotificationLog)
       .where(eq(appleNotificationLog.jti, jti))
       .limit(1);
     if (!existing) {
       throw new Error("apple_notification_log jti conflict but no existing row");
     }
-    return { logId: existing.id, alreadySeen: true };
+    const retryEligible =
+      existing.actionTaken === "received" || existing.actionTaken === "processing_failed";
+    return { logId: existing.id, alreadySeen: !retryEligible };
   }
 
   throw new Error("apple_notification_log insert returned no rows");

--- a/src/lib/apple-notifications.ts
+++ b/src/lib/apple-notifications.ts
@@ -1,13 +1,21 @@
 import { and, desc, eq, isNotNull } from "drizzle-orm";
+import { createHash } from "crypto";
 import { db } from "@/db";
 import { appleNotificationLog, oauthAccounts, users } from "@/db/schema";
 import { deleteUserAccount } from "@/lib/accountDeletion";
+import { isUniqueViolation } from "@/lib/dbErrors";
 
 /** Column widths from schema.ts — externally sourced strings are truncated to
  *  fit so a pathological value can never turn an audit insert into a 500. */
 const EVENT_TYPE_MAX = 50;
 const SUBJECT_MAX = 255;
 const JTI_MAX = 255;
+
+/** Fit a JWT `jti` into the audit column without truncating distinct values. */
+function storageJti(raw: string): string {
+  if (raw.length <= JTI_MAX) return raw;
+  return `sha256:${createHash("sha256").update(raw).digest("hex")}`;
+}
 
 /** One event from the JWT `events` claim of an Apple server-to-server notification. */
 export type AppleNotificationEvent = {
@@ -145,7 +153,7 @@ export async function recordAppleNotificationReceipt(params: {
   eventTime: number | undefined;
   jti: string | undefined;
 }): Promise<AppleNotificationReceiptResult> {
-  const jti = params.jti !== undefined ? params.jti.slice(0, JTI_MAX) : null;
+  const jti = params.jti !== undefined ? storageJti(params.jti) : null;
   const values = {
     eventType: params.eventType.slice(0, EVENT_TYPE_MAX),
     subject: params.subject.slice(0, SUBJECT_MAX),
@@ -153,16 +161,6 @@ export async function recordAppleNotificationReceipt(params: {
     jti,
     actionTaken: "received",
   };
-
-  const insertQuery = db.insert(appleNotificationLog).values(values);
-  const inserted = await (jti !== null
-    ? insertQuery.onConflictDoNothing({ target: appleNotificationLog.jti })
-    : insertQuery
-  ).returning({ id: appleNotificationLog.id });
-
-  if (inserted.length > 0) {
-    return { logId: inserted[0].id, alreadySeen: false };
-  }
 
   if (jti !== null) {
     const [existing] = await db
@@ -173,15 +171,40 @@ export async function recordAppleNotificationReceipt(params: {
       .from(appleNotificationLog)
       .where(eq(appleNotificationLog.jti, jti))
       .limit(1);
-    if (!existing) {
-      throw new Error("apple_notification_log jti conflict but no existing row");
+    if (existing) {
+      const retryEligible =
+        existing.actionTaken === "received" || existing.actionTaken === "processing_failed";
+      return { logId: existing.id, alreadySeen: !retryEligible };
     }
-    const retryEligible =
-      existing.actionTaken === "received" || existing.actionTaken === "processing_failed";
-    return { logId: existing.id, alreadySeen: !retryEligible };
   }
 
-  throw new Error("apple_notification_log insert returned no rows");
+  try {
+    const inserted = await db.insert(appleNotificationLog).values(values).returning({
+      id: appleNotificationLog.id,
+    });
+    if (inserted.length === 0) {
+      throw new Error("apple_notification_log insert returned no rows");
+    }
+    return { logId: inserted[0].id, alreadySeen: false };
+  } catch (error) {
+    if (jti !== null && isUniqueViolation(error)) {
+      const [existing] = await db
+        .select({
+          id: appleNotificationLog.id,
+          actionTaken: appleNotificationLog.actionTaken,
+        })
+        .from(appleNotificationLog)
+        .where(eq(appleNotificationLog.jti, jti))
+        .limit(1);
+      if (!existing) {
+        throw new Error("apple_notification_log jti conflict but no existing row");
+      }
+      const retryEligible =
+        existing.actionTaken === "received" || existing.actionTaken === "processing_failed";
+      return { logId: existing.id, alreadySeen: !retryEligible };
+    }
+    throw error;
+  }
 }
 
 /** Finalize the receipt row with the handler outcome (or `processing_failed`). */

--- a/src/lib/apple-notifications.ts
+++ b/src/lib/apple-notifications.ts
@@ -131,24 +131,51 @@ export async function handleAppleNotificationEvent(
 
 /** Append the audit row for a verified notification BEFORE it is handled, with
  *  `action_taken = "received"`. Two-phase logging means a crash mid-handling can
- *  never lose the receipt — the row is finalized with the real action afterwards. */
+ *  never lose the receipt — the row is finalized with the real action afterwards.
+ *  Duplicate deliveries sharing a `jti` return `alreadySeen: true` (#532). */
+export type AppleNotificationReceiptResult = {
+  logId: string;
+  alreadySeen: boolean;
+};
+
 export async function recordAppleNotificationReceipt(params: {
   eventType: string;
   subject: string;
   eventTime: number | undefined;
   jti: string | undefined;
-}): Promise<string> {
-  const [row] = await db
-    .insert(appleNotificationLog)
-    .values({
-      eventType: params.eventType.slice(0, EVENT_TYPE_MAX),
-      subject: params.subject.slice(0, SUBJECT_MAX),
-      eventTime: params.eventTime !== undefined ? new Date(params.eventTime) : null,
-      jti: params.jti !== undefined ? params.jti.slice(0, JTI_MAX) : null,
-      actionTaken: "received",
-    })
-    .returning({ id: appleNotificationLog.id });
-  return row.id;
+}): Promise<AppleNotificationReceiptResult> {
+  const jti = params.jti !== undefined ? params.jti.slice(0, JTI_MAX) : null;
+  const values = {
+    eventType: params.eventType.slice(0, EVENT_TYPE_MAX),
+    subject: params.subject.slice(0, SUBJECT_MAX),
+    eventTime: params.eventTime !== undefined ? new Date(params.eventTime) : null,
+    jti,
+    actionTaken: "received",
+  };
+
+  const insertQuery = db.insert(appleNotificationLog).values(values);
+  const inserted = await (jti !== null
+    ? insertQuery.onConflictDoNothing({ target: appleNotificationLog.jti })
+    : insertQuery
+  ).returning({ id: appleNotificationLog.id });
+
+  if (inserted.length > 0) {
+    return { logId: inserted[0].id, alreadySeen: false };
+  }
+
+  if (jti !== null) {
+    const [existing] = await db
+      .select({ id: appleNotificationLog.id })
+      .from(appleNotificationLog)
+      .where(eq(appleNotificationLog.jti, jti))
+      .limit(1);
+    if (!existing) {
+      throw new Error("apple_notification_log jti conflict but no existing row");
+    }
+    return { logId: existing.id, alreadySeen: true };
+  }
+
+  throw new Error("apple_notification_log insert returned no rows");
 }
 
 /** Finalize the receipt row with the handler outcome (or `processing_failed`). */


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #532.

## Summary

Apple server-to-server notifications were verified correctly but could be replayed: the audit log stored `jti` without uniqueness enforcement, so a captured payload could re-trigger handlers (notably `consent-revoked` re-unlinking an Apple account after re-link).

This PR adds database-level replay protection and short-circuits duplicate deliveries before event handling.

## Changes

- **Schema/migration:** partial unique index on `apple_notification_log.jti` (`WHERE jti IS NOT NULL`) via `drizzle/apple_notification_log_jti_unique_incremental.sql`
- **`recordAppleNotificationReceipt`:** insert-or-skip with `onConflictDoNothing`, returning `{ logId, alreadySeen }`
- **Notifications route:** when `alreadySeen`, return `200 { received: true }` without calling handlers
- **Tests:** module + route replay coverage

## Verification

- `npm ci`
- `npm run typecheck`
- `npm run test:unit` (597 tests)
- `npx vitest run src --exclude "**/.claude/**"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24a65932-d1f9-49ac-be88-93b0d7ecdb31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24a65932-d1f9-49ac-be88-93b0d7ecdb31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Prevent Apple notification replays from running twice**

### What Changed
- Duplicate Apple notifications with the same `jti` are now recorded once and skipped on later deliveries, so replayed notifications return success without re-running account changes
- Notifications are claimed before handling so concurrent duplicate deliveries do not trigger the same side effects twice
- Oversized `jti` values are stored safely, and blank or missing `jti` values are still accepted
- Audit logging now keeps failed processing separate from successful handling, so retries can still proceed when a previous attempt did not finish cleanly

### Impact
`✅ Fewer duplicate account changes from replayed Apple notifications`
`✅ Safer Apple sign-in and consent handling`
`✅ Fewer false retries after temporary notification failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
