### PR TITLE
iOS parity: history month grid + prior-month summaries (#523)

### DIFF
--- a/e2e/board/board.spec.ts
+++ b/e2e/board/board.spec.ts
@@ -15,8 +15,8 @@ test.describe("public board @critical", () => {
 
     // Mock fixture returns practitioners sorted by currentDay descending.
     await expect(page.getByText("contemplative_practitioner")).toBeVisible();
-    await expect(page.getByText("128")).toBeVisible();
-    await expect(page.getByText("91%")).toBeVisible();
+    await expect(page.getByText("128", { exact: true })).toBeVisible();
+    await expect(page.getByText("91%", { exact: true })).toBeVisible();
 
     const youMarker = page.getByText("(you)");
     await expect(youMarker).toBeVisible();

--- a/ios/PARITY_CHECKLIST.md
+++ b/ios/PARITY_CHECKLIST.md
@@ -1,6 +1,6 @@
 # iOS vs Web Feature Parity Checklist (Issue #210)
 
-Last updated: 2026-07-16  
+Last updated: 2026-07-17  
 Release owner: iOS release DRI
 
 ## Core product parity
@@ -13,7 +13,7 @@ Release owner: iOS release DRI
 | Solo session timer + pause for “I’m thinking” | Implemented | Implemented | ✅ Complete | Shared session timing logic is in `StillPointShared/SessionLogic.swift`. |
 | Thought capture during session | Implemented | Implemented | ✅ Complete | Both clients write to `/api/thoughts/batch`. |
 | Completion screen + end note | Implemented | Implemented | ✅ Complete | End note uses `timeInSession = -1` in both clients. |
-| Progress/history view | Implemented | Implemented | ✅ Complete | iOS `HistoryView` maps to web `HistoryView`. |
+| Progress/history view | Implemented | Implemented | ✅ Complete | iOS `HistoryView` mirrors web calendar-first History: month grid, prior-month summaries, year-in-review, mind-state trends, and session-buildup journey toggle (#523/#520/#522). |
 | Thought journal | Implemented | Implemented | ✅ Complete | iOS `ThoughtJournalView` maps to web `ThoughtJournal`. |
 | Public board + visibility toggle | Implemented | Implemented | ✅ Complete | iOS `SettingsView` includes `isPublic` toggle and board read. |
 | Buddy session create/join/wait/start/leave/complete | Implemented | Implemented | ✅ Complete | iOS uses same buddy session API contract as web. |

--- a/ios/StillPointApp/ViewModels/HistoryViewModel.swift
+++ b/ios/StillPointApp/ViewModels/HistoryViewModel.swift
@@ -38,9 +38,8 @@ final class HistoryViewModel {
     /// Longest actualTime across sessions in the journey (floor 60).
     var maxDuration: Int = 60
 
-    var todayIsoDate: String {
-        Self.localIsoDateFormatter.string(from: Date())
-    }
+    /// Stable local calendar day for the current load cycle (refreshed in `load()`).
+    private(set) var todayIsoDate: String = HistoryViewModel.currentLocalIsoDate()
 
     var monthGrid: CurrentMonthGrid {
         HistoryMonthGrid.buildCurrentMonthGrid(sessions: sessions, todayIso: todayIsoDate)
@@ -65,11 +64,12 @@ final class HistoryViewModel {
         defer { isLoading = false }
 
         do {
-            let today = todayIsoDate
+            let today = Self.currentLocalIsoDate()
+            todayIsoDate = today
             let result = try await APIClient.shared.getSessions(today: today)
             sessions = result.sessions.sorted { $0.sessionDate < $1.sessionDate }
             stats = StatsDTO.enrich(result.stats, sessions: sessions, todayIso: today)
-            buildJourney()
+            buildJourney(todayIso: today)
         } catch {
             errorMessage = "Failed to load sessions. Check your connection."
             print("Failed to load sessions: \(error)")
@@ -97,11 +97,18 @@ final class HistoryViewModel {
 
     // MARK: - Private
 
-    private func buildJourney() {
-        journeyRows = HistoryJourney.buildRows(fromSessions: sessions, todayIsoDate: todayIsoDate)
+    private func buildJourney(todayIso: String? = nil) {
+        journeyRows = HistoryJourney.buildRows(
+            fromSessions: sessions,
+            todayIsoDate: todayIso ?? todayIsoDate
+        )
 
         let sessionTimes = sessions.map { $0.actualTime ?? $0.duration }
         maxDuration = max(sessionTimes.max() ?? 60, 60)
+    }
+
+    private static func currentLocalIsoDate() -> String {
+        localIsoDateFormatter.string(from: Date())
     }
 
     private static let localIsoDateFormatter: DateFormatter = {

--- a/ios/StillPointApp/ViewModels/HistoryViewModel.swift
+++ b/ios/StillPointApp/ViewModels/HistoryViewModel.swift
@@ -1,6 +1,23 @@
 import SwiftUI
 import StillPointShared
 
+enum HistoryViewMode: String, CaseIterable {
+    case calendar
+    case journey
+
+    var label: String {
+        switch self {
+        case .calendar: return "Calendar"
+        case .journey: return "Session buildup"
+        }
+    }
+}
+
+enum HistoryCalendarSubView {
+    case `default`
+    case yearInReview
+}
+
 @MainActor
 @Observable
 final class HistoryViewModel {
@@ -12,11 +29,34 @@ final class HistoryViewModel {
     var expandedSessionId: String?
     var sessionThoughts: [String: [ThoughtDTO]] = [:]
 
+    var viewMode: HistoryViewMode = .calendar
+    var calendarSubView: HistoryCalendarSubView = .default
+
     /// All sits (standard + quick), ordered for the Journey list with collapsed missed-day gaps.
     var journeyRows: [HistoryJourneyListRow] = []
 
     /// Longest actualTime across sessions in the journey (floor 60).
     var maxDuration: Int = 60
+
+    var todayIsoDate: String {
+        Self.localIsoDateFormatter.string(from: Date())
+    }
+
+    var monthGrid: CurrentMonthGrid {
+        HistoryMonthGrid.buildCurrentMonthGrid(sessions: sessions, todayIso: todayIsoDate)
+    }
+
+    var priorMonthSummaries: [MonthlySummary] {
+        HistoryMonthGrid.buildPriorMonthSummaries(sessions: sessions, todayIso: todayIsoDate)
+    }
+
+    var trailing12MonthSummaries: [MonthlySummary] {
+        HistoryMonthlyAggregation.buildTrailing12MonthSummaries(sessions: sessions, todayIso: todayIsoDate)
+    }
+
+    var mindStateTrends: MindStateTrendStats {
+        stats?.mindStateTrends ?? .empty
+    }
 
     func load() async {
         guard !isLoading else { return }
@@ -25,9 +65,10 @@ final class HistoryViewModel {
         defer { isLoading = false }
 
         do {
-            let result = try await APIClient.shared.getSessions()
+            let today = todayIsoDate
+            let result = try await APIClient.shared.getSessions(today: today)
             sessions = result.sessions.sorted { $0.sessionDate < $1.sessionDate }
-            stats = result.stats
+            stats = StatsDTO.enrich(result.stats, sessions: sessions, todayIso: today)
             buildJourney()
         } catch {
             errorMessage = "Failed to load sessions. Check your connection."
@@ -57,10 +98,7 @@ final class HistoryViewModel {
     // MARK: - Private
 
     private func buildJourney() {
-        // Today in device-local time, matching how `sessionDate` is stamped at creation,
-        // so the gap between the last session and today renders (#379).
-        let today = Self.localIsoDateFormatter.string(from: Date())
-        journeyRows = HistoryJourney.buildRows(fromSessions: sessions, todayIsoDate: today)
+        journeyRows = HistoryJourney.buildRows(fromSessions: sessions, todayIsoDate: todayIsoDate)
 
         let sessionTimes = sessions.map { $0.actualTime ?? $0.duration }
         maxDuration = max(sessionTimes.max() ?? 60, 60)

--- a/ios/StillPointApp/ViewModels/HistoryViewModel.swift
+++ b/ios/StillPointApp/ViewModels/HistoryViewModel.swift
@@ -41,17 +41,13 @@ final class HistoryViewModel {
     /// Stable local calendar day for the current load cycle (refreshed in `load()`).
     private(set) var todayIsoDate: String = HistoryViewModel.currentLocalIsoDate()
 
-    var monthGrid: CurrentMonthGrid {
-        HistoryMonthGrid.buildCurrentMonthGrid(sessions: sessions, todayIso: todayIsoDate)
-    }
-
-    var priorMonthSummaries: [MonthlySummary] {
-        HistoryMonthGrid.buildPriorMonthSummaries(sessions: sessions, todayIso: todayIsoDate)
-    }
-
-    var trailing12MonthSummaries: [MonthlySummary] {
-        HistoryMonthlyAggregation.buildTrailing12MonthSummaries(sessions: sessions, todayIso: todayIsoDate)
-    }
+    private(set) var monthGrid: CurrentMonthGrid = CurrentMonthGrid(
+        yearMonth: "",
+        monthLabel: "",
+        cells: []
+    )
+    private(set) var priorMonthSummaries: [MonthlySummary] = []
+    private(set) var trailing12MonthSummaries: [MonthlySummary] = []
 
     var mindStateTrends: MindStateTrendStats {
         stats?.mindStateTrends ?? .empty
@@ -70,6 +66,7 @@ final class HistoryViewModel {
             sessions = result.sessions.sorted { $0.sessionDate < $1.sessionDate }
             stats = StatsDTO.enrich(result.stats, sessions: sessions, todayIso: today)
             buildJourney(todayIso: today)
+            rebuildCalendarAggregates(todayIso: today)
         } catch {
             errorMessage = "Failed to load sessions. Check your connection."
             print("Failed to load sessions: \(error)")
@@ -105,6 +102,15 @@ final class HistoryViewModel {
 
         let sessionTimes = sessions.map { $0.actualTime ?? $0.duration }
         maxDuration = max(sessionTimes.max() ?? 60, 60)
+    }
+
+    private func rebuildCalendarAggregates(todayIso: String) {
+        monthGrid = HistoryMonthGrid.buildCurrentMonthGrid(sessions: sessions, todayIso: todayIso)
+        priorMonthSummaries = HistoryMonthGrid.buildPriorMonthSummaries(sessions: sessions, todayIso: todayIso)
+        trailing12MonthSummaries = HistoryMonthlyAggregation.buildTrailing12MonthSummaries(
+            sessions: sessions,
+            todayIso: todayIso
+        )
     }
 
     private static func currentLocalIsoDate() -> String {

--- a/ios/StillPointApp/Views/HistoryView.swift
+++ b/ios/StillPointApp/Views/HistoryView.swift
@@ -177,7 +177,7 @@ struct HistoryView: View {
 
     private var mindStateAllTimeSummaryText: String {
         let allTime = vm.mindStateTrends.allTime
-        return "Trailing 4 weeks · all time "
+        return "All time "
             + String(format: "%.1f%%", allTime.lightDistractionPercent) + " light · "
             + String(format: "%.1f%%", allTime.heavyDistractionPercent) + " heavy · "
             + String(format: "%.1f%%", allTime.hyperfocusPercent) + " hyperfocus"

--- a/ios/StillPointApp/Views/HistoryView.swift
+++ b/ios/StillPointApp/Views/HistoryView.swift
@@ -496,6 +496,38 @@ struct HistoryView: View {
 
     // MARK: - Journey
 
+    private struct JourneyRowDisplay: Identifiable {
+        let id: Int
+        let row: HistoryJourneyListRow
+        let showDateColumn: Bool
+    }
+
+    private var journeyRowDisplays: [JourneyRowDisplay] {
+        var displays: [JourneyRowDisplay] = []
+        var lastSessionDate: String?
+        for (index, row) in vm.journeyRows.enumerated() {
+            switch row {
+            case .missed(let date):
+                displays.append(JourneyRowDisplay(id: index, row: row, showDateColumn: false))
+                lastSessionDate = date
+            case .missedRange(_, let endDate, _):
+                displays.append(JourneyRowDisplay(id: index, row: row, showDateColumn: false))
+                lastSessionDate = endDate
+            case .session(let session, let sessionIndex):
+                let showDate = lastSessionDate.map { $0 != session.sessionDate } ?? true
+                displays.append(
+                    JourneyRowDisplay(
+                        id: index,
+                        row: .session(session: session, sessionIndexInDay: sessionIndex),
+                        showDateColumn: showDate
+                    )
+                )
+                lastSessionDate = session.sessionDate
+            }
+        }
+        return displays
+    }
+
     private var journeyContent: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text("JOURNEY")
@@ -504,17 +536,18 @@ struct HistoryView: View {
                 .tracking(2)
                 .padding(.bottom, 4)
 
-            ForEach(0..<vm.journeyRows.count, id: \.self) { index in
-                let row = vm.journeyRows[index]
-                let prevDate: String? = index > 0 ? previousSessionDate(before: index) : nil
-                switch row {
+            ForEach(journeyRowDisplays) { display in
+                switch display.row {
                 case .missed(let date):
                     missedRow(date: date)
                 case .missedRange(let startDate, _, let dayCount):
                     missedRangeRow(startDate: startDate, dayCount: dayCount)
                 case .session(let session, let sessionIndex):
-                    let showDate = prevDate.map { $0 != session.sessionDate } ?? true
-                    sessionRow(session: session, sessionIndexInDay: sessionIndex, showDateColumn: showDate)
+                    sessionRow(
+                        session: session,
+                        sessionIndexInDay: sessionIndex,
+                        showDateColumn: display.showDateColumn
+                    )
                 }
             }
 
@@ -838,22 +871,6 @@ struct HistoryView: View {
     }
 
     // MARK: - Helpers
-
-    private func previousSessionDate(before index: Int) -> String? {
-        var i = index - 1
-        while i >= 0 {
-            switch vm.journeyRows[i] {
-            case .missed(let date):
-                return date
-            case .missedRange(_, let endDate, _):
-                return endDate
-            case .session(let session, _):
-                return session.sessionDate
-            }
-            i -= 1
-        }
-        return nil
-    }
 
     private static let isoDateFormatter: DateFormatter = {
         let df = DateFormatter()

--- a/ios/StillPointApp/Views/HistoryView.swift
+++ b/ios/StillPointApp/Views/HistoryView.swift
@@ -5,10 +5,11 @@ struct HistoryView: View {
     let appVM: AppViewModel
     @State private var vm = HistoryViewModel()
 
+    private let weekdayLabels = ["S", "M", "T", "W", "T", "F", "S"]
+
     var body: some View {
         ScrollView {
             VStack(spacing: SPSpacing.s5) {
-                // Welcome header
                 if let username = appVM.currentUser?.username {
                     Text("WELCOME, \(username.uppercased())")
                         .font(SPFont.mono(11, weight: .medium))
@@ -27,69 +28,16 @@ struct HistoryView: View {
                         .tint(SPColor.green)
                         .padding(.top, SPSpacing.s6)
                 } else if let errorMessage = vm.errorMessage {
-                    VStack(spacing: SPSpacing.s3) {
-                        Text(errorMessage)
-                            .font(SPFont.serif(15))
-                            .foregroundStyle(SPColor.dangerMuted)
-                            .multilineTextAlignment(.center)
-                            .accessibilityIdentifier("history.errorMessage")
-                        Button("Retry") {
-                            Task { await vm.load() }
-                        }
-                        .font(SPFont.mono(13, weight: .medium))
-                        .foregroundStyle(SPColor.green)
-                    }
-                    .padding(.top, SPSpacing.s6)
-                } else if vm.journeyRows.isEmpty {
-                    VStack(spacing: SPSpacing.s3) {
-                        Text("No sessions yet")
-                            .font(SPFont.serifItalic(15))
-                            .foregroundStyle(Color(SPColor.fg4))
-
-                        todayPreview
-                    }
-                    .padding(.top, SPSpacing.s6)
+                    errorContent(errorMessage)
+                } else if vm.sessions.isEmpty && vm.journeyRows.isEmpty {
+                    emptyContent
                 } else {
-                    // Aggregate stats
-                    if let stats = vm.stats {
-                        LazyVGrid(columns: [
-                            GridItem(.flexible()),
-                            GridItem(.flexible()),
-                            GridItem(.flexible()),
-                            GridItem(.flexible()),
-                            GridItem(.flexible()),
-                        ], spacing: SPSpacing.s3) {
-                            statCell(value: "\(stats.streak)", label: "STREAK")
-                            statCell(value: "\(stats.avgClearPercent)%", label: "AVG CLEAR")
-                            statCell(value: String(format: "%.1f", stats.avgThoughtsPerSession), label: "THOUGHTS/SESSION")
-                            statCell(value: String(format: "%.2f", stats.avgThoughtsPerMinute), label: "THOUGHTS/MIN")
-                            statCell(value: "\(stats.bonusMinutesTotal ?? 0)", label: "BONUS MIN TOTAL")
-                        }
-                    }
+                    viewModeToggle
 
-                    // Journey
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("JOURNEY")
-                            .font(SPFont.mono(11, weight: .medium))
-                            .foregroundStyle(Color(SPColor.fg4))
-                            .tracking(2)
-                            .padding(.bottom, 4)
-
-                        ForEach(0..<vm.journeyRows.count, id: \.self) { index in
-                            let row = vm.journeyRows[index]
-                            let prevDate: String? = index > 0 ? previousSessionDate(before: index) : nil
-                            switch row {
-                            case .missed(let date):
-                                missedRow(date: date)
-                            case .missedRange(let startDate, _, let dayCount):
-                                missedRangeRow(startDate: startDate, dayCount: dayCount)
-                            case .session(let session, let sessionIndex):
-                                let showDate = prevDate.map { $0 != session.sessionDate } ?? true
-                                sessionRow(session: session, sessionIndexInDay: sessionIndex, showDateColumn: showDate)
-                            }
-                        }
-
-                        todayPreview
+                    if vm.viewMode == .calendar {
+                        calendarContent
+                    } else {
+                        journeyContent
                     }
                 }
 
@@ -103,20 +51,523 @@ struct HistoryView: View {
         }
     }
 
-    private func previousSessionDate(before index: Int) -> String? {
-        var i = index - 1
-        while i >= 0 {
-            switch vm.journeyRows[i] {
-            case .missed(let date):
-                return date
-            case .missedRange(_, let endDate, _):
-                return endDate
-            case .session(let session, _):
-                return session.sessionDate
+    // MARK: - View Toggle
+
+    private var viewModeToggle: some View {
+        HStack(spacing: 8) {
+            ForEach(HistoryViewMode.allCases, id: \.self) { mode in
+                Button {
+                    vm.viewMode = mode
+                    if mode == .journey {
+                        vm.calendarSubView = .default
+                    }
+                } label: {
+                    Text(mode.label.uppercased())
+                        .font(SPFont.mono(11, weight: .medium))
+                        .tracking(1)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 6)
+                        .foregroundStyle(vm.viewMode == mode ? Color(SPColor.fg) : Color(SPColor.fg3))
+                        .background(vm.viewMode == mode ? Color(SPColor.surface2) : Color.clear)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 4)
+                                .stroke(
+                                    vm.viewMode == mode ? SPColor.border3 : SPColor.border1,
+                                    lineWidth: 1
+                                )
+                        )
+                }
+                .accessibilityIdentifier("history.viewMode.\(mode.rawValue)")
             }
-            i -= 1
         }
-        return nil
+    }
+
+    // MARK: - Calendar
+
+    @ViewBuilder
+    private var calendarContent: some View {
+        if vm.calendarSubView == .yearInReview {
+            yearInReviewContent
+        } else {
+            trailing4WeekStats
+            mindStateTrendsSection
+            allTimeProgressBar
+            legacyStatsGrid
+            priorMonthSummariesSection
+            currentMonthGridSection
+        }
+    }
+
+    private var trailing4WeekStats: some View {
+        LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 2), spacing: SPSpacing.s3) {
+            statCard(value: "\(vm.stats?.trailing4WeekDays ?? 0)", label: "DAYS MEDITATED")
+            statCard(
+                value: String(format: "%.1f%%", vm.stats?.trailing4WeekDayPercent ?? 0),
+                label: "OF DAYS"
+            )
+            statCard(
+                value: HistoryMonthGrid.formatTotalTime(vm.stats?.trailing4WeekTotalTime ?? 0),
+                label: "TOTAL TIME"
+            )
+            statCard(
+                value: String(format: "%.2f%%", vm.stats?.trailing4WeekTimePercent ?? 0),
+                label: "OF TIME"
+            )
+        }
+    }
+
+    private var mindStateTrendsSection: some View {
+        VStack(spacing: SPSpacing.s3) {
+            Text("SIT-TIME COMPOSITION")
+                .font(SPFont.serif(14))
+                .foregroundStyle(Color(SPColor.fg2))
+                .tracking(2)
+
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 2), spacing: SPSpacing.s3) {
+                mindStateStatCard(
+                    value: String(format: "%.1f%%", vm.mindStateTrends.trailing4Week.lightDistractionPercent),
+                    label: "LIGHT DISTRACTION",
+                    color: SPColor.amberText
+                )
+                mindStateStatCard(
+                    value: String(format: "%.1f%%", vm.mindStateTrends.trailing4Week.heavyDistractionPercent),
+                    label: "HEAVY DISTRACTION",
+                    color: SPColor.dangerMuted
+                )
+                mindStateStatCard(
+                    value: String(format: "%.1f%%", vm.mindStateTrends.trailing4Week.hyperfocusPercent),
+                    label: "HYPERFOCUS",
+                    color: Color(red: 96/255, green: 165/255, blue: 250/255).opacity(0.95)
+                )
+                mindStateStatCard(
+                    value: HistoryMonthGrid.formatTotalTime(vm.mindStateTrends.trailing4Week.totalSitSeconds),
+                    label: "SIT TIME",
+                    color: Color(SPColor.fg)
+                )
+            }
+
+            Text(
+                "Trailing 4 weeks · all time "
+                + String(format: "%.1f%%", vm.mindStateTrends.allTime.lightDistractionPercent) + " light · "
+                + String(format: "%.1f%%", vm.mindStateTrends.allTime.heavyDistractionPercent) + " heavy · "
+                + String(format: "%.1f%%", vm.mindStateTrends.allTime.hyperfocusPercent) + " hyperfocus"
+            )
+            .font(SPFont.mono(10))
+            .foregroundStyle(Color(SPColor.fg4))
+            .multilineTextAlignment(.center)
+
+            let activeDays = vm.mindStateTrends.dailyTrend.filter { $0.totalSitSeconds > 0 }
+            if activeDays.isEmpty {
+                Text("No sits in the trailing 4 weeks yet.")
+                    .font(SPFont.mono(11))
+                    .foregroundStyle(Color(SPColor.fg4))
+            } else {
+                VStack(spacing: 6) {
+                    ForEach(activeDays, id: \.date) { day in
+                        mindStateDayRow(day)
+                    }
+                }
+            }
+
+            mindStateLegend
+        }
+        .frame(maxWidth: 480)
+        .accessibilityIdentifier("history.mindStateTrends")
+    }
+
+    private func mindStateDayRow(_ day: MindStateDailyTrendBucket) -> some View {
+        HStack(spacing: 8) {
+            Text(shortTrendDayLabel(day.date))
+                .font(SPFont.mono(10))
+                .foregroundStyle(Color(SPColor.fg3))
+                .frame(width: 72, alignment: .trailing)
+                .lineLimit(1)
+
+            GeometryReader { geo in
+                let totalWidth = geo.size.width
+                HStack(spacing: 0) {
+                    mindStateBarSegment(
+                        width: totalWidth * day.composition.clearPercent / 100,
+                        color: SPColor.green,
+                        opacity: 0.75
+                    )
+                    mindStateBarSegment(
+                        width: totalWidth * day.composition.lightDistractionPercent / 100,
+                        color: SPColor.amber,
+                        opacity: 0.85
+                    )
+                    mindStateBarSegment(
+                        width: totalWidth * day.composition.heavyDistractionPercent / 100,
+                        color: SPColor.dangerMuted,
+                        opacity: 0.85
+                    )
+                    mindStateBarSegment(
+                        width: totalWidth * day.composition.hyperfocusPercent / 100,
+                        color: Color(red: 96/255, green: 165/255, blue: 250/255),
+                        opacity: 0.85
+                    )
+                }
+                .frame(width: totalWidth, height: 10)
+                .background(Color(SPColor.surface1))
+                .clipShape(RoundedRectangle(cornerRadius: 3))
+            }
+            .frame(height: 10)
+
+            Text(HistoryMonthGrid.formatTotalTime(day.totalSitSeconds))
+                .font(SPFont.mono(10))
+                .foregroundStyle(Color(SPColor.fg4))
+                .frame(width: 44, alignment: .leading)
+        }
+    }
+
+    private func mindStateBarSegment(width: CGFloat, color: Color, opacity: Double) -> some View {
+        Group {
+            if width > 0 {
+                Rectangle()
+                    .fill(color.opacity(opacity))
+                    .frame(width: width, height: 10)
+            }
+        }
+    }
+
+    private var mindStateLegend: some View {
+        HStack(spacing: 12) {
+            legendDot(color: SPColor.green, label: "aware")
+            legendDot(color: SPColor.amber, label: "light distraction")
+            legendDot(color: SPColor.dangerMuted, label: "heavy distraction")
+            legendDot(color: Color(red: 96/255, green: 165/255, blue: 250/255), label: "hyperfocus")
+        }
+        .font(SPFont.mono(10))
+        .foregroundStyle(Color(SPColor.fg3))
+    }
+
+    private var allTimeProgressBar: some View {
+        VStack(spacing: 8) {
+            HStack {
+                Text("\(HistoryMonthGrid.formatTotalTime(vm.stats?.totalTimeAllTime ?? 0)) all time")
+                Spacer()
+                Text(String(format: "%.2f%% to 10,000 hours", vm.stats?.progressTo10kHours ?? 0))
+            }
+            .font(SPFont.mono(11))
+            .foregroundStyle(Color(SPColor.fg3))
+
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(Color(SPColor.surface1))
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(SPColor.greenBgSubtle)
+                        .frame(width: geo.size.width * min(1, (vm.stats?.progressTo10kHours ?? 0) / 100))
+                }
+            }
+            .frame(height: 6)
+        }
+        .frame(maxWidth: 480)
+    }
+
+    private var legacyStatsGrid: some View {
+        Group {
+            if let stats = vm.stats {
+                LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 3), spacing: SPSpacing.s3) {
+                    statCell(value: "\(stats.streak)", label: "STREAK")
+                    statCell(value: "\(stats.avgClearPercent)%", label: "AVG CLEAR")
+                    statCell(value: String(format: "%.1f", stats.avgThoughtsPerSession), label: "THOUGHTS/SESSION")
+                    statCell(value: String(format: "%.2f", stats.avgThoughtsPerMinute), label: "THOUGHTS/MIN")
+                    statCell(value: "\(stats.bonusMinutesTotal ?? 0)", label: "BONUS MIN TOTAL")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var priorMonthSummariesSection: some View {
+        if !vm.priorMonthSummaries.isEmpty {
+            VStack(spacing: 6) {
+                ForEach(vm.priorMonthSummaries, id: \.yearMonth) { month in
+                    HStack {
+                        Text(month.label)
+                            .foregroundStyle(Color(SPColor.fg2))
+                        Spacer()
+                        Text("\(month.daysActive)/\(month.daysInMonth) days · \(HistoryMonthGrid.formatTotalTime(month.totalTimeSeconds))")
+                    }
+                    .font(SPFont.mono(11))
+                    .foregroundStyle(Color(SPColor.fg3))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(Color(SPColor.surface1))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .stroke(SPColor.border1, lineWidth: 1)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                }
+            }
+            .frame(maxWidth: 480)
+            .accessibilityIdentifier("history.priorMonths")
+        }
+    }
+
+    private var currentMonthGridSection: some View {
+        VStack(spacing: 12) {
+            HStack {
+                Text(vm.monthGrid.monthLabel.uppercased())
+                    .font(SPFont.serif(14))
+                    .foregroundStyle(Color(SPColor.fg2))
+                    .tracking(2)
+                Spacer()
+                Button("Year in review") {
+                    vm.calendarSubView = .yearInReview
+                }
+                .font(SPFont.mono(10, weight: .medium))
+                .tracking(1)
+                .foregroundStyle(Color(SPColor.fg3))
+                .padding(.horizontal, 14)
+                .padding(.vertical, 12)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(SPColor.border1, lineWidth: 1)
+                )
+                .accessibilityIdentifier("history.yearInReviewButton")
+            }
+
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 4), count: 7), spacing: 4) {
+                ForEach(Array(weekdayLabels.enumerated()), id: \.offset) { _, label in
+                    Text(label)
+                        .font(SPFont.mono(10))
+                        .foregroundStyle(Color(SPColor.fg3))
+                        .padding(.bottom, 4)
+                }
+
+                ForEach(Array(vm.monthGrid.cells.enumerated()), id: \.offset) { index, cell in
+                    switch cell {
+                    case .blank:
+                        Color.clear.frame(minHeight: 36)
+                            .accessibilityIdentifier("history.monthCell.blank.\(index)")
+                    case .day(let day):
+                        monthDayCell(day)
+                    }
+                }
+            }
+
+            HStack(spacing: 16) {
+                legendDot(color: SPColor.greenBgSubtle, border: SPColor.greenBorder, label: "meditated")
+                legendDot(color: Color(SPColor.surface1), border: SPColor.border1, label: "missed")
+                legendDot(color: Color(SPColor.surface3), border: SPColor.border3, label: "today")
+            }
+        }
+        .frame(maxWidth: 480)
+        .accessibilityIdentifier("history.monthGrid")
+    }
+
+    private func monthDayCell(_ day: MonthGridDay) -> some View {
+        let isTodayCell = day.isoDate == vm.todayIsoDate
+        let isMeditated = day.state == .meditated
+        let isMissed = day.state == .missed
+        let isFuture = day.state == .future
+
+        let background: Color = isMeditated
+            ? SPColor.greenBgSubtle
+            : isTodayCell ? Color(SPColor.surface3) : Color(SPColor.surface1)
+        let border: Color = isTodayCell
+            ? SPColor.border3
+            : isMeditated ? SPColor.greenBorder : SPColor.border1
+        let borderWidth: CGFloat = isTodayCell ? 2 : 1
+        let opacity: Double = isMissed ? 0.45 : isFuture ? 0.35 : 1
+
+        return VStack(spacing: 2) {
+            Text("\(day.dayOfMonth)")
+                .font(SPFont.mono(10))
+                .foregroundStyle(isMeditated ? SPColor.greenText : Color(SPColor.fg3))
+            if !day.durationLabels.isEmpty {
+                Text(day.durationLabels.joined(separator: ", "))
+                    .font(SPFont.mono(8))
+                    .foregroundStyle(Color(SPColor.fg4))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 36)
+        .padding(2)
+        .background(background)
+        .overlay(
+            RoundedRectangle(cornerRadius: 4)
+                .stroke(border, lineWidth: borderWidth)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+        .opacity(opacity)
+        .accessibilityIdentifier("history.monthCell.\(day.isoDate)")
+    }
+
+    // MARK: - Year in Review
+
+    private var yearInReviewContent: some View {
+        VStack(spacing: SPSpacing.s4) {
+            HStack {
+                Button("← Calendar") {
+                    vm.calendarSubView = .default
+                }
+                .font(SPFont.mono(11, weight: .medium))
+                .tracking(1)
+                .foregroundStyle(Color(SPColor.fg3))
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(SPColor.border1, lineWidth: 1)
+                )
+                Spacer()
+                Text("YEAR IN REVIEW")
+                    .font(SPFont.serif(14))
+                    .foregroundStyle(Color(SPColor.fg2))
+                    .tracking(2)
+                Spacer()
+                Color.clear.frame(width: 88)
+            }
+
+            let totals = yearInReviewTotals
+            HStack(spacing: SPSpacing.s4) {
+                statCard(value: "\(totals.daysActive)", label: "DAYS ACTIVE")
+                statCard(
+                    value: HistoryMonthGrid.formatTotalTime(totals.totalTimeSeconds),
+                    label: "TOTAL TIME"
+                )
+            }
+
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 8) {
+                ForEach(vm.trailing12MonthSummaries, id: \.yearMonth) { month in
+                    yearMonthCard(month)
+                }
+            }
+
+            Text("trailing 12 months · days active / days in month")
+                .font(SPFont.mono(10))
+                .foregroundStyle(Color(SPColor.fg4))
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: 480)
+        .accessibilityIdentifier("history.yearInReview")
+    }
+
+    private var yearInReviewTotals: (daysActive: Int, totalTimeSeconds: Int) {
+        let months = vm.trailing12MonthSummaries
+        return (
+            daysActive: months.reduce(0) { $0 + $1.daysActive },
+            totalTimeSeconds: months.reduce(0) { $0 + $1.totalTimeSeconds }
+        )
+    }
+
+    private func yearMonthCard(_ month: MonthlySummary) -> some View {
+        let hasActivity = month.daysActive > 0
+        let intensity = month.daysInMonth > 0
+            ? Double(month.daysActive) / Double(month.daysInMonth)
+            : 0
+        let opacity = hasActivity ? 0.45 + intensity * 0.55 : 0.65
+
+        return VStack(alignment: .leading, spacing: 6) {
+            Text(HistoryMonthlyAggregation.formatShortMonthLabel(month.yearMonth))
+                .font(SPFont.mono(10))
+                .foregroundStyle(hasActivity ? SPColor.greenText : Color(SPColor.fg3))
+            Text("\(month.daysActive)/\(month.daysInMonth)")
+                .font(SPFont.mono(15, weight: .light))
+                .foregroundStyle(Color(SPColor.fg))
+            Text(HistoryMonthGrid.formatTotalTime(month.totalTimeSeconds))
+                .font(SPFont.mono(10))
+                .foregroundStyle(Color(SPColor.fg4))
+        }
+        .frame(maxWidth: .infinity, minHeight: 72, alignment: .leading)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 12)
+        .background(hasActivity ? SPColor.greenBgSubtle : Color(SPColor.surface1))
+        .overlay(
+            RoundedRectangle(cornerRadius: 4)
+                .stroke(hasActivity ? SPColor.greenBorder : SPColor.border1, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+        .opacity(opacity)
+    }
+
+    // MARK: - Journey
+
+    private var journeyContent: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("JOURNEY")
+                .font(SPFont.mono(11, weight: .medium))
+                .foregroundStyle(Color(SPColor.fg4))
+                .tracking(2)
+                .padding(.bottom, 4)
+
+            ForEach(0..<vm.journeyRows.count, id: \.self) { index in
+                let row = vm.journeyRows[index]
+                let prevDate: String? = index > 0 ? previousSessionDate(before: index) : nil
+                switch row {
+                case .missed(let date):
+                    missedRow(date: date)
+                case .missedRange(let startDate, _, let dayCount):
+                    missedRangeRow(startDate: startDate, dayCount: dayCount)
+                case .session(let session, let sessionIndex):
+                    let showDate = prevDate.map { $0 != session.sessionDate } ?? true
+                    sessionRow(session: session, sessionIndexInDay: sessionIndex, showDateColumn: showDate)
+                }
+            }
+
+            todayPreview
+        }
+    }
+
+    // MARK: - Empty / Error
+
+    private var emptyContent: some View {
+        VStack(spacing: SPSpacing.s3) {
+            Text("No sessions yet")
+                .font(SPFont.serifItalic(15))
+                .foregroundStyle(Color(SPColor.fg4))
+            todayPreview
+        }
+        .padding(.top, SPSpacing.s6)
+    }
+
+    private func errorContent(_ message: String) -> some View {
+        VStack(spacing: SPSpacing.s3) {
+            Text(message)
+                .font(SPFont.serif(15))
+                .foregroundStyle(SPColor.dangerMuted)
+                .multilineTextAlignment(.center)
+                .accessibilityIdentifier("history.errorMessage")
+            Button("Retry") {
+                Task { await vm.load() }
+            }
+            .font(SPFont.mono(13, weight: .medium))
+            .foregroundStyle(SPColor.green)
+        }
+        .padding(.top, SPSpacing.s6)
+    }
+
+    // MARK: - Shared Stat Helpers
+
+    private func statCard(value: String, label: String) -> some View {
+        VStack(spacing: 4) {
+            Text(value)
+                .font(SPFont.mono(24, weight: .light))
+                .foregroundStyle(Color(SPColor.fg))
+            Text(label)
+                .font(SPFont.mono(10, weight: .medium))
+                .foregroundStyle(Color(SPColor.fg3))
+                .tracking(1)
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    private func mindStateStatCard(value: String, label: String, color: Color) -> some View {
+        VStack(spacing: 4) {
+            Text(value)
+                .font(SPFont.mono(22, weight: .light))
+                .foregroundStyle(color)
+            Text(label)
+                .font(SPFont.mono(10, weight: .medium))
+                .foregroundStyle(Color(SPColor.fg3))
+                .tracking(1)
+                .multilineTextAlignment(.center)
+        }
     }
 
     private func statCell(value: String, label: String) -> some View {
@@ -132,6 +583,21 @@ struct HistoryView: View {
         }
     }
 
+    private func legendDot(color: Color, border: Color? = nil, label: String) -> some View {
+        HStack(spacing: 6) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(color)
+                .frame(width: 10, height: 10)
+                .overlay {
+                    if let border {
+                        RoundedRectangle(cornerRadius: 2)
+                            .stroke(border, lineWidth: 1)
+                    }
+                }
+            Text(label)
+        }
+    }
+
     // MARK: - Session Row
 
     @ViewBuilder
@@ -143,20 +609,17 @@ struct HistoryView: View {
                 Task { await vm.toggleSession(session.id) }
             } label: {
                 HStack(spacing: 8) {
-                    // Date label (only first row of each calendar day)
                     Text(showDateColumn ? shortDateLabel(session.sessionDate) : "")
                         .font(SPFont.mono(10))
                         .foregroundStyle(Color(SPColor.fg4))
                         .frame(width: 56, alignment: .trailing)
                         .lineLimit(1)
 
-                    // Session label within the day (quick / breath sits visually distinct)
                     Text(sessionLabel(session: session, index: sessionIndexInDay))
                         .font(SPFont.mono(11, weight: .medium))
                         .foregroundStyle(sessionLabelColor(session: session))
                         .frame(width: 72, alignment: .trailing)
 
-                    // Proportional bar
                     GeometryReader { geo in
                         let barFraction = vm.maxDuration > 0
                             ? CGFloat(session.actualTime ?? session.duration) / CGFloat(vm.maxDuration)
@@ -166,12 +629,10 @@ struct HistoryView: View {
                         let thinkWidth = barWidth - clearWidth
 
                         ZStack(alignment: .leading) {
-                            // Background track
                             RoundedRectangle(cornerRadius: 3)
                                 .fill(Color(SPColor.surface1))
                                 .frame(width: geo.size.width, height: 16)
 
-                            // Proportional filled portion
                             HStack(spacing: 0) {
                                 Rectangle()
                                     .fill(SPColor.green.opacity(session.completed ? 0.7 : 0.4))
@@ -186,7 +647,6 @@ struct HistoryView: View {
                     }
                     .frame(height: 16)
 
-                    // Metadata: duration · clear% · thoughts
                     HStack(spacing: 4) {
                         Text("\(session.actualTime ?? session.duration)s")
                             .foregroundStyle(Color(SPColor.fg3))
@@ -213,7 +673,6 @@ struct HistoryView: View {
             }
             .accessibilityIdentifier("history.session.\(session.id)")
 
-            // Expanded thoughts
             if isExpanded, let thoughts = vm.sessionThoughts[session.id] {
                 VStack(alignment: .leading, spacing: 4) {
                     ForEach(thoughts, id: \.id) { thought in
@@ -242,7 +701,6 @@ struct HistoryView: View {
         case .quick:
             return "Quick \(index)"
         case .breath:
-            // Optionally surface breath count when available
             if let count = session.breathCount, count > 0 {
                 return "Breath \(count)b"
             }
@@ -257,8 +715,6 @@ struct HistoryView: View {
         case .quick:
             return SPColor.amberText
         case .breath:
-            // Muted green, matching the breath-count accent in BreathCountingView and
-            // distinct from quick (amber) and standard (fg3).
             return SPColor.greenText
         case .standard:
             return Color(SPColor.fg3)
@@ -269,20 +725,17 @@ struct HistoryView: View {
 
     private func missedRow(date: String) -> some View {
         HStack(spacing: 8) {
-            // Date label
             Text(shortDateLabel(date))
                 .font(SPFont.mono(10))
                 .foregroundStyle(Color(SPColor.fg4))
                 .frame(width: 56, alignment: .trailing)
                 .lineLimit(1)
 
-            // Em-dash instead of session label
             Text("\u{2014}")
                 .font(SPFont.mono(11, weight: .medium))
                 .foregroundStyle(Color(SPColor.fg3))
                 .frame(width: 72, alignment: .trailing)
 
-            // Dashed border container
             RoundedRectangle(cornerRadius: 3)
                 .stroke(SPColor.border2, style: StrokeStyle(lineWidth: 1, dash: [4]))
                 .frame(height: 16)
@@ -294,7 +747,6 @@ struct HistoryView: View {
                         .padding(.leading, 8)
                 }
 
-            // Empty metadata spacer
             Color.clear
                 .frame(width: 100)
         }
@@ -302,25 +754,19 @@ struct HistoryView: View {
         .opacity(0.35)
     }
 
-    // MARK: - Missed Range Row
-
-    /// Compact summary for a collapsed run of consecutive missed days (#379).
     private func missedRangeRow(startDate: String, dayCount: Int) -> some View {
         HStack(spacing: 8) {
-            // Date label (first missed day of the range)
             Text(shortDateLabel(startDate))
                 .font(SPFont.mono(10))
                 .foregroundStyle(Color(SPColor.fg4))
                 .frame(width: 56, alignment: .trailing)
                 .lineLimit(1)
 
-            // Em-dash instead of session label
             Text("\u{2014}")
                 .font(SPFont.mono(11, weight: .medium))
                 .foregroundStyle(Color(SPColor.fg3))
                 .frame(width: 72, alignment: .trailing)
 
-            // Dashed border container
             RoundedRectangle(cornerRadius: 3)
                 .stroke(SPColor.border2, style: StrokeStyle(lineWidth: 1, dash: [4]))
                 .frame(height: 16)
@@ -333,7 +779,6 @@ struct HistoryView: View {
                         .lineLimit(1)
                 }
 
-            // Empty metadata spacer
             Color.clear
                 .frame(width: 100)
         }
@@ -348,19 +793,16 @@ struct HistoryView: View {
         let todayDuration = appVM.todayDuration
 
         return HStack(spacing: 8) {
-            // Date label
             Text("today")
                 .font(SPFont.mono(10))
                 .foregroundStyle(Color(SPColor.fg4))
                 .frame(width: 56, alignment: .trailing)
 
-            // Placeholder aligned with session label column
             Text("\u{2014}")
                 .font(SPFont.mono(11, weight: .medium))
                 .foregroundStyle(Color(SPColor.fg4))
                 .frame(width: 72, alignment: .trailing)
 
-            // Proportional dashed bar
             GeometryReader { geo in
                 let barFraction = vm.maxDuration > 0
                     ? CGFloat(todayDuration) / CGFloat(vm.maxDuration)
@@ -368,12 +810,10 @@ struct HistoryView: View {
                 let barWidth = geo.size.width * barFraction
 
                 ZStack(alignment: .leading) {
-                    // Background track
                     RoundedRectangle(cornerRadius: 3)
                         .fill(Color(SPColor.surface1))
                         .frame(width: geo.size.width, height: 16)
 
-                    // Dashed outline scaled to duration
                     RoundedRectangle(cornerRadius: 3)
                         .stroke(SPColor.border2, style: StrokeStyle(lineWidth: 1, dash: [4]))
                         .frame(width: max(0, barWidth), height: 16)
@@ -381,7 +821,6 @@ struct HistoryView: View {
             }
             .frame(height: 16)
 
-            // Duration label
             Text("\(todayDuration)s")
                 .font(SPFont.mono(10))
                 .foregroundStyle(Color(SPColor.fg4))
@@ -391,6 +830,22 @@ struct HistoryView: View {
     }
 
     // MARK: - Helpers
+
+    private func previousSessionDate(before index: Int) -> String? {
+        var i = index - 1
+        while i >= 0 {
+            switch vm.journeyRows[i] {
+            case .missed(let date):
+                return date
+            case .missedRange(_, let endDate, _):
+                return endDate
+            case .session(let session, _):
+                return session.sessionDate
+            }
+            i -= 1
+        }
+        return nil
+    }
 
     private static let isoDateFormatter: DateFormatter = {
         let df = DateFormatter()
@@ -406,9 +861,19 @@ struct HistoryView: View {
         return df
     }()
 
-    /// Format "YYYY-MM-DD" → "Mon Mar 16" (short, fits mobile).
+    private static let trendDayFormatter: DateFormatter = {
+        let df = DateFormatter()
+        df.dateFormat = "EEE M/d"
+        return df
+    }()
+
     private func shortDateLabel(_ isoDate: String) -> String {
         guard let date = Self.isoDateFormatter.date(from: isoDate) else { return isoDate }
         return Self.displayDateFormatter.string(from: date)
+    }
+
+    private func shortTrendDayLabel(_ isoDate: String) -> String {
+        guard let date = Self.isoDateFormatter.date(from: isoDate) else { return isoDate }
+        return Self.trendDayFormatter.string(from: date)
     }
 }

--- a/ios/StillPointApp/Views/HistoryView.swift
+++ b/ios/StillPointApp/Views/HistoryView.swift
@@ -123,35 +123,9 @@ struct HistoryView: View {
                 .foregroundStyle(Color(SPColor.fg2))
                 .tracking(2)
 
-            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 2), spacing: SPSpacing.s3) {
-                mindStateStatCard(
-                    value: String(format: "%.1f%%", vm.mindStateTrends.trailing4Week.lightDistractionPercent),
-                    label: "LIGHT DISTRACTION",
-                    color: SPColor.amberText
-                )
-                mindStateStatCard(
-                    value: String(format: "%.1f%%", vm.mindStateTrends.trailing4Week.heavyDistractionPercent),
-                    label: "HEAVY DISTRACTION",
-                    color: SPColor.dangerMuted
-                )
-                mindStateStatCard(
-                    value: String(format: "%.1f%%", vm.mindStateTrends.trailing4Week.hyperfocusPercent),
-                    label: "HYPERFOCUS",
-                    color: Color(red: 96/255, green: 165/255, blue: 250/255).opacity(0.95)
-                )
-                mindStateStatCard(
-                    value: HistoryMonthGrid.formatTotalTime(vm.mindStateTrends.trailing4Week.totalSitSeconds),
-                    label: "SIT TIME",
-                    color: Color(SPColor.fg)
-                )
-            }
+            mindStateTrailing4WeekStatGrid
 
-            Text(
-                "Trailing 4 weeks · all time "
-                + String(format: "%.1f%%", vm.mindStateTrends.allTime.lightDistractionPercent) + " light · "
-                + String(format: "%.1f%%", vm.mindStateTrends.allTime.heavyDistractionPercent) + " heavy · "
-                + String(format: "%.1f%%", vm.mindStateTrends.allTime.hyperfocusPercent) + " hyperfocus"
-            )
+            Text(mindStateAllTimeSummaryText)
             .font(SPFont.mono(10))
             .foregroundStyle(Color(SPColor.fg4))
             .multilineTextAlignment(.center)
@@ -173,6 +147,40 @@ struct HistoryView: View {
         }
         .frame(maxWidth: 480)
         .accessibilityIdentifier("history.mindStateTrends")
+    }
+
+    private var mindStateTrailing4WeekStatGrid: some View {
+        let trailing = vm.mindStateTrends.trailing4Week
+        return LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 2), spacing: SPSpacing.s3) {
+            mindStateStatCard(
+                value: String(format: "%.1f%%", trailing.lightDistractionPercent),
+                label: "LIGHT DISTRACTION",
+                color: SPColor.amberText
+            )
+            mindStateStatCard(
+                value: String(format: "%.1f%%", trailing.heavyDistractionPercent),
+                label: "HEAVY DISTRACTION",
+                color: SPColor.dangerMuted
+            )
+            mindStateStatCard(
+                value: String(format: "%.1f%%", trailing.hyperfocusPercent),
+                label: "HYPERFOCUS",
+                color: Color(red: 96/255, green: 165/255, blue: 250/255).opacity(0.95)
+            )
+            mindStateStatCard(
+                value: HistoryMonthGrid.formatTotalTime(trailing.totalSitSeconds),
+                label: "SIT TIME",
+                color: Color(SPColor.fg)
+            )
+        }
+    }
+
+    private var mindStateAllTimeSummaryText: String {
+        let allTime = vm.mindStateTrends.allTime
+        return "Trailing 4 weeks · all time "
+            + String(format: "%.1f%%", allTime.lightDistractionPercent) + " light · "
+            + String(format: "%.1f%%", allTime.heavyDistractionPercent) + " heavy · "
+            + String(format: "%.1f%%", allTime.hyperfocusPercent) + " hyperfocus"
     }
 
     private func mindStateDayRow(_ day: MindStateDailyTrendBucket) -> some View {

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -199,11 +199,18 @@ public actor APIClient {
 
     // MARK: - Sessions
 
-    public func getSessions() async throws -> (sessions: [SessionDTO], stats: StatsDTO) {
+    public func getSessions(today: String? = nil) async throws -> (sessions: [SessionDTO], stats: StatsDTO) {
         if let uiTestAPIStore {
-            return try await uiTestAPIStore.getSessions()
+            return try await uiTestAPIStore.getSessions(today: today)
         }
-        let response: SessionsResponse = try await get("/api/sessions")
+        let path: String
+        if let today, !today.isEmpty {
+            let encoded = today.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? today
+            path = "/api/sessions?today=\(encoded)"
+        } else {
+            path = "/api/sessions"
+        }
+        let response: SessionsResponse = try await get(path)
         return (response.sessions, response.stats)
     }
 

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -151,19 +151,92 @@ public struct StatsDTO: Codable, Sendable {
     public let avgThoughtsPerSession: Double
     public let avgThoughtsPerMinute: Double
     public let bonusMinutesTotal: Int?
+    public let trailing4WeekDays: Int
+    public let trailing4WeekDayPercent: Double
+    public let trailing4WeekTotalTime: Int
+    public let trailing4WeekTimePercent: Double
+    public let totalTimeAllTime: Int
+    public let progressTo10kHours: Double
+    public let mindStateTrends: MindStateTrendStats
 
     public init(
         streak: Int,
         avgClearPercent: Int,
         avgThoughtsPerSession: Double,
         avgThoughtsPerMinute: Double,
-        bonusMinutesTotal: Int? = nil
+        bonusMinutesTotal: Int? = nil,
+        trailing4WeekDays: Int = 0,
+        trailing4WeekDayPercent: Double = 0,
+        trailing4WeekTotalTime: Int = 0,
+        trailing4WeekTimePercent: Double = 0,
+        totalTimeAllTime: Int = 0,
+        progressTo10kHours: Double = 0,
+        mindStateTrends: MindStateTrendStats = .empty
     ) {
         self.streak = streak
         self.avgClearPercent = avgClearPercent
         self.avgThoughtsPerSession = avgThoughtsPerSession
         self.avgThoughtsPerMinute = avgThoughtsPerMinute
         self.bonusMinutesTotal = bonusMinutesTotal
+        self.trailing4WeekDays = trailing4WeekDays
+        self.trailing4WeekDayPercent = trailing4WeekDayPercent
+        self.trailing4WeekTotalTime = trailing4WeekTotalTime
+        self.trailing4WeekTimePercent = trailing4WeekTimePercent
+        self.totalTimeAllTime = totalTimeAllTime
+        self.progressTo10kHours = progressTo10kHours
+        self.mindStateTrends = mindStateTrends
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        streak = try c.decode(Int.self, forKey: .streak)
+        avgClearPercent = try c.decode(Int.self, forKey: .avgClearPercent)
+        avgThoughtsPerSession = try c.decode(Double.self, forKey: .avgThoughtsPerSession)
+        avgThoughtsPerMinute = try c.decode(Double.self, forKey: .avgThoughtsPerMinute)
+        bonusMinutesTotal = try c.decodeIfPresent(Int.self, forKey: .bonusMinutesTotal)
+        trailing4WeekDays = try c.decodeIfPresent(Int.self, forKey: .trailing4WeekDays) ?? 0
+        trailing4WeekDayPercent = try c.decodeIfPresent(Double.self, forKey: .trailing4WeekDayPercent) ?? 0
+        trailing4WeekTotalTime = try c.decodeIfPresent(Int.self, forKey: .trailing4WeekTotalTime) ?? 0
+        trailing4WeekTimePercent = try c.decodeIfPresent(Double.self, forKey: .trailing4WeekTimePercent) ?? 0
+        totalTimeAllTime = try c.decodeIfPresent(Int.self, forKey: .totalTimeAllTime) ?? 0
+        progressTo10kHours = try c.decodeIfPresent(Double.self, forKey: .progressTo10kHours) ?? 0
+        mindStateTrends = try c.decodeIfPresent(MindStateTrendStats.self, forKey: .mindStateTrends) ?? .empty
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case streak, avgClearPercent, avgThoughtsPerSession, avgThoughtsPerMinute, bonusMinutesTotal
+        case trailing4WeekDays, trailing4WeekDayPercent, trailing4WeekTotalTime, trailing4WeekTimePercent
+        case totalTimeAllTime, progressTo10kHours, mindStateTrends
+    }
+
+    /// Fills period and mind-state trend fields client-side when the API omits them.
+    public static func enrich(
+        _ base: StatsDTO,
+        sessions: [SessionDTO],
+        todayIso: String
+    ) -> StatsDTO {
+        let period = HistoryStats.calculatePeriodStats(sessions: sessions, todayIso: todayIso)
+        let trends = HistoryMindStateTrends.calculateTrendStats(sessions: sessions, todayIso: todayIso)
+        let needsPeriod = base.trailing4WeekDays == 0
+            && base.trailing4WeekTotalTime == 0
+            && base.totalTimeAllTime == 0
+            && !sessions.isEmpty
+        let needsTrends = base.mindStateTrends == .empty && !sessions.isEmpty
+
+        return StatsDTO(
+            streak: base.streak,
+            avgClearPercent: base.avgClearPercent,
+            avgThoughtsPerSession: base.avgThoughtsPerSession,
+            avgThoughtsPerMinute: base.avgThoughtsPerMinute,
+            bonusMinutesTotal: base.bonusMinutesTotal,
+            trailing4WeekDays: needsPeriod ? period.trailing4WeekDays : base.trailing4WeekDays,
+            trailing4WeekDayPercent: needsPeriod ? period.trailing4WeekDayPercent : base.trailing4WeekDayPercent,
+            trailing4WeekTotalTime: needsPeriod ? period.trailing4WeekTotalTime : base.trailing4WeekTotalTime,
+            trailing4WeekTimePercent: needsPeriod ? period.trailing4WeekTimePercent : base.trailing4WeekTimePercent,
+            totalTimeAllTime: needsPeriod ? period.totalTimeAllTime : base.totalTimeAllTime,
+            progressTo10kHours: needsPeriod ? period.progressTo10kHours : base.progressTo10kHours,
+            mindStateTrends: needsTrends ? trends : base.mindStateTrends
+        )
     }
 }
 

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -215,17 +215,32 @@ public struct StatsDTO: Codable, Sendable {
         sessions: [SessionDTO],
         todayIso: String
     ) -> StatsDTO {
-        let needsPeriod = base.trailing4WeekDays == 0
-            && base.trailing4WeekTotalTime == 0
-            && base.totalTimeAllTime == 0
-            && !sessions.isEmpty
-        let needsTrends = base.mindStateTrends == .empty && !sessions.isEmpty
-        let period = needsPeriod
+        let hasSessions = !sessions.isEmpty
+        let needsTrends = base.mindStateTrends == .empty && hasSessions
+        let needsPeriodComputation = hasSessions && (
+            base.trailing4WeekDays == 0
+                || base.trailing4WeekTotalTime == 0
+                || base.trailing4WeekDayPercent == 0
+                || base.trailing4WeekTimePercent == 0
+                || base.totalTimeAllTime == 0
+                || base.progressTo10kHours == 0
+        )
+        let period = needsPeriodComputation
             ? HistoryStats.calculatePeriodStats(sessions: sessions, todayIso: todayIso)
             : nil
         let trends = needsTrends
             ? HistoryMindStateTrends.calculateTrendStats(sessions: sessions, todayIso: todayIso)
             : nil
+
+        func pickInt(_ baseValue: Int, _ computed: Int?) -> Int {
+            guard baseValue == 0, let computed else { return baseValue }
+            return computed
+        }
+
+        func pickDouble(_ baseValue: Double, _ computed: Double?) -> Double {
+            guard baseValue == 0, let computed else { return baseValue }
+            return computed
+        }
 
         return StatsDTO(
             streak: base.streak,
@@ -233,12 +248,12 @@ public struct StatsDTO: Codable, Sendable {
             avgThoughtsPerSession: base.avgThoughtsPerSession,
             avgThoughtsPerMinute: base.avgThoughtsPerMinute,
             bonusMinutesTotal: base.bonusMinutesTotal,
-            trailing4WeekDays: needsPeriod ? period!.trailing4WeekDays : base.trailing4WeekDays,
-            trailing4WeekDayPercent: needsPeriod ? period!.trailing4WeekDayPercent : base.trailing4WeekDayPercent,
-            trailing4WeekTotalTime: needsPeriod ? period!.trailing4WeekTotalTime : base.trailing4WeekTotalTime,
-            trailing4WeekTimePercent: needsPeriod ? period!.trailing4WeekTimePercent : base.trailing4WeekTimePercent,
-            totalTimeAllTime: needsPeriod ? period!.totalTimeAllTime : base.totalTimeAllTime,
-            progressTo10kHours: needsPeriod ? period!.progressTo10kHours : base.progressTo10kHours,
+            trailing4WeekDays: pickInt(base.trailing4WeekDays, period?.trailing4WeekDays),
+            trailing4WeekDayPercent: pickDouble(base.trailing4WeekDayPercent, period?.trailing4WeekDayPercent),
+            trailing4WeekTotalTime: pickInt(base.trailing4WeekTotalTime, period?.trailing4WeekTotalTime),
+            trailing4WeekTimePercent: pickDouble(base.trailing4WeekTimePercent, period?.trailing4WeekTimePercent),
+            totalTimeAllTime: pickInt(base.totalTimeAllTime, period?.totalTimeAllTime),
+            progressTo10kHours: pickDouble(base.progressTo10kHours, period?.progressTo10kHours),
             mindStateTrends: needsTrends ? trends! : base.mindStateTrends
         )
     }

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -215,13 +215,17 @@ public struct StatsDTO: Codable, Sendable {
         sessions: [SessionDTO],
         todayIso: String
     ) -> StatsDTO {
-        let period = HistoryStats.calculatePeriodStats(sessions: sessions, todayIso: todayIso)
-        let trends = HistoryMindStateTrends.calculateTrendStats(sessions: sessions, todayIso: todayIso)
         let needsPeriod = base.trailing4WeekDays == 0
             && base.trailing4WeekTotalTime == 0
             && base.totalTimeAllTime == 0
             && !sessions.isEmpty
         let needsTrends = base.mindStateTrends == .empty && !sessions.isEmpty
+        let period = needsPeriod
+            ? HistoryStats.calculatePeriodStats(sessions: sessions, todayIso: todayIso)
+            : nil
+        let trends = needsTrends
+            ? HistoryMindStateTrends.calculateTrendStats(sessions: sessions, todayIso: todayIso)
+            : nil
 
         return StatsDTO(
             streak: base.streak,
@@ -229,13 +233,13 @@ public struct StatsDTO: Codable, Sendable {
             avgThoughtsPerSession: base.avgThoughtsPerSession,
             avgThoughtsPerMinute: base.avgThoughtsPerMinute,
             bonusMinutesTotal: base.bonusMinutesTotal,
-            trailing4WeekDays: needsPeriod ? period.trailing4WeekDays : base.trailing4WeekDays,
-            trailing4WeekDayPercent: needsPeriod ? period.trailing4WeekDayPercent : base.trailing4WeekDayPercent,
-            trailing4WeekTotalTime: needsPeriod ? period.trailing4WeekTotalTime : base.trailing4WeekTotalTime,
-            trailing4WeekTimePercent: needsPeriod ? period.trailing4WeekTimePercent : base.trailing4WeekTimePercent,
-            totalTimeAllTime: needsPeriod ? period.totalTimeAllTime : base.totalTimeAllTime,
-            progressTo10kHours: needsPeriod ? period.progressTo10kHours : base.progressTo10kHours,
-            mindStateTrends: needsTrends ? trends : base.mindStateTrends
+            trailing4WeekDays: needsPeriod ? period!.trailing4WeekDays : base.trailing4WeekDays,
+            trailing4WeekDayPercent: needsPeriod ? period!.trailing4WeekDayPercent : base.trailing4WeekDayPercent,
+            trailing4WeekTotalTime: needsPeriod ? period!.trailing4WeekTotalTime : base.trailing4WeekTotalTime,
+            trailing4WeekTimePercent: needsPeriod ? period!.trailing4WeekTimePercent : base.trailing4WeekTimePercent,
+            totalTimeAllTime: needsPeriod ? period!.totalTimeAllTime : base.totalTimeAllTime,
+            progressTo10kHours: needsPeriod ? period!.progressTo10kHours : base.progressTo10kHours,
+            mindStateTrends: needsTrends ? trends! : base.mindStateTrends
         )
     }
 }

--- a/ios/StillPointShared/Sources/StillPointShared/HistoryMindStateTrends.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/HistoryMindStateTrends.swift
@@ -126,7 +126,7 @@ public enum HistoryMindStateTrends {
         )
     }
 
-    /// Session-elapsed seconds for trend replay (same axis as clear-percent endT, not wall-clock actualTime).
+    /// Cap mind-state replay at elapsed sit seconds (`actualTime` when present, else `duration`).
     private static func sessionEndTime(_ session: some MindStateTrendSessionInput) -> Int {
         let elapsedCap = max(HistorySessionTime.sessionTimeSeconds(session), 0)
         let log = session.mindStateLog ?? []

--- a/ios/StillPointShared/Sources/StillPointShared/HistoryMindStateTrends.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/HistoryMindStateTrends.swift
@@ -1,0 +1,212 @@
+import Foundation
+
+public struct MindStateCompositionPercents: Codable, Sendable, Equatable {
+    public let clearPercent: Double
+    public let lightDistractionPercent: Double
+    public let heavyDistractionPercent: Double
+    public let hyperfocusPercent: Double
+
+    public init(
+        clearPercent: Double,
+        lightDistractionPercent: Double,
+        heavyDistractionPercent: Double,
+        hyperfocusPercent: Double
+    ) {
+        self.clearPercent = clearPercent
+        self.lightDistractionPercent = lightDistractionPercent
+        self.heavyDistractionPercent = heavyDistractionPercent
+        self.hyperfocusPercent = hyperfocusPercent
+    }
+
+    public static let empty = MindStateCompositionPercents(
+        clearPercent: 0,
+        lightDistractionPercent: 0,
+        heavyDistractionPercent: 0,
+        hyperfocusPercent: 0
+    )
+}
+
+public struct MindStateDailyTrendBucket: Codable, Sendable, Equatable {
+    public let date: String
+    public let totalSitSeconds: Int
+    public let composition: MindStateCompositionPercents
+
+    public init(date: String, totalSitSeconds: Int, composition: MindStateCompositionPercents) {
+        self.date = date
+        self.totalSitSeconds = totalSitSeconds
+        self.composition = composition
+    }
+}
+
+public struct MindStateTrendPeriodStats: Codable, Sendable, Equatable {
+    public let totalSitSeconds: Int
+    public let clearPercent: Double
+    public let lightDistractionPercent: Double
+    public let heavyDistractionPercent: Double
+    public let hyperfocusPercent: Double
+
+    public init(
+        totalSitSeconds: Int,
+        clearPercent: Double,
+        lightDistractionPercent: Double,
+        heavyDistractionPercent: Double,
+        hyperfocusPercent: Double
+    ) {
+        self.totalSitSeconds = totalSitSeconds
+        self.clearPercent = clearPercent
+        self.lightDistractionPercent = lightDistractionPercent
+        self.heavyDistractionPercent = heavyDistractionPercent
+        self.hyperfocusPercent = hyperfocusPercent
+    }
+
+    public static let empty = MindStateTrendPeriodStats(
+        totalSitSeconds: 0,
+        clearPercent: 0,
+        lightDistractionPercent: 0,
+        heavyDistractionPercent: 0,
+        hyperfocusPercent: 0
+    )
+}
+
+public struct MindStateTrendStats: Codable, Sendable, Equatable {
+    public let trailing4Week: MindStateTrendPeriodStats
+    public let allTime: MindStateTrendPeriodStats
+    public let dailyTrend: [MindStateDailyTrendBucket]
+
+    public init(
+        trailing4Week: MindStateTrendPeriodStats,
+        allTime: MindStateTrendPeriodStats,
+        dailyTrend: [MindStateDailyTrendBucket]
+    ) {
+        self.trailing4Week = trailing4Week
+        self.allTime = allTime
+        self.dailyTrend = dailyTrend
+    }
+
+    public static let empty = MindStateTrendStats(
+        trailing4Week: .empty,
+        allTime: .empty,
+        dailyTrend: []
+    )
+}
+
+public protocol MindStateTrendSessionInput: HistorySessionTimeInput {
+    var mindStateLog: [MindStateEntry]? { get }
+    var duration: Int { get }
+}
+
+extension SessionDTO: MindStateTrendSessionInput {}
+
+public enum HistoryMindStateTrends {
+    private static func emptyComposition() -> MindStateCompositionSeconds {
+        MindStateCompositionSeconds()
+    }
+
+    private static func addComposition(
+        _ target: inout MindStateCompositionSeconds,
+        _ next: MindStateCompositionSeconds
+    ) {
+        target.clearSeconds += next.clearSeconds
+        target.lightDistractionSeconds += next.lightDistractionSeconds
+        target.heavyDistractionSeconds += next.heavyDistractionSeconds
+        target.hyperfocusSeconds += next.hyperfocusSeconds
+        target.totalSeconds += next.totalSeconds
+    }
+
+    private static func compositionPercents(_ composition: MindStateCompositionSeconds) -> MindStateCompositionPercents {
+        let denom = max(composition.totalSeconds, 1)
+        func toPercent(_ seconds: Int) -> Double {
+            (Double(seconds) / Double(denom) * 100 * 10).rounded() / 10
+        }
+        return MindStateCompositionPercents(
+            clearPercent: toPercent(composition.clearSeconds),
+            lightDistractionPercent: toPercent(composition.lightDistractionSeconds),
+            heavyDistractionPercent: toPercent(composition.heavyDistractionSeconds),
+            hyperfocusPercent: toPercent(composition.hyperfocusSeconds)
+        )
+    }
+
+    /// Session-elapsed seconds for trend replay (same axis as clear-percent endT, not wall-clock actualTime).
+    private static func sessionEndTime(_ session: some MindStateTrendSessionInput) -> Int {
+        let duration = max(session.duration, 0)
+        let log = session.mindStateLog ?? []
+        var elapsedEnd = 0
+        for entry in log {
+            elapsedEnd = max(elapsedEnd, max(Int(entry.time.rounded(.down)), 0))
+        }
+        if elapsedEnd > 0 { return elapsedEnd }
+        return duration
+    }
+
+    private static func compositionForSession(_ session: some MindStateTrendSessionInput) -> MindStateCompositionSeconds {
+        let endTime = sessionEndTime(session)
+        return MindStateSession.computeCompositionFromLog(session.mindStateLog ?? [], endTime: endTime)
+    }
+
+    /// Aggregates sit-time composition from persisted `mindStateLog` rows for History trends (#182).
+    public static func calculateTrendStats(
+        sessions: [some MindStateTrendSessionInput],
+        todayIso: String
+    ) -> MindStateTrendStats {
+        let periodStart = SessionCalendar.addDays(
+            toIsoDate: todayIso,
+            deltaDays: -(HistoryStats.trailing4WeekDays - 1)
+        )
+        var trailingTotals = emptyComposition()
+        var allTimeTotals = emptyComposition()
+        var dailyTotals: [String: MindStateCompositionSeconds] = [:]
+
+        for offset in 0..<HistoryStats.trailing4WeekDays {
+            let date = SessionCalendar.addDays(toIsoDate: periodStart, deltaDays: offset)
+            dailyTotals[date] = emptyComposition()
+        }
+
+        for session in sessions {
+            guard SessionCalendar.isValidSessionCalendarDate(session.sessionDate) else { continue }
+            let composition = compositionForSession(session)
+            guard composition.totalSeconds > 0 else { continue }
+
+            addComposition(&allTimeTotals, composition)
+
+            if session.sessionDate >= periodStart && session.sessionDate <= todayIso {
+                addComposition(&trailingTotals, composition)
+                if var dayBucket = dailyTotals[session.sessionDate] {
+                    addComposition(&dayBucket, composition)
+                    dailyTotals[session.sessionDate] = dayBucket
+                }
+            }
+        }
+
+        var dailyTrend: [MindStateDailyTrendBucket] = []
+        for offset in 0..<HistoryStats.trailing4WeekDays {
+            let date = SessionCalendar.addDays(toIsoDate: periodStart, deltaDays: offset)
+            let totals = dailyTotals[date] ?? emptyComposition()
+            dailyTrend.append(MindStateDailyTrendBucket(
+                date: date,
+                totalSitSeconds: totals.totalSeconds,
+                composition: compositionPercents(totals)
+            ))
+        }
+
+        let trailingPercents = compositionPercents(trailingTotals)
+        let allTimePercents = compositionPercents(allTimeTotals)
+
+        return MindStateTrendStats(
+            trailing4Week: MindStateTrendPeriodStats(
+                totalSitSeconds: trailingTotals.totalSeconds,
+                clearPercent: trailingPercents.clearPercent,
+                lightDistractionPercent: trailingPercents.lightDistractionPercent,
+                heavyDistractionPercent: trailingPercents.heavyDistractionPercent,
+                hyperfocusPercent: trailingPercents.hyperfocusPercent
+            ),
+            allTime: MindStateTrendPeriodStats(
+                totalSitSeconds: allTimeTotals.totalSeconds,
+                clearPercent: allTimePercents.clearPercent,
+                lightDistractionPercent: allTimePercents.lightDistractionPercent,
+                heavyDistractionPercent: allTimePercents.heavyDistractionPercent,
+                hyperfocusPercent: allTimePercents.hyperfocusPercent
+            ),
+            dailyTrend: dailyTrend
+        )
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/HistoryMindStateTrends.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/HistoryMindStateTrends.swift
@@ -133,7 +133,9 @@ public enum HistoryMindStateTrends {
         var elapsedEnd = 0
         for entry in log {
             guard entry.time.isFinite else { continue }
-            elapsedEnd = max(elapsedEnd, max(Int(entry.time.rounded(.down)), 0))
+            let clamped = min(max(entry.time, 0), Double(elapsedCap))
+            guard clamped <= Double(Int.max) else { continue }
+            elapsedEnd = max(elapsedEnd, Int(clamped.rounded(.down)))
         }
         if elapsedEnd > 0 { return min(elapsedEnd, elapsedCap) }
         return elapsedCap

--- a/ios/StillPointShared/Sources/StillPointShared/HistoryMindStateTrends.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/HistoryMindStateTrends.swift
@@ -128,14 +128,15 @@ public enum HistoryMindStateTrends {
 
     /// Session-elapsed seconds for trend replay (same axis as clear-percent endT, not wall-clock actualTime).
     private static func sessionEndTime(_ session: some MindStateTrendSessionInput) -> Int {
-        let duration = max(session.duration, 0)
+        let elapsedCap = max(HistorySessionTime.sessionTimeSeconds(session), 0)
         let log = session.mindStateLog ?? []
         var elapsedEnd = 0
         for entry in log {
             guard entry.time.isFinite else { continue }
             elapsedEnd = max(elapsedEnd, max(Int(entry.time.rounded(.down)), 0))
         }
-        return max(elapsedEnd, duration)
+        if elapsedEnd > 0 { return min(elapsedEnd, elapsedCap) }
+        return elapsedCap
     }
 
     private static func compositionForSession(_ session: some MindStateTrendSessionInput) -> MindStateCompositionSeconds {

--- a/ios/StillPointShared/Sources/StillPointShared/HistoryMindStateTrends.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/HistoryMindStateTrends.swift
@@ -132,10 +132,10 @@ public enum HistoryMindStateTrends {
         let log = session.mindStateLog ?? []
         var elapsedEnd = 0
         for entry in log {
+            guard entry.time.isFinite else { continue }
             elapsedEnd = max(elapsedEnd, max(Int(entry.time.rounded(.down)), 0))
         }
-        if elapsedEnd > 0 { return elapsedEnd }
-        return duration
+        return max(elapsedEnd, duration)
     }
 
     private static func compositionForSession(_ session: some MindStateTrendSessionInput) -> MindStateCompositionSeconds {

--- a/ios/StillPointShared/Sources/StillPointShared/HistoryMonthGrid.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/HistoryMonthGrid.swift
@@ -140,7 +140,6 @@ public enum HistoryMonthGrid {
             return "\(hours)h \(minutes)m"
         }
         let minutes = Int((Double(safeSeconds) / 60.0).rounded())
-        if minutes >= 60 { return "1h" }
         return "\(minutes)m"
     }
 

--- a/ios/StillPointShared/Sources/StillPointShared/HistoryMonthGrid.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/HistoryMonthGrid.swift
@@ -131,8 +131,15 @@ public enum HistoryMonthGrid {
 
     /// Format sit length for calendar cells — minutes when ≥60s, else seconds.
     public static func formatSessionDurationLabel(_ seconds: Int) -> String {
-        if seconds < 60 { return "\(seconds)s" }
-        let minutes = Int((Double(seconds) / 60.0).rounded())
+        let safeSeconds = max(seconds, 0)
+        if safeSeconds < 60 { return "\(safeSeconds)s" }
+        if safeSeconds >= 3600 {
+            let hours = safeSeconds / 3600
+            let minutes = (safeSeconds % 3600) / 60
+            if minutes == 0 { return "\(hours)h" }
+            return "\(hours)h \(minutes)m"
+        }
+        let minutes = Int((Double(safeSeconds) / 60.0).rounded())
         if minutes >= 60 { return "1h" }
         return "\(minutes)m"
     }

--- a/ios/StillPointShared/Sources/StillPointShared/HistoryMonthGrid.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/HistoryMonthGrid.swift
@@ -99,6 +99,19 @@ public enum HistoryMonthGrid {
         return monthLabelFormatter.string(from: date)
     }
 
+    private static func sortSessionsChronologically(_ sessions: [any HistorySessionTimeInput]) -> [any HistorySessionTimeInput] {
+        sessions.sorted { lhs, rhs in
+            guard let a = lhs as? SessionDTO, let b = rhs as? SessionDTO else {
+                return lhs.sessionDate < rhs.sessionDate
+            }
+            if a.sessionDate != b.sessionDate { return a.sessionDate < b.sessionDate }
+            let aCreated = a.createdAt ?? ""
+            let bCreated = b.createdAt ?? ""
+            if aCreated != bCreated { return aCreated < bCreated }
+            return a.id < b.id
+        }
+    }
+
     private static func groupSessionsByDate(
         _ sessions: [some HistorySessionTimeInput]
     ) -> [String: [any HistorySessionTimeInput]] {
@@ -120,6 +133,7 @@ public enum HistoryMonthGrid {
     public static func formatSessionDurationLabel(_ seconds: Int) -> String {
         if seconds < 60 { return "\(seconds)s" }
         let minutes = Int((Double(seconds) / 60.0).rounded())
+        if minutes >= 60 { return "1h" }
         return "\(minutes)m"
     }
 
@@ -130,7 +144,10 @@ public enum HistoryMonthGrid {
         let minutes = hours == 0
             ? Int((Double(seconds) / 60.0).rounded())
             : (seconds % 3600) / 60
-        if hours == 0 { return "\(minutes)m" }
+        if hours == 0 {
+            if minutes >= 60 { return "1h" }
+            return "\(minutes)m"
+        }
         if minutes == 0 { return "\(hours)h" }
         return "\(hours)h \(minutes)m"
     }
@@ -156,7 +173,7 @@ public enum HistoryMonthGrid {
         for day in 1...dim {
             let dd = String(format: "%02d", day)
             let isoDate = "\(ym)-\(dd)"
-            let daySessions = byDate[isoDate] ?? []
+            let daySessions = sortSessionsChronologically(byDate[isoDate] ?? [])
             let durationLabels = daySessions.map {
                 formatSessionDurationLabel(HistorySessionTime.sessionTimeSeconds($0))
             }

--- a/ios/StillPointShared/Sources/StillPointShared/HistoryMonthGrid.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/HistoryMonthGrid.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+public enum MonthDayState: String, Sendable, Equatable {
+    case future
+    case today
+    case meditated
+    case missed
+}
+
+public struct MonthGridDay: Sendable, Equatable {
+    public let isoDate: String
+    public let dayOfMonth: Int
+    public let state: MonthDayState
+    /// Short labels per session that day, e.g. ["8m", "1m"].
+    public let durationLabels: [String]
+
+    public init(isoDate: String, dayOfMonth: Int, state: MonthDayState, durationLabels: [String]) {
+        self.isoDate = isoDate
+        self.dayOfMonth = dayOfMonth
+        self.state = state
+        self.durationLabels = durationLabels
+    }
+}
+
+public enum MonthGridCell: Sendable, Equatable {
+    case blank
+    case day(MonthGridDay)
+}
+
+public struct CurrentMonthGrid: Sendable, Equatable {
+    public let yearMonth: String
+    public let monthLabel: String
+    public let cells: [MonthGridCell]
+
+    public init(yearMonth: String, monthLabel: String, cells: [MonthGridCell]) {
+        self.yearMonth = yearMonth
+        self.monthLabel = monthLabel
+        self.cells = cells
+    }
+}
+
+public enum HistoryMonthGrid {
+    private static let monthLabelFormatter: DateFormatter = {
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.timeZone = TimeZone(secondsFromGMT: 0)
+        df.dateFormat = "MMMM yyyy"
+        return df
+    }()
+
+    private static let utcCalendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }()
+
+    private static func parseYearMonth(_ isoDate: String) -> (year: Int, month: Int) {
+        let parts = isoDate.split(separator: "-").compactMap { Int($0) }
+        guard parts.count >= 2 else { return (0, 0) }
+        return (parts[0], parts[1])
+    }
+
+    private static func daysInCalendarMonth(year: Int, month: Int) -> Int {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = 1
+        components.calendar = utcCalendar
+        components.timeZone = TimeZone(secondsFromGMT: 0)
+        guard let date = utcCalendar.date(from: components),
+              let range = utcCalendar.range(of: .day, in: .month, for: date) else { return 30 }
+        return range.count
+    }
+
+    private static func weekdayUtc(_ isoDate: String) -> Int {
+        let parts = isoDate.split(separator: "-").compactMap { Int($0) }
+        guard parts.count == 3 else { return 0 }
+        var components = DateComponents()
+        components.year = parts[0]
+        components.month = parts[1]
+        components.day = parts[2]
+        components.calendar = utcCalendar
+        components.timeZone = TimeZone(secondsFromGMT: 0)
+        guard let date = utcCalendar.date(from: components) else { return 0 }
+        return utcCalendar.component(.weekday, from: date) - 1
+    }
+
+    private static func monthLabel(year: Int, month: Int) -> String {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = 1
+        components.hour = 12
+        components.calendar = utcCalendar
+        components.timeZone = TimeZone(secondsFromGMT: 0)
+        guard let date = utcCalendar.date(from: components) else {
+            return HistoryMonthlyAggregation.yearMonthKey(year: year, month: month)
+        }
+        return monthLabelFormatter.string(from: date)
+    }
+
+    private static func groupSessionsByDate(
+        _ sessions: [some HistorySessionTimeInput]
+    ) -> [String: [any HistorySessionTimeInput]] {
+        var map: [String: [any HistorySessionTimeInput]] = [:]
+        for session in sessions {
+            guard SessionCalendar.isValidSessionCalendarDate(session.sessionDate) else { continue }
+            map[session.sessionDate, default: []].append(session)
+        }
+        return map
+    }
+
+    private static func dayState(_ isoDate: String, todayIso: String, hasSession: Bool) -> MonthDayState {
+        if isoDate > todayIso { return hasSession ? .meditated : .future }
+        if isoDate == todayIso { return hasSession ? .meditated : .today }
+        return hasSession ? .meditated : .missed
+    }
+
+    /// Format sit length for calendar cells — minutes when ≥60s, else seconds.
+    public static func formatSessionDurationLabel(_ seconds: Int) -> String {
+        if seconds < 60 { return "\(seconds)s" }
+        let minutes = Int((Double(seconds) / 60.0).rounded())
+        return "\(minutes)m"
+    }
+
+    /// Human-readable total time for summary rows.
+    public static func formatTotalTime(_ seconds: Int) -> String {
+        if seconds < 60 { return "\(seconds)s" }
+        let hours = seconds / 3600
+        let minutes = hours == 0
+            ? Int((Double(seconds) / 60.0).rounded())
+            : (seconds % 3600) / 60
+        if hours == 0 { return "\(minutes)m" }
+        if minutes == 0 { return "\(hours)h" }
+        return "\(hours)h \(minutes)m"
+    }
+
+    /// Builds a Sunday-start month grid for the calendar month containing `todayIso`.
+    /// Any session on a day (including quick sits) marks the cell meditated (#379/#83).
+    public static func buildCurrentMonthGrid(
+        sessions: [some HistorySessionTimeInput],
+        todayIso: String
+    ) -> CurrentMonthGrid {
+        let (year, month) = parseYearMonth(todayIso)
+        let ym = HistoryMonthlyAggregation.yearMonthKey(year: year, month: month)
+        let byDate = groupSessionsByDate(sessions)
+        let dim = daysInCalendarMonth(year: year, month: month)
+        let firstIso = "\(ym)-01"
+        let leadingBlanks = weekdayUtc(firstIso)
+
+        var cells: [MonthGridCell] = []
+        for _ in 0..<leadingBlanks {
+            cells.append(.blank)
+        }
+
+        for day in 1...dim {
+            let dd = String(format: "%02d", day)
+            let isoDate = "\(ym)-\(dd)"
+            let daySessions = byDate[isoDate] ?? []
+            let durationLabels = daySessions.map {
+                formatSessionDurationLabel(HistorySessionTime.sessionTimeSeconds($0))
+            }
+            cells.append(.day(MonthGridDay(
+                isoDate: isoDate,
+                dayOfMonth: day,
+                state: dayState(isoDate, todayIso: todayIso, hasSession: !daySessions.isEmpty),
+                durationLabels: durationLabels
+            )))
+        }
+
+        return CurrentMonthGrid(
+            yearMonth: ym,
+            monthLabel: monthLabel(year: year, month: month),
+            cells: cells
+        )
+    }
+
+    public static func buildPriorMonthSummaries(
+        sessions: [some HistorySessionTimeInput],
+        todayIso: String
+    ) -> [MonthlySummary] {
+        HistoryMonthlyAggregation.buildPriorMonthSummaries(sessions: sessions, todayIso: todayIso)
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/HistoryMonthlyAggregation.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/HistoryMonthlyAggregation.swift
@@ -1,0 +1,216 @@
+import Foundation
+
+public struct MonthlySummary: Sendable, Equatable {
+    public let yearMonth: String
+    public let label: String
+    public let daysActive: Int
+    public let daysInMonth: Int
+    public let totalTimeSeconds: Int
+
+    public init(
+        yearMonth: String,
+        label: String,
+        daysActive: Int,
+        daysInMonth: Int,
+        totalTimeSeconds: Int
+    ) {
+        self.yearMonth = yearMonth
+        self.label = label
+        self.daysActive = daysActive
+        self.daysInMonth = daysInMonth
+        self.totalTimeSeconds = totalTimeSeconds
+    }
+}
+
+public enum HistoryMonthlyAggregation {
+    private static let monthLabelFormatter: DateFormatter = {
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.timeZone = TimeZone(secondsFromGMT: 0)
+        df.dateFormat = "MMMM yyyy"
+        return df
+    }()
+
+    private static let shortMonthLabelFormatter: DateFormatter = {
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.timeZone = TimeZone(secondsFromGMT: 0)
+        df.dateFormat = "MMM yyyy"
+        return df
+    }()
+
+    public static func yearMonthKey(year: Int, month: Int) -> String {
+        String(format: "%04d-%02d", year, month)
+    }
+
+    private static func parseYearMonth(_ isoDate: String) -> (year: Int, month: Int) {
+        let parts = isoDate.split(separator: "-").compactMap { Int($0) }
+        guard parts.count >= 2 else { return (0, 0) }
+        return (parts[0], parts[1])
+    }
+
+    private static func daysInCalendarMonth(year: Int, month: Int) -> Int {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = 1
+        components.calendar = utcCalendar
+        components.timeZone = TimeZone(secondsFromGMT: 0)
+        guard let date = utcCalendar.date(from: components),
+              let range = utcCalendar.range(of: .day, in: .month, for: date) else { return 30 }
+        return range.count
+    }
+
+    private static let utcCalendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }()
+
+    private static func monthLabel(year: Int, month: Int) -> String {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = 1
+        components.hour = 12
+        components.calendar = utcCalendar
+        components.timeZone = TimeZone(secondsFromGMT: 0)
+        guard let date = utcCalendar.date(from: components) else { return yearMonthKey(year: year, month: month) }
+        return monthLabelFormatter.string(from: date)
+    }
+
+    private static func shortMonthLabel(year: Int, month: Int) -> String {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = 1
+        components.hour = 12
+        components.calendar = utcCalendar
+        components.timeZone = TimeZone(secondsFromGMT: 0)
+        guard let date = utcCalendar.date(from: components) else { return yearMonthKey(year: year, month: month) }
+        return shortMonthLabelFormatter.string(from: date)
+    }
+
+    private static func groupAnySessionsByDate(
+        _ sessions: [some HistorySessionTimeInput]
+    ) -> [String: [any HistorySessionTimeInput]] {
+        var map: [String: [any HistorySessionTimeInput]] = [:]
+        for session in sessions {
+            guard SessionCalendar.isValidSessionCalendarDate(session.sessionDate) else { continue }
+            map[session.sessionDate, default: []].append(session)
+        }
+        return map
+    }
+
+    private static func aggregateMonthSummaryFromGrouped(
+        byDate: [String: [any HistorySessionTimeInput]],
+        year: Int,
+        month: Int
+    ) -> MonthlySummary {
+        let ym = yearMonthKey(year: year, month: month)
+        let dim = daysInCalendarMonth(year: year, month: month)
+        var daysActive = 0
+        var totalTimeSeconds = 0
+
+        for day in 1...dim {
+            let dd = String(format: "%02d", day)
+            let isoDate = "\(ym)-\(dd)"
+            guard let daySessions = byDate[isoDate], !daySessions.isEmpty else { continue }
+            daysActive += 1
+            for session in daySessions {
+                totalTimeSeconds += HistorySessionTime.sessionTimeSeconds(session)
+            }
+        }
+
+        return MonthlySummary(
+            yearMonth: ym,
+            label: monthLabel(year: year, month: month),
+            daysActive: daysActive,
+            daysInMonth: dim,
+            totalTimeSeconds: totalTimeSeconds
+        )
+    }
+
+    public static func aggregateMonthSummary(
+        sessions: [some HistorySessionTimeInput],
+        year: Int,
+        month: Int
+    ) -> MonthlySummary {
+        aggregateMonthSummaryFromGrouped(
+            byDate: groupAnySessionsByDate(sessions),
+            year: year,
+            month: month
+        )
+    }
+
+    private static func advanceMonth(year: Int, month: Int, delta: Int) -> (year: Int, month: Int) {
+        var y = year
+        var m = month + delta
+        while m < 1 {
+            m += 12
+            y -= 1
+        }
+        while m > 12 {
+            m -= 12
+            y += 1
+        }
+        return (y, m)
+    }
+
+    /// Trailing 12 calendar months ending with the month containing `todayIso`.
+    public static func buildTrailing12MonthSummaries(
+        sessions: [some HistorySessionTimeInput],
+        todayIso: String
+    ) -> [MonthlySummary] {
+        let (todayYear, todayMonth) = parseYearMonth(todayIso)
+        let start = advanceMonth(year: todayYear, month: todayMonth, delta: -11)
+        let byDate = groupAnySessionsByDate(sessions)
+
+        var summaries: [MonthlySummary] = []
+        var y = start.year
+        var m = start.month
+
+        for _ in 0..<12 {
+            summaries.append(aggregateMonthSummaryFromGrouped(byDate: byDate, year: y, month: m))
+            (y, m) = advanceMonth(year: y, month: m, delta: 1)
+        }
+
+        return summaries
+    }
+
+    /// Short month label for compact grid cells (e.g. "Jul 2026").
+    public static func formatShortMonthLabel(_ yearMonth: String) -> String {
+        let (year, month) = parseYearMonth("\(yearMonth)-01")
+        return shortMonthLabel(year: year, month: month)
+    }
+
+    /// One compact row per calendar month strictly before the month of `todayIso`.
+    public static func buildPriorMonthSummaries(
+        sessions: [some HistorySessionTimeInput],
+        todayIso: String
+    ) -> [MonthlySummary] {
+        let (todayYear, todayMonth) = parseYearMonth(todayIso)
+        let currentYm = yearMonthKey(year: todayYear, month: todayMonth)
+
+        let validDates = sessions
+            .map(\.sessionDate)
+            .filter(SessionCalendar.isValidSessionCalendarDate)
+        guard let earliest = validDates.min() else { return [] }
+
+        let (startYear, startMonth) = parseYearMonth(earliest)
+        let byDate = groupAnySessionsByDate(sessions)
+
+        var summaries: [MonthlySummary] = []
+        var y = startYear
+        var m = startMonth
+
+        while true {
+            let ym = yearMonthKey(year: y, month: m)
+            if ym >= currentYm { break }
+            summaries.append(aggregateMonthSummaryFromGrouped(byDate: byDate, year: y, month: m))
+            (y, m) = advanceMonth(year: y, month: m, delta: 1)
+        }
+
+        return summaries
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/HistorySessionTime.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/HistorySessionTime.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Minimal session fields for history time totals (matches web `HistorySessionTimeInput`).
+public protocol HistorySessionTimeInput {
+    var sessionDate: String { get }
+    var duration: Int { get }
+    var actualTime: Int? { get }
+}
+
+extension SessionDTO: HistorySessionTimeInput {}
+
+public enum HistorySessionTime {
+    /// Seconds counted toward history time totals (elapsed wall time for the sit).
+    public static func sessionTimeSeconds(_ session: some HistorySessionTimeInput) -> Int {
+        session.actualTime ?? session.duration
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/HistorySessionTime.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/HistorySessionTime.swift
@@ -12,6 +12,6 @@ extension SessionDTO: HistorySessionTimeInput {}
 public enum HistorySessionTime {
     /// Seconds counted toward history time totals (elapsed wall time for the sit).
     public static func sessionTimeSeconds(_ session: some HistorySessionTimeInput) -> Int {
-        session.actualTime ?? session.duration
+        max(0, session.actualTime ?? session.duration)
     }
 }

--- a/ios/StillPointShared/Sources/StillPointShared/HistoryStats.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/HistoryStats.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+public enum HistoryStats {
+    public static let trailing4WeekDays = 28
+    private static let secondsIn4Weeks = trailing4WeekDays * 24 * 60 * 60
+    private static let tenThousandHoursSeconds = 10_000 * 60 * 60
+
+    public struct PeriodStats: Sendable, Equatable {
+        public let trailing4WeekDays: Int
+        public let trailing4WeekDayPercent: Double
+        public let trailing4WeekTotalTime: Int
+        public let trailing4WeekTimePercent: Double
+        public let totalTimeAllTime: Int
+        public let progressTo10kHours: Double
+
+        public init(
+            trailing4WeekDays: Int,
+            trailing4WeekDayPercent: Double,
+            trailing4WeekTotalTime: Int,
+            trailing4WeekTimePercent: Double,
+            totalTimeAllTime: Int,
+            progressTo10kHours: Double
+        ) {
+            self.trailing4WeekDays = trailing4WeekDays
+            self.trailing4WeekDayPercent = trailing4WeekDayPercent
+            self.trailing4WeekTotalTime = trailing4WeekTotalTime
+            self.trailing4WeekTimePercent = trailing4WeekTimePercent
+            self.totalTimeAllTime = totalTimeAllTime
+            self.progressTo10kHours = progressTo10kHours
+        }
+    }
+
+    /// Trailing 4-week and all-time stats for the History view (#83).
+    /// `todayIso` should match the client's local calendar day (same convention as
+    /// `sessionDate` stamping) so the window ends on the user's "today".
+    public static func calculatePeriodStats(
+        sessions: [some HistorySessionTimeInput],
+        todayIso: String
+    ) -> PeriodStats {
+        let periodStart = SessionCalendar.addDays(toIsoDate: todayIso, deltaDays: -(trailing4WeekDays - 1))
+        var datesInPeriod = Set<String>()
+        var trailing4WeekTotalTime = 0
+        var totalTimeAllTime = 0
+
+        for session in sessions {
+            guard SessionCalendar.isValidSessionCalendarDate(session.sessionDate) else { continue }
+            let secs = HistorySessionTime.sessionTimeSeconds(session)
+            totalTimeAllTime += secs
+            if session.sessionDate >= periodStart && session.sessionDate <= todayIso {
+                datesInPeriod.insert(session.sessionDate)
+                trailing4WeekTotalTime += secs
+            }
+        }
+
+        let trailing4WeekDayCount = datesInPeriod.count
+        let trailing4WeekDayPercent = roundToOneDecimal(
+            (Double(trailing4WeekDayCount) / Double(trailing4WeekDays)) * 100
+        )
+        let trailing4WeekTimePercent = roundToTwoDecimals(
+            (Double(trailing4WeekTotalTime) / Double(secondsIn4Weeks)) * 100
+        )
+        let progressTo10kHours = roundToTwoDecimals(
+            (Double(totalTimeAllTime) / Double(tenThousandHoursSeconds)) * 100
+        )
+
+        return PeriodStats(
+            trailing4WeekDays: trailing4WeekDayCount,
+            trailing4WeekDayPercent: trailing4WeekDayPercent,
+            trailing4WeekTotalTime: trailing4WeekTotalTime,
+            trailing4WeekTimePercent: trailing4WeekTimePercent,
+            totalTimeAllTime: totalTimeAllTime,
+            progressTo10kHours: progressTo10kHours
+        )
+    }
+
+    private static func roundToOneDecimal(_ value: Double) -> Double {
+        (value * 10).rounded() / 10
+    }
+
+    private static func roundToTwoDecimals(_ value: Double) -> Double {
+        (value * 100).rounded() / 100
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/HistoryStats.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/HistoryStats.swift
@@ -34,7 +34,7 @@ public enum HistoryStats {
     /// `todayIso` should match the client's local calendar day (same convention as
     /// `sessionDate` stamping) so the window ends on the user's "today".
     public static func calculatePeriodStats(
-        sessions: [some HistorySessionTimeInput],
+        sessions: [any HistorySessionTimeInput],
         todayIso: String
     ) -> PeriodStats {
         let periodStart = SessionCalendar.addDays(toIsoDate: todayIso, deltaDays: -(trailing4WeekDays - 1))

--- a/ios/StillPointShared/Sources/StillPointShared/MindStateSession.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/MindStateSession.swift
@@ -64,7 +64,7 @@ public enum MindStateSession {
             if clampedTime > lastTime {
                 bucketMindStateSeconds(
                     lastState,
-                    seconds: Int(clampedTime - lastTime),
+                    seconds: clampedTime - lastTime,
                     into: &out
                 )
             }
@@ -77,19 +77,21 @@ public enum MindStateSession {
 
     private static func bucketMindStateSeconds(
         _ state: String,
-        seconds: Int,
+        seconds: Double,
         into out: inout MindStateCompositionSeconds
     ) {
         guard seconds > 0 else { return }
+        let wholeSeconds = Int(seconds.rounded(.down))
+        guard wholeSeconds > 0 else { return }
         switch state {
         case "thinking":
-            out.lightDistractionSeconds += seconds
+            out.lightDistractionSeconds += wholeSeconds
         case "heavy":
-            out.heavyDistractionSeconds += seconds
+            out.heavyDistractionSeconds += wholeSeconds
         case "hyperfocus":
-            out.hyperfocusSeconds += seconds
+            out.hyperfocusSeconds += wholeSeconds
         default:
-            out.clearSeconds += seconds
+            out.clearSeconds += wholeSeconds
         }
     }
 }

--- a/ios/StillPointShared/Sources/StillPointShared/MindStateSession.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/MindStateSession.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+public struct MindStateCompositionSeconds: Sendable, Equatable {
+    public var clearSeconds: Int
+    public var lightDistractionSeconds: Int
+    public var heavyDistractionSeconds: Int
+    public var hyperfocusSeconds: Int
+    public var totalSeconds: Int
+
+    public init(
+        clearSeconds: Int = 0,
+        lightDistractionSeconds: Int = 0,
+        heavyDistractionSeconds: Int = 0,
+        hyperfocusSeconds: Int = 0,
+        totalSeconds: Int = 0
+    ) {
+        self.clearSeconds = clearSeconds
+        self.lightDistractionSeconds = lightDistractionSeconds
+        self.heavyDistractionSeconds = heavyDistractionSeconds
+        self.hyperfocusSeconds = hyperfocusSeconds
+        self.totalSeconds = totalSeconds
+    }
+}
+
+public enum MindStateSession {
+    /// Replays `mindStateLog` into sit-time seconds for clear, light distraction,
+    /// heavy distraction, and hyperfocus. Uses the same segment boundaries as
+    /// `SessionLogic.calculateClearPercent`.
+    public static func computeCompositionFromLog(
+        _ log: [MindStateEntry],
+        endTime: Int
+    ) -> MindStateCompositionSeconds {
+        let totalSeconds = max(endTime, 0)
+        var out = MindStateCompositionSeconds(totalSeconds: totalSeconds)
+        guard totalSeconds > 0 else { return out }
+
+        let safeLog = log
+            .filter { $0.time.isFinite }
+            .map { entry in
+                MindStateEntry(
+                    time: min(max(entry.time, 0), Double(totalSeconds)),
+                    state: entry.state
+                )
+            }
+            .sorted { $0.time < $1.time }
+
+        var lastTime = 0.0
+        var lastState = "clear"
+        let full: [MindStateEntry]
+        if safeLog.isEmpty {
+            full = [MindStateEntry(time: Double(totalSeconds), state: "clear")]
+        } else {
+            full = safeLog + [MindStateEntry(time: Double(totalSeconds), state: "clear")]
+        }
+
+        for entry in full {
+            let clampedTime = min(max(entry.time, lastTime), Double(totalSeconds))
+            if clampedTime > lastTime {
+                bucketMindStateSeconds(
+                    lastState,
+                    seconds: Int(clampedTime - lastTime),
+                    into: &out
+                )
+            }
+            lastTime = clampedTime
+            lastState = entry.state
+        }
+
+        return out
+    }
+
+    private static func bucketMindStateSeconds(
+        _ state: String,
+        seconds: Int,
+        into out: inout MindStateCompositionSeconds
+    ) {
+        guard seconds > 0 else { return }
+        switch state {
+        case "thinking":
+            out.lightDistractionSeconds += seconds
+        case "heavy":
+            out.heavyDistractionSeconds += seconds
+        case "hyperfocus":
+            out.hyperfocusSeconds += seconds
+        default:
+            out.clearSeconds += seconds
+        }
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/MindStateSession.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/MindStateSession.swift
@@ -35,14 +35,20 @@ public enum MindStateSession {
         guard totalSeconds > 0 else { return out }
 
         let safeLog = log
-            .filter { $0.time.isFinite }
-            .map { entry in
+            .enumerated()
+            .filter { $0.element.time.isFinite }
+            .sorted { lhs, rhs in
+                if lhs.element.time != rhs.element.time {
+                    return lhs.element.time < rhs.element.time
+                }
+                return lhs.offset < rhs.offset
+            }
+            .map { _, entry in
                 MindStateEntry(
                     time: min(max(entry.time, 0), Double(totalSeconds)),
                     state: entry.state
                 )
             }
-            .sorted { $0.time < $1.time }
 
         var lastTime = 0.0
         var lastState = "clear"
@@ -58,7 +64,7 @@ public enum MindStateSession {
             if clampedTime > lastTime {
                 bucketMindStateSeconds(
                     lastState,
-                    seconds: Int(clampedTime - lastTime),
+                    seconds: Int((clampedTime - lastTime).rounded()),
                     into: &out
                 )
             }

--- a/ios/StillPointShared/Sources/StillPointShared/MindStateSession.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/MindStateSession.swift
@@ -64,7 +64,7 @@ public enum MindStateSession {
             if clampedTime > lastTime {
                 bucketMindStateSeconds(
                     lastState,
-                    seconds: Int((clampedTime - lastTime).rounded()),
+                    seconds: Int(clampedTime - lastTime),
                     into: &out
                 )
             }

--- a/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
@@ -196,7 +196,12 @@ actor UITestAPIStore {
         }
 
         let sortedSessions = store.sessions.sorted { $0.sessionDate < $1.sessionDate }
-        let todayIso = today ?? localTodayIsoDate()
+        let todayIso: String
+        if let today, !today.isEmpty {
+            todayIso = today
+        } else {
+            todayIso = localTodayIsoDate()
+        }
         let base = SessionStatistics.calculateStats(for: sortedSessions)
         let period = HistoryStats.calculatePeriodStats(sessions: sortedSessions, todayIso: todayIso)
         let trends = HistoryMindStateTrends.calculateTrendStats(sessions: sortedSessions, todayIso: todayIso)

--- a/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
@@ -188,7 +188,7 @@ actor UITestAPIStore {
 
     // MARK: - Sessions
 
-    func getSessions() throws -> (sessions: [SessionDTO], stats: StatsDTO) {
+    func getSessions(today: String? = nil) throws -> (sessions: [SessionDTO], stats: StatsDTO) {
         try ensureAuthenticated()
 
         if config.forceSessionsFailure {
@@ -196,7 +196,33 @@ actor UITestAPIStore {
         }
 
         let sortedSessions = store.sessions.sorted { $0.sessionDate < $1.sessionDate }
-        return (sortedSessions, SessionStatistics.calculateStats(for: sortedSessions))
+        let todayIso = today ?? localTodayIsoDate()
+        let base = SessionStatistics.calculateStats(for: sortedSessions)
+        let period = HistoryStats.calculatePeriodStats(sessions: sortedSessions, todayIso: todayIso)
+        let trends = HistoryMindStateTrends.calculateTrendStats(sessions: sortedSessions, todayIso: todayIso)
+        let stats = StatsDTO(
+            streak: base.streak,
+            avgClearPercent: base.avgClearPercent,
+            avgThoughtsPerSession: base.avgThoughtsPerSession,
+            avgThoughtsPerMinute: base.avgThoughtsPerMinute,
+            bonusMinutesTotal: base.bonusMinutesTotal,
+            trailing4WeekDays: period.trailing4WeekDays,
+            trailing4WeekDayPercent: period.trailing4WeekDayPercent,
+            trailing4WeekTotalTime: period.trailing4WeekTotalTime,
+            trailing4WeekTimePercent: period.trailing4WeekTimePercent,
+            totalTimeAllTime: period.totalTimeAllTime,
+            progressTo10kHours: period.progressTo10kHours,
+            mindStateTrends: trends
+        )
+        return (sortedSessions, stats)
+    }
+
+    private func localTodayIsoDate() -> String {
+        let df = DateFormatter()
+        df.dateFormat = "yyyy-MM-dd"
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.calendar = Calendar(identifier: .gregorian)
+        return df.string(from: Date())
     }
 
     func getTracksDoneToday(date: String) throws -> TracksDoneTodayDTO {

--- a/ios/StillPointShared/Tests/StillPointSharedTests/HistoryMindStateTrendsTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/HistoryMindStateTrendsTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+import StillPointShared
+
+final class HistoryMindStateTrendsTests: XCTestCase {
+    private func makeSession(
+        date: String,
+        duration: Int,
+        log: [MindStateEntry]
+    ) -> SessionDTO {
+        SessionDTO(
+            id: UUID().uuidString,
+            dayNumber: 1,
+            sessionType: .standard,
+            duration: duration,
+            completed: true,
+            actualTime: duration,
+            clearPercent: 50,
+            thoughtCount: 0,
+            mindStateLog: log,
+            sessionDate: date,
+            createdAt: nil,
+            buddySessionId: nil
+        )
+    }
+
+    func testComputeCompositionFromLogEmpty() {
+        let composition = MindStateSession.computeCompositionFromLog([], endTime: 300)
+        XCTAssertEqual(composition.clearSeconds, 300)
+        XCTAssertEqual(composition.totalSeconds, 300)
+    }
+
+    func testComputeCompositionFromLogSplitsSegments() {
+        let composition = MindStateSession.computeCompositionFromLog([
+            MindStateEntry(time: 0, state: "clear"),
+            MindStateEntry(time: 60, state: "thinking"),
+            MindStateEntry(time: 120, state: "clear"),
+            MindStateEntry(time: 180, state: "hyperfocus"),
+            MindStateEntry(time: 240, state: "heavy"),
+            MindStateEntry(time: 300, state: "clear"),
+        ], endTime: 300)
+
+        XCTAssertEqual(composition.clearSeconds, 120)
+        XCTAssertEqual(composition.lightDistractionSeconds, 60)
+        XCTAssertEqual(composition.heavyDistractionSeconds, 60)
+        XCTAssertEqual(composition.hyperfocusSeconds, 60)
+        XCTAssertEqual(composition.totalSeconds, 300)
+    }
+
+    func testCalculateTrendStatsAggregatesTrailingWindow() {
+        let stats = HistoryMindStateTrends.calculateTrendStats(
+            sessions: [
+                makeSession(
+                    date: "2026-07-01",
+                    duration: 180,
+                    log: [
+                        MindStateEntry(time: 0, state: "clear"),
+                        MindStateEntry(time: 60, state: "thinking"),
+                        MindStateEntry(time: 120, state: "hyperfocus"),
+                        MindStateEntry(time: 180, state: "clear"),
+                    ]
+                ),
+            ],
+            todayIso: "2026-07-02"
+        )
+
+        XCTAssertEqual(stats.trailing4Week.totalSitSeconds, 180)
+        XCTAssertEqual(stats.trailing4Week.lightDistractionPercent, 33.3, accuracy: 0.1)
+        XCTAssertEqual(stats.trailing4Week.hyperfocusPercent, 33.3, accuracy: 0.1)
+        XCTAssertEqual(stats.trailing4Week.heavyDistractionPercent, 0)
+        XCTAssertEqual(stats.dailyTrend.count, 28)
+    }
+}

--- a/ios/StillPointShared/Tests/StillPointSharedTests/HistoryMonthGridTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/HistoryMonthGridTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+import StillPointShared
+
+final class HistoryMonthGridTests: XCTestCase {
+    private func makeSession(
+        date: String,
+        duration: Int,
+        actualTime: Int? = nil,
+        sessionType: SessionType = .standard
+    ) -> SessionDTO {
+        SessionDTO(
+            id: UUID().uuidString,
+            dayNumber: 1,
+            sessionType: sessionType,
+            duration: duration,
+            completed: true,
+            actualTime: actualTime ?? duration,
+            clearPercent: 50,
+            thoughtCount: 0,
+            mindStateLog: nil,
+            sessionDate: date,
+            createdAt: nil,
+            buddySessionId: nil
+        )
+    }
+
+    func testFormatSessionDurationLabel() {
+        XCTAssertEqual(HistoryMonthGrid.formatSessionDurationLabel(45), "45s")
+        XCTAssertEqual(HistoryMonthGrid.formatSessionDurationLabel(480), "8m")
+    }
+
+    func testBuildCurrentMonthGridMarksMeditatedAndFutureDays() {
+        let grid = HistoryMonthGrid.buildCurrentMonthGrid(
+            sessions: [
+                makeSession(date: "2026-07-01", duration: 480),
+                makeSession(date: "2026-07-02", duration: 60, sessionType: .quick),
+            ],
+            todayIso: "2026-07-02"
+        )
+
+        XCTAssertEqual(grid.yearMonth, "2026-07")
+        let dayCells = grid.cells.compactMap { cell -> MonthGridDay? in
+            if case .day(let day) = cell { return day }
+            return nil
+        }
+        let jul1 = dayCells.first { $0.isoDate == "2026-07-01" }!
+        let jul2 = dayCells.first { $0.isoDate == "2026-07-02" }!
+        let jul3 = dayCells.first { $0.isoDate == "2026-07-03" }!
+
+        XCTAssertEqual(jul1.state, .meditated)
+        XCTAssertEqual(jul1.durationLabels, ["8m"])
+        XCTAssertEqual(jul2.state, .meditated)
+        XCTAssertEqual(jul3.state, .future)
+    }
+
+    func testBuildCurrentMonthGridShowsTodayWithoutSession() {
+        let grid = HistoryMonthGrid.buildCurrentMonthGrid(
+            sessions: [makeSession(date: "2026-07-01", duration: 60)],
+            todayIso: "2026-07-02"
+        )
+        let today = grid.cells.compactMap { cell -> MonthGridDay? in
+            if case .day(let day) = cell { return day }
+            return nil
+        }.first { $0.isoDate == "2026-07-02" }!
+        XCTAssertEqual(today.state, .today)
+    }
+
+    func testMultipleSessionsOnOneDay() {
+        let grid = HistoryMonthGrid.buildCurrentMonthGrid(
+            sessions: [
+                makeSession(date: "2026-07-01", duration: 480),
+                makeSession(date: "2026-07-01", duration: 60),
+            ],
+            todayIso: "2026-07-02"
+        )
+        let jul1 = grid.cells.compactMap { cell -> MonthGridDay? in
+            if case .day(let day) = cell { return day }
+            return nil
+        }.first { $0.isoDate == "2026-07-01" }!
+        XCTAssertEqual(jul1.durationLabels, ["8m", "1m"])
+    }
+
+    func testBuildPriorMonthSummaries() {
+        let summaries = HistoryMonthGrid.buildPriorMonthSummaries(
+            sessions: [
+                makeSession(date: "2026-05-10", duration: 600),
+                makeSession(date: "2026-05-20", duration: 300),
+                makeSession(date: "2026-06-15", duration: 120),
+                makeSession(date: "2026-07-01", duration: 60),
+            ],
+            todayIso: "2026-07-02"
+        )
+
+        XCTAssertEqual(summaries.map(\.yearMonth), ["2026-05", "2026-06"])
+        XCTAssertEqual(summaries[0].daysActive, 2)
+        XCTAssertEqual(summaries[0].daysInMonth, 31)
+        XCTAssertEqual(summaries[0].totalTimeSeconds, 900)
+        XCTAssertEqual(summaries[1].daysActive, 1)
+        XCTAssertEqual(summaries[1].daysInMonth, 30)
+        XCTAssertEqual(summaries[1].totalTimeSeconds, 120)
+    }
+
+    func testBuildPriorMonthSummariesEmptyForCurrentMonthOnly() {
+        let summaries = HistoryMonthGrid.buildPriorMonthSummaries(
+            sessions: [makeSession(date: "2026-07-01", duration: 60)],
+            todayIso: "2026-07-02"
+        )
+        XCTAssertTrue(summaries.isEmpty)
+    }
+
+    func testFormatTotalTime() {
+        XCTAssertEqual(HistoryMonthGrid.formatTotalTime(8100), "2h 15m")
+        XCTAssertEqual(HistoryMonthGrid.formatTotalTime(3600), "1h")
+        XCTAssertEqual(HistoryMonthGrid.formatTotalTime(90), "2m")
+    }
+
+    func testBuildTrailing12MonthSummaries() {
+        let summaries = HistoryMonthlyAggregation.buildTrailing12MonthSummaries(
+            sessions: [makeSession(date: "2026-06-15", duration: 120)],
+            todayIso: "2026-07-02"
+        )
+        XCTAssertEqual(summaries.count, 12)
+        XCTAssertEqual(summaries.last?.yearMonth, "2026-07")
+        XCTAssertEqual(summaries.first?.yearMonth, "2025-08")
+    }
+}

--- a/ios/StillPointShared/Tests/StillPointSharedTests/HistoryMonthGridTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/HistoryMonthGridTests.swift
@@ -6,10 +6,12 @@ final class HistoryMonthGridTests: XCTestCase {
         date: String,
         duration: Int,
         actualTime: Int? = nil,
-        sessionType: SessionType = .standard
+        sessionType: SessionType = .standard,
+        createdAt: String? = nil,
+        id: String = UUID().uuidString
     ) -> SessionDTO {
         SessionDTO(
-            id: UUID().uuidString,
+            id: id,
             dayNumber: 1,
             sessionType: sessionType,
             duration: duration,
@@ -19,7 +21,7 @@ final class HistoryMonthGridTests: XCTestCase {
             thoughtCount: 0,
             mindStateLog: nil,
             sessionDate: date,
-            createdAt: nil,
+            createdAt: createdAt,
             buddySessionId: nil
         )
     }
@@ -68,8 +70,8 @@ final class HistoryMonthGridTests: XCTestCase {
     func testMultipleSessionsOnOneDay() {
         let grid = HistoryMonthGrid.buildCurrentMonthGrid(
             sessions: [
-                makeSession(date: "2026-07-01", duration: 480),
-                makeSession(date: "2026-07-01", duration: 60),
+                makeSession(date: "2026-07-01", duration: 480, createdAt: "2026-07-01T10:00:00Z"),
+                makeSession(date: "2026-07-01", duration: 60, createdAt: "2026-07-01T11:00:00Z"),
             ],
             todayIso: "2026-07-02"
         )

--- a/ios/StillPointShared/Tests/StillPointSharedTests/HistoryStatsTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/HistoryStatsTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+import StillPointShared
+
+final class HistoryStatsTests: XCTestCase {
+    private func makeSession(date: String, duration: Int, actualTime: Int? = nil) -> SessionDTO {
+        SessionDTO(
+            id: UUID().uuidString,
+            dayNumber: 1,
+            sessionType: .standard,
+            duration: duration,
+            completed: true,
+            actualTime: actualTime ?? duration,
+            clearPercent: 50,
+            thoughtCount: 0,
+            mindStateLog: nil,
+            sessionDate: date,
+            createdAt: nil,
+            buddySessionId: nil
+        )
+    }
+
+    func testCalculatePeriodStats() {
+        let stats = HistoryStats.calculatePeriodStats(
+            sessions: [
+                makeSession(date: "2026-06-20", duration: 120),
+                makeSession(date: "2026-07-01", duration: 60, actualTime: 90),
+            ],
+            todayIso: "2026-07-02"
+        )
+
+        XCTAssertEqual(stats.trailing4WeekDays, 2)
+        XCTAssertEqual(stats.trailing4WeekTotalTime, 210)
+        XCTAssertEqual(stats.trailing4WeekDayPercent, 7.1, accuracy: 0.05)
+        XCTAssertEqual(stats.trailing4WeekTimePercent, 0.01, accuracy: 0.01)
+        XCTAssertEqual(stats.totalTimeAllTime, 210)
+    }
+
+    func testCalculatePeriodStatsEmptySessions() {
+        let stats = HistoryStats.calculatePeriodStats(sessions: [], todayIso: "2026-07-02")
+        XCTAssertEqual(stats.trailing4WeekDays, 0)
+        XCTAssertEqual(stats.totalTimeAllTime, 0)
+    }
+}


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #523

Ports web PR #504 to iOS HistoryView, stacking the year-in-review grid (#520) and mind-state sit-time trends (#522).

## Summary

- **StillPointShared**: new history aggregation modules mirroring web `historyMonthGrid.ts`, `historyMonthlyAggregation.ts`, `historyStats.ts`, and `historyMindStateTrends.ts`
- **API**: `getSessions(today:)` passes client-local day for accurate trailing-window stats; `StatsDTO` decodes period stats + `mindStateTrends`
- **HistoryView**: calendar-first layout with Calendar / Session buildup toggle
  - Trailing 4-week stat cards + 10k-hour progress bar
  - Mind-state sit-time composition chart (#522)
  - Compact prior-month summary rows
  - Current-month 7-column grid (green/missed/today states, multi-session duration labels)
  - Year-in-review 12-month sub-view (#520)
  - Journey list preserved with gap-collapse behavior

## Test plan

- [x] Added `HistoryMonthGridTests`, `HistoryStatsTests`, `HistoryMindStateTrendsTests` in StillPointShared
- [ ] CI: `swift test` (StillPointShared)
- [ ] Manual: History tab opens in Calendar view with month grid
- [ ] Manual: prior-month rows appear for accounts with older sessions
- [ ] Manual: Year in review button navigates to 12-month grid and back
- [ ] Manual: Session buildup toggle shows journey list with thought expansion
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be3a8f90-fe9e-456a-aa4d-656ac63d956c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be3a8f90-fe9e-456a-aa4d-656ac63d956c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a calendar view to History with monthly session grids, prior-month summaries, and a 12-month overview.
  * Added year-in-review insights, including all-time progress and trailing four-week statistics.
  * Added mind-state trend visualizations with daily breakdowns and composition percentages.
  * Improved Journey and Calendar navigation with clearer view controls and date presentation.

* **Bug Fixes**
  * Improved date consistency when loading history data.
  * Tightened end-to-end validation for key practitioner metrics.

* **Tests**
  * Added coverage for calendar grids, monthly summaries, statistics, and mind-state trends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add a calendar-first History view with monthly summaries, year review, and sit-time trends**

### What Changed
- History now opens with a calendar view that shows the current month grid, prior-month summary rows, a year-in-review view, and a switch to the session-buildup journey list.
- The calendar highlights today, past meditation days, missed days, and future days, and shows short duration labels for sessions on each day.
- History stats now include trailing-4-week activity, total time toward 10,000 hours, and sit-time composition trends for clear, light distraction, heavy distraction, and hyperfocus.
- Empty history stats and UI-test sessions now use the user's local current day when the date is not provided, which keeps history totals and trend windows aligned with what users see.
- Added coverage for the new month grid, monthly summaries, period stats, and mind-state trend calculations.

### Impact
`✅ Clearer progress tracking`
`✅ Faster review of monthly history`
`✅ More accurate history totals`
`✅ Fewer date-related test failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
