### PR TITLE
security(auth): native Apple nonce round-trip + shared JWKS verifier (#533)

### DIFF
--- a/ios/StillPointApp/Services/AppleSignInController.swift
+++ b/ios/StillPointApp/Services/AppleSignInController.swift
@@ -6,7 +6,10 @@ import StillPointShared
 /// `SignInWithAppleButton`, or a raw `ASAuthorizationController` — all deliver the same credential type.
 enum AppleSignInController {
     /// Returns `nil` if the identity token cannot be decoded as UTF-8 (should not happen for valid credentials).
-    static func nativeSignInRequest(from credential: ASAuthorizationAppleIDCredential) -> AppleNativeSignInRequest? {
+    static func nativeSignInRequest(
+        from credential: ASAuthorizationAppleIDCredential,
+        rawNonce: String?
+    ) -> AppleNativeSignInRequest? {
         guard
             let tokenData = credential.identityToken,
             let identityToken = String(data: tokenData, encoding: .utf8),
@@ -31,6 +34,7 @@ enum AppleSignInController {
         return AppleNativeSignInRequest(
             identityToken: identityToken,
             authorizationCode: authorizationCode,
+            rawNonce: rawNonce,
             user: user
         )
     }

--- a/ios/StillPointApp/Services/AppleSignInController.swift
+++ b/ios/StillPointApp/Services/AppleSignInController.swift
@@ -8,9 +8,10 @@ enum AppleSignInController {
     /// Returns `nil` if the identity token cannot be decoded as UTF-8 (should not happen for valid credentials).
     static func nativeSignInRequest(
         from credential: ASAuthorizationAppleIDCredential,
-        rawNonce: String?
+        rawNonce: String
     ) -> AppleNativeSignInRequest? {
         guard
+            !rawNonce.isEmpty,
             let tokenData = credential.identityToken,
             let identityToken = String(data: tokenData, encoding: .utf8),
             !identityToken.isEmpty

--- a/ios/StillPointApp/Views/AuthView.swift
+++ b/ios/StillPointApp/Views/AuthView.swift
@@ -5,6 +5,7 @@ import StillPointShared
 struct AuthView: View {
     let appVM: AppViewModel
     @State private var vm = AuthViewModel()
+    @State private var appleSignInRawNonce: String?
     let launchAuthStatusMessage: String?
 
     var body: some View {
@@ -157,13 +158,21 @@ struct AuthView: View {
                         .opacity(vm.isAuthInFlight ? 0.5 : 1)
 
                         SignInWithAppleButton(.signIn) { request in
+                            let rawNonce = AppleSignInNonce.randomNonceString()
+                            appleSignInRawNonce = rawNonce
                             request.requestedScopes = [.fullName, .email]
+                            request.nonce = AppleSignInNonce.sha256Hex(rawNonce)
                         } onCompletion: { result in
+                            let rawNonce = appleSignInRawNonce
+                            appleSignInRawNonce = nil
                             switch result {
                             case .success(let authorization):
                                 guard
                                     let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
-                                    let body = AppleSignInController.nativeSignInRequest(from: credential)
+                                    let body = AppleSignInController.nativeSignInRequest(
+                                        from: credential,
+                                        rawNonce: rawNonce
+                                    )
                                 else {
                                     vm.error = "Could not read Sign in with Apple credentials."
                                     return

--- a/ios/StillPointApp/Views/AuthView.swift
+++ b/ios/StillPointApp/Views/AuthView.swift
@@ -158,12 +158,18 @@ struct AuthView: View {
                         .opacity(vm.isAuthInFlight ? 0.5 : 1)
 
                         SignInWithAppleButton(.signIn) { request in
-                            let rawNonce = AppleSignInNonce.randomNonceString()
+                            guard let rawNonce = try? AppleSignInNonce.randomNonceString() else {
+                                appleSignInRawNonce = nil
+                                return
+                            }
                             appleSignInRawNonce = rawNonce
                             request.requestedScopes = [.fullName, .email]
                             request.nonce = AppleSignInNonce.sha256Hex(rawNonce)
                         } onCompletion: { result in
-                            let rawNonce = appleSignInRawNonce
+                            guard let rawNonce = appleSignInRawNonce else {
+                                vm.error = "Could not prepare Sign in with Apple. Please try again."
+                                return
+                            }
                             appleSignInRawNonce = nil
                             switch result {
                             case .success(let authorization):

--- a/ios/StillPointApp/Views/AuthView.swift
+++ b/ios/StillPointApp/Views/AuthView.swift
@@ -6,6 +6,7 @@ struct AuthView: View {
     let appVM: AppViewModel
     @State private var vm = AuthViewModel()
     @State private var appleSignInRawNonce: String?
+    @State private var appleSignInInFlight = false
     let launchAuthStatusMessage: String?
 
     var body: some View {
@@ -158,19 +159,26 @@ struct AuthView: View {
                         .opacity(vm.isAuthInFlight ? 0.5 : 1)
 
                         SignInWithAppleButton(.signIn) { request in
+                            guard !appleSignInInFlight else { return }
                             guard let rawNonce = try? AppleSignInNonce.randomNonceString() else {
                                 appleSignInRawNonce = nil
+                                vm.error = "Could not prepare Sign in with Apple. Please try again."
                                 return
                             }
+                            appleSignInInFlight = true
                             appleSignInRawNonce = rawNonce
                             request.requestedScopes = [.fullName, .email]
                             request.nonce = AppleSignInNonce.sha256Hex(rawNonce)
                         } onCompletion: { result in
-                            guard let rawNonce = appleSignInRawNonce else {
+                            let rawNonce = appleSignInRawNonce
+                            defer {
+                                appleSignInInFlight = false
+                                appleSignInRawNonce = nil
+                            }
+                            guard let rawNonce else {
                                 vm.error = "Could not prepare Sign in with Apple. Please try again."
                                 return
                             }
-                            appleSignInRawNonce = nil
                             switch result {
                             case .success(let authorization):
                                 guard
@@ -200,8 +208,8 @@ struct AuthView: View {
                         .frame(height: 44)
                         .clipShape(Capsule())
                         .overlay(Capsule().stroke(SPColor.border2))
-                        .disabled(vm.isAuthInFlight)
-                        .opacity(vm.isAuthInFlight ? 0.5 : 1)
+                        .disabled(vm.isAuthInFlight || appleSignInInFlight)
+                        .opacity(vm.isAuthInFlight || appleSignInInFlight ? 0.5 : 1)
                     }
                 }
                 .padding(.horizontal, SPSpacing.s4)

--- a/ios/StillPointApp/Views/AuthView.swift
+++ b/ios/StillPointApp/Views/AuthView.swift
@@ -171,16 +171,14 @@ struct AuthView: View {
                             request.nonce = AppleSignInNonce.sha256Hex(rawNonce)
                         } onCompletion: { result in
                             let rawNonce = appleSignInRawNonce
-                            defer {
-                                appleSignInInFlight = false
-                                appleSignInRawNonce = nil
-                            }
-                            guard let rawNonce else {
-                                vm.error = "Could not prepare Sign in with Apple. Please try again."
-                                return
-                            }
                             switch result {
                             case .success(let authorization):
+                                guard let rawNonce else {
+                                    appleSignInInFlight = false
+                                    appleSignInRawNonce = nil
+                                    vm.error = "Could not prepare Sign in with Apple. Please try again."
+                                    return
+                                }
                                 guard
                                     let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
                                     let body = AppleSignInController.nativeSignInRequest(
@@ -188,15 +186,23 @@ struct AuthView: View {
                                         rawNonce: rawNonce
                                     )
                                 else {
+                                    appleSignInInFlight = false
+                                    appleSignInRawNonce = nil
                                     vm.error = "Could not read Sign in with Apple credentials."
                                     return
                                 }
                                 Task {
+                                    defer {
+                                        appleSignInInFlight = false
+                                        appleSignInRawNonce = nil
+                                    }
                                     if let user = await vm.signInWithApple(using: body) {
                                         appVM.didLogin(user: user)
                                     }
                                 }
                             case .failure(let error):
+                                appleSignInInFlight = false
+                                appleSignInRawNonce = nil
                                 if let authError = error as? ASAuthorizationError,
                                    authError.code == .canceled {
                                     return

--- a/ios/StillPointShared/Sources/StillPointShared/AppleSignInNonce.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AppleSignInNonce.swift
@@ -3,11 +3,17 @@ import Foundation
 
 /// Nonce helpers for native Sign in with Apple (#533).
 public enum AppleSignInNonce {
+    public enum Error: Swift.Error {
+        case randomBytesGenerationFailed(OSStatus)
+    }
+
     /// Cryptographically random nonce string for binding an identity token to this request.
-    public static func randomNonceString(byteCount: Int = 32) -> String {
+    public static func randomNonceString(byteCount: Int = 32) throws -> String {
         var bytes = [UInt8](repeating: 0, count: byteCount)
         let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
-        precondition(status == errSecSuccess, "SecRandomCopyBytes failed: \(status)")
+        guard status == errSecSuccess else {
+            throw Error.randomBytesGenerationFailed(status)
+        }
         return Data(bytes).base64EncodedString()
     }
 

--- a/ios/StillPointShared/Sources/StillPointShared/AppleSignInNonce.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AppleSignInNonce.swift
@@ -1,0 +1,19 @@
+import CryptoKit
+import Foundation
+
+/// Nonce helpers for native Sign in with Apple (#533).
+public enum AppleSignInNonce {
+    /// Cryptographically random nonce string for binding an identity token to this request.
+    public static func randomNonceString(byteCount: Int = 32) -> String {
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        precondition(status == errSecSuccess, "SecRandomCopyBytes failed: \(status)")
+        return Data(bytes).base64EncodedString()
+    }
+
+    /// SHA-256 hex digest — matches the server-side `createHash("sha256").digest("hex")` check.
+    public static func sha256Hex(_ value: String) -> String {
+        let digest = SHA256.hash(data: Data(value.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -351,7 +351,7 @@ public struct RecordBuddyPersonalSessionRequest: Codable, Sendable {
 public struct AppleNativeSignInRequest: Encodable, Sendable {
     public let identityToken: String
     public let authorizationCode: String?
-    public let rawNonce: String?
+    public let rawNonce: String
     public let user: AppleUserFirstSignInPayload?
 
     public struct AppleUserFirstSignInPayload: Encodable, Sendable {
@@ -377,7 +377,7 @@ public struct AppleNativeSignInRequest: Encodable, Sendable {
     public init(
         identityToken: String,
         authorizationCode: String?,
-        rawNonce: String? = nil,
+        rawNonce: String,
         user: AppleUserFirstSignInPayload?
     ) {
         self.identityToken = identityToken

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -351,6 +351,7 @@ public struct RecordBuddyPersonalSessionRequest: Codable, Sendable {
 public struct AppleNativeSignInRequest: Encodable, Sendable {
     public let identityToken: String
     public let authorizationCode: String?
+    public let rawNonce: String?
     public let user: AppleUserFirstSignInPayload?
 
     public struct AppleUserFirstSignInPayload: Encodable, Sendable {
@@ -376,10 +377,12 @@ public struct AppleNativeSignInRequest: Encodable, Sendable {
     public init(
         identityToken: String,
         authorizationCode: String?,
+        rawNonce: String? = nil,
         user: AppleUserFirstSignInPayload?
     ) {
         self.identityToken = identityToken
         self.authorizationCode = authorizationCode
+        self.rawNonce = rawNonce
         self.user = user
     }
 }

--- a/ios/StillPointShared/Tests/StillPointSharedTests/AppleSignInNonceTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/AppleSignInNonceTests.swift
@@ -9,9 +9,9 @@ final class AppleSignInNonceTests: XCTestCase {
         )
     }
 
-    func testRandomNonceStringIsSufficientlyLongAndUnique() {
-        let first = AppleSignInNonce.randomNonceString()
-        let second = AppleSignInNonce.randomNonceString()
+    func testRandomNonceStringIsSufficientlyLongAndUnique() throws {
+        let first = try AppleSignInNonce.randomNonceString()
+        let second = try AppleSignInNonce.randomNonceString()
 
         XCTAssertGreaterThanOrEqual(first.count, 32)
         XCTAssertGreaterThanOrEqual(second.count, 32)
@@ -34,20 +34,5 @@ final class AppleNativeSignInRequestEncodingTests: XCTestCase {
         XCTAssertEqual(object["identityToken"] as? String, "header.payload.signature")
         XCTAssertEqual(object["authorizationCode"] as? String, "opaque-code")
         XCTAssertEqual(object["rawNonce"] as? String, "nonce-abc")
-    }
-
-    func testOmitsRawNonceWhenNil() throws {
-        let request = AppleNativeSignInRequest(
-            identityToken: "tok",
-            authorizationCode: nil,
-            user: nil
-        )
-
-        let data = try JSONEncoder().encode(request)
-        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
-
-        XCTAssertEqual(object["identityToken"] as? String, "tok")
-        XCTAssertNil(object["rawNonce"])
-        XCTAssertFalse(object.keys.contains("rawNonce"))
     }
 }

--- a/ios/StillPointShared/Tests/StillPointSharedTests/AppleSignInNonceTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/AppleSignInNonceTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import StillPointShared
+
+final class AppleSignInNonceTests: XCTestCase {
+    func testSha256HexMatchesKnownVector() {
+        XCTAssertEqual(
+            AppleSignInNonce.sha256Hex("hello"),
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        )
+    }
+
+    func testRandomNonceStringIsSufficientlyLongAndUnique() {
+        let first = AppleSignInNonce.randomNonceString()
+        let second = AppleSignInNonce.randomNonceString()
+
+        XCTAssertGreaterThanOrEqual(first.count, 32)
+        XCTAssertGreaterThanOrEqual(second.count, 32)
+        XCTAssertNotEqual(first, second)
+    }
+}
+
+final class AppleNativeSignInRequestEncodingTests: XCTestCase {
+    func testEncodesRawNonce() throws {
+        let request = AppleNativeSignInRequest(
+            identityToken: "header.payload.signature",
+            authorizationCode: "opaque-code",
+            rawNonce: "nonce-abc",
+            user: nil
+        )
+
+        let data = try JSONEncoder().encode(request)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(object["identityToken"] as? String, "header.payload.signature")
+        XCTAssertEqual(object["authorizationCode"] as? String, "opaque-code")
+        XCTAssertEqual(object["rawNonce"] as? String, "nonce-abc")
+    }
+
+    func testOmitsRawNonceWhenNil() throws {
+        let request = AppleNativeSignInRequest(
+            identityToken: "tok",
+            authorizationCode: nil,
+            user: nil
+        )
+
+        let data = try JSONEncoder().encode(request)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(object["identityToken"] as? String, "tok")
+        XCTAssertNil(object["rawNonce"])
+        XCTAssertFalse(object.keys.contains("rawNonce"))
+    }
+}

--- a/src/app/api/auth/apple-native/route.test.ts
+++ b/src/app/api/auth/apple-native/route.test.ts
@@ -1,11 +1,10 @@
 import type { NextRequest } from "next/server";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-const jwtVerify = vi.fn();
+const verifyAppleJwt = vi.fn();
 
-vi.mock("jose", () => ({
-  createRemoteJWKSet: vi.fn(() => ({})),
-  jwtVerify,
+vi.mock("@/lib/apple-auth", () => ({
+  verifyAppleJwt,
 }));
 
 const { resolveOAuthUserId } = vi.hoisted(() => ({
@@ -47,12 +46,10 @@ describe("POST /api/auth/apple-native", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubEnv("NODE_ENV", "test");
-    jwtVerify.mockResolvedValue({
-      payload: {
-        sub: "apple-sub-1",
-        email: "relay@privaterelay.appleid.com",
-        email_verified: true,
-      },
+    verifyAppleJwt.mockResolvedValue({
+      sub: "apple-sub-1",
+      email: "relay@privaterelay.appleid.com",
+      email_verified: true,
     });
     resolveOAuthUserId.mockResolvedValue("user-uuid-1");
     dbSelectWhereLimit.mockResolvedValue([
@@ -73,6 +70,7 @@ describe("POST /api/auth/apple-native", () => {
       json: async () => ({
         identityToken: "header.payload.sig",
         authorizationCode: "opaque-code",
+        rawNonce: "nonce-abc",
       }),
     } as unknown as NextRequest;
 
@@ -84,6 +82,9 @@ describe("POST /api/auth/apple-native", () => {
     expect(json.user.id).toBe("user-uuid-1");
     expect(json.user.username).toBe("alice");
 
+    expect(verifyAppleJwt).toHaveBeenCalledWith("header.payload.sig", {
+      expectedNonce: "nonce-abc",
+    });
     expect(resolveOAuthUserId).toHaveBeenCalledWith({
       provider: "apple",
       providerAccountId: "apple-sub-1",
@@ -96,15 +97,13 @@ describe("POST /api/auth/apple-native", () => {
   });
 
   test("accepts token without email when resolveOAuthUserId links by sub", async () => {
-    jwtVerify.mockResolvedValue({
-      payload: {
-        sub: "apple-sub-repeat",
-        email_verified: true,
-      },
+    verifyAppleJwt.mockResolvedValue({
+      sub: "apple-sub-repeat",
+      email_verified: true,
     });
     const { POST } = await import("./route");
     const req = {
-      json: async () => ({ identityToken: "tok" }),
+      json: async () => ({ identityToken: "tok", rawNonce: "nonce-abc" }),
     } as unknown as NextRequest;
 
     const res = await POST(req);
@@ -117,18 +116,32 @@ describe("POST /api/auth/apple-native", () => {
     });
   });
 
+  test("returns 401 when nonce verification fails", async () => {
+    verifyAppleJwt.mockRejectedValue(new Error("nonce mismatch"));
+    const { POST } = await import("./route");
+    const req = {
+      json: async () => ({
+        identityToken: "tok",
+        rawNonce: "wrong-nonce",
+      }),
+    } as unknown as NextRequest;
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    expect(resolveOAuthUserId).not.toHaveBeenCalled();
+    expect(res.cookies.get("sp_token")).toBeUndefined();
+  });
+
   test("returns 400 when OAuthEmailRequiredError is thrown", async () => {
     const { OAuthEmailRequiredError } = await import("@/lib/oauth-user-resolution");
-    jwtVerify.mockResolvedValue({
-      payload: {
-        sub: "apple-new",
-        email_verified: true,
-      },
+    verifyAppleJwt.mockResolvedValue({
+      sub: "apple-new",
+      email_verified: true,
     });
     resolveOAuthUserId.mockRejectedValueOnce(new OAuthEmailRequiredError());
     const { POST } = await import("./route");
     const req = {
-      json: async () => ({ identityToken: "tok" }),
+      json: async () => ({ identityToken: "tok", rawNonce: "nonce-abc" }),
     } as unknown as NextRequest;
 
     const res = await POST(req);
@@ -137,8 +150,16 @@ describe("POST /api/auth/apple-native", () => {
 
   test("rejects missing identity token", async () => {
     const { POST } = await import("./route");
-    const req = { json: async () => ({}) } as unknown as NextRequest;
+    const req = { json: async () => ({ rawNonce: "nonce-abc" }) } as unknown as NextRequest;
     const res = await POST(req);
     expect(res.status).toBe(400);
+  });
+
+  test("rejects missing rawNonce", async () => {
+    const { POST } = await import("./route");
+    const req = { json: async () => ({ identityToken: "tok" }) } as unknown as NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect(verifyAppleJwt).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/auth/apple-native/route.ts
+++ b/src/app/api/auth/apple-native/route.ts
@@ -1,18 +1,11 @@
-import { createRemoteJWKSet, jwtVerify } from "jose";
 import { NextRequest, NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { createToken, SP_TOKEN_COOKIE } from "@/lib/auth";
+import { verifyAppleJwt } from "@/lib/apple-auth";
 import { withApiHandler } from "@/lib/api/withApiHandler";
 import { resolveOAuthUserId, OAuthEmailRequiredError } from "@/lib/oauth-user-resolution";
-
-const APPLE_JWKS = createRemoteJWKSet(new URL("https://appleid.apple.com/auth/keys"));
-const ISSUER = "https://appleid.apple.com";
-
-function defaultIOSAudience(): string {
-  return process.env.AUTH_APPLE_IOS_AUDIENCE ?? "com.brettonauerbach.stillpoint";
-}
 
 type AppleUserPayload = {
   name?: { firstName?: string; lastName?: string };
@@ -22,6 +15,7 @@ type AppleUserPayload = {
 type RequestBody = {
   identityToken?: string;
   authorizationCode?: string;
+  rawNonce?: string;
   user?: AppleUserPayload;
 };
 
@@ -45,13 +39,15 @@ export const POST = withApiHandler("apple-native", async (request: NextRequest) 
     return NextResponse.json({ error: "identityToken required" }, { status: 400 });
   }
 
+  const rawNonce = typeof body.rawNonce === "string" ? body.rawNonce : "";
+  if (!rawNonce) {
+    return NextResponse.json({ error: "rawNonce required" }, { status: 400 });
+  }
+
   let sub: string;
   let emailFromToken: string | undefined;
   try {
-    const { payload } = await jwtVerify(identityToken, APPLE_JWKS, {
-      issuer: ISSUER,
-      audience: defaultIOSAudience(),
-    });
+    const payload = await verifyAppleJwt(identityToken, { expectedNonce: rawNonce });
     if (typeof payload.sub !== "string" || !payload.sub) {
       return NextResponse.json({ error: "Invalid token" }, { status: 401 });
     }

--- a/src/lib/apple-auth.test.ts
+++ b/src/lib/apple-auth.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "vitest";
 import { vi } from "vitest";
+import { createHash } from "crypto";
 import {
   SignJWT,
   createLocalJWKSet,
@@ -23,6 +24,10 @@ async function makeAppleLikeKeys(): Promise<{
   return { privateKey, jwks: createLocalJWKSet({ keys: [jwk] }) };
 }
 
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
 function signNotificationJwt(
   privateKey: CryptoKey,
   { issuer = APPLE_ISSUER, audience = BUNDLE_ID }: { issuer?: string; audience?: string } = {},
@@ -40,6 +45,25 @@ function signNotificationJwt(
     .setIssuedAt()
     .setJti("jti-abc")
     .sign(privateKey);
+}
+
+function signIdentityJwt(
+  privateKey: CryptoKey,
+  {
+    issuer = APPLE_ISSUER,
+    audience = BUNDLE_ID,
+    rawNonce,
+  }: { issuer?: string; audience?: string; rawNonce?: string } = {},
+): Promise<string> {
+  const builder = new SignJWT({
+    ...(rawNonce !== undefined ? { nonce: sha256Hex(rawNonce) } : {}),
+  })
+    .setProtectedHeader({ alg: "ES256", kid: TEST_KID })
+    .setIssuer(issuer)
+    .setAudience(audience)
+    .setSubject("apple-sub-native")
+    .setIssuedAt();
+  return builder.sign(privateKey);
 }
 
 afterEach(() => {
@@ -103,6 +127,34 @@ describe("verifyAppleJwt", () => {
 
     const payload = await verifyAppleJwt(token, { jwks });
     expect(payload.aud).toBe("me.still-point.web");
+  });
+
+  test("accepts a matching hashed nonce when expectedNonce is provided", async () => {
+    const { privateKey, jwks } = await makeAppleLikeKeys();
+    const rawNonce = "random-nonce-abc";
+    const token = await signIdentityJwt(privateKey, { rawNonce });
+
+    const payload = await verifyAppleJwt(token, { jwks, expectedNonce: rawNonce });
+
+    expect(payload.nonce).toBe(sha256Hex(rawNonce));
+  });
+
+  test("rejects a mismatched nonce", async () => {
+    const { privateKey, jwks } = await makeAppleLikeKeys();
+    const token = await signIdentityJwt(privateKey, { rawNonce: "correct-nonce" });
+
+    await expect(
+      verifyAppleJwt(token, { jwks, expectedNonce: "wrong-nonce" }),
+    ).rejects.toThrow();
+  });
+
+  test("rejects when expectedNonce is provided but the token omits nonce", async () => {
+    const { privateKey, jwks } = await makeAppleLikeKeys();
+    const token = await signIdentityJwt(privateKey);
+
+    await expect(
+      verifyAppleJwt(token, { jwks, expectedNonce: "any-nonce" }),
+    ).rejects.toThrow();
   });
 });
 

--- a/src/lib/apple-auth.ts
+++ b/src/lib/apple-auth.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import { createRemoteJWKSet, jwtVerify, type JWTPayload, type JWTVerifyGetKey } from "jose";
 
 /** Issuer for every Sign in with Apple JWT (identity tokens and server-to-server notifications). */
@@ -32,9 +33,22 @@ export function appleAudiences(): string[] {
 export type VerifyAppleJwtOptions = {
   /** Override the accepted audiences (defaults to `appleAudiences()`). */
   audience?: string | string[];
+  /** Raw nonce from the client; hashed and compared to the token's `nonce` claim. */
+  expectedNonce?: string;
   /** Test seam: local key set instead of Apple's remote JWKS. */
   jwks?: JWTVerifyGetKey;
 };
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function assertNonceMatches(payload: JWTPayload, expectedNonce: string): void {
+  const expectedHashed = sha256Hex(expectedNonce);
+  if (typeof payload.nonce !== "string" || payload.nonce !== expectedHashed) {
+    throw new Error("nonce mismatch");
+  }
+}
 
 /** Verify an Apple-signed JWT — signature against Apple's JWKS, issuer, audience —
  *  and return its payload. Throws on any verification failure. */
@@ -46,5 +60,8 @@ export async function verifyAppleJwt(
     issuer: APPLE_ISSUER,
     audience: options.audience ?? appleAudiences(),
   });
+  if (options.expectedNonce !== undefined) {
+    assertNonceMatches(payload, options.expectedNonce);
+  }
   return payload;
 }


### PR DESCRIPTION
## **User description**
## Summary
- Require `rawNonce` on native Apple sign-in for replay protection (coordinated iOS client update in same release)
- Serialize nonce handoff in `AuthView` and keep sign-in in-flight until network completes
- Reuse shared JWKS verifier for Apple token validation

Reopened after #575 merged (previous PR #576 closed when stacked base branch was deleted).

Closes #533

## Test plan
- [x] Unit tests for apple-native route
- [x] StillPointShared swift test (when package changed)
- [ ] iOS e2e smoke/critical on CI

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Require and verify a matching nonce for native Apple sign-in**

### What Changed
- Native Apple sign-in now sends a fresh nonce from the app and the server rejects sign-ins when the nonce is missing or does not match
- The Apple sign-in button is blocked while a request is in progress, so repeated taps no longer start overlapping sign-in attempts
- If nonce generation fails or Apple sign-in cannot be prepared, the app now shows a clear error instead of continuing with a broken request
- Apple token verification now covers the nonce check in tests, along with the native request payload including the nonce

### Impact
`✅ Fewer Apple sign-in replay risks`
`✅ Fewer failed Apple sign-ins from double taps`
`✅ Clearer Apple sign-in errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
