### PR TITLE
feat(ios): offline write-queue with idempotent session sync (#557)

### DIFF
--- a/drizzle/sessions_client_session_id_557_incremental.sql
+++ b/drizzle/sessions_client_session_id_557_incremental.sql
@@ -1,0 +1,11 @@
+-- #557: iOS offline write-queue idempotency — client-supplied session UUID.
+-- Nullable so web and legacy clients are unchanged; partial unique index only
+-- applies when client_session_id is present.
+-- Idempotent + safe to re-run. Do NOT edit after applied (schema_migrations checksum).
+
+ALTER TABLE "sessions"
+ADD COLUMN IF NOT EXISTS "client_session_id" uuid;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "sessions_user_client_session_unique"
+ON "sessions" ("user_id", "client_session_id")
+WHERE "client_session_id" IS NOT NULL;

--- a/drizzle/sessions_client_session_id_557_incremental.sql
+++ b/drizzle/sessions_client_session_id_557_incremental.sql
@@ -6,6 +6,9 @@
 ALTER TABLE "sessions"
 ADD COLUMN IF NOT EXISTS "client_session_id" uuid;
 
+-- Partial unique index (non-CONCURRENTLY): incremental migrations run inside the
+-- apply-migrations outer transaction, which cannot wrap CREATE INDEX CONCURRENTLY.
+-- Safe for typical deploy sizes; re-run is idempotent via IF NOT EXISTS.
 CREATE UNIQUE INDEX IF NOT EXISTS "sessions_user_client_session_unique"
 ON "sessions" ("user_id", "client_session_id")
 WHERE "client_session_id" IS NOT NULL;

--- a/ios/StillPointApp/Services/NetworkReachabilityMonitor.swift
+++ b/ios/StillPointApp/Services/NetworkReachabilityMonitor.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Network
+import StillPointShared
+
+/// Observes network reachability and flushes the offline session queue on reconnect (#557).
+@Observable
+final class NetworkReachabilityMonitor {
+    private(set) var isConnected = true
+
+    private let monitor = NWPathMonitor()
+    private let queue = DispatchQueue(label: "com.brettonauerbach.stillpoint.network-reachability")
+
+    init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            let connected = path.status == .satisfied
+            Task { @MainActor in
+                guard let self else { return }
+                let wasConnected = self.isConnected
+                self.isConnected = connected
+                if !wasConnected && connected {
+                    await self.flushOfflineQueue()
+                }
+            }
+        }
+        monitor.start(queue: queue)
+    }
+
+    deinit {
+        monitor.cancel()
+    }
+
+    @MainActor
+    func flushOfflineQueue() async {
+        do {
+            _ = try await SessionSyncCoordinator.shared.flushPending()
+        } catch {
+            print("Failed to flush offline session queue on reconnect: \(error)")
+        }
+    }
+}

--- a/ios/StillPointApp/Services/NetworkReachabilityMonitor.swift
+++ b/ios/StillPointApp/Services/NetworkReachabilityMonitor.swift
@@ -6,6 +6,7 @@ import StillPointShared
 @Observable
 final class NetworkReachabilityMonitor {
     private(set) var isConnected = true
+    var ownerUserIdProvider: (@MainActor () -> String?)?
 
     private let monitor = NWPathMonitor()
     private let queue = DispatchQueue(label: "com.brettonauerbach.stillpoint.network-reachability")
@@ -18,7 +19,7 @@ final class NetworkReachabilityMonitor {
                 let wasConnected = self.isConnected
                 self.isConnected = connected
                 if !wasConnected && connected {
-                    await self.flushOfflineQueue()
+                    await self.flushOfflineQueue(ownerUserId: self.ownerUserIdProvider?())
                 }
             }
         }
@@ -30,9 +31,10 @@ final class NetworkReachabilityMonitor {
     }
 
     @MainActor
