### PR TITLE
tech-debt(db): remove no-op pg_advisory_xact_lock calls under Neon HTTP (#534)

### DIFF
--- a/.github/workflows/ios-shared-tests.yml
+++ b/.github/workflows/ios-shared-tests.yml
@@ -74,4 +74,4 @@ jobs:
       # "StillPointShared swift test" check green without macOS minutes (issue #463).
       - name: Skip (StillPointShared unchanged)
         if: needs.changes.outputs.shared != 'true'
-        run: echo "StillPointShared unchanged on this PR — required check satisfied without running swift test (issue #463)."
+        run: 'echo "StillPointShared unchanged on this PR — required check satisfied without running swift test (issue #463)."'

--- a/src/db/atomic.ts
+++ b/src/db/atomic.ts
@@ -9,6 +9,13 @@ import { shouldAdvanceDay, type SessionType, type Track } from "@/lib/constants"
 import { and, eq, ne, sql } from "drizzle-orm";
 import { isUniqueViolation } from "@/lib/dbErrors";
 
+/**
+ * Neon HTTP driver contract: each `db.execute()` / query is its own autocommit
+ * transaction. Multi-statement serialization (e.g. `pg_advisory_xact_lock` in a
+ * separate call) does not hold across statements. Atomicity here relies on single
+ * SQL statements (CTEs) and DB constraints — not advisory locks in prior calls.
+ */
+
 type SessionInsertValues = typeof sessions.$inferInsert;
 type ThoughtInsertRow = Pick<
   typeof thoughts.$inferInsert,
@@ -378,8 +385,6 @@ export async function atomicIssuePasswordResetToken(params: {
   newTokenId: string;
   previousTokenId: string | null;
 } | null> {
-  await db.execute(sql`select pg_advisory_xact_lock(hashtext(${params.userId}::text))`);
-
   const result = await db.execute(sql`
     with recent as (
       select id
@@ -430,8 +435,6 @@ export async function atomicRollbackPasswordResetToken(params: {
   newTokenId: string;
   previousTokenId: string | null;
 }): Promise<void> {
-  await db.execute(sql`select pg_advisory_xact_lock(hashtext(${params.userId}::text))`);
-
   if (params.previousTokenId) {
     await db.execute(sql`
       with invalidated as (


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #534

## Summary

Under the Neon HTTP driver, each `db.execute()` is its own autocommit transaction, so `pg_advisory_xact_lock` calls in separate statements release immediately and serialize nothing.

Removes the two misleading advisory-lock calls in password-reset helpers and documents the HTTP-driver single-statement atomicity contract at the top of `atomic.ts`.

Password-reset correctness is unchanged — multi-CTE statements remain atomic on their own, and `password_reset_tokens_active_user_unique` catches races.

## Test plan

- [x] `npm ci`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba6e0892-c749-4b7b-9825-6e1ba7c28b44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba6e0892-c749-4b7b-9825-6e1ba7c28b44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of password reset token issuance and rollback under concurrent requests.
  * Ensured token updates remain atomic and prevent inconsistent reset states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Remove ineffective password-reset locking under Neon HTTP**

### What Changed
- Removed password reset lock calls that did not actually protect anything with the Neon HTTP driver
- Password reset behavior stays the same, since the flow still relies on single-statement database changes and existing uniqueness checks
- Kept the shared iOS test job output stable by quoting the skip message to avoid YAML parsing issues

### Impact
`✅ No change to password reset behavior`
`✅ Clearer password reset data handling`
`✅ Fewer CI skip-message parsing issues`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
