### PR TITLE
fix(notifications): scheduler #531 follow-ups + breath suppression #530

### DIFF
--- a/ios/StillPointApp/ViewModels/BreathCountingViewModel.swift
+++ b/ios/StillPointApp/ViewModels/BreathCountingViewModel.swift
@@ -14,6 +14,7 @@ final class BreathCountingViewModel {
 
     private(set) var tapCount: Int = 0
     private(set) var startedAt: Date?
+    private(set) var sessionInProgress = false
     private(set) var elapsedSeconds: Int = 0
 
     // MARK: - Computed from BreathCounting helpers
@@ -42,6 +43,7 @@ final class BreathCountingViewModel {
 
         if startedAt == nil {
             startedAt = Date()
+            sessionInProgress = true
             startTimer()
         }
 
@@ -53,6 +55,7 @@ final class BreathCountingViewModel {
         // Recompute elapsed from the wall clock so ending between 1-second ticks
         // (or right after the first tap) doesn't under-report the persisted duration.
         let finalElapsed = startedAt.map { BreathCounting.elapsedSeconds(since: $0) } ?? elapsedSeconds
+        sessionInProgress = false
         stop()
         return (elapsed: finalElapsed, breaths: breathCount)
     }
@@ -62,6 +65,7 @@ final class BreathCountingViewModel {
     /// under strict concurrency, and the timer's `[weak self]` closure means it
     /// never retains the view model, so lifecycle-driven cleanup is sufficient.)
     func stop() {
+        sessionInProgress = false
         timer?.invalidate()
         timer = nil
     }

--- a/ios/StillPointApp/Views/BreathCountingView.swift
+++ b/ios/StillPointApp/Views/BreathCountingView.swift
@@ -82,34 +82,25 @@ struct BreathCountingView: View {
             }
         }
         .onAppear {
-            // No session until the first tap; reflect actual running state.
-            let inProgress = vm.startedAt != nil
-            SessionIdleTimerController.syncLocalSession(appVM: appVM, isRunning: inProgress)
-            SessionNotificationSuppressionController.syncLocalSession(
-                appVM: appVM,
-                inProgress: inProgress
-            )
+            syncSessionSideEffects(inProgress: vm.sessionInProgress)
         }
         .onDisappear {
             vm.stop()
-            SessionIdleTimerController.syncLocalSession(appVM: appVM, isRunning: false)
-            SessionNotificationSuppressionController.syncLocalSession(
-                appVM: appVM,
-                inProgress: false
-            )
+            syncSessionSideEffects(inProgress: false)
         }
-        .onChange(of: vm.startedAt) { _, _ in
-            // The session starts on the first tap — keep the screen awake from then on.
-            let inProgress = vm.startedAt != nil
-            SessionIdleTimerController.syncLocalSession(appVM: appVM, isRunning: inProgress)
-            SessionNotificationSuppressionController.syncLocalSession(
-                appVM: appVM,
-                inProgress: inProgress
-            )
+        .onChange(of: vm.sessionInProgress) { _, inProgress in
+            syncSessionSideEffects(inProgress: inProgress)
         }
         .onChange(of: appVM.keepScreenAwakeDuringSession) { _, _ in
-            // Re-sync when the preference toggles while on screen.
-            SessionIdleTimerController.syncLocalSession(appVM: appVM, isRunning: vm.startedAt != nil)
+            syncSessionSideEffects(inProgress: vm.sessionInProgress)
         }
+    }
+
+    private func syncSessionSideEffects(inProgress: Bool) {
+        SessionIdleTimerController.syncLocalSession(appVM: appVM, isRunning: inProgress)
+        SessionNotificationSuppressionController.syncLocalSession(
+            appVM: appVM,
+            inProgress: inProgress
+        )
     }
 }

--- a/ios/StillPointApp/Views/BreathCountingView.swift
+++ b/ios/StillPointApp/Views/BreathCountingView.swift
@@ -83,15 +83,29 @@ struct BreathCountingView: View {
         }
         .onAppear {
             // No session until the first tap; reflect actual running state.
-            SessionIdleTimerController.syncLocalSession(appVM: appVM, isRunning: vm.startedAt != nil)
+            let inProgress = vm.startedAt != nil
+            SessionIdleTimerController.syncLocalSession(appVM: appVM, isRunning: inProgress)
+            SessionNotificationSuppressionController.syncLocalSession(
+                appVM: appVM,
+                inProgress: inProgress
+            )
         }
         .onDisappear {
             vm.stop()
             SessionIdleTimerController.syncLocalSession(appVM: appVM, isRunning: false)
+            SessionNotificationSuppressionController.syncLocalSession(
+                appVM: appVM,
+                inProgress: false
+            )
         }
         .onChange(of: vm.startedAt) { _, _ in
             // The session starts on the first tap — keep the screen awake from then on.
-            SessionIdleTimerController.syncLocalSession(appVM: appVM, isRunning: vm.startedAt != nil)
+            let inProgress = vm.startedAt != nil
+            SessionIdleTimerController.syncLocalSession(appVM: appVM, isRunning: inProgress)
+            SessionNotificationSuppressionController.syncLocalSession(
+                appVM: appVM,
+                inProgress: inProgress
+            )
         }
         .onChange(of: appVM.keepScreenAwakeDuringSession) { _, _ in
             // Re-sync when the preference toggles while on screen.

--- a/src/components/BreathCountView.tsx
+++ b/src/components/BreathCountView.tsx
@@ -14,6 +14,7 @@ import {
   subscribeBreathKeyBinding,
   type BreathKeyBinding,
 } from "@/lib/breathKeyBinding";
+import { useSessionSuppressionRelay } from "@/lib/useSessionSuppression";
 import { useKeepScreenAwakePref, useWakeLock } from "@/lib/useWakeLock";
 
 export type BreathSessionResult = {
@@ -52,6 +53,8 @@ export function BreathCountView({ onEnd }: BreathCountViewProps) {
   // Wake lock parity with sits (#317): keep the screen awake once running.
   const keepAwakePref = useKeepScreenAwakePref();
   useWakeLock(keepAwakePref && startMs !== null);
+  // Suppress push display while breath counting is in progress (#530 / #431).
+  useSessionSuppressionRelay(startMs !== null);
 
   // Re-entrancy guard so a second End (button + key in the same frame) can't
   // double-report. Mirrors iOS `isSavingBreathSession`.

--- a/src/components/BreathCountView.tsx
+++ b/src/components/BreathCountView.tsx
@@ -47,6 +47,7 @@ function useBreathKeyBinding(): BreathKeyBinding {
 export function BreathCountView({ onEnd }: BreathCountViewProps) {
   const [tapCount, setTapCount] = useState(0);
   const [startMs, setStartMs] = useState<number | null>(null);
+  const [sessionActive, setSessionActive] = useState(false);
   const [seconds, setSeconds] = useState(0);
   const keyBinding = useBreathKeyBinding();
 
@@ -54,7 +55,7 @@ export function BreathCountView({ onEnd }: BreathCountViewProps) {
   const keepAwakePref = useKeepScreenAwakePref();
   useWakeLock(keepAwakePref && startMs !== null);
   // Suppress push display while breath counting is in progress (#530 / #431).
-  useSessionSuppressionRelay(startMs !== null);
+  useSessionSuppressionRelay(sessionActive);
 
   // Re-entrancy guard so a second End (button + key in the same frame) can't
   // double-report. Mirrors iOS `isSavingBreathSession`.
@@ -73,12 +74,14 @@ export function BreathCountView({ onEnd }: BreathCountViewProps) {
     if (startMsRef.current === null) {
       startMsRef.current = Date.now();
       setStartMs(startMsRef.current);
+      setSessionActive(true);
     }
   }, []);
 
   const handleEnd = useCallback(() => {
     if (endedRef.current) return;
     endedRef.current = true;
+    setSessionActive(false);
     // Recompute elapsed from the wall clock so ending between 1-second ticks
     // (or right after the first tap) doesn't under-report the duration. When
     // no tap was recorded, startMsRef is null and the session is empty (0s).

--- a/src/lib/notification-scheduler.ts
+++ b/src/lib/notification-scheduler.ts
@@ -18,6 +18,10 @@ import {
   sendMissADayNotification,
 } from "@/lib/notifications";
 
+/** Five-minute lookback for each cron tick. See docs/notifications.md § Scheduler
+ *  for the DST spring-forward gap: a reminder inside the skipped local hour (e.g.
+ *  02:30 America/New_York) is dropped for that day — ticks land at 01:55 then 03:00,
+ *  both outside this window. Fall-back (repeated hour) is safe via windowKey dedup. */
 const CRON_WINDOW_MINUTES = 5;
 
 type LocalParts = {


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #531. Stacks #530.

## Summary

Completes the remaining scheduler follow-ups from #531 and fixes the breath-counting push suppression gap from #530.

### #531 (already on main; this PR finishes the last item)

- **Widen `dispatchDueIdx`:** schema + `drizzle/notification_preferences_dispatch_idx_531_incremental.sql` already present on main.
- **DST spring-forward gap:** documented in `docs/notifications.md` on main; this PR adds the matching inline comment near `CRON_WINDOW_MINUTES` in `notification-scheduler.ts`.
- **Remove dead `notificationTime.ts`:** already removed on main (no remaining imports).

### #530 (stacked)

Breath-counting sessions now honor the "suppress push during a sit" opt-in (#431):

- **iOS:** `BreathCountingView` calls `SessionNotificationSuppressionController.syncLocalSession` on appear/disappear and when `startedAt` changes (after first tap), mirroring `SessionView`.
- **Web:** `BreathCountView` relays `useSessionSuppressionRelay(startMs !== null)` to the service worker.

Suppression clears on all exit paths (`onDisappear` / hook unmount).

## Verification

- `npm ci`
- `npm run test:unit` — 635 passed
- `npm run typecheck`
- `npm run build:verify -- 3` — 3/3 clean builds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9bc45737-3f2c-4cc3-b182-af8a01cfae3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9bc45737-3f2c-4cc3-b182-af8a01cfae3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Keep breath-counting sessions and reminder timing in sync**

### What Changed
- Breath-counting sessions now suppress push notifications while the session is active on both web and iOS, and the suppression clears as soon as the session ends or the screen closes
- iOS now treats the session as ended immediately when you tap End, so notification suppression and idle behavior stop right away instead of waiting for the view to go away
- Added a note in the scheduler about the daylight-saving spring-forward gap so reminders skipped by the missing hour are expected behavior

### Impact
`✅ Fewer distraction alerts during breath sessions`
`✅ Faster stop of session-only behavior after tapping End`
`✅ Clearer reminder timing during daylight-saving changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
