### PR TITLE
fix(ios): habit widget streak counts quick and breath sits (#589)

### DIFF
--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -333,6 +333,11 @@ final class AppViewModel {
     /// server-side filtered query.
     func refreshTracksDoneToday() async {
         guard currentUser != nil else { return }
+        let now = Date()
+        let prior = WidgetDataStore.load()
+        if let prior, prior.isLoggedIn, !WidgetDataStore.isSameLocalDay(prior.lastUpdated, now) {
+            practiceDoneToday = false
+        }
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")
@@ -349,6 +354,7 @@ final class AppViewModel {
             // Non-fatal: fail closed so stale "done today" badges do not leak.
             primaryDoneToday = false
             secondDoneToday = false
+            practiceDoneToday = false
         }
         syncWidgetData()
         refreshWidgetWeekHistory()
@@ -511,7 +517,7 @@ final class AppViewModel {
         thoughts: [CapturedThought],
         dayNumber: Int,
         sessionType: SessionType = .standard,
-        track: Track = .primary,
+        track: Track,
         duration: Int,
         bonusSeconds: Int = 0,
         unlockAppGate: Bool,

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -103,6 +103,8 @@ final class AppViewModel {
     /// #240: per-track "completed a standard sit today", drives the Home badges.
     var primaryDoneToday = false
     var secondDoneToday = false
+    /// Any counted practice today (standard primary, quick, or breath) for the widget.
+    var practiceDoneToday = false
 
     var currentDay: Int {
         StillPoint.clampedCurrentDay(for: currentUser)
@@ -309,6 +311,7 @@ final class AppViewModel {
     private func resetTrackCompletionBadges() {
         primaryDoneToday = false
         secondDoneToday = false
+        practiceDoneToday = false
     }
 
     func beginSession(type: SessionType = .standard, track: Track = .primary) {
@@ -339,6 +342,9 @@ final class AppViewModel {
             let tracksDoneToday = try await APIClient.shared.getTracksDoneToday(date: today)
             primaryDoneToday = tracksDoneToday.primary
             secondDoneToday = tracksDoneToday.second
+            if primaryDoneToday {
+                practiceDoneToday = true
+            }
         } catch {
             // Non-fatal: fail closed so stale "done today" badges do not leak.
             primaryDoneToday = false
@@ -394,6 +400,7 @@ final class AppViewModel {
                 ownerUserId: ownerUserId,
                 thoughts: []
             )
+            markPracticeDoneToday()
             currentView = .home
         } catch {
             print("Failed to persist breath session locally: \(error)")
@@ -504,12 +511,16 @@ final class AppViewModel {
         thoughts: [CapturedThought],
         dayNumber: Int,
         sessionType: SessionType = .standard,
+        track: Track = .primary,
         duration: Int,
         bonusSeconds: Int = 0,
         unlockAppGate: Bool,
         attentionLog: [AttentionEntry]? = nil,
         attentionElapsed: Double? = nil
     ) {
+        if countsForWidgetPractice(sessionType: sessionType, track: track) {
+            markPracticeDoneToday()
+        }
         applyAppGateAfterSessionCompletion(unlock: unlockAppGate)
         currentView = .completion(
             sessionId: sessionId,
@@ -602,7 +613,8 @@ final class AppViewModel {
         let snapshot = WidgetDataStore.makeSnapshot(
             user: currentUser,
             primaryDoneToday: primaryDoneToday,
-            secondDoneToday: secondDoneToday
+            secondDoneToday: secondDoneToday,
+            practiceDoneToday: practiceDoneToday
         )
         if snapshot.isLoggedIn {
             WidgetDataStore.save(snapshot)
@@ -645,19 +657,36 @@ final class AppViewModel {
             guard !Task.isCancelled,
                   let current = currentUser, current.id == user.id else { return }
             let now = Date()
-            let completed = WidgetDataStore.recentCompletedPrimaryDates(from: result.sessions, now: now)
+            let completed = WidgetDataStore.recentCompletedPracticeDates(from: result.sessions, now: now)
             // Derive today's completion from the fetched sessions (consistent with
             // `now`) rather than the in-memory flag, which could be stale past midnight.
             let doneToday = completed.contains(WidgetDataStore.localDayString(now))
             let snapshot = WidgetDataStore.makeSnapshot(
                 user: current,
-                primaryDoneToday: doneToday,
+                primaryDoneToday: primaryDoneToday,
                 secondDoneToday: secondDoneToday,
+                practiceDoneToday: doneToday,
                 now: now,
-                completedPrimaryDates: completed
+                completedPracticeDates: completed
             )
             WidgetDataStore.save(snapshot)
             WidgetTimelineReloader.reloadHabitWidget()
+        }
+    }
+
+    /// Mark today as having counted practice and push an immediate widget snapshot.
+    /// Shared touchpoint with #590 completion-handler work — rebase carefully.
+    private func markPracticeDoneToday() {
+        practiceDoneToday = true
+        syncWidgetData()
+    }
+
+    private func countsForWidgetPractice(sessionType: SessionType, track: Track) -> Bool {
+        switch sessionType {
+        case .quick, .breath:
+            return true
+        case .standard:
+            return track == .primary
         }
     }
 }

--- a/ios/StillPointApp/Views/BuddySession/BuddySessionContainerView.swift
+++ b/ios/StillPointApp/Views/BuddySession/BuddySessionContainerView.swift
@@ -184,6 +184,7 @@ struct BuddySessionContainerView: View {
             thoughts: vm.capturedThoughts,
             dayNumber: saved.dayNumber,
             sessionType: saved.sessionType,
+            track: .primary,
             duration: saved.duration,
             bonusSeconds: saved.bonusSeconds ?? 0,
             unlockAppGate: true

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -717,6 +717,7 @@ struct SessionView: View {
                 thoughts: vm.capturedThoughts,
                 dayNumber: session.dayNumber,
                 sessionType: session.sessionType,
+                track: vm.track,
                 duration: vm.plannedSeconds,
                 bonusSeconds: vm.bonusSeconds,
                 unlockAppGate: vm.completedNaturally,

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -255,6 +255,7 @@ struct SessionView: View {
                     thoughts: vm.capturedThoughts,
                     dayNumber: vm.dayNumber,
                     sessionType: vm.sessionType,
+                    track: vm.track,
                     duration: vm.plannedSeconds,
                     bonusSeconds: vm.bonusSeconds,
                     unlockAppGate: vm.completedNaturally

--- a/ios/StillPointShared/Sources/StillPointShared/WidgetData.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/WidgetData.swift
@@ -41,8 +41,8 @@ public struct WidgetData: Codable, Sendable, Equatable {
     public var primaryDoneToday: Bool
     public var secondDoneToday: Bool
     /// True when any counted practice (standard primary, quick, or breath) was
-    /// completed today. Drives widget streak + weekday row; decoded as `false`
-    /// for snapshots written before this field shipped (#589).
+    /// completed today. Drives widget streak + weekday row. Legacy snapshots
+    /// without this field decode using `primaryDoneToday` (#589).
     public var practiceDoneToday: Bool
     public var streak: Int
     /// #84 follow-up: ISO local-day strings (`yyyy-MM-dd`) within the trailing

--- a/ios/StillPointShared/Sources/StillPointShared/WidgetData.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/WidgetData.swift
@@ -7,7 +7,7 @@ public enum WidgetAppGroup {
 }
 
 /// One column in the widget's Duolingo-style weekday row: a single-letter
-/// weekday label plus whether the primary standard sit was completed that day.
+/// weekday label plus whether any counted practice was completed that day.
 public struct WidgetDayMark: Sendable, Equatable, Identifiable {
     /// ISO local-day string (`yyyy-MM-dd`) this column represents.
     public let iso: String
@@ -15,7 +15,7 @@ public struct WidgetDayMark: Sendable, Equatable, Identifiable {
     public let letter: String
     /// Full weekday name (e.g. `Monday`) for the VoiceOver label.
     public let weekdayName: String
-    /// True when the primary standard sit was completed on `iso`.
+    /// True when any counted practice (standard, quick, or breath) was completed on `iso`.
     public let done: Bool
     /// True for the trailing column (the caller's local "today").
     public let isToday: Bool
@@ -40,9 +40,13 @@ public struct WidgetData: Codable, Sendable, Equatable {
     public var dualTrackEnabled: Bool
     public var primaryDoneToday: Bool
     public var secondDoneToday: Bool
+    /// True when any counted practice (standard primary, quick, or breath) was
+    /// completed today. Drives widget streak + weekday row; decoded as `false`
+    /// for snapshots written before this field shipped (#589).
+    public var practiceDoneToday: Bool
     public var streak: Int
     /// #84 follow-up: ISO local-day strings (`yyyy-MM-dd`) within the trailing
-    /// 7-day window on which the primary standard sit was completed. Drives the
+    /// 7-day window on which counted practice was completed. Drives the
     /// Duolingo-style weekday checkmark row. Decoded permissively so snapshots
     /// written before this field shipped (build 15) still load.
     public var completedDates: [String]
@@ -56,6 +60,7 @@ public struct WidgetData: Codable, Sendable, Equatable {
         dualTrackEnabled: Bool,
         primaryDoneToday: Bool,
         secondDoneToday: Bool,
+        practiceDoneToday: Bool = false,
         streak: Int,
         completedDates: [String] = [],
         lastUpdated: Date
@@ -67,6 +72,7 @@ public struct WidgetData: Codable, Sendable, Equatable {
         self.dualTrackEnabled = dualTrackEnabled
         self.primaryDoneToday = primaryDoneToday
         self.secondDoneToday = secondDoneToday
+        self.practiceDoneToday = practiceDoneToday
         self.streak = streak
         self.completedDates = completedDates
         self.lastUpdated = lastUpdated
@@ -74,7 +80,7 @@ public struct WidgetData: Codable, Sendable, Equatable {
 
     private enum CodingKeys: String, CodingKey {
         case isLoggedIn, userId, currentDay, secondTrackDay, dualTrackEnabled
-        case primaryDoneToday, secondDoneToday, streak, completedDates, lastUpdated
+        case primaryDoneToday, secondDoneToday, practiceDoneToday, streak, completedDates, lastUpdated
     }
 
     /// Custom decoder so blobs persisted before `completedDates` existed still
@@ -88,6 +94,8 @@ public struct WidgetData: Codable, Sendable, Equatable {
         dualTrackEnabled = try c.decode(Bool.self, forKey: .dualTrackEnabled)
         primaryDoneToday = try c.decode(Bool.self, forKey: .primaryDoneToday)
         secondDoneToday = try c.decode(Bool.self, forKey: .secondDoneToday)
+        practiceDoneToday = try c.decodeIfPresent(Bool.self, forKey: .practiceDoneToday)
+            ?? primaryDoneToday
         streak = try c.decode(Int.self, forKey: .streak)
         completedDates = try c.decodeIfPresent([String].self, forKey: .completedDates) ?? []
         lastUpdated = try c.decode(Date.self, forKey: .lastUpdated)
@@ -101,6 +109,7 @@ public struct WidgetData: Codable, Sendable, Equatable {
         dualTrackEnabled: false,
         primaryDoneToday: false,
         secondDoneToday: false,
+        practiceDoneToday: false,
         streak: 0,
         completedDates: [],
         lastUpdated: .distantPast
@@ -116,9 +125,15 @@ public struct WidgetData: Codable, Sendable, Equatable {
         primaryDoneToday && WidgetDataStore.isSameLocalDay(lastUpdated, now)
     }
 
+    /// Whether the user has logged any counted practice today (standard primary,
+    /// quick, or breath).
+    public func isPracticeCompleteForToday(at now: Date = Date()) -> Bool {
+        practiceDoneToday && WidgetDataStore.isSameLocalDay(lastUpdated, now)
+    }
+
     /// Trailing 7-day window (oldest → newest, ending on the caller's local
     /// "today") of weekday marks for the Duolingo-style row. `now`'s column is
-    /// checked when either `completedDates` records it or the primary sit is
+    /// checked when either `completedDates` records it or counted practice is
     /// already complete today.
     public func weekMarks(now: Date = Date(), calendar: Calendar = .current) -> [WidgetDayMark] {
         let completed = Set(completedDates)
@@ -129,7 +144,7 @@ public struct WidgetData: Codable, Sendable, Equatable {
             guard let date = calendar.date(byAdding: .day, value: -offset, to: start) else { return nil }
             let iso = WidgetDataStore.localDayString(date, calendar: calendar)
             let isToday = offset == 0
-            let done = completed.contains(iso) || (isToday && isPrimaryCompleteForToday(at: now))
+            let done = completed.contains(iso) || (isToday && isPracticeCompleteForToday(at: now))
             let weekday = calendar.component(.weekday, from: date)
             let letter = letters.isEmpty ? "" : letters[(weekday - 1) % letters.count]
             let name = names.isEmpty ? "" : names[(weekday - 1) % names.count]
@@ -164,6 +179,7 @@ public struct WidgetData: Codable, Sendable, Equatable {
         dualTrackEnabled: false,
         primaryDoneToday: false,
         secondDoneToday: false,
+        practiceDoneToday: false,
         streak: 12,
         completedDates: WidgetDataStore.previewCompletedDates(),
         lastUpdated: Date()
@@ -200,18 +216,19 @@ public enum WidgetDataStore {
     /// Build a widget snapshot from in-memory app state, adjusting streak without
     /// extra network calls by comparing against the last persisted snapshot.
     ///
-    /// `completedPrimaryDates`, when supplied (from a real `getSessions()` fetch),
+    /// `completedPracticeDates`, when supplied (from a real `getSessions()` fetch),
     /// becomes the authoritative 7-day completion set. When omitted, the prior
     /// snapshot's dates are carried forward so the fast, network-free sync path
-    /// never wipes history it can't recompute. Today is always folded in when the
-    /// primary sit is done, so completing a sit checks today's box immediately.
+    /// never wipes history it can't recompute. Today is always folded in when
+    /// counted practice is done, so completing a sit checks today's box immediately.
     public static func makeSnapshot(
         user: UserDTO?,
         primaryDoneToday: Bool,
         secondDoneToday: Bool,
+        practiceDoneToday: Bool,
         now: Date = Date(),
         previous: WidgetData? = nil,
-        completedPrimaryDates: Set<String>? = nil
+        completedPracticeDates: Set<String>? = nil
     ) -> WidgetData {
         guard let user else {
             return .loggedOut
@@ -220,15 +237,15 @@ public enum WidgetDataStore {
         let prior = previous ?? load()
         let streak = resolvedStreak(
             userId: user.id,
-            primaryDoneToday: primaryDoneToday,
+            practiceDoneToday: practiceDoneToday,
             previous: prior,
             now: now
         )
 
         let window = Set(localDayStrings(lastN: 7, endingAt: now))
         var dates: Set<String>
-        if let completedPrimaryDates {
-            dates = completedPrimaryDates.intersection(window)
+        if let completedPracticeDates {
+            dates = completedPracticeDates.intersection(window)
         } else if let prior, prior.isLoggedIn, prior.userId == user.id {
             // Carry forward what we already knew; drop the other account's history.
             dates = Set(prior.completedDates).intersection(window)
@@ -236,11 +253,11 @@ public enum WidgetDataStore {
             dates = []
         }
         // Fold today in only on the synchronous fast path (no session set), where
-        // `primaryDoneToday` is always same-day fresh. The authoritative path
-        // already carries today's real completion in `completedPrimaryDates`, so
+        // `practiceDoneToday` is always same-day fresh. The authoritative path
+        // already carries today's real completion in `completedPracticeDates`, so
         // trusting a possibly-stale flag there could wrongly check a new day if the
         // async fetch crossed local midnight.
-        if completedPrimaryDates == nil, primaryDoneToday {
+        if completedPracticeDates == nil, practiceDoneToday {
             dates.insert(localDayString(now))
         }
 
@@ -252,27 +269,35 @@ public enum WidgetDataStore {
             dualTrackEnabled: user.dualTrackEnabled,
             primaryDoneToday: primaryDoneToday,
             secondDoneToday: secondDoneToday,
+            practiceDoneToday: practiceDoneToday,
             streak: streak,
             completedDates: dates.sorted(),
             lastUpdated: now
         )
     }
 
-    /// The set of local days in the trailing 7-day window on which a completed
-    /// primary standard sit was recorded. Quick and breath sits are excluded
-    /// (they don't advance the daily practice), matching `SessionStatistics`.
+    /// Whether a completed session counts toward widget streak / weekday marks.
+    public static func sessionCountsForWidgetPractice(_ session: SessionDTO) -> Bool {
+        guard session.completed else { return false }
+        switch session.sessionType {
+        case .quick, .breath:
+            return true
+        case .standard:
+            return (session.track ?? .primary) == .primary
+        }
+    }
+
+    /// The set of local days in the trailing 7-day window on which counted
+    /// practice was recorded: primary standard sits, quick sits, and breath sits.
     /// Pure and network-free so it's unit-testable; the caller supplies sessions.
-    public static func recentCompletedPrimaryDates(
+    public static func recentCompletedPracticeDates(
         from sessions: [SessionDTO],
         now: Date = Date(),
         calendar: Calendar = .current
     ) -> Set<String> {
         let window = Set(localDayStrings(lastN: 7, endingAt: now, calendar: calendar))
         var result = Set<String>()
-        for session in sessions
-        where session.completed
-            && session.sessionType == .standard
-            && (session.track ?? .primary) == .primary {
+        for session in sessions where sessionCountsForWidgetPractice(session) {
             if window.contains(session.sessionDate) {
                 result.insert(session.sessionDate)
             }
@@ -289,7 +314,8 @@ public enum WidgetDataStore {
         var copy = data
         copy.primaryDoneToday = false
         copy.secondDoneToday = false
-        if data.primaryDoneToday {
+        copy.practiceDoneToday = false
+        if data.practiceDoneToday {
             copy.streak = max(data.streak, 0)
         } else {
             copy.streak = 0
@@ -300,30 +326,30 @@ public enum WidgetDataStore {
         return copy
     }
 
-    /// Increment streak once per local day when the primary track flips to done.
+    /// Increment streak once per local day when counted practice flips to done.
     /// Preserves the last known streak across launches; resets on account switch.
     public static func resolvedStreak(
         userId: String,
-        primaryDoneToday: Bool,
+        practiceDoneToday: Bool,
         previous: WidgetData?,
         now: Date = Date()
     ) -> Int {
         guard let previous, previous.isLoggedIn, previous.userId == userId else {
-            return primaryDoneToday ? 1 : 0
+            return practiceDoneToday ? 1 : 0
         }
 
-        if primaryDoneToday && !previous.primaryDoneToday {
+        if practiceDoneToday && !previous.practiceDoneToday {
             return max(previous.streak, 0) + 1
         }
 
-        if primaryDoneToday && !isSameLocalDay(previous.lastUpdated, now) {
+        if practiceDoneToday && !isSameLocalDay(previous.lastUpdated, now) {
             // New local day and today is already complete (e.g. cold start after sync).
             return max(previous.streak, 0) + 1
         }
 
-        if !primaryDoneToday && !isSameLocalDay(previous.lastUpdated, now) {
+        if !practiceDoneToday && !isSameLocalDay(previous.lastUpdated, now) {
             // New day before today's sit: keep streak when yesterday was completed.
-            if previous.primaryDoneToday {
+            if previous.practiceDoneToday {
                 return max(previous.streak, 0)
             }
             return 0

--- a/ios/StillPointShared/Tests/StillPointSharedTests/WidgetDataTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/WidgetDataTests.swift
@@ -21,6 +21,7 @@ final class WidgetDataTests: XCTestCase {
             dualTrackEnabled: true,
             primaryDoneToday: true,
             secondDoneToday: false,
+            practiceDoneToday: true,
             streak: 5,
             lastUpdated: Date(timeIntervalSince1970: 1_700_000_000)
         )
@@ -34,7 +35,8 @@ final class WidgetDataTests: XCTestCase {
         let snapshot = WidgetDataStore.makeSnapshot(
             user: nil,
             primaryDoneToday: false,
-            secondDoneToday: false
+            secondDoneToday: false,
+            practiceDoneToday: false
         )
         XCTAssertEqual(snapshot, .loggedOut)
     }
@@ -51,12 +53,13 @@ final class WidgetDataTests: XCTestCase {
             user: user,
             primaryDoneToday: false,
             secondDoneToday: false,
+            practiceDoneToday: false,
             previous: nil
         )
         XCTAssertEqual(snapshot.currentDay, 1)
     }
 
-    func testResolvedStreakIncrementsWhenPrimaryDoneFlips() {
+    func testResolvedStreakIncrementsWhenPracticeDoneFlips() {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let previous = WidgetData(
             isLoggedIn: true,
@@ -66,13 +69,14 @@ final class WidgetDataTests: XCTestCase {
             dualTrackEnabled: false,
             primaryDoneToday: false,
             secondDoneToday: false,
+            practiceDoneToday: false,
             streak: 3,
             lastUpdated: now
         )
 
         let streak = WidgetDataStore.resolvedStreak(
             userId: "u1",
-            primaryDoneToday: true,
+            practiceDoneToday: true,
             previous: previous,
             now: now
         )
@@ -88,13 +92,14 @@ final class WidgetDataTests: XCTestCase {
             dualTrackEnabled: false,
             primaryDoneToday: true,
             secondDoneToday: false,
+            practiceDoneToday: true,
             streak: 8,
             lastUpdated: Date()
         )
 
         let streak = WidgetDataStore.resolvedStreak(
             userId: "new-user",
-            primaryDoneToday: false,
+            practiceDoneToday: false,
             previous: previous
         )
         XCTAssertEqual(streak, 0)
@@ -110,13 +115,14 @@ final class WidgetDataTests: XCTestCase {
             dualTrackEnabled: false,
             primaryDoneToday: false,
             secondDoneToday: false,
+            practiceDoneToday: false,
             streak: 6,
             lastUpdated: yesterday
         )
 
         let streak = WidgetDataStore.resolvedStreak(
             userId: "u1",
-            primaryDoneToday: false,
+            practiceDoneToday: false,
             previous: previous,
             now: Date()
         )
@@ -133,13 +139,14 @@ final class WidgetDataTests: XCTestCase {
             dualTrackEnabled: false,
             primaryDoneToday: true,
             secondDoneToday: false,
+            practiceDoneToday: true,
             streak: 6,
             lastUpdated: yesterday
         )
 
         let streak = WidgetDataStore.resolvedStreak(
             userId: "u1",
-            primaryDoneToday: false,
+            practiceDoneToday: false,
             previous: previous,
             now: Date()
         )
@@ -157,13 +164,14 @@ final class WidgetDataTests: XCTestCase {
             dualTrackEnabled: false,
             primaryDoneToday: true,
             secondDoneToday: false,
+            practiceDoneToday: true,
             streak: 5,
             lastUpdated: yesterday
         )
 
         let streak = WidgetDataStore.resolvedStreak(
             userId: "u1",
-            primaryDoneToday: true,
+            practiceDoneToday: true,
             previous: previous,
             now: now
         )
@@ -180,12 +188,13 @@ final class WidgetDataTests: XCTestCase {
             dualTrackEnabled: false,
             primaryDoneToday: true,
             secondDoneToday: false,
+            practiceDoneToday: true,
             streak: 6,
             lastUpdated: yesterday
         )
 
         let normalized = WidgetDataStore.normalizedForDisplay(stale, now: Date())
-        XCTAssertFalse(normalized.isPrimaryCompleteForToday(at: Date()))
+        XCTAssertFalse(normalized.isPracticeCompleteForToday(at: Date()))
         XCTAssertEqual(normalized.streak, 6)
     }
 
@@ -200,6 +209,7 @@ final class WidgetDataTests: XCTestCase {
             dualTrackEnabled: false,
             primaryDoneToday: true,
             secondDoneToday: false,
+            practiceDoneToday: true,
             streak: 9,
             lastUpdated: now
         )
@@ -208,6 +218,7 @@ final class WidgetDataTests: XCTestCase {
             user: user,
             primaryDoneToday: true,
             secondDoneToday: false,
+            practiceDoneToday: true,
             now: now,
             previous: previous
         )
@@ -262,9 +273,10 @@ final class WidgetDataTests: XCTestCase {
         XCTAssertEqual(decoded.completedDates, [])
         XCTAssertEqual(decoded.streak, 7)
         XCTAssertTrue(decoded.primaryDoneToday)
+        XCTAssertTrue(decoded.practiceDoneToday, "legacy blobs fall back to primaryDoneToday")
     }
 
-    func testRecentCompletedPrimaryDatesFiltersTypeTrackAndWindow() {
+    func testRecentCompletedPracticeDatesFiltersTypeTrackAndWindow() {
         let now = Date()
         let today = localDay(0, from: now)
         let twoDaysAgo = localDay(-2, from: now)
@@ -274,12 +286,13 @@ final class WidgetDataTests: XCTestCase {
             session(date: today, type: .standard, completed: true, track: .primary),
             session(date: twoDaysAgo, type: .standard, completed: true, track: nil), // nil treated as primary
             session(date: tenDaysAgo, type: .standard, completed: true, track: .primary), // outside 7-day window
-            session(date: today, type: .quick, completed: true, track: .primary), // quick excluded
+            session(date: today, type: .quick, completed: true, track: .primary), // quick counts (#589)
+            session(date: twoDaysAgo, type: .breath, completed: true, track: nil), // breath counts (#589)
             session(date: today, type: .standard, completed: false, track: .primary), // incomplete excluded
             session(date: today, type: .standard, completed: true, track: .second) // second track excluded
         ]
 
-        let result = WidgetDataStore.recentCompletedPrimaryDates(from: sessions, now: now)
+        let result = WidgetDataStore.recentCompletedPracticeDates(from: sessions, now: now)
         XCTAssertEqual(result, [today, twoDaysAgo])
     }
 
@@ -294,6 +307,7 @@ final class WidgetDataTests: XCTestCase {
             dualTrackEnabled: false,
             primaryDoneToday: false,
             secondDoneToday: false,
+            practiceDoneToday: false,
             streak: 3,
             completedDates: [today],
             lastUpdated: now
@@ -306,7 +320,7 @@ final class WidgetDataTests: XCTestCase {
         XCTAssertEqual(marks.first?.isToday, false)
     }
 
-    func testWeekMarksChecksTodayViaPrimaryFlagWithoutCompletedDate() {
+    func testWeekMarksChecksTodayViaPracticeFlagWithoutCompletedDate() {
         let now = Date()
         let data = WidgetData(
             isLoggedIn: true,
@@ -314,8 +328,9 @@ final class WidgetDataTests: XCTestCase {
             currentDay: 5,
             secondTrackDay: 1,
             dualTrackEnabled: false,
-            primaryDoneToday: true,
+            primaryDoneToday: false,
             secondDoneToday: false,
+            practiceDoneToday: true,
             streak: 3,
             completedDates: [],
             lastUpdated: now
@@ -334,6 +349,7 @@ final class WidgetDataTests: XCTestCase {
             dualTrackEnabled: false,
             primaryDoneToday: false,
             secondDoneToday: false,
+            practiceDoneToday: false,
             streak: 4,
             completedDates: [twoDaysAgo],
             lastUpdated: now
@@ -342,18 +358,20 @@ final class WidgetDataTests: XCTestCase {
             user: makeUser(id: "u1"),
             primaryDoneToday: false,
             secondDoneToday: false,
+            practiceDoneToday: false,
             now: now,
             previous: previous
         )
         XCTAssertEqual(snapshot.completedDates, [twoDaysAgo])
     }
 
-    func testMakeSnapshotFoldsTodayWhenPrimaryDone() {
+    func testMakeSnapshotFoldsTodayWhenPracticeDone() {
         let now = Date()
         let snapshot = WidgetDataStore.makeSnapshot(
             user: makeUser(id: "u1"),
-            primaryDoneToday: true,
+            primaryDoneToday: false,
             secondDoneToday: false,
+            practiceDoneToday: true,
             now: now,
             previous: nil
         )
@@ -372,6 +390,7 @@ final class WidgetDataTests: XCTestCase {
             dualTrackEnabled: false,
             primaryDoneToday: false,
             secondDoneToday: false,
+            practiceDoneToday: false,
             streak: 4,
             completedDates: ["1999-01-01"], // stale; must be discarded
             lastUpdated: now
@@ -380,9 +399,10 @@ final class WidgetDataTests: XCTestCase {
             user: makeUser(id: "u1"),
             primaryDoneToday: false,
             secondDoneToday: false,
+            practiceDoneToday: false,
             now: now,
             previous: previous,
-            completedPrimaryDates: [today, threeDaysAgo]
+            completedPracticeDates: [today, threeDaysAgo]
         )
         XCTAssertEqual(Set(snapshot.completedDates), [today, threeDaysAgo])
     }
@@ -397,6 +417,7 @@ final class WidgetDataTests: XCTestCase {
             dualTrackEnabled: false,
             primaryDoneToday: false,
             secondDoneToday: false,
+            practiceDoneToday: false,
             streak: 4,
             completedDates: [localDay(-2, from: now)],
             lastUpdated: now
@@ -405,6 +426,7 @@ final class WidgetDataTests: XCTestCase {
             user: makeUser(id: "new-user"),
             primaryDoneToday: false,
             secondDoneToday: false,
+            practiceDoneToday: false,
             now: now,
             previous: previous
         )
@@ -423,6 +445,7 @@ final class WidgetDataTests: XCTestCase {
             dualTrackEnabled: false,
             primaryDoneToday: true,
             secondDoneToday: false,
+            practiceDoneToday: true,
             streak: 6,
             completedDates: ["2000-01-01", inWindow],
             lastUpdated: yesterday
@@ -432,21 +455,49 @@ final class WidgetDataTests: XCTestCase {
     }
 
     /// Authoritative (session-derived) path must not inject today from a possibly
-    /// stale `primaryDoneToday` flag — it trusts the fetched completion set.
+    /// stale `practiceDoneToday` flag — it trusts the fetched completion set.
     func testMakeSnapshotDoesNotFoldTodayWhenSessionsAuthoritative() {
         let now = Date()
         let today = localDay(0, from: now)
         let threeDaysAgo = localDay(-3, from: now)
         let snapshot = WidgetDataStore.makeSnapshot(
             user: makeUser(id: "u1"),
-            primaryDoneToday: true, // stale flag; sessions say today is not complete
+            primaryDoneToday: true,
             secondDoneToday: false,
+            practiceDoneToday: true, // stale flag; sessions say today is not complete
             now: now,
             previous: nil,
-            completedPrimaryDates: [threeDaysAgo]
+            completedPracticeDates: [threeDaysAgo]
         )
         XCTAssertFalse(snapshot.completedDates.contains(today))
         XCTAssertEqual(snapshot.completedDates, [threeDaysAgo])
+    }
+
+    /// Quick-only practice must extend widget streak (#589).
+    func testMakeSnapshotIncrementsStreakForQuickOnlyDay() {
+        let now = Date()
+        let previous = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 5,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            practiceDoneToday: false,
+            streak: 2,
+            lastUpdated: now
+        )
+        let snapshot = WidgetDataStore.makeSnapshot(
+            user: makeUser(id: "u1"),
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            practiceDoneToday: true,
+            now: now,
+            previous: previous
+        )
+        XCTAssertEqual(snapshot.streak, 3)
+        XCTAssertTrue(snapshot.completedDates.contains(localDay(0, from: now)))
     }
 
     /// `localDayString` must emit Gregorian digits even when the supplied calendar
@@ -470,6 +521,7 @@ final class WidgetDataTests: XCTestCase {
             dualTrackEnabled: false,
             primaryDoneToday: false,
             secondDoneToday: false,
+            practiceDoneToday: false,
             streak: 3,
             completedDates: [],
             lastUpdated: now


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #589 — the habit widget's streak and weekday checkmark row now count **quick (60s)** and **breath** sits in addition to the primary standard sit.

## Changes

### `WidgetData.swift` / `WidgetDataStore`
- Added `practiceDoneToday` to the widget snapshot (backward-compatible decode: falls back to `primaryDoneToday` for legacy blobs).
- Renamed session-derived completion helper to `recentCompletedPracticeDates`, including `.quick` and `.breath` sessions (still excludes second-track standard sits).
- Streak resolution (`resolvedStreak`), weekday marks (`weekMarks`), midnight normalization, and `makeSnapshot` now key off counted practice instead of primary standard only.

### `AppViewModel.swift` (#590 coordination)
- Tracks `practiceDoneToday` separately from `primaryDoneToday` (Home badges unchanged).
- `markPracticeDoneToday()` syncs widget data immediately on quick/breath/primary completion.
- `completeBreathSession` and `completeSession` call into the shared helper.
- `refreshWidgetWeekHistory` uses the expanded practice date set.

### Tests
- Updated `WidgetDataTests` and added coverage for quick-only streak increment and quick/breath date inclusion.

## Verification

- [ ] `StillPointShared swift test` (CI — no Swift toolchain in cloud agent environment)
- App build: CI-only per issue scope

## Merge note

`AppViewModel.swift` is shared with #590 — whoever merges second should rebase.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f9a96e6-86ce-4c6a-aa94-ad5966af4b06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f9a96e6-86ce-4c6a-aa94-ad5966af4b06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Count quick and breath practice in the habit widget**

### What Changed
- The habit widget now treats primary standard sits, quick sits, and breath sits as counted practice for streaks and weekday checkmarks
- Completing quick or breath practice updates the widget right away instead of waiting for a later refresh
- Widget history now keeps this practice count across app launches and still handles older saved widget data

### Impact
`✅ Habit widget streaks match quick and breath practice`
`✅ Fewer missing checkmarks after non-standard sits`
`✅ Faster widget updates after completing practice`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
