### PR TITLE
refactor(api): migrate track/ routes to requireAuth/withApiHandler (#536)

### DIFF
--- a/src/app/api/track/done-today/route.ts
+++ b/src/app/api/track/done-today/route.ts
@@ -2,15 +2,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { and, eq, inArray } from "drizzle-orm";
 import { db } from "@/db";
 import { sessions } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { isValidSessionCalendarDate } from "@/lib/sessionCalendar";
 
-export async function GET(request: NextRequest) {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const GET = withApiHandler(
+  "Get track completion",
+  async (request: NextRequest) => {
+    const auth = await requireAuth();
+    if (!auth.ok) return auth.response;
 
     const date = request.nextUrl.searchParams.get("date");
     if (!date || !isValidSessionCalendarDate(date)) {
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest) {
       .select({ track: sessions.track })
       .from(sessions)
       .where(and(
-        eq(sessions.userId, auth.userId),
+        eq(sessions.userId, auth.user.userId),
         eq(sessions.sessionDate, date),
         eq(sessions.completed, true),
         eq(sessions.sessionType, "standard"),
@@ -34,8 +34,5 @@ export async function GET(request: NextRequest) {
         second: completedTracks.some((session) => session.track === "second"),
       },
     });
-  } catch (error) {
-    console.error("Get track completion error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  },
+);

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { db } from "@/db";
 import { users } from "@/db/schema";
-import { getCurrentUser } from "@/lib/auth";
+import { requireAuth } from "@/lib/api/requireAuth";
+import { withApiHandler } from "@/lib/api/withApiHandler";
 import { isDualTrackEligible } from "@/lib/duration";
 import { eq } from "drizzle-orm";
 
@@ -27,44 +28,37 @@ const RETURN_FIELDS = {
  * returns the current state. The second track's day counter (`secondTrackDay`) is
  * left at its default so it starts at 1 minute the first time it is run.
  */
-export async function POST() {
-  try {
-    const auth = await getCurrentUser();
-    if (!auth) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+export const POST = withApiHandler("Enable dual track", async () => {
+  const auth = await requireAuth();
+  if (!auth.ok) return auth.response;
 
-    const [current] = await db
-      .select({ currentDay: users.currentDay, dualTrackEnabled: users.dualTrackEnabled })
-      .from(users)
-      .where(eq(users.id, auth.userId))
-      .limit(1);
+  const [current] = await db
+    .select({ currentDay: users.currentDay, dualTrackEnabled: users.dualTrackEnabled })
+    .from(users)
+    .where(eq(users.id, auth.user.userId))
+    .limit(1);
 
-    if (!current) {
-      return NextResponse.json({ error: "User not found" }, { status: 404 });
-    }
-
-    // Guard server-side so a client can't flip the flag before reaching the fork.
-    if (!current.dualTrackEnabled && !isDualTrackEligible(current.currentDay)) {
-      return NextResponse.json(
-        { error: "Reach the 10-minute mark before adding a second track." },
-        { status: 409 },
-      );
-    }
-
-    const [updated] = await db
-      .update(users)
-      .set({ dualTrackEnabled: true, updatedAt: new Date() })
-      .where(eq(users.id, auth.userId))
-      .returning(RETURN_FIELDS);
-
-    if (!updated) {
-      return NextResponse.json({ error: "User not found" }, { status: 404 });
-    }
-
-    return NextResponse.json({ user: updated });
-  } catch (error) {
-    console.error("Enable dual track error:", error);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  if (!current) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
   }
-}
+
+  // Guard server-side so a client can't flip the flag before reaching the fork.
+  if (!current.dualTrackEnabled && !isDualTrackEligible(current.currentDay)) {
+    return NextResponse.json(
+      { error: "Reach the 10-minute mark before adding a second track." },
+      { status: 409 },
+    );
+  }
+
+  const [updated] = await db
+    .update(users)
+    .set({ dualTrackEnabled: true, updatedAt: new Date() })
+    .where(eq(users.id, auth.user.userId))
+    .returning(RETURN_FIELDS);
+
+  if (!updated) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ user: updated });
+});

--- a/src/app/api/track/route.ts
+++ b/src/app/api/track/route.ts
@@ -50,6 +50,18 @@ export const POST = withApiHandler("Enable dual track", async () => {
     );
   }
 
+  if (current.dualTrackEnabled) {
+    const [existing] = await db
+      .select(RETURN_FIELDS)
+      .from(users)
+      .where(eq(users.id, auth.user.userId))
+      .limit(1);
+    if (!existing) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+    return NextResponse.json({ user: existing });
+  }
+
   const [updated] = await db
     .update(users)
     .set({ dualTrackEnabled: true, updatedAt: new Date() })


### PR DESCRIPTION
## **User description**
## Summary
- Migrate track/ API routes to `requireAuth` + `withApiHandler` pattern (#536)
- Rebased onto main after #580 merge

## Test plan
- [ ] CI green (unit + e2e)
- [ ] CodeAnt APPROVED on HEAD

Closes #536

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Keep track routes consistent and make repeat dual-track requests idempotent**

### What Changed
- Track routes now return the same login and error responses as other API routes, while keeping the existing track completion and dual-track behavior
- Repeating the request to enable dual track now returns the current user instead of updating the account again
- This avoids unnecessary account updates on duplicate requests, so `updatedAt` and any follow-on effects are no longer triggered twice

### Impact
`✅ Consistent login errors on track routes`
`✅ No duplicate updates when enabling dual track twice`
`✅ Fewer unintended side effects from repeat requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