-    func flushOfflineQueue() async {
+    func flushOfflineQueue(ownerUserId: String?) async {
+        guard let ownerUserId, !ownerUserId.isEmpty else { return }
         do {
-            _ = try await SessionSyncCoordinator.shared.flushPending()
+            _ = try await SessionSyncCoordinator.shared.flushPending(ownerUserId: ownerUserId)
         } catch {
             print("Failed to flush offline session queue on reconnect: \(error)")
         }

--- a/ios/StillPointApp/StillPointApp.swift
+++ b/ios/StillPointApp/StillPointApp.swift
@@ -17,6 +17,11 @@ struct StillPointApp: App {
         // container opens leaves the in-memory ModelContainer attached to
         // stale SQLite state via Unix file handles.
         // Issue #276 — flagged in PR #277 review by both CodeAnt and Cursor.
+        //
+        // #557: the offline write queue lives in a separate JSON file
+        // (`offline-session-queue.json`) and is intentionally NOT removed here,
+        // so unsynced sits survive UI-test SwiftData wipes. UITest reset clears
+        // the queue explicitly via `OfflineSessionQueue.removePersistedQueue()`.
         StillPointApp.resetSwiftDataIfRequested()
     }
 

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -289,24 +289,21 @@ final class AppViewModel {
     }
 
     func didLogout() {
-        currentUser = nil
-        pendingBuddyInviteToken = nil
-        pendingSessionDeepLink = nil
-        pendingLogReasonDate = nil
-        buddyInviteError = nil
-        authStatusMessage = nil
-        resetTrackCompletionBadges()
-        currentView = .auth
-        // Drop the cached suppress opt-in so it can't leak into the next account.
-        SessionNotificationSuppressionController.clearSuppressPreference()
-        // Cancel any in-flight backfill and clear the throttle so the next login
-        // (even the same account, same day) re-fetches fresh widget history.
         widgetHistoryTask?.cancel()
         widgetHistoryRefreshKey = nil
-        Task {
+        Task { @MainActor in
             try? await SessionSyncCoordinator.shared.clearQueue()
+            currentUser = nil
+            pendingBuddyInviteToken = nil
+            pendingSessionDeepLink = nil
+            pendingLogReasonDate = nil
+            buddyInviteError = nil
+            authStatusMessage = nil
+            resetTrackCompletionBadges()
+            currentView = .auth
+            SessionNotificationSuppressionController.clearSuppressPreference()
+            syncWidgetData()
         }
-        syncWidgetData()
     }
 
     private func resetTrackCompletionBadges() {
@@ -399,6 +396,7 @@ final class AppViewModel {
             currentView = .home
         } catch {
             print("Failed to persist breath session locally: \(error)")
+            currentView = .home
         }
     }
 

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -303,6 +303,9 @@ final class AppViewModel {
         // (even the same account, same day) re-fetches fresh widget history.
         widgetHistoryTask?.cancel()
         widgetHistoryRefreshKey = nil
+        Task {
+            try? await SessionSyncCoordinator.shared.clearQueue()
+        }
         syncWidgetData()
     }
 
@@ -361,7 +364,9 @@ final class AppViewModel {
             return
         }
         guard !isSavingBreathSession else { return }
+        guard let ownerUserId = currentUser?.id else { return }
         isSavingBreathSession = true
+        defer { isSavingBreathSession = false }
 
         let clientSessionId = UUID()
         let dateFormatter = DateFormatter()
@@ -388,14 +393,13 @@ final class AppViewModel {
             _ = try await SessionSyncCoordinator.shared.saveCompletedSession(
                 request: request,
                 clientSessionId: clientSessionId,
+                ownerUserId: ownerUserId,
                 thoughts: []
             )
+            currentView = .home
         } catch {
             print("Failed to persist breath session locally: \(error)")
         }
-
-        isSavingBreathSession = false
-        currentView = .home
     }
 
     func beginBuddySession() {
@@ -519,11 +523,13 @@ final class AppViewModel {
     func returnHome() async {
         currentView = .home
         selectedTab = 0
-        do {
-            _ = try await SessionSyncCoordinator.shared.flushPending()
-            try await SessionSyncCoordinator.shared.pruneCompletedEntries()
-        } catch {
-            print("Failed to flush offline session queue: \(error)")
+        if let ownerUserId = currentUser?.id {
+            do {
+                _ = try await SessionSyncCoordinator.shared.flushPending(ownerUserId: ownerUserId)
+                try await SessionSyncCoordinator.shared.pruneCompletedEntries(ownerUserId: ownerUserId)
+            } catch {
+                print("Failed to flush offline session queue: \(error)")
+            }
         }
         if let user = try? await APIClient.shared.me() {
             currentUser = user

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -13,6 +13,7 @@ enum AppView: Equatable {
     case buddySession(sessionId: String)
     case completion(
         sessionId: String,
+        clientSessionId: UUID,
         clearPercent: Int,
         thoughtCount: Int,
         thoughts: [CapturedThought],
@@ -353,20 +354,16 @@ final class AppViewModel {
 
     /// Save a completed breath session and return to home.
     ///
-    /// Mirrors SessionViewModel.saveSession / AppViewModel.completeSession field construction exactly.
-    /// On API failure the error is logged and the user returns home anyway — we never trap them on the breath screen.
+    /// Local-first via the offline write queue (#557); non-fatal API failures no longer drop data.
     func completeBreathSession(elapsedSeconds: Int, breathCount: Int) async {
-        // Skip empty sessions (entered then ended with no taps) — nothing to log.
         guard elapsedSeconds > 0 || breathCount > 0 else {
             currentView = .home
             return
         }
-        // Re-entrancy guard: a second End tap during the await must not create a
-        // duplicate row. Cleared explicitly after the await rather than via defer,
-        // which would not fire at the @MainActor suspension point.
         guard !isSavingBreathSession else { return }
         isSavingBreathSession = true
 
+        let clientSessionId = UUID()
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")
@@ -383,14 +380,18 @@ final class AppViewModel {
             thoughtCount: 0,
             mindStateLog: [],
             sessionDate: dateFormatter.string(from: Date()),
-            breathCount: breathCount
+            breathCount: breathCount,
+            clientSessionId: clientSessionId
         )
 
         do {
-            _ = try await APIClient.shared.createSession(request)
+            _ = try await SessionSyncCoordinator.shared.saveCompletedSession(
+                request: request,
+                clientSessionId: clientSessionId,
+                thoughts: []
+            )
         } catch {
-            // Non-fatal: session save failure is logged but does not block navigation home.
-            print("Failed to save breath session: \(error)")
+            print("Failed to persist breath session locally: \(error)")
         }
 
         isSavingBreathSession = false
@@ -483,6 +484,7 @@ final class AppViewModel {
 
     func completeSession(
         sessionId: String,
+        clientSessionId: UUID,
         clearPercent: Int,
         thoughtCount: Int,
         thoughts: [CapturedThought],
@@ -494,8 +496,6 @@ final class AppViewModel {
         attentionLog: [AttentionEntry]? = nil,
         attentionElapsed: Double? = nil
     ) {
-        // Daily-lock model (#348): any naturally-completed session — quick-minute
-        // or standard — unlocks the gated apps for the rest of the day.
         if unlockAppGate {
             appBlockingManager.unlockAfterCompletedSession()
         } else {
@@ -503,6 +503,7 @@ final class AppViewModel {
         }
         currentView = .completion(
             sessionId: sessionId,
+            clientSessionId: clientSessionId,
             clearPercent: clearPercent,
             thoughtCount: thoughtCount,
             thoughts: thoughts,
@@ -518,6 +519,12 @@ final class AppViewModel {
     func returnHome() async {
         currentView = .home
         selectedTab = 0
+        do {
+            _ = try await SessionSyncCoordinator.shared.flushPending()
+            try await SessionSyncCoordinator.shared.pruneCompletedEntries()
+        } catch {
+            print("Failed to flush offline session queue: \(error)")
+        }
         if let user = try? await APIClient.shared.me() {
             currentUser = user
         }

--- a/ios/StillPointApp/ViewModels/SessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/SessionViewModel.swift
@@ -252,10 +252,16 @@ final class SessionViewModel {
     /// #557: stable local key for offline end-note sync during completion.
     private(set) var lastClientSessionId: UUID?
 
-    /// Save session locally first, then sync when online (#557). Always returns a session DTO.
-    func saveSession(completed: Bool) async -> SessionDTO? {
-        let clientSessionId = UUID()
-        lastClientSessionId = clientSessionId
+    /// Save session locally first, then sync when online (#557). Returns nil when persistence fails.
+    func saveSession(completed: Bool, ownerUserId: String) async -> SessionDTO? {
+        let clientSessionId: UUID
+        if let existing = lastClientSessionId {
+            clientSessionId = existing
+        } else {
+            let newId = UUID()
+            lastClientSessionId = newId
+            clientSessionId = newId
+        }
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")
@@ -285,6 +291,7 @@ final class SessionViewModel {
             let result = try await SessionSyncCoordinator.shared.saveCompletedSession(
                 request: request,
                 clientSessionId: clientSessionId,
+                ownerUserId: ownerUserId,
                 thoughts: pendingThoughts
             )
             return result.session

--- a/ios/StillPointApp/ViewModels/SessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/SessionViewModel.swift
@@ -249,9 +249,13 @@ final class SessionViewModel {
         isComplete = true
     }
 
-    /// Save session to the API. Returns the session on success.
-    /// Thought batch failure is logged but does not fail the session save.
+    /// #557: stable local key for offline end-note sync during completion.
+    private(set) var lastClientSessionId: UUID?
+
+    /// Save session locally first, then sync when online (#557). Always returns a session DTO.
     func saveSession(completed: Bool) async -> SessionDTO? {
+        let clientSessionId = UUID()
+        lastClientSessionId = clientSessionId
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")
@@ -269,37 +273,23 @@ final class SessionViewModel {
             mindStateLog: mindStateLog,
             attentionLog: attentionLog,
             sessionDate: dateFormatter.string(from: Date()),
-            track: track
+            track: track,
+            clientSessionId: clientSessionId
         )
 
+        let pendingThoughts = capturedThoughts.map {
+            PendingSessionThought(timeInSession: $0.timeInSession, text: $0.text)
+        }
+
         do {
-            let session = try await APIClient.shared.createSession(request)
-
-            // Batch save thoughts — failure here is non-fatal since the session is already persisted
-            let allThoughts = capturedThoughts.map {
-                BatchThoughtsRequest.ThoughtInput(
-                    timeInSession: $0.timeInSession,
-                    text: $0.text
-                )
-            }
-
-            if !allThoughts.isEmpty {
-                do {
-                    _ = try await APIClient.shared.batchThoughts(
-                        BatchThoughtsRequest(
-                            sessionId: session.id,
-                            dayNumber: session.dayNumber,
-                            thoughts: allThoughts
-                        )
-                    )
-                } catch {
-                    print("Failed to save thoughts (session was saved): \(error)")
-                }
-            }
-
-            return session
+            let result = try await SessionSyncCoordinator.shared.saveCompletedSession(
+                request: request,
+                clientSessionId: clientSessionId,
+                thoughts: pendingThoughts
+            )
+            return result.session
         } catch {
-            print("Failed to save session: \(error)")
+            print("Failed to persist session locally: \(error)")
             return nil
         }
     }

--- a/ios/StillPointApp/Views/BuddySession/BuddySessionContainerView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddySessionContainerView.swift
@@ -178,6 +178,7 @@ struct BuddySessionContainerView: View {
         guard appVM.currentView == .buddySession(sessionId: sessionId) else { return }
         appVM.completeSession(
             sessionId: saved.id,
+            clientSessionId: UUID(uuidString: saved.id) ?? UUID(),
             clearPercent: saved.clearPercent,
             thoughtCount: saved.thoughtCount,
             thoughts: vm.capturedThoughts,

--- a/ios/StillPointApp/Views/CompletionView.swift
+++ b/ios/StillPointApp/Views/CompletionView.swift
@@ -27,7 +27,11 @@ struct CompletionView: View {
     private var nextDay: Int { dayNumber + 1 }
     private var nextDuration: Int { StillPoint.duration(forDay: nextDay) }
     private var nextBlocks: Int { StillPoint.blockCount(forDuration: nextDuration) }
-    private var isSaveDisabled: Bool { endNote.isEmpty || noteSaved || isSaving || sessionId.isEmpty }
+    private var trimmedEndNote: String {
+        endNote.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var isSaveDisabled: Bool { trimmedEndNote.isEmpty || noteSaved || isSaving || sessionId.isEmpty }
     private var isQuickSession: Bool { sessionType == .quick }
     private var hasUnlockedApps: Bool { appVM.appBlockingManager.didUnlockFromLastCompletedSession }
 
@@ -300,14 +304,16 @@ struct CompletionView: View {
     }
 
     private func saveEndNote() {
-        let noteToSave = endNote
+        let noteToSave = trimmedEndNote
         guard !noteToSave.isEmpty, !sessionId.isEmpty, !isSaving, !noteSaved else { return }
+        guard let ownerUserId = appVM.currentUser?.id else { return }
         isSaving = true
         saveError = nil
         Task { @MainActor in
             do {
                 try await SessionSyncCoordinator.shared.appendEndNote(
                     clientSessionId: clientSessionId,
+                    ownerUserId: ownerUserId,
                     note: noteToSave
                 )
                 isSaving = false

--- a/ios/StillPointApp/Views/CompletionView.swift
+++ b/ios/StillPointApp/Views/CompletionView.swift
@@ -7,6 +7,7 @@ struct CompletionView: View {
 
     let appVM: AppViewModel
     let sessionId: String
+    let clientSessionId: UUID
     let clearPercent: Int
     let thoughtCount: Int
     let thoughts: [CapturedThought]
@@ -305,6 +306,14 @@ struct CompletionView: View {
         saveError = nil
         Task { @MainActor in
             do {
+                try await SessionSyncCoordinator.shared.appendEndNote(
+                    clientSessionId: clientSessionId,
+                    note: noteToSave
+                )
+                isSaving = false
+                noteSaved = true
+                logUITestDiagnostic("completion.saveEndNote.success clientSessionId=\(clientSessionId.uuidString)")
+            } catch SessionSyncError.entryNotFound {
                 let request = BatchThoughtsRequest(
                     sessionId: sessionId,
                     dayNumber: dayNumber,
@@ -315,10 +324,21 @@ struct CompletionView: View {
                         )
                     ]
                 )
-                _ = try await APIClient.shared.batchThoughts(request)
-                isSaving = false
-                noteSaved = true
-                logUITestDiagnostic("completion.saveEndNote.success sessionId=\(sessionId)")
+                do {
+                    _ = try await APIClient.shared.batchThoughts(request)
+                    isSaving = false
+                    noteSaved = true
+                    logUITestDiagnostic("completion.saveEndNote.success sessionId=\(sessionId)")
+                } catch let error as APIError {
+                    print("Failed to save end note: \(error)")
+                    isSaving = false
+                    saveError = saveErrorMessage(for: error.status)
+                    logUITestDiagnostic("completion.saveEndNote.apiError status=\(error.status) message=\(error.message)")
+                } catch {
+                    print("Failed to save end note: \(error)")
+                    isSaving = false
+                    saveError = "Could not save your note. Please try again."
+                }
             } catch let error as APIError {
                 print("Failed to save end note: \(error)")
                 isSaving = false
@@ -327,12 +347,7 @@ struct CompletionView: View {
             } catch {
                 print("Failed to save end note: \(error)")
                 isSaving = false
-                if let urlError = error as? URLError,
-                   urlError.code == .notConnectedToInternet {
-                    saveError = "No internet connection"
-                } else {
-                    saveError = "Failed to save note"
-                }
+                saveError = "Could not save your note. Please try again."
                 logUITestDiagnostic("completion.saveEndNote.error message=\(error.localizedDescription)")
             }
         }

--- a/ios/StillPointApp/Views/RootView.swift
+++ b/ios/StillPointApp/Views/RootView.swift
@@ -5,6 +5,7 @@ import UIKit
 
 struct RootView: View {
     @State private var appVM = AppViewModel()
+    @State private var reachability = NetworkReachabilityMonitor()
     @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
@@ -44,10 +45,11 @@ struct RootView: View {
                     .id(sessionId)
                     .transition(.opacity)
 
-            case .completion(let sessionId, let clearPercent, let thoughtCount, let thoughts, let dayNumber, let sessionType, let duration, let bonusSeconds, let attentionLog, let attentionElapsed):
+            case .completion(let sessionId, let clientSessionId, let clearPercent, let thoughtCount, let thoughts, let dayNumber, let sessionType, let duration, let bonusSeconds, let attentionLog, let attentionElapsed):
                 CompletionView(
                     appVM: appVM,
                     sessionId: sessionId,
+                    clientSessionId: clientSessionId,
                     clearPercent: clearPercent,
                     thoughtCount: thoughtCount,
                     thoughts: thoughts,
@@ -128,6 +130,7 @@ struct RootView: View {
         }
         .task {
             await appVM.checkAuth()
+            await reachability.flushOfflineQueue()
         }
         .onChange(of: scenePhase) { _, phase in
             SessionIdleTimerController.syncSceneForegroundActive(
@@ -144,6 +147,7 @@ struct RootView: View {
             }
             if phase == .active {
                 SessionIdleTimerController.applyDesiredIdleTimerState()
+                Task { await reachability.flushOfflineQueue() }
             } else if phase == .inactive || phase == .background {
                 // Multi-window: only clear when no scene is foreground-active (issue #87).
                 SessionIdleTimerController.applyBackgroundIdleTimerPolicyIfNoForegroundScene()

--- a/ios/StillPointApp/Views/RootView.swift
+++ b/ios/StillPointApp/Views/RootView.swift
@@ -129,8 +129,9 @@ struct RootView: View {
             )
         }
         .task {
+            reachability.ownerUserIdProvider = { appVM.currentUser?.id }
             await appVM.checkAuth()
-            await reachability.flushOfflineQueue()
+            await reachability.flushOfflineQueue(ownerUserId: appVM.currentUser?.id)
         }
         .onChange(of: scenePhase) { _, phase in
             SessionIdleTimerController.syncSceneForegroundActive(
@@ -147,7 +148,7 @@ struct RootView: View {
             }
             if phase == .active {
                 SessionIdleTimerController.applyDesiredIdleTimerState()
-                Task { await reachability.flushOfflineQueue() }
+                Task { await reachability.flushOfflineQueue(ownerUserId: appVM.currentUser?.id) }
             } else if phase == .inactive || phase == .background {
                 // Multi-window: only clear when no scene is foreground-active (issue #87).
                 SessionIdleTimerController.applyBackgroundIdleTimerPolicyIfNoForegroundScene()

--- a/ios/StillPointApp/Views/RootView.swift
+++ b/ios/StillPointApp/Views/RootView.swift
@@ -148,7 +148,10 @@ struct RootView: View {
             }
             if phase == .active {
                 SessionIdleTimerController.applyDesiredIdleTimerState()
-                Task { await reachability.flushOfflineQueue(ownerUserId: appVM.currentUser?.id) }
+                Task {
+                    await appVM.checkAuth()
+                    await reachability.flushOfflineQueue(ownerUserId: appVM.currentUser?.id)
+                }
             } else if phase == .inactive || phase == .background {
                 // Multi-window: only clear when no scene is foreground-active (issue #87).
                 SessionIdleTimerController.applyBackgroundIdleTimerPolicyIfNoForegroundScene()

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -697,10 +697,14 @@ struct SessionView: View {
 
     private func handleCompletion() {
         Task {
+            guard let ownerUserId = appVM.currentUser?.id else {
+                showSaveError = true
+                return
+            }
             // Persist session before navigating to completion screen
             guard let session = await vm.saveSession(
                 completed: vm.completedNaturally,
-                ownerUserId: appVM.currentUser?.id ?? ""
+                ownerUserId: ownerUserId
             ) else {
                 showSaveError = true
                 return

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -698,7 +698,10 @@ struct SessionView: View {
     private func handleCompletion() {
         Task {
             // Persist session before navigating to completion screen
-            guard let session = await vm.saveSession(completed: vm.completedNaturally) else {
+            guard let session = await vm.saveSession(
+                completed: vm.completedNaturally,
+                ownerUserId: appVM.currentUser?.id ?? ""
+            ) else {
                 showSaveError = true
                 return
             }

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -249,6 +249,7 @@ struct SessionView: View {
             Button("Continue without saving", role: .destructive) {
                 appVM.completeSession(
                     sessionId: "",
+                    clientSessionId: UUID(),
                     clearPercent: vm.clearPercent,
                     thoughtCount: vm.thoughtCount,
                     thoughts: vm.capturedThoughts,
@@ -260,7 +261,7 @@ struct SessionView: View {
                 )
             }
         } message: {
-            Text("Your session data couldn't be saved. You can retry or continue without saving.")
+            Text("Your session couldn't be saved on this device. You can retry or continue without saving.")
         }
         .alert("Gaze tracking unavailable", isPresented: $showAttentionUnsupportedAlert) {
             Button("OK", role: .cancel) {}
@@ -703,6 +704,7 @@ struct SessionView: View {
             }
             appVM.completeSession(
                 sessionId: session.id,
+                clientSessionId: vm.lastClientSessionId ?? UUID(uuidString: session.id) ?? UUID(),
                 clearPercent: vm.clearPercent,
                 thoughtCount: vm.thoughtCount,
                 thoughts: vm.capturedThoughts,

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -186,6 +186,8 @@ public struct CreateSessionRequest: Codable, Sendable {
     public let breathCount: Int?
     /// #240: which daily track this sit advances. Defaults to `.primary`.
     public let track: Track
+    /// #557: client-generated UUID for offline idempotent create; omitted for web.
+    public let clientSessionId: UUID?
 
     public init(
         dayNumber: Int,
@@ -200,7 +202,8 @@ public struct CreateSessionRequest: Codable, Sendable {
         attentionLog: [AttentionEntry]? = nil,
         sessionDate: String,
         breathCount: Int? = nil,
-        track: Track = .primary
+        track: Track = .primary,
+        clientSessionId: UUID? = nil
     ) {
         self.dayNumber = dayNumber
         self.sessionType = sessionType
@@ -215,6 +218,7 @@ public struct CreateSessionRequest: Codable, Sendable {
         self.sessionDate = sessionDate
         self.breathCount = breathCount
         self.track = track
+        self.clientSessionId = clientSessionId
     }
 }
 

--- a/ios/StillPointShared/Sources/StillPointShared/OfflineSessionQueue.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/OfflineSessionQueue.swift
@@ -74,13 +74,13 @@ public struct FileOfflineSessionQueueStore: OfflineSessionQueueStore {
     public init(
         fileURL: URL,
         fileManager: FileManager = .default,
-        encoder: JSONEncoder = FileOfflineSessionQueueStore.makeEncoder(),
-        decoder: JSONDecoder = FileOfflineSessionQueueStore.makeDecoder()
+        encoder: JSONEncoder? = nil,
+        decoder: JSONDecoder? = nil
     ) {
         self.fileURL = fileURL
         self.fileManager = fileManager
-        self.encoder = encoder
-        self.decoder = decoder
+        self.encoder = encoder ?? Self.makeEncoder()
+        self.decoder = decoder ?? Self.makeDecoder()
     }
 
     public func loadEntries() throws -> [PendingSessionEntry] {
@@ -111,7 +111,7 @@ public struct FileOfflineSessionQueueStore: OfflineSessionQueueStore {
     }
 }
 
-public struct InMemoryOfflineSessionQueueStore: OfflineSessionQueueStore {
+public final class InMemoryOfflineSessionQueueStore: OfflineSessionQueueStore, @unchecked Sendable {
     private let lock = NSLock()
     private var entries: [PendingSessionEntry]
 

--- a/ios/StillPointShared/Sources/StillPointShared/OfflineSessionQueue.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/OfflineSessionQueue.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+/// A thought captured during or after a sit, queued for offline sync (#557).
+public struct PendingSessionThought: Codable, Sendable, Equatable {
+    public let timeInSession: Int
+    public let text: String
+
+    public init(timeInSession: Int, text: String) {
+        self.timeInSession = timeInSession
+        self.text = text
+    }
+}
+
+/// Durable local record of a completed sit awaiting server sync (#557).
+public struct PendingSessionEntry: Codable, Sendable, Identifiable {
+    public var id: UUID { clientSessionId }
+    public let clientSessionId: UUID
+    public let request: CreateSessionRequest
+    public var thoughts: [PendingSessionThought]
+    public var serverSessionId: String?
+    public var sessionSynced: Bool
+    public let enqueuedAt: Date
+
+    public init(
+        clientSessionId: UUID,
+        request: CreateSessionRequest,
+        thoughts: [PendingSessionThought],
+        serverSessionId: String? = nil,
+        sessionSynced: Bool = false,
+        enqueuedAt: Date = Date()
+    ) {
+        self.clientSessionId = clientSessionId
+        self.request = request
+        self.thoughts = thoughts
+        self.serverSessionId = serverSessionId
+        self.sessionSynced = sessionSynced
+        self.enqueuedAt = enqueuedAt
+    }
+}
+
+/// File-backed outbox for offline session writes. Stored separately from SwiftData
+/// so the UI-test SwiftData wipe (#276) never drops unsynced sits.
+public enum OfflineSessionQueue {
+    public static let fileName = "offline-session-queue.json"
+
+    public static func defaultFileURL(fileManager: FileManager = .default) throws -> URL {
+        let support = try fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        return support.appendingPathComponent(fileName)
+    }
+
+    /// Remove the queue file (UI-test reset only — not part of SwiftData wipe).
+    public static func removePersistedQueue(fileManager: FileManager = .default) {
+        guard let url = try? defaultFileURL(fileManager: fileManager) else { return }
+        try? fileManager.removeItem(at: url)
+    }
+}
+
+public protocol OfflineSessionQueueStore: Sendable {
+    func loadEntries() throws -> [PendingSessionEntry]
+    func saveEntries(_ entries: [PendingSessionEntry]) throws
+}
+
+public struct FileOfflineSessionQueueStore: OfflineSessionQueueStore {
+    private let fileURL: URL
+    private let fileManager: FileManager
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    public init(
+        fileURL: URL,
+        fileManager: FileManager = .default,
+        encoder: JSONEncoder = FileOfflineSessionQueueStore.makeEncoder(),
+        decoder: JSONDecoder = FileOfflineSessionQueueStore.makeDecoder()
+    ) {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+        self.encoder = encoder
+        self.decoder = decoder
+    }
+
+    public func loadEntries() throws -> [PendingSessionEntry] {
+        guard fileManager.fileExists(atPath: fileURL.path) else { return [] }
+        let data = try Data(contentsOf: fileURL)
+        guard !data.isEmpty else { return [] }
+        return try decoder.decode([PendingSessionEntry].self, from: data)
+    }
+
+    public func saveEntries(_ entries: [PendingSessionEntry]) throws {
+        let directory = fileURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        let data = try encoder.encode(entries)
+        try data.write(to: fileURL, options: [.atomic])
+    }
+
+    private static func makeEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+
+    private static func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}
+
+public struct InMemoryOfflineSessionQueueStore: OfflineSessionQueueStore {
+    private let lock = NSLock()
+    private var entries: [PendingSessionEntry]
+
+    public init(entries: [PendingSessionEntry] = []) {
+        self.entries = entries
+    }
+
+    public func loadEntries() throws -> [PendingSessionEntry] {
+        lock.lock()
+        defer { lock.unlock() }
+        return entries
+    }
+
+    public func saveEntries(_ entries: [PendingSessionEntry]) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        self.entries = entries
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/OfflineSessionQueue.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/OfflineSessionQueue.swift
@@ -15,6 +15,8 @@ public struct PendingSessionThought: Codable, Sendable, Equatable {
 public struct PendingSessionEntry: Codable, Sendable, Identifiable {
     public var id: UUID { clientSessionId }
     public let clientSessionId: UUID
+    /// Account that enqueued this sit — prevents cross-user replay after logout/login (#557).
+    public let ownerUserId: String
     public let request: CreateSessionRequest
     public var thoughts: [PendingSessionThought]
     public var serverSessionId: String?
@@ -23,6 +25,7 @@ public struct PendingSessionEntry: Codable, Sendable, Identifiable {
 
     public init(
         clientSessionId: UUID,
+        ownerUserId: String,
         request: CreateSessionRequest,
         thoughts: [PendingSessionThought],
         serverSessionId: String? = nil,
@@ -30,11 +33,44 @@ public struct PendingSessionEntry: Codable, Sendable, Identifiable {
         enqueuedAt: Date = Date()
     ) {
         self.clientSessionId = clientSessionId
+        self.ownerUserId = ownerUserId
         self.request = request
         self.thoughts = thoughts
         self.serverSessionId = serverSessionId
         self.sessionSynced = sessionSynced
         self.enqueuedAt = enqueuedAt
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case clientSessionId
+        case ownerUserId
+        case request
+        case thoughts
+        case serverSessionId
+        case sessionSynced
+        case enqueuedAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        clientSessionId = try container.decode(UUID.self, forKey: .clientSessionId)
+        ownerUserId = try container.decodeIfPresent(String.self, forKey: .ownerUserId) ?? ""
+        request = try container.decode(CreateSessionRequest.self, forKey: .request)
+        thoughts = try container.decode([PendingSessionThought].self, forKey: .thoughts)
+        serverSessionId = try container.decodeIfPresent(String.self, forKey: .serverSessionId)
+        sessionSynced = try container.decode(Bool.self, forKey: .sessionSynced)
+        enqueuedAt = try container.decodeIfPresent(Date.self, forKey: .enqueuedAt) ?? Date()
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(clientSessionId, forKey: .clientSessionId)
+        try container.encode(ownerUserId, forKey: .ownerUserId)
+        try container.encode(request, forKey: .request)
+        try container.encode(thoughts, forKey: .thoughts)
+        try container.encodeIfPresent(serverSessionId, forKey: .serverSessionId)
+        try container.encode(sessionSynced, forKey: .sessionSynced)
+        try container.encode(enqueuedAt, forKey: .enqueuedAt)
     }
 }
 
@@ -87,7 +123,14 @@ public struct FileOfflineSessionQueueStore: OfflineSessionQueueStore {
         guard fileManager.fileExists(atPath: fileURL.path) else { return [] }
         let data = try Data(contentsOf: fileURL)
         guard !data.isEmpty else { return [] }
-        return try decoder.decode([PendingSessionEntry].self, from: data)
+        do {
+            return try decoder.decode([PendingSessionEntry].self, from: data)
+        } catch {
+            let corruptURL = fileURL.appendingPathExtension("corrupt")
+            try? fileManager.removeItem(at: corruptURL)
+            try? fileManager.moveItem(at: fileURL, to: corruptURL)
+            return []
+        }
     }
 
     public func saveEntries(_ entries: [PendingSessionEntry]) throws {

--- a/ios/StillPointShared/Sources/StillPointShared/SessionSyncCoordinator.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/SessionSyncCoordinator.swift
@@ -1,0 +1,219 @@
+import Foundation
+
+/// Persists completed sits locally first, then syncs to the server on reconnect (#557).
+public actor SessionSyncCoordinator {
+    public static let shared = SessionSyncCoordinator()
+
+    public struct SaveResult: Sendable {
+        public let session: SessionDTO
+        public let isPendingSync: Bool
+
+        public init(session: SessionDTO, isPendingSync: Bool) {
+            self.session = session
+            self.isPendingSync = isPendingSync
+        }
+    }
+
+    private let queueStore: OfflineSessionQueueStore
+    private let apiClient: APIClient
+
+    public init(
+        queueStore: OfflineSessionQueueStore? = nil,
+        apiClient: APIClient = .shared
+    ) {
+        if let queueStore {
+            self.queueStore = queueStore
+        } else if let url = try? OfflineSessionQueue.defaultFileURL() {
+            self.queueStore = FileOfflineSessionQueueStore(fileURL: url)
+        } else {
+            self.queueStore = InMemoryOfflineSessionQueueStore()
+        }
+        self.apiClient = apiClient
+    }
+
+    /// Number of sits still waiting for server sync.
+    public func pendingCount() async throws -> Int {
+        try queueStore.loadEntries().filter { !$0.sessionSynced || !$0.thoughts.isEmpty }.count
+    }
+
+    /// Local-first save: enqueue durably, attempt immediate sync, return a session DTO either way.
+    public func saveCompletedSession(
+        request: CreateSessionRequest,
+        clientSessionId: UUID,
+        thoughts: [PendingSessionThought]
+    ) async throws -> SaveResult {
+        var entries = try queueStore.loadEntries()
+        if let existingIndex = entries.firstIndex(where: { $0.clientSessionId == clientSessionId }) {
+            let existing = entries[existingIndex]
+            if existing.sessionSynced, existing.thoughts.isEmpty, let serverId = existing.serverSessionId {
+                return SaveResult(
+                    session: Self.sessionDTO(from: existing.request, id: serverId),
+                    isPendingSync: false
+                )
+            }
+        } else {
+            let requestWithId = Self.requestWithClientId(request, clientSessionId: clientSessionId)
+            entries.append(PendingSessionEntry(
+                clientSessionId: clientSessionId,
+                request: requestWithId,
+                thoughts: thoughts
+            ))
+            try queueStore.saveEntries(entries)
+        }
+
+        if let synced = try await flushEntry(clientSessionId: clientSessionId) {
+            return SaveResult(session: synced, isPendingSync: false)
+        }
+
+        let entry = try queueStore.loadEntries().first { $0.clientSessionId == clientSessionId }
+        let provisionalRequest = entry?.request ?? Self.requestWithClientId(request, clientSessionId: clientSessionId)
+        return SaveResult(
+            session: Self.provisionalSessionDTO(from: provisionalRequest, clientSessionId: clientSessionId),
+            isPendingSync: true
+        )
+    }
+
+    /// Append an end-of-sit note to a queued or already-synced local entry.
+    public func appendEndNote(clientSessionId: UUID, note: String) async throws {
+        let trimmed = note.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        var entries = try queueStore.loadEntries()
+        guard let index = entries.firstIndex(where: { $0.clientSessionId == clientSessionId }) else {
+            throw SessionSyncError.entryNotFound
+        }
+
+        entries[index].thoughts.append(PendingSessionThought(timeInSession: -1, text: trimmed))
+        try queueStore.saveEntries(entries)
+        _ = try await flushEntry(clientSessionId: clientSessionId)
+    }
+
+    /// Flush all pending entries. Returns how many fully synced.
+    @discardableResult
+    public func flushPending() async throws -> Int {
+        let entries = try queueStore.loadEntries()
+        var syncedCount = 0
+        for entry in entries where !entry.sessionSynced || !entry.thoughts.isEmpty {
+            if try await flushEntry(clientSessionId: entry.clientSessionId) != nil {
+                syncedCount += 1
+            }
+        }
+        return syncedCount
+    }
+
+    /// Resolve the best session id for API calls (server id when known).
+    public func resolvedServerSessionId(for clientSessionId: UUID) async throws -> String? {
+        let entry = try queueStore.loadEntries().first { $0.clientSessionId == clientSessionId }
+        return entry?.serverSessionId
+    }
+
+    // MARK: - Private
+
+    @discardableResult
+    private func flushEntry(clientSessionId: UUID) async throws -> SessionDTO? {
+        var entries = try queueStore.loadEntries()
+        guard let index = entries.firstIndex(where: { $0.clientSessionId == clientSessionId }) else {
+            return nil
+        }
+
+        var entry = entries[index]
+
+        if !entry.sessionSynced {
+            do {
+                let session = try await apiClient.createSession(entry.request)
+                entry.serverSessionId = session.id
+                entry.sessionSynced = true
+                entries[index] = entry
+                try queueStore.saveEntries(entries)
+            } catch {
+                return nil
+            }
+        }
+
+        guard let serverSessionId = entry.serverSessionId else { return nil }
+
+        if !entry.thoughts.isEmpty {
+            do {
+                let batch = BatchThoughtsRequest(
+                    sessionId: serverSessionId,
+                    dayNumber: entry.request.dayNumber,
+                    thoughts: entry.thoughts.map {
+                        BatchThoughtsRequest.ThoughtInput(timeInSession: $0.timeInSession, text: $0.text)
+                    }
+                )
+                _ = try await apiClient.batchThoughts(batch)
+                entry.thoughts = []
+                entries[index] = entry
+                try queueStore.saveEntries(entries)
+            } catch {
+                return nil
+            }
+        }
+
+        return Self.sessionDTO(from: entry.request, id: serverSessionId)
+    }
+
+    /// Drop fully-synced entries once the completion flow finishes.
+    public func pruneCompletedEntries() async throws {
+        var entries = try queueStore.loadEntries()
+        let before = entries.count
+        entries.removeAll { $0.sessionSynced && $0.thoughts.isEmpty }
+        if entries.count != before {
+            try queueStore.saveEntries(entries)
+        }
+    }
+
+    private static func requestWithClientId(
+        _ request: CreateSessionRequest,
+        clientSessionId: UUID
+    ) -> CreateSessionRequest {
+        CreateSessionRequest(
+            dayNumber: request.dayNumber,
+            sessionType: request.sessionType,
+            duration: request.duration,
+            bonusSeconds: request.bonusSeconds,
+            completed: request.completed,
+            actualTime: request.actualTime,
+            clearPercent: request.clearPercent,
+            thoughtCount: request.thoughtCount,
+            mindStateLog: request.mindStateLog,
+            attentionLog: request.attentionLog,
+            sessionDate: request.sessionDate,
+            breathCount: request.breathCount,
+            track: request.track,
+            clientSessionId: clientSessionId
+        )
+    }
+
+    static func provisionalSessionDTO(
+        from request: CreateSessionRequest,
+        clientSessionId: UUID
+    ) -> SessionDTO {
+        sessionDTO(from: request, id: clientSessionId.uuidString)
+    }
+
+    static func sessionDTO(from request: CreateSessionRequest, id: String) -> SessionDTO {
+        SessionDTO(
+            id: id,
+            dayNumber: request.dayNumber,
+            sessionType: request.sessionType,
+            duration: request.duration,
+            bonusSeconds: request.bonusSeconds == 0 ? nil : request.bonusSeconds,
+            completed: request.completed,
+            actualTime: request.actualTime,
+            clearPercent: request.clearPercent,
+            thoughtCount: request.thoughtCount,
+            mindStateLog: request.mindStateLog,
+            attentionLog: request.attentionLog,
+            sessionDate: request.sessionDate,
+            createdAt: nil,
+            buddySessionId: nil,
+            breathCount: request.breathCount,
+            track: request.track
+        )
+    }
+}
+
+public enum SessionSyncError: Error, Sendable {
+    case entryNotFound
+}

--- a/ios/StillPointShared/Sources/StillPointShared/SessionSyncCoordinator.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/SessionSyncCoordinator.swift
@@ -1,5 +1,33 @@
 import Foundation
 
+/// Network hooks for offline session sync — injectable for unit tests (#557).
+public struct SessionSyncTransport: Sendable {
+    public var createSession: @Sendable (CreateSessionRequest) async throws -> SessionDTO
+    public var batchThoughts: @Sendable (BatchThoughtsRequest) async throws -> [ThoughtDTO]
+
+    public init(
+        createSession: @escaping @Sendable (CreateSessionRequest) async throws -> SessionDTO,
+        batchThoughts: @escaping @Sendable (BatchThoughtsRequest) async throws -> [ThoughtDTO]
+    ) {
+        self.createSession = createSession
+        self.batchThoughts = batchThoughts
+    }
+
+    public static func live(client: APIClient = .shared) -> SessionSyncTransport {
+        SessionSyncTransport(
+            createSession: { try await client.createSession($0) },
+            batchThoughts: { try await client.batchThoughts($0) }
+        )
+    }
+
+    public static var alwaysFailing: SessionSyncTransport {
+        SessionSyncTransport(
+            createSession: { _ in throw URLError(.notConnectedToInternet) },
+            batchThoughts: { _ in throw URLError(.notConnectedToInternet) }
+        )
+    }
+}
+
 /// Persists completed sits locally first, then syncs to the server on reconnect (#557).
 public actor SessionSyncCoordinator {
     public static let shared = SessionSyncCoordinator()
@@ -15,11 +43,11 @@ public actor SessionSyncCoordinator {
     }
 
     private let queueStore: OfflineSessionQueueStore
-    private let apiClient: APIClient
+    private let transport: SessionSyncTransport
 
     public init(
         queueStore: OfflineSessionQueueStore? = nil,
-        apiClient: APIClient = .shared
+        transport: SessionSyncTransport = .live()
     ) {
         if let queueStore {
             self.queueStore = queueStore
@@ -28,23 +56,33 @@ public actor SessionSyncCoordinator {
         } else {
             self.queueStore = InMemoryOfflineSessionQueueStore()
         }
-        self.apiClient = apiClient
+        self.transport = transport
     }
 
-    /// Number of sits still waiting for server sync.
-    public func pendingCount() async throws -> Int {
-        try queueStore.loadEntries().filter { !$0.sessionSynced || !$0.thoughts.isEmpty }.count
+    /// Number of sits still waiting for server sync for the signed-in user.
+    public func pendingCount(ownerUserId: String) async throws -> Int {
+        try queueStore.loadEntries()
+            .filter { $0.ownerUserId == ownerUserId && (!$0.sessionSynced || !$0.thoughts.isEmpty) }
+            .count
     }
 
     /// Local-first save: enqueue durably, attempt immediate sync, return a session DTO either way.
     public func saveCompletedSession(
         request: CreateSessionRequest,
         clientSessionId: UUID,
+        ownerUserId: String,
         thoughts: [PendingSessionThought]
     ) async throws -> SaveResult {
+        guard !ownerUserId.isEmpty else {
+            throw SessionSyncError.missingOwnerUserId
+        }
+
         var entries = try queueStore.loadEntries()
         if let existingIndex = entries.firstIndex(where: { $0.clientSessionId == clientSessionId }) {
             let existing = entries[existingIndex]
+            guard existing.ownerUserId == ownerUserId else {
+                throw SessionSyncError.ownerMismatch
+            }
             if existing.sessionSynced, existing.thoughts.isEmpty, let serverId = existing.serverSessionId {
                 return SaveResult(
                     session: Self.sessionDTO(from: existing.request, id: serverId),
@@ -55,13 +93,14 @@ public actor SessionSyncCoordinator {
             let requestWithId = Self.requestWithClientId(request, clientSessionId: clientSessionId)
             entries.append(PendingSessionEntry(
                 clientSessionId: clientSessionId,
+                ownerUserId: ownerUserId,
                 request: requestWithId,
                 thoughts: thoughts
             ))
             try queueStore.saveEntries(entries)
         }
 
-        if let synced = try await flushEntry(clientSessionId: clientSessionId) {
+        if let synced = try await flushEntry(clientSessionId: clientSessionId, ownerUserId: ownerUserId) {
             return SaveResult(session: synced, isPendingSync: false)
         }
 
@@ -74,27 +113,35 @@ public actor SessionSyncCoordinator {
     }
 
     /// Append an end-of-sit note to a queued or already-synced local entry.
-    public func appendEndNote(clientSessionId: UUID, note: String) async throws {
+    public func appendEndNote(clientSessionId: UUID, ownerUserId: String, note: String) async throws {
         let trimmed = note.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
+        guard !ownerUserId.isEmpty else {
+            throw SessionSyncError.missingOwnerUserId
+        }
 
         var entries = try queueStore.loadEntries()
         guard let index = entries.firstIndex(where: { $0.clientSessionId == clientSessionId }) else {
             throw SessionSyncError.entryNotFound
         }
+        guard entries[index].ownerUserId == ownerUserId else {
+            throw SessionSyncError.ownerMismatch
+        }
 
         entries[index].thoughts.append(PendingSessionThought(timeInSession: -1, text: trimmed))
         try queueStore.saveEntries(entries)
-        _ = try await flushEntry(clientSessionId: clientSessionId)
+        _ = try await flushEntry(clientSessionId: clientSessionId, ownerUserId: ownerUserId)
     }
 
-    /// Flush all pending entries. Returns how many fully synced.
+    /// Flush pending entries for the signed-in user. Returns how many fully synced.
     @discardableResult
-    public func flushPending() async throws -> Int {
+    public func flushPending(ownerUserId: String) async throws -> Int {
+        guard !ownerUserId.isEmpty else { return 0 }
+
         let entries = try queueStore.loadEntries()
         var syncedCount = 0
-        for entry in entries where !entry.sessionSynced || !entry.thoughts.isEmpty {
-            if try await flushEntry(clientSessionId: entry.clientSessionId) != nil {
+        for entry in entries where entry.ownerUserId == ownerUserId && (!entry.sessionSynced || !entry.thoughts.isEmpty) {
+            if try await flushEntry(clientSessionId: entry.clientSessionId, ownerUserId: ownerUserId) != nil {
                 syncedCount += 1
             }
         }
@@ -102,35 +149,63 @@ public actor SessionSyncCoordinator {
     }
 
     /// Resolve the best session id for API calls (server id when known).
-    public func resolvedServerSessionId(for clientSessionId: UUID) async throws -> String? {
-        let entry = try queueStore.loadEntries().first { $0.clientSessionId == clientSessionId }
+    public func resolvedServerSessionId(for clientSessionId: UUID, ownerUserId: String) async throws -> String? {
+        let entry = try queueStore.loadEntries().first {
+            $0.clientSessionId == clientSessionId && $0.ownerUserId == ownerUserId
+        }
         return entry?.serverSessionId
+    }
+
+    /// Drop fully-synced entries once the completion flow finishes.
+    public func pruneCompletedEntries(ownerUserId: String) async throws {
+        guard !ownerUserId.isEmpty else { return }
+
+        var entries = try queueStore.loadEntries()
+        let before = entries.count
+        entries.removeAll { $0.ownerUserId == ownerUserId && $0.sessionSynced && $0.thoughts.isEmpty }
+        if entries.count != before {
+            try queueStore.saveEntries(entries)
+        }
+    }
+
+    /// Remove all queued entries (logout / account switch).
+    public func clearQueue() async throws {
+        try queueStore.saveEntries([])
     }
 
     // MARK: - Private
 
     @discardableResult
-    private func flushEntry(clientSessionId: UUID) async throws -> SessionDTO? {
-        var entries = try queueStore.loadEntries()
-        guard let index = entries.firstIndex(where: { $0.clientSessionId == clientSessionId }) else {
+    private func flushEntry(clientSessionId: UUID, ownerUserId: String) async throws -> SessionDTO? {
+        guard var entry = try queueStore.loadEntries().first(where: {
+            $0.clientSessionId == clientSessionId && $0.ownerUserId == ownerUserId
+        }) else {
             return nil
         }
 
-        var entry = entries[index]
-
         if !entry.sessionSynced {
             do {
-                let session = try await apiClient.createSession(entry.request)
-                entry.serverSessionId = session.id
-                entry.sessionSynced = true
-                entries[index] = entry
+                let session = try await transport.createSession(entry.request)
+                var entries = try queueStore.loadEntries()
+                guard let index = entries.firstIndex(where: {
+                    $0.clientSessionId == clientSessionId && $0.ownerUserId == ownerUserId
+                }) else {
+                    return nil
+                }
+                entries[index].serverSessionId = session.id
+                entries[index].sessionSynced = true
                 try queueStore.saveEntries(entries)
+                entry = entries[index]
             } catch {
                 return nil
             }
         }
 
         guard let serverSessionId = entry.serverSessionId else { return nil }
+
+        entry = try queueStore.loadEntries().first(where: {
+            $0.clientSessionId == clientSessionId && $0.ownerUserId == ownerUserId
+        }) ?? entry
 
         if !entry.thoughts.isEmpty {
             do {
@@ -141,26 +216,22 @@ public actor SessionSyncCoordinator {
                         BatchThoughtsRequest.ThoughtInput(timeInSession: $0.timeInSession, text: $0.text)
                     }
                 )
-                _ = try await apiClient.batchThoughts(batch)
-                entry.thoughts = []
-                entries[index] = entry
+                _ = try await transport.batchThoughts(batch)
+                var entries = try queueStore.loadEntries()
+                guard let index = entries.firstIndex(where: {
+                    $0.clientSessionId == clientSessionId && $0.ownerUserId == ownerUserId
+                }) else {
+                    return Self.sessionDTO(from: entry.request, id: serverSessionId)
+                }
+                entries[index].thoughts = []
                 try queueStore.saveEntries(entries)
+                entry = entries[index]
             } catch {
                 return nil
             }
         }
 
         return Self.sessionDTO(from: entry.request, id: serverSessionId)
-    }
-
-    /// Drop fully-synced entries once the completion flow finishes.
-    public func pruneCompletedEntries() async throws {
-        var entries = try queueStore.loadEntries()
-        let before = entries.count
-        entries.removeAll { $0.sessionSynced && $0.thoughts.isEmpty }
-        if entries.count != before {
-            try queueStore.saveEntries(entries)
-        }
     }
 
     private static func requestWithClientId(
@@ -216,4 +287,6 @@ public actor SessionSyncCoordinator {
 
 public enum SessionSyncError: Error, Sendable {
     case entryNotFound
+    case missingOwnerUserId
+    case ownerMismatch
 }

--- a/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
@@ -63,8 +63,9 @@ actor UITestAPIStore {
             // silent-skip fix from issue #253.
             // Note: the SwiftData store is wiped earlier in
             // `StillPointApp.init()`, before `.modelContainer(...)` opens
-            // its SQLite files (issue #276). The session artifacts owned by
-            // `APIClient` are cleared by the client itself via `resetStore`.
+            // its SQLite files (issue #276). The offline write queue (#557)
+            // is stored separately and cleared here on UI-test reset.
+            OfflineSessionQueue.removePersistedQueue()
             defaults.removeObject(forKey: defaultsKey)
             AudioEngine.resetPersistedPrefs()
             SessionIntroPrefs.resetPersistedPrefs()
@@ -222,9 +223,15 @@ actor UITestAPIStore {
     func createSession(_ data: CreateSessionRequest) throws -> SessionDTO {
         try ensureAuthenticated()
 
+        if let clientSessionId = data.clientSessionId?.uuidString,
+           let existing = store.sessions.first(where: { $0.id == clientSessionId }) {
+            return existing
+        }
+
         let nextOrdinal = store.nextSessionOrdinal
+        let sessionId = data.clientSessionId?.uuidString ?? "ui-session-\(nextOrdinal)"
         let session = SessionDTO(
-            id: "ui-session-\(nextOrdinal)",
+            id: sessionId,
             dayNumber: data.dayNumber,
             sessionType: data.sessionType,
             duration: data.duration,

--- a/ios/StillPointShared/Tests/StillPointSharedTests/CreateSessionEncodingTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/CreateSessionEncodingTests.swift
@@ -46,4 +46,23 @@ final class CreateSessionEncodingTests: XCTestCase {
         XCTAssertEqual(object["duration"] as? Int, 60)
         XCTAssertEqual(object["dayNumber"] as? Int, 7)
     }
+
+    func testCreateSessionRequestIncludesClientSessionIdWhenPresent() throws {
+        let clientSessionId = UUID()
+        let request = CreateSessionRequest(
+            dayNumber: 1,
+            duration: 60,
+            completed: true,
+            actualTime: 60,
+            clearPercent: 90,
+            thoughtCount: 0,
+            mindStateLog: [],
+            sessionDate: "2026-07-17",
+            clientSessionId: clientSessionId
+        )
+
+        let data = try JSONEncoder().encode(request)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(object["clientSessionId"] as? String, clientSessionId.uuidString)
+    }
 }

--- a/ios/StillPointShared/Tests/StillPointSharedTests/OfflineSessionQueueTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/OfflineSessionQueueTests.swift
@@ -2,6 +2,8 @@ import XCTest
 @testable import StillPointShared
 
 final class OfflineSessionQueueTests: XCTestCase {
+    private let testOwnerUserId = "user-test-557"
+
     func testFileStoreRoundTrip() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -24,6 +26,7 @@ final class OfflineSessionQueueTests: XCTestCase {
         )
         let entry = PendingSessionEntry(
             clientSessionId: clientSessionId,
+            ownerUserId: testOwnerUserId,
             request: request,
             thoughts: [PendingSessionThought(timeInSession: 10, text: "hello")]
         )
@@ -33,8 +36,23 @@ final class OfflineSessionQueueTests: XCTestCase {
 
         XCTAssertEqual(loaded.count, 1)
         XCTAssertEqual(loaded[0].clientSessionId, clientSessionId)
+        XCTAssertEqual(loaded[0].ownerUserId, testOwnerUserId)
         XCTAssertEqual(loaded[0].thoughts.first?.text, "hello")
         XCTAssertEqual(loaded[0].request.clientSessionId, clientSessionId)
+    }
+
+    func testFileStoreRecoversFromCorruptQueueFile() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let fileURL = directory.appendingPathComponent(OfflineSessionQueue.fileName)
+        try Data("{not-json".utf8).write(to: fileURL)
+        let store = FileOfflineSessionQueueStore(fileURL: fileURL)
+
+        XCTAssertTrue(try store.loadEntries().isEmpty)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path + ".corrupt"))
     }
 
     func testInMemoryStoreStartsEmpty() throws {
@@ -44,9 +62,14 @@ final class OfflineSessionQueueTests: XCTestCase {
 }
 
 final class SessionSyncCoordinatorTests: XCTestCase {
+    private let testOwnerUserId = "user-test-557"
+
     func testSaveCompletedSessionEnqueuesWhenSyncUnavailable() async throws {
         let store = InMemoryOfflineSessionQueueStore()
-        let coordinator = SessionSyncCoordinator(queueStore: store)
+        let coordinator = SessionSyncCoordinator(
+            queueStore: store,
+            transport: .alwaysFailing
+        )
         let clientSessionId = UUID()
         let request = CreateSessionRequest(
             dayNumber: 1,
@@ -63,6 +86,7 @@ final class SessionSyncCoordinatorTests: XCTestCase {
         let result = try await coordinator.saveCompletedSession(
             request: request,
             clientSessionId: clientSessionId,
+            ownerUserId: testOwnerUserId,
             thoughts: []
         )
 
@@ -70,12 +94,16 @@ final class SessionSyncCoordinatorTests: XCTestCase {
         XCTAssertEqual(result.session.id, clientSessionId.uuidString)
         let entries = try store.loadEntries()
         XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries[0].ownerUserId, testOwnerUserId)
         XCTAssertFalse(entries[0].sessionSynced)
     }
 
     func testDuplicateClientSessionIdDoesNotDuplicateQueueEntries() async throws {
         let store = InMemoryOfflineSessionQueueStore()
-        let coordinator = SessionSyncCoordinator(queueStore: store)
+        let coordinator = SessionSyncCoordinator(
+            queueStore: store,
+            transport: .alwaysFailing
+        )
         let clientSessionId = UUID()
         let request = CreateSessionRequest(
             dayNumber: 1,
@@ -92,14 +120,47 @@ final class SessionSyncCoordinatorTests: XCTestCase {
         _ = try await coordinator.saveCompletedSession(
             request: request,
             clientSessionId: clientSessionId,
+            ownerUserId: testOwnerUserId,
             thoughts: []
         )
         _ = try await coordinator.saveCompletedSession(
             request: request,
             clientSessionId: clientSessionId,
+            ownerUserId: testOwnerUserId,
             thoughts: []
         )
 
+        XCTAssertEqual(try store.loadEntries().count, 1)
+    }
+
+    func testFlushPendingSkipsEntriesOwnedByAnotherUser() async throws {
+        let store = InMemoryOfflineSessionQueueStore()
+        let coordinator = SessionSyncCoordinator(
+            queueStore: store,
+            transport: .alwaysFailing
+        )
+        let clientSessionId = UUID()
+        let request = CreateSessionRequest(
+            dayNumber: 1,
+            duration: 60,
+            completed: true,
+            actualTime: 60,
+            clearPercent: 100,
+            thoughtCount: 0,
+            mindStateLog: [],
+            sessionDate: "2026-07-17",
+            clientSessionId: clientSessionId
+        )
+
+        _ = try await coordinator.saveCompletedSession(
+            request: request,
+            clientSessionId: clientSessionId,
+            ownerUserId: "user-a",
+            thoughts: []
+        )
+
+        let flushed = try await coordinator.flushPending(ownerUserId: "user-b")
+        XCTAssertEqual(flushed, 0)
         XCTAssertEqual(try store.loadEntries().count, 1)
     }
 

--- a/ios/StillPointShared/Tests/StillPointSharedTests/OfflineSessionQueueTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/OfflineSessionQueueTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import StillPointShared
+
+final class OfflineSessionQueueTests: XCTestCase {
+    func testFileStoreRoundTrip() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let fileURL = directory.appendingPathComponent(OfflineSessionQueue.fileName)
+        let store = FileOfflineSessionQueueStore(fileURL: fileURL)
+        let clientSessionId = UUID()
+        let request = CreateSessionRequest(
+            dayNumber: 2,
+            duration: 120,
+            completed: true,
+            actualTime: 120,
+            clearPercent: 80,
+            thoughtCount: 1,
+            mindStateLog: [],
+            sessionDate: "2026-07-17",
+            clientSessionId: clientSessionId
+        )
+        let entry = PendingSessionEntry(
+            clientSessionId: clientSessionId,
+            request: request,
+            thoughts: [PendingSessionThought(timeInSession: 10, text: "hello")]
+        )
+
+        try store.saveEntries([entry])
+        let loaded = try store.loadEntries()
+
+        XCTAssertEqual(loaded.count, 1)
+        XCTAssertEqual(loaded[0].clientSessionId, clientSessionId)
+        XCTAssertEqual(loaded[0].thoughts.first?.text, "hello")
+        XCTAssertEqual(loaded[0].request.clientSessionId, clientSessionId)
+    }
+
+    func testInMemoryStoreStartsEmpty() throws {
+        let store = InMemoryOfflineSessionQueueStore()
+        XCTAssertTrue(try store.loadEntries().isEmpty)
+    }
+}
+
+final class SessionSyncCoordinatorTests: XCTestCase {
+    func testSaveCompletedSessionEnqueuesWhenSyncUnavailable() async throws {
+        let store = InMemoryOfflineSessionQueueStore()
+        let coordinator = SessionSyncCoordinator(queueStore: store)
+        let clientSessionId = UUID()
+        let request = CreateSessionRequest(
+            dayNumber: 1,
+            duration: 60,
+            completed: true,
+            actualTime: 60,
+            clearPercent: 100,
+            thoughtCount: 0,
+            mindStateLog: [],
+            sessionDate: "2026-07-17",
+            clientSessionId: clientSessionId
+        )
+
+        let result = try await coordinator.saveCompletedSession(
+            request: request,
+            clientSessionId: clientSessionId,
+            thoughts: []
+        )
+
+        XCTAssertTrue(result.isPendingSync)
+        XCTAssertEqual(result.session.id, clientSessionId.uuidString)
+        let entries = try store.loadEntries()
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertFalse(entries[0].sessionSynced)
+    }
+
+    func testDuplicateClientSessionIdDoesNotDuplicateQueueEntries() async throws {
+        let store = InMemoryOfflineSessionQueueStore()
+        let coordinator = SessionSyncCoordinator(queueStore: store)
+        let clientSessionId = UUID()
+        let request = CreateSessionRequest(
+            dayNumber: 1,
+            duration: 60,
+            completed: true,
+            actualTime: 60,
+            clearPercent: 100,
+            thoughtCount: 0,
+            mindStateLog: [],
+            sessionDate: "2026-07-17",
+            clientSessionId: clientSessionId
+        )
+
+        _ = try await coordinator.saveCompletedSession(
+            request: request,
+            clientSessionId: clientSessionId,
+            thoughts: []
+        )
+        _ = try await coordinator.saveCompletedSession(
+            request: request,
+            clientSessionId: clientSessionId,
+            thoughts: []
+        )
+
+        XCTAssertEqual(try store.loadEntries().count, 1)
+    }
+
+    func testProvisionalSessionDTOUsesClientId() {
+        let clientSessionId = UUID()
+        let request = CreateSessionRequest(
+            dayNumber: 3,
+            sessionType: .quick,
+            duration: 60,
+            completed: true,
+            actualTime: 60,
+            clearPercent: 100,
+            thoughtCount: 0,
+            mindStateLog: [],
+            sessionDate: "2026-07-17",
+            clientSessionId: clientSessionId
+        )
+
+        let dto = SessionSyncCoordinator.provisionalSessionDTO(
+            from: request,
+            clientSessionId: clientSessionId
+        )
+        XCTAssertEqual(dto.id, clientSessionId.uuidString)
+        XCTAssertEqual(dto.sessionType, .quick)
+    }
+}

--- a/src/app/api/sessions/route.idempotency.integration.test.ts
+++ b/src/app/api/sessions/route.idempotency.integration.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Issue #557 — idempotent POST /api/sessions via clientSessionId.
+ */
+import { NextRequest } from "next/server";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { sessions, users } from "@/db/schema";
+import { closeTestDb, getTestDb, type TestDb } from "@/lib/testing/pgliteTestDb";
+
+const { getCurrentUser } = vi.hoisted(() => ({ getCurrentUser: vi.fn() }));
+
+vi.mock("@/lib/auth", () => ({ getCurrentUser }));
+vi.mock("@/db", async () => ({ db: await getTestDb() }));
+
+import { POST } from "./route";
+
+let db: TestDb;
+let seq = 0;
+
+function makeUser(overrides: Partial<typeof users.$inferInsert> = {}) {
+  seq += 1;
+  return db
+    .insert(users)
+    .values({ email: `idemp557-${seq}@test.local`, username: `idemp557_${seq}`, ...overrides })
+    .returning()
+    .then((rows) => rows[0]!);
+}
+
+function sessionRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://test.local/api/sessions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function baseSessionBody(overrides: Record<string, unknown> = {}) {
+  return {
+    dayNumber: 1,
+    duration: 60,
+    actualTime: 60,
+    clearPercent: 90,
+    thoughtCount: 0,
+    mindStateLog: [],
+    sessionDate: "2026-07-17",
+    completed: true,
+    sessionType: "standard",
+    track: "primary",
+    ...overrides,
+  };
+}
+
+afterAll(async () => {
+  await closeTestDb();
+});
+
+beforeEach(async () => {
+  db = await getTestDb();
+});
+
+describe("POST /api/sessions — clientSessionId idempotency (#557)", () => {
+  test("repeated POST with the same clientSessionId returns the existing row and does not advance currentDay twice", async () => {
+    const user = await makeUser({ currentDay: 3 });
+    getCurrentUser.mockResolvedValue({ userId: user.id, email: user.email });
+
+    const clientSessionId = "550e8400-e29b-41d4-a716-446655440000";
+    const body = baseSessionBody({ dayNumber: 3, clientSessionId });
+
+    const first = await POST(sessionRequest(body));
+    expect(first.status).toBe(200);
+    const firstJson = await first.json();
+    expect(firstJson.already).toBeUndefined();
+    expect(firstJson.session.id).toBeTruthy();
+
+    const [afterFirst] = await db.select().from(users).where(eq(users.id, user.id));
+    expect(afterFirst!.currentDay).toBe(4);
+
+    const second = await POST(sessionRequest(body));
+    expect(second.status).toBe(200);
+    const secondJson = await second.json();
+    expect(secondJson.already).toBe(true);
+    expect(secondJson.session.id).toBe(firstJson.session.id);
+
+    const [afterSecond] = await db.select().from(users).where(eq(users.id, user.id));
+    expect(afterSecond!.currentDay).toBe(4);
+
+    const rows = await db.select().from(sessions).where(eq(sessions.userId, user.id));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.clientSessionId).toBe(clientSessionId);
+  });
+
+  test("rejects invalid clientSessionId", async () => {
+    const user = await makeUser();
+    getCurrentUser.mockResolvedValue({ userId: user.id, email: user.email });
+
+    const res = await POST(sessionRequest(baseSessionBody({ clientSessionId: "not-a-uuid" })));
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -9,6 +9,7 @@ import { calculateMindStateTrendStats } from "@/lib/historyMindStateTrends";
 import { isValidSessionCalendarDate, todayLocalIsoDate } from "@/lib/sessionCalendar";
 import { eq, desc } from "drizzle-orm";
 import { sessions } from "@/db/schema";
+import { isUuid } from "@/lib/friends";
 
 export const GET = withApiHandler("Get sessions", async (request: NextRequest) => {
   const auth = await requireAuth();
@@ -79,13 +80,23 @@ export const POST = withApiHandler("Create session", async (request: NextRequest
     return NextResponse.json({ error: "Invalid track" }, { status: 400 });
   }
 
-  const session = await atomicCreateSessionWithProgression({
+  const clientSessionIdRaw = body.clientSessionId;
+  let clientSessionId: string | null = null;
+  if (clientSessionIdRaw != null) {
+    if (typeof clientSessionIdRaw !== "string" || !isUuid(clientSessionIdRaw)) {
+      return NextResponse.json({ error: "Invalid clientSessionId" }, { status: 400 });
+    }
+    clientSessionId = clientSessionIdRaw;
+  }
+
+  const { session, already } = await atomicCreateSessionWithProgression({
     userId: auth.user.userId,
     sessionType,
     completed,
     track,
     session: {
       userId: auth.user.userId,
+      clientSessionId,
       dayNumber,
       sessionType,
       track,
@@ -102,5 +113,5 @@ export const POST = withApiHandler("Create session", async (request: NextRequest
     },
   });
 
-  return NextResponse.json({ session });
+  return NextResponse.json(already ? { session, already: true } : { session });
 });

--- a/src/db/atomic.ts
+++ b/src/db/atomic.ts
@@ -506,6 +506,7 @@ function mapSessionRow(row: Record<string, unknown>): typeof sessions.$inferSele
   return {
     id: String(row.id),
     userId: String(row.user_id),
+    clientSessionId: row.client_session_id ? String(row.client_session_id) : null,
     buddySessionId: row.buddy_session_id ? String(row.buddy_session_id) : null,
     dayNumber: Number(row.day_number),
     sessionType: String(row.session_type),
@@ -583,54 +584,91 @@ export async function atomicCreateSessionWithProgression(params: {
   sessionType: SessionType;
   completed: boolean;
   track: Track;
-}): Promise<typeof sessions.$inferSelect> {
+}): Promise<{ session: typeof sessions.$inferSelect; already: boolean }> {
   const shouldAdvance = shouldAdvanceDay(params.sessionType, params.completed);
   const { session, userId, track } = params;
+  const clientSessionId = session.clientSessionId ?? null;
 
-  const result = await db.execute(sql`
-    with locked as (
-      select id from users where id = ${userId}::uuid for update
-    ),
-    inserted as (
-      insert into sessions (
-        user_id, buddy_session_id, day_number, session_type, track, duration,
-        bonus_seconds, completed, actual_time, clear_percent, thought_count,
-        breath_count, mind_state_log, attention_log, session_date
+  if (clientSessionId) {
+    const [existing] = await db
+      .select()
+      .from(sessions)
+      .where(
+        and(
+          eq(sessions.userId, userId),
+          eq(sessions.clientSessionId, clientSessionId),
+        ),
       )
-      values (
-        ${userId}::uuid,
-        ${session.buddySessionId ?? null},
-        ${session.dayNumber},
-        ${session.sessionType ?? "standard"},
-        ${session.track ?? "primary"},
-        ${session.duration},
-        ${session.bonusSeconds ?? 0},
-        ${session.completed},
-        ${session.actualTime ?? session.duration},
-        ${session.clearPercent},
-        ${session.thoughtCount ?? 0},
-        ${session.breathCount ?? null},
-        ${JSON.stringify(session.mindStateLog ?? [])}::jsonb,
-        ${session.attentionLog ? JSON.stringify(session.attentionLog) : null}::jsonb,
-        ${session.sessionDate}
-      )
-      returning *
-    ),
-    progressed as (
-      update users u
-      set ${progressionUpdateSql(shouldAdvance, track)}
-      from locked l
-      where u.id = l.id
-      returning u.id
-    )
-    select * from inserted
-  `);
-
-  const row = result.rows[0];
-  if (!row) {
-    throw new Error("SESSION_INSERT_FAILED");
+      .limit(1);
+    if (existing) {
+      return { session: existing, already: true };
+    }
   }
-  return mapSessionRow(row);
+
+  try {
+    const result = await db.execute(sql`
+      with locked as (
+        select id from users where id = ${userId}::uuid for update
+      ),
+      inserted as (
+        insert into sessions (
+          user_id, client_session_id, buddy_session_id, day_number, session_type, track, duration,
+          bonus_seconds, completed, actual_time, clear_percent, thought_count,
+          breath_count, mind_state_log, attention_log, session_date
+        )
+        values (
+          ${userId}::uuid,
+          ${clientSessionId},
+          ${session.buddySessionId ?? null},
+          ${session.dayNumber},
+          ${session.sessionType ?? "standard"},
+          ${session.track ?? "primary"},
+          ${session.duration},
+          ${session.bonusSeconds ?? 0},
+          ${session.completed},
+          ${session.actualTime ?? session.duration},
+          ${session.clearPercent},
+          ${session.thoughtCount ?? 0},
+          ${session.breathCount ?? null},
+          ${JSON.stringify(session.mindStateLog ?? [])}::jsonb,
+          ${session.attentionLog ? JSON.stringify(session.attentionLog) : null}::jsonb,
+          ${session.sessionDate}
+        )
+        returning *
+      ),
+      progressed as (
+        update users u
+        set ${progressionUpdateSql(shouldAdvance, track)}
+        from locked l
+        where u.id = l.id
+        returning u.id
+      )
+      select * from inserted
+    `);
+
+    const row = result.rows[0];
+    if (!row) {
+      throw new Error("SESSION_INSERT_FAILED");
+    }
+    return { session: mapSessionRow(row), already: false };
+  } catch (error) {
+    if (clientSessionId && isUniqueViolation(error)) {
+      const [again] = await db
+        .select()
+        .from(sessions)
+        .where(
+          and(
+            eq(sessions.userId, userId),
+            eq(sessions.clientSessionId, clientSessionId),
+          ),
+        )
+        .limit(1);
+      if (again) {
+        return { session: again, already: true };
+      }
+    }
+    throw error;
+  }
 }
 
 export async function atomicRecordBuddyPersonalSession(params: {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -357,6 +357,8 @@ export const buddySessionCalendarEvents = pgTable("buddy_session_calendar_events
 export const sessions = pgTable("sessions", {
   id: uuid("id").primaryKey().defaultRandom(),
   userId: uuid("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
+  /** #557: iOS offline write-queue idempotency key; null for web/legacy creates. */
+  clientSessionId: uuid("client_session_id"),
   /** #119: provenance when this row was created from a completed buddy sit (personal copy per user). */
   buddySessionId: uuid("buddy_session_id").references(() => buddySessions.id, { onDelete: "set null" }),
   dayNumber: integer("day_number").notNull(),
@@ -406,6 +408,11 @@ export const sessions = pgTable("sessions", {
     table.userId,
     table.buddySessionId,
   ).where(sql`${table.buddySessionId} is not null`),
+  /** #557: idempotent offline iOS session create — one row per user per client UUID. */
+  userClientSessionUnique: uniqueIndex("sessions_user_client_session_unique").on(
+    table.userId,
+    table.clientSessionId,
+  ).where(sql`${table.clientSessionId} is not null`),
   focusRatingCheck: check(
     "sessions_focus_rating_range",
     sql`${table.focusRating} is null or (${table.focusRating} between 1 and 10)`,

--- a/src/lib/friends.ts
+++ b/src/lib/friends.ts
@@ -1,5 +1,5 @@
 const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export function isUuid(value: string): boolean {
   return UUID_RE.test(value);


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements issue #557 — iOS offline write-queue (v1: session completions + thoughts only).

- **Local-first save:** completing a sit (standard/quick/breath) writes to a durable JSON outbox (`offline-session-queue.json`) before attempting network sync.
- **Auto-sync on reconnect:** `NetworkReachabilityMonitor` + foreground hooks flush pending entries via `SessionSyncCoordinator`.
- **Idempotent create:** `POST /api/sessions` accepts optional `clientSessionId`; duplicate submits return the existing row without re-advancing progression.
- **#276 reconciliation:** UI-test SwiftData wipe still clears `default.store*` only; the outbox lives in a separate file and is cleared explicitly on `SP_UI_TEST_RESET_STORE`.

## Backend

- Migration: `drizzle/sessions_client_session_id_557_incremental.sql`
- Schema + `atomicCreateSessionWithProgression` dedupe by `(userId, clientSessionId)`
- Integration test: `route.idempotency.integration.test.ts`

## iOS

- `OfflineSessionQueue` + `SessionSyncCoordinator` in StillPointShared
- Wired through `SessionViewModel`, `AppViewModel.completeBreathSession`, `CompletionView` end notes
- Unit tests in `OfflineSessionQueueTests.swift`

## Verification

- `npm ci` + `npm run test:unit` (637 tests) ✅
- `npm run typecheck` ✅
- `npm run build:verify` ✅
- `swift test` (StillPointShared) — CI-only on this Linux agent; macOS job `ios-shared-tests.yml` will run on merge

## Out of scope (per issue)

- Offline reads (history/board/stats) remain network-only
- Buddy personal session offline queue (still online path)

Closes #557
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fbfb0cd-2a58-491f-a037-cc9fff313a76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fbfb0cd-2a58-491f-a037-cc9fff313a76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Save completed iOS sessions offline and avoid duplicate session records**

### What Changed
- Completed sessions are now saved locally first, so they can still be kept when the app is offline and synced later
- Reconnecting or returning to the app now flushes pending session saves automatically
- Repeating the same session submit now returns the existing session instead of creating a duplicate or advancing progress twice
- End notes now attach to the offline session record and show a clearer save error when they cannot be stored

### Impact
`✅ Fewer lost sessions when offline`
`✅ Fewer duplicate session records`
`✅ Clearer end-note save errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
