### PR TITLE
test: buddy lifecycle routes + high-risk server paths (#538/#539)

### DIFF
--- a/src/app/api/buddy/sessions/[id]/cancel/route.integration.test.ts
+++ b/src/app/api/buddy/sessions/[id]/cancel/route.integration.test.ts
@@ -1,0 +1,107 @@
+import { NextRequest } from "next/server";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { buddySessionParticipants, buddySessions, users } from "@/db/schema";
+import { BUDDY_POLICY_CODES } from "@/lib/buddyPolicyCodes";
+import { closeTestDb, getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
+
+const { getCurrentUser } = vi.hoisted(() => ({ getCurrentUser: vi.fn() }));
+
+vi.mock("@/lib/auth", () => ({ getCurrentUser }));
+vi.mock("@/lib/daily", () => ({ deleteRoom: vi.fn() }));
+vi.mock("@/db", async () => ({ db: await getTestDb() }));
+
+import { POST } from "./route";
+
+let db: TestDb;
+let userId: string;
+let guestUserId: string;
+let buddySessionId: string;
+let seq = 0;
+
+function cancelRequest(sessionId: string = buddySessionId) {
+  return POST(
+    new NextRequest(`http://test.local/api/buddy/sessions/${sessionId}/cancel`, {
+      method: "POST",
+    }),
+    { params: Promise.resolve({ id: sessionId }) },
+  );
+}
+
+async function seedSession(
+  state: "waiting" | "ready_check" | "active" | "completed",
+  asHost: boolean,
+) {
+  seq += 1;
+  const [host] = await db
+    .insert(users)
+    .values({ email: `host538-cancel-${seq}@test.local`, username: `host538c_${seq}` })
+    .returning({ id: users.id });
+  const [guest] = await db
+    .insert(users)
+    .values({ email: `guest538-cancel-${seq}@test.local`, username: `guest538c_${seq}` })
+    .returning({ id: users.id });
+  userId = asHost ? host!.id : guest!.id;
+  guestUserId = guest!.id;
+
+  const [session] = await db
+    .insert(buddySessions)
+    .values({
+      shareToken: `tok-cancel-${seq}`,
+      hostUserId: host!.id,
+      state,
+      durationSeconds: 80,
+    })
+    .returning({ id: buddySessions.id });
+  buddySessionId = session!.id;
+
+  await db.insert(buddySessionParticipants).values([
+    { buddySessionId, userId: host!.id, isHost: true, ready: true },
+    { buddySessionId, userId: guest!.id, isHost: false, ready: true },
+  ]);
+}
+
+beforeEach(async () => {
+  db = await getTestDb();
+  await seedSession("ready_check", true);
+  getCurrentUser.mockResolvedValue({ userId, email: `host538-cancel-${seq}@test.local` });
+});
+
+afterAll(async () => {
+  await closeTestDb();
+});
+
+describe("POST /api/buddy/sessions/[id]/cancel", () => {
+  test("host cancels a lobby session and marks it abandoned", async () => {
+    const res = await cancelRequest();
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+
+    const [session] = await db
+      .select()
+      .from(buddySessions)
+      .where(eq(buddySessions.id, buddySessionId));
+    expect(session!.state).toBe("abandoned");
+  });
+
+  test("rejects cancel when the session is no longer in the lobby", async () => {
+    await db
+      .update(buddySessions)
+      .set({ state: "active" })
+      .where(eq(buddySessions.id, buddySessionId));
+
+    const res = await cancelRequest();
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe(BUDDY_POLICY_CODES.CANCEL_WRONG_PHASE);
+  });
+
+  test("rejects non-host callers", async () => {
+    getCurrentUser.mockResolvedValue({ userId: guestUserId, email: `guest538-cancel-${seq}@test.local` });
+
+    const res = await cancelRequest();
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe(BUDDY_POLICY_CODES.HOST_ONLY);
+  });
+});

--- a/src/app/api/buddy/sessions/[id]/leave/route.integration.test.ts
+++ b/src/app/api/buddy/sessions/[id]/leave/route.integration.test.ts
@@ -1,0 +1,141 @@
+import { NextRequest } from "next/server";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { buddySessionParticipants, buddySessions, users } from "@/db/schema";
+import { closeTestDb, getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
+
+const { getCurrentUser, deleteRoom } = vi.hoisted(() => ({
+  getCurrentUser: vi.fn(),
+  deleteRoom: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({ getCurrentUser }));
+vi.mock("@/lib/daily", () => ({ deleteRoom }));
+vi.mock("@/db", async () => ({ db: await getTestDb() }));
+
+import { POST } from "./route";
+
+let db: TestDb;
+let userId: string;
+let hostUserId: string;
+let buddySessionId: string;
+let seq = 0;
+
+function leaveRequest(sessionId: string = buddySessionId) {
+  return POST(
+    new NextRequest(`http://test.local/api/buddy/sessions/${sessionId}/leave`, {
+      method: "POST",
+    }),
+    { params: Promise.resolve({ id: sessionId }) },
+  );
+}
+
+async function seedActiveSession(opts: { asHost: boolean; dailyRoomName?: string | null }) {
+  seq += 1;
+  const [host] = await db
+    .insert(users)
+    .values({ email: `host538-leave-${seq}@test.local`, username: `host538l_${seq}`, currentDay: 4 })
+    .returning({ id: users.id });
+  const [guest] = await db
+    .insert(users)
+    .values({ email: `guest538-leave-${seq}@test.local`, username: `guest538l_${seq}`, currentDay: 2 })
+    .returning({ id: users.id });
+  hostUserId = host!.id;
+  userId = opts.asHost ? host!.id : guest!.id;
+
+  const [session] = await db
+    .insert(buddySessions)
+    .values({
+      shareToken: `tok-leave-${seq}`,
+      hostUserId,
+      state: "active",
+      durationSeconds: 70,
+      startedAt: new Date(),
+      dailyRoomName: opts.dailyRoomName ?? null,
+      dailyRoomUrl: opts.dailyRoomName ? `https://daily.co/${opts.dailyRoomName}` : null,
+      revision: 4,
+    })
+    .returning({ id: buddySessions.id });
+  buddySessionId = session!.id;
+
+  await db.insert(buddySessionParticipants).values([
+    { buddySessionId, userId: hostUserId, isHost: true, ready: true },
+    { buddySessionId, userId: guest!.id, isHost: false, ready: true },
+  ]);
+}
+
+beforeEach(async () => {
+  db = await getTestDb();
+  deleteRoom.mockResolvedValue(undefined);
+});
+
+afterAll(async () => {
+  await closeTestDb();
+});
+
+describe("POST /api/buddy/sessions/[id]/leave", () => {
+  test("non-host leave marks the participant row and keeps the session active", async () => {
+    await seedActiveSession({ asHost: false });
+    getCurrentUser.mockResolvedValue({ userId, email: `guest538-leave-${seq}@test.local` });
+
+    const res = await leaveRequest();
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+
+    const [participant] = await db
+      .select()
+      .from(buddySessionParticipants)
+      .where(eq(buddySessionParticipants.userId, userId));
+    expect(participant!.leftAt).not.toBeNull();
+    expect(participant!.ready).toBe(false);
+
+    const [session] = await db
+      .select()
+      .from(buddySessions)
+      .where(eq(buddySessions.id, buddySessionId));
+    expect(session!.state).toBe("active");
+    expect(session!.revision).toBe(5);
+    expect(deleteRoom).not.toHaveBeenCalled();
+  });
+
+  test("host leave abandons the session and tears down the Daily room", async () => {
+    await seedActiveSession({ asHost: true, dailyRoomName: "buddy-room-538" });
+    getCurrentUser.mockResolvedValue({ userId: hostUserId, email: `host538-leave-${seq}@test.local` });
+
+    const res = await leaveRequest();
+    expect(res.status).toBe(200);
+
+    const [session] = await db
+      .select()
+      .from(buddySessions)
+      .where(eq(buddySessions.id, buddySessionId));
+    expect(session!.state).toBe("abandoned");
+    expect(session!.dailyRoomName).toBeNull();
+    expect(session!.dailyRoomUrl).toBeNull();
+    expect(deleteRoom).toHaveBeenCalledWith("buddy-room-538", { ignoreMissing: true });
+  });
+
+  test("is a no-op when the participant already left", async () => {
+    await seedActiveSession({ asHost: false });
+    await db
+      .update(buddySessionParticipants)
+      .set({ leftAt: new Date(), ready: false })
+      .where(eq(buddySessionParticipants.userId, userId));
+    getCurrentUser.mockResolvedValue({ userId, email: `guest538-leave-${seq}@test.local` });
+
+    const before = await db
+      .select()
+      .from(buddySessions)
+      .where(eq(buddySessions.id, buddySessionId));
+
+    const res = await leaveRequest();
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+
+    const after = await db
+      .select()
+      .from(buddySessions)
+      .where(eq(buddySessions.id, buddySessionId));
+    expect(after[0]!.revision).toBe(before[0]!.revision);
+  });
+});

--- a/src/app/api/buddy/sessions/[id]/meeting-token/route.integration.test.ts
+++ b/src/app/api/buddy/sessions/[id]/meeting-token/route.integration.test.ts
@@ -1,0 +1,150 @@
+import { NextRequest } from "next/server";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { buddySessionParticipants, buddySessions, users } from "@/db/schema";
+import { BUDDY_POLICY_CODES } from "@/lib/buddyPolicyCodes";
+import { closeTestDb, getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
+
+const { getCurrentUser, createMeetingToken, DailyApiError } = vi.hoisted(() => {
+  class DailyApiError extends Error {
+    readonly status: number;
+    readonly body: unknown;
+    constructor(message: string, status: number, body: unknown) {
+      super(message);
+      this.name = "DailyApiError";
+      this.status = status;
+      this.body = body;
+    }
+  }
+
+  return {
+    getCurrentUser: vi.fn(),
+    createMeetingToken: vi.fn(),
+    DailyApiError,
+  };
+});
+
+vi.mock("@/lib/auth", () => ({ getCurrentUser }));
+vi.mock("@/lib/daily", () => ({
+  createMeetingToken,
+  DailyApiError,
+}));
+vi.mock("@/db", async () => ({ db: await getTestDb() }));
+
+import { POST } from "./route";
+
+let db: TestDb;
+let userId: string;
+let hostUserId: string;
+let buddySessionId: string;
+let seq = 0;
+
+function tokenRequest(sessionId: string = buddySessionId) {
+  return POST(
+    new NextRequest(`http://test.local/api/buddy/sessions/${sessionId}/meeting-token`, {
+      method: "POST",
+    }),
+    { params: Promise.resolve({ id: sessionId }) },
+  );
+}
+
+async function seedActiveSession(opts?: { dailyRoomName?: string | null; left?: boolean }) {
+  seq += 1;
+  const [host] = await db
+    .insert(users)
+    .values({ email: `host538-token-${seq}@test.local`, username: `host538t_${seq}` })
+    .returning({ id: users.id });
+  const [guest] = await db
+    .insert(users)
+    .values({ email: `guest538-token-${seq}@test.local`, username: `guest538t_${seq}` })
+    .returning({ id: users.id });
+  hostUserId = host!.id;
+  userId = guest!.id;
+
+  const roomName = opts?.dailyRoomName === undefined ? `buddy-${seq}` : opts.dailyRoomName;
+  const [session] = await db
+    .insert(buddySessions)
+    .values({
+      shareToken: `tok-token-${seq}`,
+      hostUserId,
+      state: "active",
+      durationSeconds: 80,
+      startedAt: new Date(),
+      dailyRoomName: roomName,
+      dailyRoomUrl: roomName ? `https://daily.co/${roomName}` : null,
+    })
+    .returning({ id: buddySessions.id });
+  buddySessionId = session!.id;
+
+  await db.insert(buddySessionParticipants).values([
+    { buddySessionId, userId: hostUserId, isHost: true, ready: true },
+    {
+      buddySessionId,
+      userId,
+      isHost: false,
+      ready: true,
+      leftAt: opts?.left ? new Date() : null,
+    },
+  ]);
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  db = await getTestDb();
+  await seedActiveSession();
+  getCurrentUser.mockResolvedValue({ userId, email: `guest538-token-${seq}@test.local` });
+  createMeetingToken.mockResolvedValue("daily-meeting-token-abc");
+});
+
+afterAll(async () => {
+  await closeTestDb();
+});
+
+describe("POST /api/buddy/sessions/[id]/meeting-token", () => {
+  test("mints a token for an active participant", async () => {
+    const res = await tokenRequest();
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ token: "daily-meeting-token-abc" });
+
+    expect(createMeetingToken).toHaveBeenCalledWith({
+      roomName: `buddy-${seq}`,
+      userName: `guest538t_${seq}`,
+      userId,
+    });
+  });
+
+  test("rejects callers who left the session", async () => {
+    await db
+      .update(buddySessionParticipants)
+      .set({ leftAt: new Date() })
+      .where(eq(buddySessionParticipants.userId, userId));
+
+    const res = await tokenRequest();
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe(BUDDY_POLICY_CODES.NOT_IN_SESSION);
+    expect(createMeetingToken).not.toHaveBeenCalled();
+  });
+
+  test("rejects token requests when the session is not active", async () => {
+    await db
+      .update(buddySessions)
+      .set({ state: "ready_check", dailyRoomName: null, dailyRoomUrl: null })
+      .where(eq(buddySessions.id, buddySessionId));
+
+    const res = await tokenRequest();
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("Video token is only available during an active buddy sit");
+    expect(body.code).toBeUndefined();
+  });
+
+  test("returns 503 when Daily token minting fails", async () => {
+    createMeetingToken.mockRejectedValue(new DailyApiError("Daily unavailable", 503, null));
+
+    const res = await tokenRequest();
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe("Could not issue a video token. Check Daily configuration.");
+  });
+});

--- a/src/app/api/buddy/sessions/[id]/participant-complete/route.integration.test.ts
+++ b/src/app/api/buddy/sessions/[id]/participant-complete/route.integration.test.ts
@@ -1,0 +1,139 @@
+import { NextRequest } from "next/server";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { buddySessionParticipants, buddySessions, users } from "@/db/schema";
+import { BUDDY_POLICY_CODES } from "@/lib/buddyPolicyCodes";
+import { closeTestDb, getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
+
+const { getCurrentUser } = vi.hoisted(() => ({ getCurrentUser: vi.fn() }));
+
+vi.mock("@/lib/auth", () => ({ getCurrentUser }));
+vi.mock("@/lib/daily", () => ({ deleteRoom: vi.fn() }));
+vi.mock("@/db", async () => ({ db: await getTestDb() }));
+
+import { POST } from "./route";
+
+let db: TestDb;
+let userId: string;
+let hostUserId: string;
+let buddySessionId: string;
+let seq = 0;
+
+function completeRequest(sessionId: string = buddySessionId) {
+  return POST(
+    new NextRequest(`http://test.local/api/buddy/sessions/${sessionId}/participant-complete`, {
+      method: "POST",
+    }),
+    { params: Promise.resolve({ id: sessionId }) },
+  );
+}
+
+async function seedSession(state: "active" | "completed" | "waiting") {
+  seq += 1;
+  const [host] = await db
+    .insert(users)
+    .values({ email: `host538-pc-${seq}@test.local`, username: `host538pc_${seq}` })
+    .returning({ id: users.id });
+  const [guest] = await db
+    .insert(users)
+    .values({ email: `guest538-pc-${seq}@test.local`, username: `guest538pc_${seq}` })
+    .returning({ id: users.id });
+  hostUserId = host!.id;
+  userId = guest!.id;
+
+  const [session] = await db
+    .insert(buddySessions)
+    .values({
+      shareToken: `tok-pc-${seq}`,
+      hostUserId,
+      state,
+      durationSeconds: 80,
+      startedAt: state === "active" ? new Date() : null,
+      revision: 1,
+    })
+    .returning({ id: buddySessions.id });
+  buddySessionId = session!.id;
+
+  await db.insert(buddySessionParticipants).values([
+    { buddySessionId, userId: hostUserId, isHost: true, ready: true },
+    { buddySessionId, userId, isHost: false, ready: true },
+  ]);
+}
+
+beforeEach(async () => {
+  db = await getTestDb();
+  await seedSession("active");
+  getCurrentUser.mockResolvedValue({ userId, email: `guest538-pc-${seq}@test.local` });
+});
+
+afterAll(async () => {
+  await closeTestDb();
+});
+
+describe("POST /api/buddy/sessions/[id]/participant-complete", () => {
+  test("marks participant completion and bumps revision", async () => {
+    const res = await completeRequest();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(typeof body.participantCompletedAt).toBe("string");
+
+    const [participant] = await db
+      .select()
+      .from(buddySessionParticipants)
+      .where(eq(buddySessionParticipants.userId, userId));
+    expect(participant!.participantCompletedAt).not.toBeNull();
+
+    const [session] = await db
+      .select()
+      .from(buddySessions)
+      .where(eq(buddySessions.id, buddySessionId));
+    expect(session!.revision).toBe(2);
+  });
+
+  test("repeat calls are idempotent with already=true", async () => {
+    const first = await completeRequest();
+    expect(first.status).toBe(200);
+    const firstBody = await first.json();
+
+    const second = await completeRequest();
+    expect(second.status).toBe(200);
+    const secondBody = await second.json();
+    expect(secondBody.already).toBe(true);
+    expect(secondBody.participantCompletedAt).toBeUndefined();
+
+    const [participant] = await db
+      .select()
+      .from(buddySessionParticipants)
+      .where(eq(buddySessionParticipants.userId, userId));
+    expect(participant!.participantCompletedAt!.toISOString()).toBe(firstBody.participantCompletedAt);
+  });
+
+  test("rejects completion before the shared sit is active", async () => {
+    await db
+      .update(buddySessions)
+      .set({ state: "waiting" })
+      .where(eq(buddySessions.id, buddySessionId));
+
+    const res = await completeRequest();
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe(BUDDY_POLICY_CODES.PARTICIPANT_COMPLETE_WRONG_PHASE);
+  });
+
+  test("rejects callers who are not in the session", async () => {
+    const [stranger] = await db
+      .insert(users)
+      .values({ email: `stranger538-${seq}@test.local`, username: `stranger538_${seq}` })
+      .returning({ id: users.id });
+    getCurrentUser.mockResolvedValue({
+      userId: stranger!.id,
+      email: `stranger538-${seq}@test.local`,
+    });
+
+    const res = await completeRequest();
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe(BUDDY_POLICY_CODES.NOT_IN_SESSION);
+  });
+});

--- a/src/app/api/buddy/sessions/[id]/ready/route.integration.test.ts
+++ b/src/app/api/buddy/sessions/[id]/ready/route.integration.test.ts
@@ -1,0 +1,129 @@
+import { NextRequest } from "next/server";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { buddySessionParticipants, buddySessions, users } from "@/db/schema";
+import { BUDDY_POLICY_CODES } from "@/lib/buddyPolicyCodes";
+import { closeTestDb, getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
+
+const { getCurrentUser } = vi.hoisted(() => ({ getCurrentUser: vi.fn() }));
+
+vi.mock("@/lib/auth", () => ({ getCurrentUser }));
+vi.mock("@/lib/daily", () => ({ deleteRoom: vi.fn() }));
+vi.mock("@/db", async () => ({ db: await getTestDb() }));
+
+import { PATCH } from "./route";
+
+let db: TestDb;
+let userId: string;
+let hostUserId: string;
+let buddySessionId: string;
+let seq = 0;
+
+function readyRequest(body: unknown, sessionId: string = buddySessionId) {
+  return PATCH(
+    new NextRequest(`http://test.local/api/buddy/sessions/${sessionId}/ready`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    { params: Promise.resolve({ id: sessionId }) },
+  );
+}
+
+async function seedLobbySession(state: "waiting" | "ready_check" = "ready_check") {
+  seq += 1;
+  const [host] = await db
+    .insert(users)
+    .values({ email: `host538-ready-${seq}@test.local`, username: `host538r_${seq}` })
+    .returning({ id: users.id });
+  const [guest] = await db
+    .insert(users)
+    .values({ email: `guest538-ready-${seq}@test.local`, username: `guest538r_${seq}`, currentDay: 3 })
+    .returning({ id: users.id });
+  hostUserId = host!.id;
+  userId = guest!.id;
+
+  const [session] = await db
+    .insert(buddySessions)
+    .values({
+      shareToken: `tok-ready-${seq}`,
+      hostUserId,
+      state,
+      durationSeconds: 80,
+      revision: 2,
+    })
+    .returning({ id: buddySessions.id });
+  buddySessionId = session!.id;
+
+  await db.insert(buddySessionParticipants).values([
+    { buddySessionId, userId: hostUserId, isHost: true, ready: true },
+    { buddySessionId, userId, isHost: false, ready: false },
+  ]);
+}
+
+beforeEach(async () => {
+  db = await getTestDb();
+  await seedLobbySession();
+  getCurrentUser.mockResolvedValue({ userId, email: `guest538-ready-${seq}@test.local` });
+});
+
+afterAll(async () => {
+  await closeTestDb();
+});
+
+describe("PATCH /api/buddy/sessions/[id]/ready", () => {
+  test("sets ready=true and bumps revision in the lobby", async () => {
+    const res = await readyRequest({ ready: true });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+
+    const [participant] = await db
+      .select()
+      .from(buddySessionParticipants)
+      .where(eq(buddySessionParticipants.userId, userId));
+    expect(participant!.ready).toBe(true);
+    expect(participant!.lastSeenAt).not.toBeNull();
+
+    const [session] = await db
+      .select()
+      .from(buddySessions)
+      .where(eq(buddySessions.id, buddySessionId));
+    expect(session!.revision).toBe(3);
+  });
+
+  test("rejects invalid session id", async () => {
+    const res = await readyRequest({ ready: true }, "not-a-uuid");
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid session id" });
+  });
+
+  test("rejects non-boolean ready", async () => {
+    const res = await readyRequest({ ready: "yes" });
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "ready must be a boolean" });
+  });
+
+  test("rejects ready toggle after the lobby phase", async () => {
+    await db
+      .update(buddySessions)
+      .set({ state: "active" })
+      .where(eq(buddySessions.id, buddySessionId));
+
+    const res = await readyRequest({ ready: true });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe(BUDDY_POLICY_CODES.READY_LOBBY_ONLY);
+  });
+
+  test("rejects callers who left the session", async () => {
+    await db
+      .update(buddySessionParticipants)
+      .set({ leftAt: new Date() })
+      .where(eq(buddySessionParticipants.userId, userId));
+
+    const res = await readyRequest({ ready: true });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe(BUDDY_POLICY_CODES.NOT_IN_SESSION);
+  });
+});

--- a/src/app/api/buddy/sessions/[id]/start/route.integration.test.ts
+++ b/src/app/api/buddy/sessions/[id]/start/route.integration.test.ts
@@ -1,0 +1,246 @@
+import { NextRequest } from "next/server";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { buddySessionParticipants, buddySessions, users } from "@/db/schema";
+import { BUDDY_POLICY_CODES } from "@/lib/buddyPolicyCodes";
+import { closeTestDb, getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
+
+const { getCurrentUser, createRoom, deleteRoom, DailyApiError, isDailyRoomNameConflict } = vi.hoisted(() => {
+  class DailyApiError extends Error {
+    readonly status: number;
+    readonly body: unknown;
+    constructor(message: string, status: number, body: unknown) {
+      super(message);
+      this.name = "DailyApiError";
+      this.status = status;
+      this.body = body;
+    }
+  }
+
+  function isDailyRoomNameConflict(error: DailyApiError): boolean {
+    if (error.status !== 400 && error.status !== 409) return false;
+    const raw = `${error.message}\n${JSON.stringify(error.body)}`.toLowerCase();
+    return (
+      raw.includes("already") ||
+      raw.includes("exists") ||
+      raw.includes("taken") ||
+      raw.includes("in use") ||
+      raw.includes("duplicate")
+    );
+  }
+
+  return {
+    getCurrentUser: vi.fn(),
+    createRoom: vi.fn(),
+    deleteRoom: vi.fn(),
+    DailyApiError,
+    isDailyRoomNameConflict,
+  };
+});
+
+vi.mock("@/lib/auth", () => ({ getCurrentUser }));
+vi.mock("@/lib/daily", () => ({
+  createRoom,
+  deleteRoom,
+  DailyApiError,
+  isDailyRoomNameConflict,
+}));
+vi.mock("@/db", async () => ({ db: await getTestDb() }));
+
+import { POST } from "./route";
+
+let db: TestDb;
+let userId: string;
+let guestUserId: string;
+let buddySessionId: string;
+let seq = 0;
+
+function startRequest(sessionId: string = buddySessionId) {
+  return POST(
+    new NextRequest(`http://test.local/api/buddy/sessions/${sessionId}/start`, {
+      method: "POST",
+    }),
+    { params: Promise.resolve({ id: sessionId }) },
+  );
+}
+
+async function seedReadyCheckSession(opts?: { scheduledStartAt?: Date | null }) {
+  seq += 1;
+  const [host] = await db
+    .insert(users)
+    .values({ email: `host538-start-${seq}@test.local`, username: `host538s_${seq}` })
+    .returning({ id: users.id });
+  const [guest] = await db
+    .insert(users)
+    .values({ email: `guest538-start-${seq}@test.local`, username: `guest538s_${seq}` })
+    .returning({ id: users.id });
+  userId = host!.id;
+  guestUserId = guest!.id;
+
+  const [session] = await db
+    .insert(buddySessions)
+    .values({
+      shareToken: `tok-start-${seq}`,
+      hostUserId: userId,
+      state: "ready_check",
+      durationSeconds: 80,
+      scheduledStartAt: opts?.scheduledStartAt ?? null,
+      revision: 1,
+    })
+    .returning({ id: buddySessions.id });
+  buddySessionId = session!.id;
+
+  await db.insert(buddySessionParticipants).values([
+    { buddySessionId, userId, isHost: true, ready: true },
+    { buddySessionId, userId: guestUserId, isHost: false, ready: true },
+  ]);
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  db = await getTestDb();
+  await seedReadyCheckSession();
+  getCurrentUser.mockResolvedValue({ userId, email: `host538-start-${seq}@test.local` });
+  createRoom.mockResolvedValue({
+    name: `buddy-${buddySessionId}`,
+    url: `https://daily.co/buddy-${buddySessionId}`,
+  });
+  deleteRoom.mockResolvedValue(undefined);
+});
+
+afterAll(async () => {
+  await closeTestDb();
+});
+
+describe("POST /api/buddy/sessions/[id]/start", () => {
+  test("host starts a ready_check session and provisions a Daily room", async () => {
+    const res = await startRequest();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(typeof body.startedAt).toBe("string");
+
+    const [session] = await db
+      .select()
+      .from(buddySessions)
+      .where(eq(buddySessions.id, buddySessionId));
+    expect(session!.state).toBe("active");
+    expect(session!.dailyRoomName).toBe(`buddy-${buddySessionId}`);
+    expect(session!.dailyRoomUrl).toBe(`https://daily.co/buddy-${buddySessionId}`);
+    expect(session!.revision).toBe(2);
+    expect(createRoom).toHaveBeenCalledWith({
+      name: `buddy-${buddySessionId}`,
+      privacy: "private",
+    });
+  });
+
+  test("retries once after a Daily room name conflict", async () => {
+    createRoom
+      .mockRejectedValueOnce(new DailyApiError("Room already exists", 409, { info: "already taken" }))
+      .mockResolvedValueOnce({
+        name: `buddy-${buddySessionId}`,
+        url: `https://daily.co/buddy-${buddySessionId}`,
+      });
+
+    const res = await startRequest();
+    expect(res.status).toBe(200);
+
+    expect(deleteRoom).toHaveBeenCalledWith(`buddy-${buddySessionId}`, { ignoreMissing: true });
+    expect(createRoom).toHaveBeenCalledTimes(2);
+
+    const [session] = await db
+      .select()
+      .from(buddySessions)
+      .where(eq(buddySessions.id, buddySessionId));
+    expect(session!.state).toBe("active");
+  });
+
+  test("returns 503 when the retry after a name conflict also fails", async () => {
+    createRoom
+      .mockRejectedValueOnce(new DailyApiError("Room already exists", 409, { info: "already taken" }))
+      .mockRejectedValueOnce(new DailyApiError("Still conflicted", 409, { info: "duplicate" }));
+
+    const res = await startRequest();
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toContain("name conflict after cleanup");
+
+    const [session] = await db
+      .select()
+      .from(buddySessions)
+      .where(eq(buddySessions.id, buddySessionId));
+    expect(session!.state).toBe("ready_check");
+  });
+
+  test("returns 503 when DAILY_API_KEY is missing", async () => {
+    createRoom.mockRejectedValueOnce(new Error("DAILY_API_KEY is not set. Add it to your environment"));
+
+    const res = await startRequest();
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toContain("DAILY_API_KEY");
+
+    const [session] = await db
+      .select()
+      .from(buddySessions)
+      .where(eq(buddySessions.id, buddySessionId));
+    expect(session!.state).toBe("ready_check");
+  });
+
+  test("only one concurrent start wins; the loser tears down its room", async () => {
+    const [first, second] = await Promise.all([startRequest(), startRequest()]);
+
+    const statuses = [first.status, second.status].sort();
+    expect(statuses).toEqual([200, 409]);
+
+    const winner = first.status === 200 ? first : second;
+    const loser = first.status === 409 ? first : second;
+    const loserBody = await loser.json();
+    expect(loserBody.code).toBe(BUDDY_POLICY_CODES.START_WRONG_PHASE);
+    expect(deleteRoom).toHaveBeenCalled();
+
+    const winnerBody = await winner.json();
+    expect(winnerBody.ok).toBe(true);
+
+    const [session] = await db
+      .select()
+      .from(buddySessions)
+      .where(eq(buddySessions.id, buddySessionId));
+    expect(session!.state).toBe("active");
+  });
+
+  test("rejects non-host callers", async () => {
+    getCurrentUser.mockResolvedValue({ userId: guestUserId, email: `guest538-start-${seq}@test.local` });
+
+    const res = await startRequest();
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe(BUDDY_POLICY_CODES.HOST_ONLY);
+    expect(createRoom).not.toHaveBeenCalled();
+  });
+
+  test("rejects start before ready_check phase", async () => {
+    await db
+      .update(buddySessions)
+      .set({ state: "active", startedAt: new Date() })
+      .where(eq(buddySessions.id, buddySessionId));
+
+    const res = await startRequest();
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.code).toBe(BUDDY_POLICY_CODES.START_WRONG_PHASE);
+  });
+
+  test("rejects start before the scheduled time", async () => {
+    await seedReadyCheckSession({
+      scheduledStartAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+    getCurrentUser.mockResolvedValue({ userId, email: `host538-start-${seq}@test.local` });
+
+    const res = await startRequest();
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({
+      error: "This session is scheduled for later.",
+    });
+  });
+});

--- a/src/app/api/sessions/route.breath.integration.test.ts
+++ b/src/app/api/sessions/route.breath.integration.test.ts
@@ -1,0 +1,112 @@
+import { NextRequest } from "next/server";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { sessions, users } from "@/db/schema";
+import { closeTestDb, getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
+
+const { getCurrentUser } = vi.hoisted(() => ({ getCurrentUser: vi.fn() }));
+
+vi.mock("@/lib/auth", () => ({ getCurrentUser }));
+vi.mock("@/db", async () => ({ db: await getTestDb() }));
+
+import { POST } from "./route";
+
+let db: TestDb;
+let seq = 0;
+
+function sessionRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://test.local/api/sessions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function breathBody(overrides: Record<string, unknown> = {}) {
+  return {
+    dayNumber: 1,
+    duration: 60,
+    actualTime: 60,
+    clearPercent: 0,
+    thoughtCount: 0,
+    mindStateLog: [],
+    sessionDate: "2026-06-11",
+    completed: true,
+    sessionType: "breath",
+    ...overrides,
+  };
+}
+
+afterAll(async () => {
+  await closeTestDb();
+});
+
+beforeEach(async () => {
+  db = await getTestDb();
+});
+
+describe("POST /api/sessions — breathCount write path (#539)", () => {
+  test("persists a finite breathCount for breath sessions", async () => {
+    seq += 1;
+    const [user] = await db
+      .insert(users)
+      .values({ email: `breath539-${seq}@test.local`, username: `breath539_${seq}` })
+      .returning();
+    getCurrentUser.mockResolvedValue({ userId: user!.id, email: user!.email });
+
+    const res = await POST(sessionRequest(breathBody({ breathCount: 42 })));
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(sessions).where(eq(sessions.userId, user!.id));
+    expect(row!.breathCount).toBe(42);
+  });
+
+  test("clamps negative breathCount to zero", async () => {
+    seq += 1;
+    const [user] = await db
+      .insert(users)
+      .values({ email: `breath539-neg-${seq}@test.local`, username: `breath539n_${seq}` })
+      .returning();
+    getCurrentUser.mockResolvedValue({ userId: user!.id, email: user!.email });
+
+    const res = await POST(sessionRequest(breathBody({ breathCount: -12.7 })));
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(sessions).where(eq(sessions.userId, user!.id));
+    expect(row!.breathCount).toBe(0);
+  });
+
+  test("floors fractional breathCount and caps at int32 max", async () => {
+    seq += 1;
+    const [user] = await db
+      .insert(users)
+      .values({ email: `breath539-cap-${seq}@test.local`, username: `breath539c_${seq}` })
+      .returning();
+    getCurrentUser.mockResolvedValue({ userId: user!.id, email: user!.email });
+
+    const res = await POST(
+      sessionRequest(breathBody({ breathCount: 2_147_483_647.9 })),
+    );
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(sessions).where(eq(sessions.userId, user!.id));
+    expect(row!.breathCount).toBe(2_147_483_647);
+  });
+
+  test("ignores breathCount for non-breath session types", async () => {
+    seq += 1;
+    const [user] = await db
+      .insert(users)
+      .values({ email: `breath539-std-${seq}@test.local`, username: `breath539s_${seq}` })
+      .returning();
+    getCurrentUser.mockResolvedValue({ userId: user!.id, email: user!.email });
+
+    const res = await POST(
+      sessionRequest(breathBody({ sessionType: "standard", breathCount: 99 })),
+    );
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(sessions).where(eq(sessions.userId, user!.id));
+    expect(row!.breathCount).toBeNull();
+  });
+});

--- a/src/lib/oauth-user-resolution.test.ts
+++ b/src/lib/oauth-user-resolution.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { oauthAccounts, users } from "@/db/schema";
+import { closeTestDb, getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
+
+vi.mock("@/db", async () => ({ db: await getTestDb() }));
+
+import {
+  OAuthEmailRequiredError,
+  resolveOAuthUserId,
+} from "./oauth-user-resolution";
+
+let db: TestDb;
+let seq = 0;
+
+afterAll(async () => {
+  await closeTestDb();
+});
+
+beforeEach(async () => {
+  db = await getTestDb();
+});
+
+describe("resolveOAuthUserId (#539)", () => {
+  test("returns an existing provider link without requiring email", async () => {
+    seq += 1;
+    const [user] = await db
+      .insert(users)
+      .values({ email: `oauth539-${seq}@test.local`, username: `oauth539_${seq}` })
+      .returning();
+    await db.insert(oauthAccounts).values({
+      userId: user!.id,
+      provider: "apple",
+      providerAccountId: `apple-sub-${seq}`,
+    });
+
+    const userId = await resolveOAuthUserId({
+      provider: "apple",
+      providerAccountId: `apple-sub-${seq}`,
+      profile: {},
+    });
+
+    expect(userId).toBe(user!.id);
+  });
+
+  test("links a new provider identity to an existing email match", async () => {
+    seq += 1;
+    const [user] = await db
+      .insert(users)
+      .values({ email: `oauth539-link-${seq}@test.local`, username: `oauth539l_${seq}` })
+      .returning();
+
+    const userId = await resolveOAuthUserId({
+      provider: "google",
+      providerAccountId: `google-sub-${seq}`,
+      email: `oauth539-link-${seq}@test.local`,
+      profile: { name: "OAuth Tester" },
+    });
+
+    expect(userId).toBe(user!.id);
+
+    const [link] = await db
+      .select()
+      .from(oauthAccounts)
+      .where(eq(oauthAccounts.providerAccountId, `google-sub-${seq}`));
+    expect(link!.userId).toBe(user!.id);
+  });
+
+  test("creates a new user when email is unseen and sanitizes the username seed", async () => {
+    seq += 1;
+    const email = `oauth539-new-${seq}@test.local`;
+
+    const userId = await resolveOAuthUserId({
+      provider: "google",
+      providerAccountId: `google-new-${seq}`,
+      email,
+      profile: { name: "!!!" },
+    });
+
+    const [user] = await db.select().from(users).where(eq(users.id, userId));
+    expect(user!.email).toBe(email);
+    expect(user!.username.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test("throws OAuthEmailRequiredError when email is missing for a new link", async () => {
+    await expect(
+      resolveOAuthUserId({
+        provider: "apple",
+        providerAccountId: "brand-new-sub",
+        profile: {},
+      }),
+    ).rejects.toBeInstanceOf(OAuthEmailRequiredError);
+  });
+});

--- a/src/lib/passwordReset.test.ts
+++ b/src/lib/passwordReset.test.ts
@@ -1,0 +1,64 @@
+import { NextRequest } from "next/server";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  createPasswordResetToken,
+  getPasswordResetPayload,
+  hashResetToken,
+  isPasswordResetRateLimited,
+  normalizeResetEmail,
+  recordPasswordResetAttempt,
+  requestIpHash,
+} from "./passwordReset";
+
+describe("passwordReset (#539)", () => {
+  const originalSecret = process.env.JWT_SECRET;
+
+  beforeEach(() => {
+    process.env.JWT_SECRET = "test-reset-secret-at-least-32-chars-long";
+  });
+
+  afterAll(() => {
+    process.env.JWT_SECRET = originalSecret;
+  });
+
+  test("round-trips a reset token and hashes it deterministically", async () => {
+    const token = await createPasswordResetToken({ userId: "user-abc" });
+    const payload = await getPasswordResetPayload(token);
+
+    expect(payload).toEqual({
+      userId: "user-abc",
+      tokenHash: hashResetToken(token),
+    });
+  });
+
+  test("returns null for tampered reset tokens", async () => {
+    const token = await createPasswordResetToken({ userId: "user-abc" });
+    const payload = await getPasswordResetPayload(`${token}x`);
+    expect(payload).toBeNull();
+  });
+
+  test("rate limits repeated reset attempts per email/ip pair", async () => {
+    const email = "reset539@test.local";
+    const ipHash = "deadbeef";
+
+    for (let i = 0; i < 5; i++) {
+      recordPasswordResetAttempt(email, ipHash);
+    }
+    expect(isPasswordResetRateLimited(email, ipHash)).toBe(true);
+    expect(isPasswordResetRateLimited(email, "other-ip")).toBe(false);
+  });
+
+  test("normalizes reset emails and request ip hashes", () => {
+    expect(normalizeResetEmail("  User@Example.COM ")).toBe("user@example.com");
+    expect(normalizeResetEmail("not-an-email")).toBe("");
+
+    const request = new NextRequest("http://test.local/api/auth/password-reset", {
+      headers: { "x-forwarded-for": "203.0.113.10, 198.51.100.2" },
+    });
+    const ipHash = requestIpHash(request);
+    expect(ipHash).toMatch(/^[a-f0-9]{64}$/);
+  });
+});


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #538. Partially addresses #539; #540 fixtures were already landed.

## Summary

Adds route-level test coverage for the six buddy session lifecycle routes that previously had zero tests, following the established PGlite integration pattern from `record-personal-session`.

Also adds high-risk server-path tests called out in #539 (password reset helpers, OAuth user resolution, breathCount write path).

## #538 — Buddy lifecycle routes

New `route.integration.test.ts` files (PGlite + mocked auth/Daily):

| Route | Happy path | Race/failure paths |
|-------|------------|-------------------|
| `ready` | Lobby ready toggle + revision bump | Invalid UUID, non-boolean body, post-lobby phase, left participant |
| `cancel` | Host abandons lobby session | Wrong phase CAS (409), non-host (403) |
| `leave` | Non-host leave; host abandon + Daily teardown | Idempotent re-leave |
| `participant-complete` | Marks completion + revision | Idempotent repeat; wrong phase; non-member |
| `start` | Daily room create + CAS to `active` | Name-conflict retry; retry exhausted; missing API key; concurrent CAS race; host/phase/schedule guards |
| `meeting-token` | Token mint for active participant | Left member; inactive session; Daily failure |

## #539 — High-risk server paths

- `src/lib/passwordReset.test.ts` — JWT round-trip, rate limiter, email/IP normalization
- `src/lib/oauth-user-resolution.test.ts` — existing link, email link, new user creation, missing-email error
- `src/app/api/sessions/route.breath.integration.test.ts` — breathCount clamp/floor/cap and non-breath ignore

Not in scope here: `apply-migrations.ts`, `apns.ts` (server-only / deploy-script constraints).

## #540 — Duration fixtures

Already present: `shared/test-fixtures/durationForDay.json` consumed by `src/lib/duration.test.ts` and iOS `StillPointDurationTests.swift`. No changes needed.

## Verification

```bash
npm ci
npx vitest run src --exclude "**/.claude/**"
```

629 tests passing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-165b6b2d-fdf7-49a6-ab9d-ee7c41605384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-165b6b2d-fdf7-49a6-ab9d-ee7c41605384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Add coverage for buddy session lifecycle flows and key server checks**

### What Changed
- Added end-to-end tests for buddy session actions: ready, start, leave, cancel, meeting token, and participant completion
- Covered the main success and failure cases for these flows, including wrong phase, non-host access, left participants, scheduled-start checks, token mint failures, and concurrent start conflicts
- Added tests for password reset helpers, OAuth user resolution, and breath session count saving to confirm they handle valid, invalid, and edge-case inputs as expected

### Impact
`✅ Fewer untested buddy session failures`
`✅ Safer start and join behavior for live buddy sessions`
`✅ Fewer password reset and OAuth regressions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
