### PR TITLE
refactor(api): migrate track/ routes to requireAuth/withApiHandler (#536)

### DIFF
--- a/.github/workflows/ios-shared-tests.yml
+++ b/.github/workflows/ios-shared-tests.yml
@@ -74,4 +74,4 @@ jobs:
       # "StillPointShared swift test" check green without macOS minutes (issue #463).
       - name: Skip (StillPointShared unchanged)
         if: needs.changes.outputs.shared != 'true'
-        run: echo "StillPointShared unchanged on this PR — required check satisfied without running swift test (issue #463)."
+        run: 'echo "StillPointShared unchanged on this PR — required check satisfied without running swift test (issue #463)."'

--- a/src/app/api/track/done-today/route.ts
+++ b/src/app/api/track/done-today/route.ts
@@ -2,15 +2,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { and, eq, inArray } from "drizzle-orm";
 import { db } from "@/db";
 import { sessions } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { isValidSessionCalendarDate } from "@/lib/sessionCalendar";
 
-export async function GET(request: NextRequest) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const GET = withApiHandler(
+  "Get track completion",
+  async (request: NextRequest) => {
+    const auth = await requireAuth();
+    if (!auth.ok) return auth.response;
 
     const date = request.nextUrl.searchParams.get("date");
     if (!date || !isValidSessionCalendarDate(date)) {
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest) {
       .select({ track: sessions.track })
       .from(sessions)
       .where(and(
-        eq(sessions.userId, auth.userId),
+        eq(sessions.userId, auth.user.userId),
         eq(sessions.sessionDate, date),
         eq(sessions.completed, true),
         eq(sessions.sessionType, "standard"),
@@ -34,8 +34,5 @@ export async function GET(request: NextRequest) {
         second: completedTracks.some((session) => session.track === "second"),
       },
     });
-  } catch (error) {
-    console.error("Get track completion error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  },
+);

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { users } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { isDualTrackEligible } from "@/lib/duration";
 import { eq } from "drizzle-orm";
 
@@ -27,44 +28,37 @@ const RETURN_FIELDS = {
  * returns the current state. The second track's day counter (`secondTrackDay`) is
  * left at its default so it starts at 1 minute the first time it is run.
  */
-export async function POST() {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const POST = withApiHandler("Enable dual track", async () => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
 
-    const [current] = await db
-      .select({ currentDay: users.currentDay, dualTrackEnabled: users.dualTrackEnabled })
-      .from(users)
-      .where(eq(users.id, auth.userId))
-      .limit(1);
+  const [current] = await db
+    .select({ currentDay: users.currentDay, dualTrackEnabled: users.dualTrackEnabled })
+    .from(users)
+    .where(eq(users.id, auth.user.userId))
+    .limit(1);
 
-    if (!current) {
-      return NextResponse.json({ error: "User not found" }, { status: 404 });
-    }
-
-    // Guard server-side so a client can't flip the flag before reaching the fork.
-    if (!current.dualTrackEnabled && !isDualTrackEligible(current.currentDay)) {
-      return NextResponse.json(
-        { error: "Reach the 10-minute mark before adding a second track." },
-        { status: 409 },
-      );
-    }
-
-    const [updated] = await db
-      .update(users)
-      .set({ dualTrackEnabled: true, updatedAt: new Date() })
-      .where(eq(users.id, auth.userId))
-      .returning(RETURN_FIELDS);
-
-    if (!updated) {
-      return NextResponse.json({ error: "User not found" }, { status: 404 });
-    }
-
-    return NextResponse.json({ user: updated });
-  } catch (error) {
-    console.error("Enable dual track error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  if (!current) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
   }
-}
+
+  // Guard server-side so a client can't flip the flag before reaching the fork.
+  if (!current.dualTrackEnabled && !isDualTrackEligible(current.currentDay)) {
+    return NextResponse.json(
+      { error: "Reach the 10-minute mark before adding a second track." },
+      { status: 409 },
+    );
+  }
+
+  const [updated] = await db
+    .update(users)
+    .set({ dualTrackEnabled: true, updatedAt: new Date() })
+    .where(eq(users.id, auth.user.userId))
+    .returning(RETURN_FIELDS);
+
+  if (!updated) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ user: updated });
+});


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #536

Stacked on #580 (#534).

## Summary

PR #493 migrated API routes to `requireAuth`/`withApiHandler`, but `track/` routes (added in PR #489) still used the old `getCurrentUser` + raw try/catch pattern. This PR wraps both handlers with the shared helpers; behavior is unchanged.

## Acceptance criteria

- [x] `POST /api/track` and `GET /api/track/done-today` use `requireAuth`/`withApiHandler`
- [x] Grep confirms no other unwrapped JSON routes (`auth/google/callback` intentionally excluded — redirect flow)

## Test plan

- [x] `npm ci`
- [x] `npm run typecheck`
- [x] `npm run test:unit` — 635 tests pass (includes track route integration tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba6e0892-c749-4b7b-9825-6e1ba7c28b44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba6e0892-c749-4b7b-9825-6e1ba7c28b44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
Use shared auth handling for track API requests

### What Changed
- Track enablement and track-completion requests now use the shared API auth and error handling path
- Users still get the same responses for unauthorized access, invalid dates, missing users, and early dual-track access
- The iOS shared test workflow keeps its required skip-step message working when the package is unchanged

### Impact
`✅ Same track features, less risk of API edge-case failures`
`✅ Consistent error responses on track requests`
`✅ Reliable required iOS shared test checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
