### PR TITLE
feat(ios): last-used sign-in tag across all AuthView methods (#528)

### DIFF
--- a/ios/PARITY_CHECKLIST.md
+++ b/ios/PARITY_CHECKLIST.md
@@ -1,6 +1,6 @@
 # iOS vs Web Feature Parity Checklist (Issue #210)
 
-Last updated: 2026-07-17  
+Last updated: 2026-07-21  
 Release owner: iOS release DRI
 
 ## Core product parity
@@ -8,6 +8,7 @@ Release owner: iOS release DRI
 | Area | Web | iOS | Status | Notes |
 |---|---|---|---|---|
 | Auth (sign up / login / logout / persisted session) | Implemented | Implemented | ✅ Complete | iOS uses the same `/api/auth/*` endpoints via `StillPointShared/APIClient.swift`. |
+| Auth "last used" sign-in tag (#337 / #528) | OAuth only (Google, Apple) | All methods (email/password, Google, Apple) | ✅ Complete | Web: `AuthScreen.tsx` + `lastAuthProvider.ts`. iOS: `AuthView.swift` + `StillPointShared/LastAuthProvider.swift` (UserDefaults key `stillpoint_last_auth_provider`). |
 | Home + day progression CTA | Implemented | Implemented | ✅ Complete | “Begin” + day-based duration behavior is present on both clients. |
 | L1–L5 lesson pathway on Home (#452 / #525) | Implemented | Implemented | ✅ Complete | Shared derivation in `src/lib/pathway.ts` / `StillPointShared/Pathway.swift`; UI in `Pathway.tsx` / `PathwayView.swift` embedded in each client's Home. |
 | Solo session timer + pause for “I’m thinking” | Implemented | Implemented | ✅ Complete | Shared session timing logic is in `StillPointShared/SessionLogic.swift`. |

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -300,6 +300,7 @@ final class AppViewModel {
             buddyInviteError = nil
             authStatusMessage = nil
             resetTrackCompletionBadges()
+            LastAuthProvider.resetPersisted()
             currentView = .auth
             SessionNotificationSuppressionController.clearSuppressPreference()
             syncWidgetData()

--- a/ios/StillPointApp/Views/AuthView.swift
+++ b/ios/StillPointApp/Views/AuthView.swift
@@ -7,6 +7,7 @@ struct AuthView: View {
     @State private var vm = AuthViewModel()
     @State private var appleSignInRawNonce: String?
     @State private var appleSignInInFlight = false
+    @State private var lastUsedMethod: LastAuthProvider.Method?
     let launchAuthStatusMessage: String?
 
     var body: some View {
@@ -84,6 +85,7 @@ struct AuthView: View {
                     Button {
                         Task {
                             if let user = await vm.submit() {
+                                LastAuthProvider.save(.email)
                                 appVM.didLogin(user: user)
                             }
                         }
@@ -92,6 +94,16 @@ struct AuthView: View {
                             .font(SPFont.serifItalic(18, weight: .light))
                             .spCapsuleButtonStyle(.neutral, size: .fullWidth, prominent: true)
                     }
+                    .overlay(alignment: .trailing) {
+                        if lastUsedMethod == .email {
+                            LastUsedAuthTag(onDark: false)
+                        }
+                    }
+                    .accessibilityLabel(
+                        lastUsedMethod == .email
+                            ? (vm.isSignUp ? "Begin the journey (last used)" : "Enter (last used)")
+                            : (vm.isSignUp ? "Begin the journey" : "Enter")
+                    )
                     .accessibilityIdentifier("auth.submitButton")
                     .disabled(!vm.isValid || vm.isAuthInFlight)
                     .opacity(vm.isValid && !vm.isAuthInFlight ? 1 : 0.5)
@@ -139,6 +151,7 @@ struct AuthView: View {
                         Button {
                             Task {
                                 if let user = await vm.signInWithGoogle() {
+                                    LastAuthProvider.save(.google)
                                     appVM.didLogin(user: user)
                                 }
                             }
@@ -154,6 +167,16 @@ struct AuthView: View {
                             .foregroundStyle(Color(SPColor.fg))
                             .frame(height: 44)
                         }
+                        .overlay(alignment: .trailing) {
+                            if lastUsedMethod == .google {
+                                LastUsedAuthTag(onDark: false)
+                            }
+                        }
+                        .accessibilityLabel(
+                            lastUsedMethod == .google
+                                ? "Continue with Google (last used)"
+                                : "Continue with Google"
+                        )
                         .accessibilityIdentifier("auth.googleButton")
                         .disabled(vm.isAuthInFlight)
                         .opacity(vm.isAuthInFlight ? 0.5 : 1)
@@ -197,6 +220,7 @@ struct AuthView: View {
                                         appleSignInRawNonce = nil
                                     }
                                     if let user = await vm.signInWithApple(using: body) {
+                                        LastAuthProvider.save(.apple)
                                         appVM.didLogin(user: user)
                                     }
                                 }
@@ -214,6 +238,16 @@ struct AuthView: View {
                         .frame(height: 44)
                         .clipShape(Capsule())
                         .overlay(Capsule().stroke(SPColor.border2))
+                        .overlay(alignment: .trailing) {
+                            if lastUsedMethod == .apple {
+                                LastUsedAuthTag(onDark: true)
+                            }
+                        }
+                        .accessibilityLabel(
+                            lastUsedMethod == .apple
+                                ? "Continue with Apple (last used)"
+                                : "Continue with Apple"
+                        )
                         .disabled(vm.isAuthInFlight || appleSignInInFlight)
                         .opacity(vm.isAuthInFlight || appleSignInInFlight ? 0.5 : 1)
                     }
@@ -223,6 +257,9 @@ struct AuthView: View {
             .padding(.bottom, SPSpacing.s6)
         }
         .stillPointBackground()
+        .onAppear {
+            lastUsedMethod = LastAuthProvider.load()
+        }
     }
 
     private var isUiTestMode: Bool {
@@ -253,6 +290,29 @@ struct AuthView: View {
                     .stroke(SPColor.border2)
             )
             .foregroundStyle(Color(SPColor.fg))
+    }
+}
+
+/// Small pill badge mirroring web `LastUsedTag` in `AuthScreen.tsx` (#337 / #528).
+private struct LastUsedAuthTag: View {
+    let onDark: Bool
+
+    var body: some View {
+        Text("last used")
+            .font(SPFont.mono(8))
+            .tracking(1)
+            .textCase(.uppercase)
+            .foregroundStyle(onDark ? Color.white.opacity(0.65) : Color(SPColor.fg3))
+            .padding(.horizontal, 7)
+            .padding(.vertical, 4)
+            .background(onDark ? Color.white.opacity(0.08) : SPColor.surface1)
+            .clipShape(Capsule())
+            .overlay(
+                Capsule().stroke(onDark ? Color.white.opacity(0.25) : SPColor.border2)
+            )
+            .padding(.trailing, SPSpacing.s3)
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
     }
 }
 

--- a/ios/StillPointShared/Sources/StillPointShared/LastAuthProvider.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/LastAuthProvider.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Tracks which sign-in method the user last used successfully (#528 / web #337).
+///
+/// Persists to `UserDefaults` with the same key as web `localStorage` so values
+/// could theoretically be shared if the platforms ever share storage (they do not
+/// today, but the key keeps naming parity).
+public enum LastAuthProvider {
+    public static let storageKey = "stillpoint_last_auth_provider"
+
+    public enum Method: String, CaseIterable, Sendable {
+        case google
+        case apple
+        case email
+    }
+
+    public static func load() -> Method? {
+        guard let raw = UserDefaults.standard.string(forKey: storageKey) else { return nil }
+        return Method(rawValue: raw)
+    }
+
+    public static func save(_ method: Method) {
+        UserDefaults.standard.set(method.rawValue, forKey: storageKey)
+    }
+
+    /// Wipes persisted value. Used by unit tests and UI-test reset paths.
+    public static func resetPersisted() {
+        UserDefaults.standard.removeObject(forKey: storageKey)
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/LastAuthProvider.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/LastAuthProvider.swift
@@ -23,7 +23,7 @@ public enum LastAuthProvider {
         UserDefaults.standard.set(method.rawValue, forKey: storageKey)
     }
 
-    /// Wipes persisted value. Used by unit tests and UI-test reset paths.
+    /// Wipes persisted value. Called on logout and UI-test reset paths.
     public static func resetPersisted() {
         UserDefaults.standard.removeObject(forKey: storageKey)
     }

--- a/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
@@ -69,6 +69,7 @@ actor UITestAPIStore {
             defaults.removeObject(forKey: defaultsKey)
             AudioEngine.resetPersistedPrefs()
             SessionIntroPrefs.resetPersistedPrefs()
+            LastAuthProvider.resetPersisted()
             // Flush the in-memory cache to cfprefsd so the immediately
             // following read sees the cleared state. Issue #266 follow-up.
             defaults.synchronize()

--- a/ios/StillPointShared/Tests/StillPointSharedTests/LastAuthProviderTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/LastAuthProviderTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import StillPointShared
+
+final class LastAuthProviderTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        LastAuthProvider.resetPersisted()
+    }
+
+    override func tearDown() {
+        LastAuthProvider.resetPersisted()
+        super.tearDown()
+    }
+
+    func testLoadReturnsNilWhenNothingStored() {
+        XCTAssertNil(LastAuthProvider.load())
+    }
+
+    func testSaveAndLoadRoundTripForGoogle() {
+        LastAuthProvider.save(.google)
+        XCTAssertEqual(LastAuthProvider.load(), .google)
+    }
+
+    func testSaveAndLoadRoundTripForApple() {
+        LastAuthProvider.save(.apple)
+        XCTAssertEqual(LastAuthProvider.load(), .apple)
+    }
+
+    func testSaveAndLoadRoundTripForEmail() {
+        LastAuthProvider.save(.email)
+        XCTAssertEqual(LastAuthProvider.load(), .email)
+    }
+
+    func testSaveOverwritesPreviousProvider() {
+        LastAuthProvider.save(.google)
+        LastAuthProvider.save(.email)
+        XCTAssertEqual(LastAuthProvider.load(), .email)
+    }
+
+    func testLoadReturnsNilForUnknownStoredValue() {
+        UserDefaults.standard.set("github", forKey: LastAuthProvider.storageKey)
+        XCTAssertNil(LastAuthProvider.load())
+    }
+
+    func testResetClearsStoredProvider() {
+        LastAuthProvider.save(.apple)
+        LastAuthProvider.resetPersisted()
+        XCTAssertNil(LastAuthProvider.load())
+    }
+
+    func testStorageKeyMatchesWebLocalStorageKey() {
+        XCTAssertEqual(LastAuthProvider.storageKey, "stillpoint_last_auth_provider")
+    }
+}


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #528 — iOS parity for the web "last used" sign-in indicator, expanded per product to cover **all three** auth methods (email/password, Google, Apple).

- Adds `StillPointShared/LastAuthProvider.swift` with UserDefaults persistence using the same key as web (`stillpoint_last_auth_provider`)
- Shows a trailing "last used" pill on the matching button in `AuthView` (Enter/Begin, Google, Apple)
- Persists the method only after a successful sign-in
- Updates accessibility labels when the badge is shown
- Adds `LastAuthProviderTests` (8 cases) and updates `ios/PARITY_CHECKLIST.md`

## Test plan

- [x] `LastAuthProviderTests` added (round-trip, overwrite, invalid value, reset, storage key parity)
- [ ] CI: `StillPointShared swift test` (macOS runner — not runnable on Linux cloud agent)
- [ ] Manual: sign in with each method, log out, confirm badge appears on the correct button
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bac664dd-2e12-4e45-8cc6-95b3aad01090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bac664dd-2e12-4e45-8cc6-95b3aad01090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Show the last-used sign-in method on the matching Auth button**

### What Changed
- The sign-in screen now shows a small “last used” badge on the button for the method the user last signed in with, across email/password, Google, and Apple
- The app now remembers the last successful sign-in method and restores it when the auth screen opens again
- The badge is hidden from screen readers, while the matching button gets a clearer label when the badge is shown
- Adds checks for saving, loading, overwriting, and clearing the remembered sign-in method

### Impact
`✅ Faster return sign-in`
`✅ Clearer login choice on revisit`
`✅ More consistent auth screen behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
