### PR TITLE
fix(ios): breath-counting completion unlocks app gate (#590)

### DIFF
--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -362,6 +362,7 @@ final class AppViewModel {
         }
         guard !isSavingBreathSession else { return }
         guard let ownerUserId = currentUser?.id else { return }
+        applyAppGateAfterSessionCompletion(unlock: true)
         isSavingBreathSession = true
         defer { isSavingBreathSession = false }
 
@@ -484,6 +485,17 @@ final class AppViewModel {
         currentView = .logReason(date: date)
     }
 
+    /// Shared app-gate side effect for any local session completion path (#590).
+    /// Keeps standard/quick (`completeSession`), breath (`completeBreathSession`), and
+    /// future completion handlers (#589 widget sync, etc.) aligned on one call site.
+    private func applyAppGateAfterSessionCompletion(unlock: Bool) {
+        if unlock {
+            appBlockingManager.unlockAfterCompletedSession()
+        } else {
+            appBlockingManager.prepareForSession()
+        }
+    }
+
     func completeSession(
         sessionId: String,
         clientSessionId: UUID,
@@ -498,11 +510,7 @@ final class AppViewModel {
         attentionLog: [AttentionEntry]? = nil,
         attentionElapsed: Double? = nil
     ) {
-        if unlockAppGate {
-            appBlockingManager.unlockAfterCompletedSession()
-        } else {
-            appBlockingManager.prepareForSession()
-        }
+        applyAppGateAfterSessionCompletion(unlock: unlockAppGate)
         currentView = .completion(
             sessionId: sessionId,
             clientSessionId: clientSessionId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Breath-counting sits now call `AppBlockingManager.unlockAfterCompletedSession()` on completion, matching standard and quick countdown sits.

- `completeBreathSession` invokes the shared unlock path when the user ends a non-empty breath sit (`elapsedSeconds > 0 || breathCount > 0`).
- Extracted `applyAppGateAfterSessionCompletion(unlock:)` so breath, countdown (`completeSession`), and future completion side effects (#589 widget sync) share one app-gate call site.

## Behavior

| Path | Before | After |
|------|--------|-------|
| Standard / quick natural completion | Unlocks app gate | Unchanged |
| Breath counting (End with activity) | Stays locked | Unlocks app gate |
| Breath End with no taps | Returns home, no unlock | Unchanged |
| Early / abandoned countdown | No unlock | Unchanged |

## Test plan

- [ ] Enable app gate → complete a breath sit → blocked apps unlock for the day
- [ ] Regression: standard and quick sits still unlock on natural completion
- [ ] `StillPointShared swift test` (no shared-package changes; CI no-op expected on this PR)
- [ ] App build verified in CI only (no macOS app target in cloud agent)

Closes #590

**Please ask before merge** — device verification with Screen Time / app gate enabled is recommended.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc57be60-8f37-4402-aa56-84956e81605a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc57be60-8f37-4402-aa56-84956e81605a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app access handling after completing breathing sessions.
  * Ensured app access is consistently unlocked or prepared based on the session completion outcome.
  * Synchronized completion behavior across session and widget updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->