### PR TITLE
Pathway coming-soon preview — stop day-derived fake progress (#587)

### DIFF
--- a/ios/PARITY_CHECKLIST.md
+++ b/ios/PARITY_CHECKLIST.md
@@ -9,7 +9,7 @@ Release owner: iOS release DRI
 |---|---|---|---|---|
 | Auth (sign up / login / logout / persisted session) | Implemented | Implemented | ✅ Complete | iOS uses the same `/api/auth/*` endpoints via `StillPointShared/APIClient.swift`. |
 | Home + day progression CTA | Implemented | Implemented | ✅ Complete | “Begin” + day-based duration behavior is present on both clients. |
-| L1–L5 lesson pathway on Home (#452 / #525) | Implemented | Implemented | ✅ Complete | Shared derivation in `src/lib/pathway.ts` / `StillPointShared/Pathway.swift`; UI in `Pathway.tsx` / `PathwayView.swift` embedded in each client's Home. |
+| L1–L5 lesson pathway on Home (#452 / #525 / #587) | Implemented | Implemented | ✅ Complete | Shared structure in `src/lib/pathway.ts` / `StillPointShared/Pathway.swift`; UI in `Pathway.tsx` / `PathwayView.swift`. Coming-soon preview — not derived from day count. |
 | Solo session timer + pause for “I’m thinking” | Implemented | Implemented | ✅ Complete | Shared session timing logic is in `StillPointShared/SessionLogic.swift`. |
 | Thought capture during session | Implemented | Implemented | ✅ Complete | Both clients write to `/api/thoughts/batch`. |
 | Completion screen + end note | Implemented | Implemented | ✅ Complete | End note uses `timeInSession = -1` in both clients. |

--- a/ios/StillPointApp/Components/PathwayView.swift
+++ b/ios/StillPointApp/Components/PathwayView.swift
@@ -1,15 +1,12 @@
 import SwiftUI
 import StillPointShared
 
-/// Duolingo-style L1–L5 lesson pathway (#525). Mirrors `src/components/Pathway.tsx`.
+/// Duolingo-style L1–L5 lesson pathway preview (#525 / #587). Mirrors `src/components/Pathway.tsx`.
 struct PathwayView: View {
-    let currentDay: Int
-
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var pulse = false
+    @State private var showComingSoonAlert = false
 
     private var levels: [Pathway.PathwayLevel] {
-        Pathway.build(currentDay: currentDay)
+        Pathway.build()
     }
 
     var body: some View {
@@ -29,6 +26,9 @@ struct PathwayView: View {
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Lesson pathway")
         .accessibilityIdentifier("home.pathway")
+        .alert(Pathway.comingSoonMessage, isPresented: $showComingSoonAlert) {
+            Button("OK", role: .cancel) {}
+        }
     }
 
     @ViewBuilder
@@ -37,24 +37,21 @@ struct PathwayView: View {
             HStack(alignment: .firstTextBaseline) {
                 Text("L\(level.level) · \(level.name)")
                     .font(SPFont.mono(11, weight: .regular))
-                    .foregroundStyle(levelLabelColor(level.state))
+                    .foregroundStyle(Color(SPColor.fg3))
                     .tracking(1.32)
                     .textCase(.uppercase)
-                    .opacity(level.state == .locked ? 0.7 : 1)
 
                 Spacer()
 
-                Text("\(level.completedCount)/\(level.nodes.count)")
+                Text("Coming soon")
                     .font(SPFont.mono(11, weight: .regular))
-                    .foregroundStyle(Color(SPColor.fg3))
+                    .foregroundStyle(Color(SPColor.fg4))
             }
 
             HStack(spacing: 0) {
                 ForEach(Array(level.nodes.enumerated()), id: \.element.day) { index, node in
                     if index > 0 {
-                        connectorLine(
-                            completed: level.nodes[index - 1].state == .completed
-                        )
+                        connectorLine()
                     }
                     nodeView(node)
                 }
@@ -62,46 +59,21 @@ struct PathwayView: View {
         }
     }
 
-    @ViewBuilder
     private func nodeView(_ node: Pathway.PathwayNode) -> some View {
-        switch node.state {
-        case .completed:
-            nodeCircle(
-                label: "✓",
-                fontSize: 13,
-                borderWidth: 1,
-                borderColor: SPColor.greenBorder,
-                background: SPColor.greenBgSubtle,
-                foreground: SPColor.green,
-                pulse: false
-            )
-            .accessibilityLabel("Day \(node.day), completed")
-
-        case .current:
-            nodeCircle(
-                label: "\(node.day)",
-                fontSize: 11,
-                borderWidth: 2,
-                borderColor: SPColor.amber,
-                background: SPColor.amberBg,
-                foreground: SPColor.amber,
-                pulse: !reduceMotion
-            )
-            .accessibilityLabel("Day \(node.day), current lesson")
-            .accessibilityAddTraits(.isSelected)
-
-        case .locked:
+        Button {
+            showComingSoonAlert = true
+        } label: {
             nodeCircle(
                 label: "\(node.day)",
                 fontSize: 11,
                 borderWidth: 1,
                 borderColor: SPColor.border1,
                 background: SPColor.surface1,
-                foreground: SPColor.fg4,
-                pulse: false
+                foreground: SPColor.fg4
             )
-            .accessibilityLabel("Day \(node.day), locked")
         }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Day \(node.day), lessons coming soon")
     }
 
     private func nodeCircle(
@@ -110,11 +82,10 @@ struct PathwayView: View {
         borderWidth: CGFloat,
         borderColor: Color,
         background: Color,
-        foreground: Color,
-        pulse: Bool
+        foreground: Color
     ) -> some View {
         Text(label)
-            .font(SPFont.mono(fontSize, weight: pulse ? .semibold : .regular))
+            .font(SPFont.mono(fontSize, weight: .regular))
             .foregroundStyle(foreground)
             .frame(minWidth: 0, maxWidth: 30)
             .aspectRatio(1, contentMode: .fit)
@@ -124,29 +95,13 @@ struct PathwayView: View {
                 Circle()
                     .strokeBorder(borderColor, lineWidth: borderWidth)
             )
-            .scaleEffect(pulse && self.pulse ? 1.06 : 1.0)
-            .opacity(pulse && self.pulse ? 1.0 : (pulse ? 0.88 : 1.0))
-            .onAppear {
-                guard pulse else { return }
-                withAnimation(.easeInOut(duration: 2.4).repeatForever(autoreverses: true)) {
-                    self.pulse = true
-                }
-            }
             .layoutPriority(1)
     }
 
-    private func connectorLine(completed: Bool) -> some View {
+    private func connectorLine() -> some View {
         Rectangle()
-            .fill(completed ? SPColor.greenBorder : SPColor.border1)
+            .fill(SPColor.border1)
             .frame(height: 1)
             .frame(minWidth: 4, maxWidth: .infinity)
-    }
-
-    private func levelLabelColor(_ state: Pathway.NodeState) -> Color {
-        switch state {
-        case .completed: Color(SPColor.greenText)
-        case .current: Color(SPColor.amberText)
-        case .locked: Color(SPColor.fg3)
-        }
     }
 }

--- a/ios/StillPointApp/Views/HomeView.swift
+++ b/ios/StillPointApp/Views/HomeView.swift
@@ -77,10 +77,10 @@ struct HomeView: View {
                     dualTrackForkCard
                 }
 
-                // L1–L5 lesson pathway (#525) — primary track day drives unlock state.
+                // L1–L5 lesson pathway preview (#525 / #587) — not tied to day count.
                 // Suppressed during UI tests (extra vertical content can push Begin off-screen).
                 if ProcessInfo.processInfo.environment["SP_UI_TEST_MODE"] != "1" {
-                    PathwayView(currentDay: appVM.currentDay)
+                    PathwayView()
                 }
 
                 aphorismSection

--- a/ios/StillPointShared/Sources/StillPointShared/Pathway.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/Pathway.swift
@@ -1,11 +1,12 @@
 import Foundation
 
-/// Duolingo-style pathway derivation (#336 / #525).
+/// Duolingo-style pathway structure (#336 / #525).
 ///
-/// Levels and node states are derived purely from the user's `currentDay`; there
-/// is no backend or migration. `currentDay` is the day the user is *on* (not yet
-/// completed) — completing a standard sit advances it by one. Mirrors
-/// `src/lib/pathway.ts` on web — keep both in sync.
+/// L1–L5 levels and node layout are fixed. Until real lesson content ships,
+/// every node is a coming-soon preview — node state is **not** derived from
+/// `currentDay` (#587). When lessons exist, real completions can drive
+/// `completed` / `current` / `locked`. Mirrors `src/lib/pathway.ts` — keep
+/// both in sync.
 public enum Pathway {
     /// Days that make up a single level. Five levels cover days 1–50.
     public static let daysPerLevel = 10
@@ -24,10 +25,14 @@ public enum Pathway {
     /// Highest day represented in the pathway (L5, day 10).
     public static let pathwayMaxDay = totalLevels * daysPerLevel
 
+    /// Copy shown when a pathway node is tapped before lessons ship.
+    public static let comingSoonMessage = "Lessons coming soon"
+
     public enum NodeState: String, Equatable, Sendable {
         case completed
         case current
         case locked
+        case comingSoon
     }
 
     public struct PathwayNode: Equatable, Sendable {
@@ -70,38 +75,23 @@ public enum Pathway {
     }
 
     /// Resolve a single day's node state relative to `currentDay`.
+    /// Reserved for future real-lesson progression — not used by `build()`.
     public static func nodeState(forDay day: Int, currentDay: Int) -> NodeState {
         if day < currentDay { return .completed }
         if day == currentDay { return .current }
         return .locked
     }
 
-    /// Build the full L1–L5 pathway for a given `currentDay`. Sub-1 inputs are
-    /// clamped to day 1 so the first node is always the current one.
-    public static func build(currentDay: Int) -> [PathwayLevel] {
-        let day = max(1, currentDay)
-
+    /// Build the L1–L5 pathway preview. Every node is `comingSoon` until lesson
+    /// completions drive state (#587).
+    public static func build() -> [PathwayLevel] {
         var levels: [PathwayLevel] = []
         for level in 1...totalLevels {
             var nodes: [PathwayNode] = []
-            var completedCount = 0
 
             for dayInLevel in 1...daysPerLevel {
                 let nodeDay = (level - 1) * daysPerLevel + dayInLevel
-                let state = nodeState(forDay: nodeDay, currentDay: day)
-                if state == .completed { completedCount += 1 }
-                nodes.append(PathwayNode(day: nodeDay, dayInLevel: dayInLevel, state: state))
-            }
-
-            let levelStartDay = (level - 1) * daysPerLevel + 1
-            let levelEndDay = level * daysPerLevel
-            let state: NodeState
-            if day > levelEndDay {
-                state = .completed
-            } else if day >= levelStartDay {
-                state = .current
-            } else {
-                state = .locked
+                nodes.append(PathwayNode(day: nodeDay, dayInLevel: dayInLevel, state: .comingSoon))
             }
 
             levels.append(
@@ -109,8 +99,8 @@ public enum Pathway {
                     level: level,
                     name: levelNames[level - 1],
                     nodes: nodes,
-                    completedCount: completedCount,
-                    state: state
+                    completedCount: 0,
+                    state: .comingSoon
                 )
             )
         }

--- a/ios/StillPointShared/Tests/StillPointSharedTests/PathwayTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/PathwayTests.swift
@@ -3,7 +3,7 @@ import StillPointShared
 
 final class PathwayTests: XCTestCase {
     func testProducesFiveNamedLevelsWithTenNodesEach() {
-        let levels = Pathway.build(currentDay: 1)
+        let levels = Pathway.build()
         XCTAssertEqual(levels.count, Pathway.totalLevels)
         XCTAssertEqual(levels.map(\.name), Pathway.levelNames)
         for level in levels {
@@ -12,7 +12,7 @@ final class PathwayTests: XCTestCase {
     }
 
     func testNodeDaysAreContiguousFromOneThroughFifty() {
-        let days = Pathway.build(currentDay: 1).flatMap { $0.nodes.map(\.day) }
+        let days = Pathway.build().flatMap { $0.nodes.map(\.day) }
         XCTAssertEqual(days, Array(1...Pathway.pathwayMaxDay))
     }
 
@@ -24,59 +24,21 @@ final class PathwayTests: XCTestCase {
         XCTAssertEqual(Pathway.nodeState(forDay: 50, currentDay: 5), .locked)
     }
 
-    func testDayOneFirstNodeCurrentRestLocked() {
-        let first = Pathway.build(currentDay: 1)[0]
-        XCTAssertEqual(first.nodes[0].state, .current)
-        XCTAssertTrue(first.nodes.dropFirst().allSatisfy { $0.state == .locked })
-        XCTAssertEqual(first.completedCount, 0)
-        XCTAssertEqual(first.state, .current)
-    }
-
-    func testMidLevelCurrentDayMarksStatesCorrectly() {
-        let levels = Pathway.build(currentDay: 13)
-        let l1 = levels[0]
-        let l2 = levels[1]
-        XCTAssertEqual(l1.state, .completed)
-        XCTAssertEqual(l1.completedCount, Pathway.daysPerLevel)
-        XCTAssertTrue(l1.nodes.allSatisfy { $0.state == .completed })
-
-        XCTAssertEqual(l2.state, .current)
-        XCTAssertEqual(l2.completedCount, 2)
-        XCTAssertEqual(l2.nodes[0].state, .completed)
-        XCTAssertEqual(l2.nodes[1].state, .completed)
-        XCTAssertEqual(l2.nodes[2].state, .current)
-        XCTAssertEqual(l2.nodes[3].state, .locked)
-    }
-
-    func testExactlyOneNodeIsCurrentWithinPathwayRange() {
-        let currents = Pathway.build(currentDay: 27)
-            .flatMap(\.nodes)
-            .filter { $0.state == .current }
-        XCTAssertEqual(currents.count, 1)
-        XCTAssertEqual(currents.map(\.day), [27])
-    }
-
-    func testCurrentDayBeyondProgramCompletesEveryNode() {
-        let levels = Pathway.build(currentDay: Pathway.pathwayMaxDay + 5)
+    func testDoesNotDeriveCompletedOrCurrentNodesFromDayCount() {
+        let levels = Pathway.build()
         let allNodes = levels.flatMap(\.nodes)
-        XCTAssertTrue(allNodes.allSatisfy { $0.state == .completed })
-        XCTAssertTrue(levels.allSatisfy { $0.state == .completed })
+        XCTAssertTrue(allNodes.allSatisfy { $0.state == .comingSoon })
+        XCTAssertTrue(levels.allSatisfy { $0.state == .comingSoon })
+        XCTAssertTrue(levels.allSatisfy { $0.completedCount == 0 })
+        XCTAssertFalse(allNodes.contains { $0.state == .completed })
+        XCTAssertFalse(allNodes.contains { $0.state == .current })
     }
 
-    func testCurrentDayExactlyAtLastDayKeepsItCurrent() {
-        let last = Pathway.build(currentDay: Pathway.pathwayMaxDay)[Pathway.totalLevels - 1]
-        XCTAssertEqual(last.nodes[Pathway.daysPerLevel - 1].state, .current)
-        XCTAssertEqual(last.state, .current)
+    func testExposesComingSoonCopyForTapAffordance() {
+        XCTAssertEqual(Pathway.comingSoonMessage, "Lessons coming soon")
     }
 
-    func testClampsSubOneInputToDayOne() {
-        for input in [0, -5] {
-            let levels = Pathway.build(currentDay: input)
-            XCTAssertEqual(levels[0].nodes[0].state, .current, "input \(input)")
-        }
-    }
-
-    // MARK: - Shared cross-platform fixtures (#421 / #525)
+    // MARK: - Shared cross-platform fixtures (#421 / #525 / #587)
 
     func testSharedPathwayFixtures() throws {
         let fixture = try SharedFixtures.load("pathway.json", as: PathwayFixture.self)
@@ -85,6 +47,7 @@ final class PathwayTests: XCTestCase {
         XCTAssertEqual(Pathway.totalLevels, fixture.totalLevels)
         XCTAssertEqual(Pathway.pathwayMaxDay, fixture.pathwayMaxDay)
         XCTAssertEqual(Pathway.levelNames, fixture.levelNames)
+        XCTAssertEqual(Pathway.comingSoonMessage, fixture.comingSoonMessage)
 
         for testCase in fixture.nodeStateForDay {
             let actual = Pathway.nodeState(forDay: testCase.day, currentDay: testCase.currentDay)
@@ -92,7 +55,7 @@ final class PathwayTests: XCTestCase {
         }
 
         for testCase in fixture.buildPathway {
-            let levels = Pathway.build(currentDay: testCase.currentDay)
+            let levels = Pathway.build()
 
             if let expectedLevelCount = testCase.expectedLevelCount {
                 XCTAssertEqual(levels.count, expectedLevelCount, testCase.name)
@@ -103,34 +66,16 @@ final class PathwayTests: XCTestCase {
                 XCTAssertEqual(days, expectedAllDays, testCase.name)
             }
 
-            if let expectedCurrentNodeCount = testCase.expectedCurrentNodeCount {
-                let currents = levels.flatMap(\.nodes).filter { $0.state == .current }
-                XCTAssertEqual(currents.count, expectedCurrentNodeCount, testCase.name)
+            if testCase.expectedAllNodesComingSoon == true {
+                XCTAssertTrue(levels.flatMap(\.nodes).allSatisfy { $0.state == .comingSoon }, testCase.name)
             }
 
-            if let expectedCurrentNodeDay = testCase.expectedCurrentNodeDay {
-                let currents = levels.flatMap(\.nodes).filter { $0.state == .current }
-                XCTAssertEqual(currents.first?.day, expectedCurrentNodeDay, testCase.name)
+            if testCase.expectedAllLevelsComingSoon == true {
+                XCTAssertTrue(levels.allSatisfy { $0.state == .comingSoon }, testCase.name)
             }
 
-            if testCase.expectedAllNodesCompleted == true {
-                XCTAssertTrue(levels.flatMap(\.nodes).allSatisfy { $0.state == .completed }, testCase.name)
-            }
-
-            if testCase.expectedAllLevelsCompleted == true {
-                XCTAssertTrue(levels.allSatisfy { $0.state == .completed }, testCase.name)
-            }
-
-            if let expectedLastLevelState = testCase.expectedLastLevelState {
-                XCTAssertEqual(levels.last?.state.rawValue, expectedLastLevelState, testCase.name)
-            }
-
-            if let expectedLastNodeState = testCase.expectedLastNodeState {
-                XCTAssertEqual(levels.last?.nodes.last?.state.rawValue, expectedLastNodeState, testCase.name)
-            }
-
-            if let expectedFirstNodeState = testCase.expectedFirstNodeState {
-                XCTAssertEqual(levels[0].nodes[0].state.rawValue, expectedFirstNodeState, testCase.name)
+            if testCase.expectedAllCompletedCountsZero == true {
+                XCTAssertTrue(levels.allSatisfy { $0.completedCount == 0 }, testCase.name)
             }
 
             for expectedLevel in testCase.expectedLevels ?? [] {

--- a/ios/StillPointShared/Tests/StillPointSharedTests/SharedFixtures.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/SharedFixtures.swift
@@ -154,23 +154,19 @@ struct PathwayFixture: Decodable {
 
     struct BuildPathwayCase: Decodable {
         let name: String
-        let currentDay: Int
-        let expectedCurrentNodeDay: Int?
-        let expectedCurrentNodeCount: Int?
         let expectedLevelCount: Int?
         let expectedAllDays: [Int]?
         let expectedLevels: [ExpectedLevel]?
-        let expectedAllNodesCompleted: Bool?
-        let expectedAllLevelsCompleted: Bool?
-        let expectedLastLevelState: String?
-        let expectedLastNodeState: String?
-        let expectedFirstNodeState: String?
+        let expectedAllNodesComingSoon: Bool?
+        let expectedAllLevelsComingSoon: Bool?
+        let expectedAllCompletedCountsZero: Bool?
     }
 
     let daysPerLevel: Int
     let totalLevels: Int
     let pathwayMaxDay: Int
     let levelNames: [String]
+    let comingSoonMessage: String
     let nodeStateForDay: [NodeStateCase]
     let buildPathway: [BuildPathwayCase]
 }

--- a/shared/test-fixtures/README.md
+++ b/shared/test-fixtures/README.md
@@ -16,7 +16,7 @@ implementations breaks CI on at least one platform.
 | `aphorisms.json` | `aphorismForDay` (`src/lib/aphorisms.ts`) | `Aphorisms.forDay` (`Aphorisms.swift`) |
 | `buddyCalendarColors.json` | `buddyColorFromUserId` (`src/lib/buddyCalendarColors.ts`) | `buddyColorIndexFromUserId` (`BuddyCalendarColors.swift`) |
 | `durationForDay.json` | `durationForDay` / `isDualTrackEligible` (`src/lib/constants.ts`, `src/lib/duration.ts`) | `StillPoint.duration(forDay:)` / `isDualTrackEligible` (`Constants.swift`). `advanceProgression` and `detectMissedDayGap` cases are web-only until iOS recovery parity (#524). |
-| `pathway.json` | `buildPathway` / `nodeStateForDay` (`src/lib/pathway.ts`) | `Pathway.build` / `Pathway.nodeState(forDay:currentDay:)` (`Pathway.swift`) |
+| `pathway.json` | `buildPathway` / `nodeStateForDay` (`src/lib/pathway.ts`) | `Pathway.build` / `Pathway.nodeState(forDay:currentDay:)` (`Pathway.swift`) — preview uses coming-soon state, not day count (#587) |
 
 ## How each suite loads them
 

--- a/shared/test-fixtures/pathway.json
+++ b/shared/test-fixtures/pathway.json
@@ -1,10 +1,11 @@
 {
   "algorithm": "pathway",
-  "description": "Duolingo-style L1–L5 lesson pathway derivation from currentDay. Web buildPathway/nodeStateForDay and iOS Pathway.build/nodeState(forDay:currentDay:) share the same unlock rule: day < currentDay → completed, day === currentDay → current, else locked. Golden cases pin level rollups, node states, and boundary clamping so drift breaks CI on both platforms.",
+  "description": "L1–L5 lesson pathway structure. buildPathway() renders a coming-soon preview: every node and level is `comingSoon` with completedCount 0 — node state is not derived from currentDay (#587). nodeStateForDay remains for future real-lesson progression. Web buildPathway and iOS Pathway.build share the same preview rule.",
   "daysPerLevel": 10,
   "totalLevels": 5,
   "pathwayMaxDay": 50,
   "levelNames": ["Stillness", "Awareness", "Focus", "Intention", "Kindness"],
+  "comingSoonMessage": "Lessons coming soon",
   "nodeStateForDay": [
     { "day": 1, "currentDay": 5, "expected": "completed" },
     { "day": 4, "currentDay": 5, "expected": "completed" },
@@ -14,70 +15,16 @@
   ],
   "buildPathway": [
     {
-      "name": "day 1 first node current",
-      "currentDay": 1,
-      "expectedCurrentNodeDay": 1,
-      "expectedCurrentNodeCount": 1,
+      "name": "coming-soon preview structure",
       "expectedLevelCount": 5,
       "expectedAllDays": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50],
+      "expectedAllNodesComingSoon": true,
+      "expectedAllLevelsComingSoon": true,
+      "expectedAllCompletedCountsZero": true,
       "expectedLevels": [
-        { "level": 1, "name": "Stillness", "state": "current", "completedCount": 0, "firstNodeState": "current", "lastNodeState": "locked" },
-        { "level": 2, "name": "Awareness", "state": "locked", "completedCount": 0, "firstNodeState": "locked", "lastNodeState": "locked" }
+        { "level": 1, "name": "Stillness", "state": "comingSoon", "completedCount": 0, "firstNodeState": "comingSoon", "lastNodeState": "comingSoon" },
+        { "level": 5, "name": "Kindness", "state": "comingSoon", "completedCount": 0, "firstNodeState": "comingSoon", "lastNodeState": "comingSoon", "nodeStates": ["comingSoon", "comingSoon", "comingSoon", "comingSoon", "comingSoon", "comingSoon", "comingSoon", "comingSoon", "comingSoon", "comingSoon"] }
       ]
-    },
-    {
-      "name": "mid-level currentDay 13",
-      "currentDay": 13,
-      "expectedCurrentNodeDay": 13,
-      "expectedCurrentNodeCount": 1,
-      "expectedLevelCount": 5,
-      "expectedLevels": [
-        { "level": 1, "name": "Stillness", "state": "completed", "completedCount": 10, "firstNodeState": "completed", "lastNodeState": "completed" },
-        {
-          "level": 2,
-          "name": "Awareness",
-          "state": "current",
-          "completedCount": 2,
-          "firstNodeState": "completed",
-          "nodeStates": ["completed", "completed", "current", "locked", "locked", "locked", "locked", "locked", "locked", "locked"]
-        }
-      ]
-    },
-    {
-      "name": "currentDay 27",
-      "currentDay": 27,
-      "expectedCurrentNodeDay": 27,
-      "expectedCurrentNodeCount": 1,
-      "expectedLevelCount": 5
-    },
-    {
-      "name": "beyond program completes all nodes",
-      "currentDay": 55,
-      "expectedCurrentNodeCount": 0,
-      "expectedAllNodesCompleted": true,
-      "expectedAllLevelsCompleted": true
-    },
-    {
-      "name": "last day keeps final node current",
-      "currentDay": 50,
-      "expectedCurrentNodeDay": 50,
-      "expectedCurrentNodeCount": 1,
-      "expectedLastLevelState": "current",
-      "expectedLastNodeState": "current"
-    },
-    {
-      "name": "clamps sub-1 input to day 1",
-      "currentDay": 0,
-      "expectedCurrentNodeDay": 1,
-      "expectedCurrentNodeCount": 1,
-      "expectedFirstNodeState": "current"
-    },
-    {
-      "name": "clamps negative input to day 1",
-      "currentDay": -5,
-      "expectedCurrentNodeDay": 1,
-      "expectedCurrentNodeCount": 1,
-      "expectedFirstNodeState": "current"
     }
   ]
 }

--- a/src/components/HomeView.tsx
+++ b/src/components/HomeView.tsx
@@ -270,8 +270,8 @@ export function HomeView({
         />
       )}
 
-      {/* Block B2: Lesson pathway (#336) */}
-      <Pathway currentDay={currentDay} />
+      {/* Block B2: Lesson pathway preview (#336 / #587) */}
+      <Pathway />
 
       {/* Block B3: pre-session aphorism, opt-in (#88) */}
       {aphorism && (

--- a/src/components/Pathway.tsx
+++ b/src/components/Pathway.tsx
@@ -1,24 +1,16 @@
 "use client";
 
-import { buildPathway, type NodeState, type PathwayNode } from "@/lib/pathway";
-
-type PathwayProps = {
-  currentDay: number;
-};
+import { useCallback, useState } from "react";
+import {
+  PATHWAY_COMING_SOON_MESSAGE,
+  buildPathway,
+  type PathwayNode,
+} from "@/lib/pathway";
 
 const mono = "var(--font-mono)";
 
-function levelLabelColor(state: NodeState): string {
-  if (state === "completed") return "var(--accent-green-text)";
-  if (state === "current") return "var(--accent-amber-text)";
-  return "var(--fg-3)";
-}
-
-function Node({ node }: { node: PathwayNode }) {
+function Node({ node, onTap }: { node: PathwayNode; onTap: () => void }) {
   const base = {
-    // Shrink-to-fit so ten nodes never overflow narrow phone widths (#336 review):
-    // grow 0 / shrink 1 / basis 30px, with aspect-ratio keeping the node circular
-    // as it shrinks. minWidth:0 lets the flex item shrink below its content box.
     flex: "0 1 30px",
     maxWidth: "30px",
     minWidth: 0,
@@ -31,83 +23,48 @@ function Node({ node }: { node: PathwayNode }) {
     fontSize: "11px",
     lineHeight: 1,
     boxSizing: "border-box" as const,
+    border: "1px solid var(--border-1)",
+    background: "var(--surface-1)",
+    color: "var(--fg-4)",
+    cursor: "pointer",
+    padding: 0,
   };
 
-  if (node.state === "completed") {
-    return (
-      <div
-        title={`Day ${node.day} · completed`}
-        aria-label={`Day ${node.day}, completed`}
-        style={{
-          ...base,
-          border: "1px solid var(--accent-green-border)",
-          background: "var(--accent-green-bg-subtle)",
-          color: "var(--accent-green)",
-          fontSize: "13px",
-        }}
-      >
-        &#10003;
-      </div>
-    );
-  }
-
-  if (node.state === "current") {
-    return (
-      <div
-        title={`Day ${node.day} · current lesson`}
-        aria-label={`Day ${node.day}, current lesson`}
-        aria-current="step"
-        style={{
-          ...base,
-          border: "2px solid var(--accent-amber)",
-          background: "var(--accent-amber-bg)",
-          color: "var(--accent-amber)",
-          fontWeight: 600,
-          animation: "pathway-pulse 2.4s ease-in-out infinite",
-        }}
-      >
-        {node.day}
-      </div>
-    );
-  }
-
   return (
-    <div
-      title={`Day ${node.day} · locked`}
-      aria-label={`Day ${node.day}, locked`}
-      style={{
-        ...base,
-        border: "1px solid var(--border-1)",
-        background: "var(--surface-1)",
-        color: "var(--fg-4)",
-      }}
+    <button
+      type="button"
+      title={`Day ${node.day} · ${PATHWAY_COMING_SOON_MESSAGE.toLowerCase()}`}
+      aria-label={`Day ${node.day}, ${PATHWAY_COMING_SOON_MESSAGE.toLowerCase()}`}
+      onClick={onTap}
+      style={base}
     >
       {node.day}
-    </div>
+    </button>
   );
 }
 
-export function Pathway({ currentDay }: PathwayProps) {
-  const levels = buildPathway(currentDay);
+export function Pathway() {
+  const levels = buildPathway();
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const showComingSoon = useCallback(() => {
+    setNotice(PATHWAY_COMING_SOON_MESSAGE);
+    window.setTimeout(() => setNotice(null), 2400);
+  }, []);
 
   return (
     <section
       aria-label="Lesson pathway"
-      // tabIndex={0} makes this overflow region keyboard-accessible: once
-      // focused, arrow keys / Page Down scroll the content so keyboard-only
-      // users can reach lower levels that are hidden below the height cap.
       tabIndex={0}
       style={{
         width: "100%",
         maxWidth: "min(420px, calc(100vw - 40px))",
-        // Cap height so the section scrolls internally rather than pushing
-        // the Begin CTA into the fixed bottom nav on narrow/short viewports
-        // (e.g. iPhone SE 375×667). clamp: 160px floor, 30vh mid, 240px ceiling.
         maxHeight: "clamp(160px, 30vh, 240px)",
         overflowY: "auto",
         display: "flex",
         flexDirection: "column",
         gap: "var(--s4)",
+        position: "relative",
       }}
     >
       <div
@@ -123,12 +80,35 @@ export function Pathway({ currentDay }: PathwayProps) {
         Pathway
       </div>
 
+      {notice && (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            position: "sticky",
+            top: 0,
+            zIndex: 1,
+            alignSelf: "center",
+            fontFamily: mono,
+            fontSize: "11px",
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            color: "var(--fg-2)",
+            background: "var(--surface-2)",
+            border: "1px solid var(--border-2)",
+            borderRadius: "999px",
+            padding: "6px 12px",
+          }}
+        >
+          {notice}
+        </div>
+      )}
+
       {levels.map((level) => (
         <div
           key={level.level}
           style={{ display: "flex", flexDirection: "column", gap: "var(--s2)" }}
         >
-          {/* Level header */}
           <div
             style={{
               display: "flex",
@@ -138,25 +118,18 @@ export function Pathway({ currentDay }: PathwayProps) {
               fontSize: "11px",
               letterSpacing: "0.12em",
               textTransform: "uppercase",
-              color: levelLabelColor(level.state),
-              opacity: level.state === "locked" ? 0.7 : 1,
+              color: "var(--fg-3)",
             }}
           >
             <span>
               L{level.level} &middot; {level.name}
             </span>
-            <span style={{ color: "var(--fg-3)" }}>
-              {level.completedCount}/{level.nodes.length}
-            </span>
+            <span style={{ color: "var(--fg-4)" }}>Coming soon</span>
           </div>
 
-          {/* Node track */}
           <div style={{ display: "flex", alignItems: "center", width: "100%" }}>
             {level.nodes.map((node, i) => (
-              <div
-                key={node.day}
-                style={{ display: "contents" }}
-              >
+              <div key={node.day} style={{ display: "contents" }}>
                 {i > 0 && (
                   <div
                     aria-hidden="true"
@@ -164,17 +137,11 @@ export function Pathway({ currentDay }: PathwayProps) {
                       flex: 1,
                       height: "1px",
                       minWidth: "4px",
-                      // Green when the *preceding* node is finished, so the
-                      // traversed path reaches all the way into the current
-                      // (amber) node rather than stopping one step short (#336 review).
-                      background:
-                        level.nodes[i - 1]?.state === "completed"
-                          ? "var(--accent-green-border)"
-                          : "var(--border-1)",
+                      background: "var(--border-1)",
                     }}
                   />
                 )}
-                <Node node={node} />
+                <Node node={node} onTap={showComingSoon} />
               </div>
             ))}
           </div>

--- a/src/components/Pathway.tsx
+++ b/src/components/Pathway.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   PATHWAY_COMING_SOON_MESSAGE,
   buildPathway,
@@ -46,10 +46,25 @@ function Node({ node, onTap }: { node: PathwayNode; onTap: () => void }) {
 export function Pathway() {
   const levels = buildPathway();
   const [notice, setNotice] = useState<string | null>(null);
+  const noticeTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (noticeTimeoutRef.current !== null) {
+        window.clearTimeout(noticeTimeoutRef.current);
+      }
+    };
+  }, []);
 
   const showComingSoon = useCallback(() => {
     setNotice(PATHWAY_COMING_SOON_MESSAGE);
-    window.setTimeout(() => setNotice(null), 2400);
+    if (noticeTimeoutRef.current !== null) {
+      window.clearTimeout(noticeTimeoutRef.current);
+    }
+    noticeTimeoutRef.current = window.setTimeout(() => {
+      noticeTimeoutRef.current = null;
+      setNotice(null);
+    }, 2400);
   }, []);
 
   return (

--- a/src/lib/pathway.test.ts
+++ b/src/lib/pathway.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   DAYS_PER_LEVEL,
   LEVEL_NAMES,
+  PATHWAY_COMING_SOON_MESSAGE,
   PATHWAY_MAX_DAY,
   TOTAL_LEVELS,
   buildPathway,
@@ -27,7 +28,7 @@ describe("nodeStateForDay", () => {
 
 describe("buildPathway", () => {
   test("produces five named levels with ten nodes each", () => {
-    const levels = buildPathway(1);
+    const levels = buildPathway();
     expect(levels).toHaveLength(TOTAL_LEVELS);
     expect(levels.map((l) => l.name)).toEqual([...LEVEL_NAMES]);
     for (const level of levels) {
@@ -36,69 +37,25 @@ describe("buildPathway", () => {
   });
 
   test("node days are contiguous from 1..50", () => {
-    const days = buildPathway(1).flatMap((l) => l.nodes.map((n) => n.day));
+    const days = buildPathway().flatMap((l) => l.nodes.map((n) => n.day));
     expect(days).toEqual(Array.from({ length: PATHWAY_MAX_DAY }, (_, i) => i + 1));
   });
 
-  test("day 1: first node current, rest locked", () => {
-    const [first] = buildPathway(1);
-    expect(first!.nodes[0]!.state).toBe("current");
-    expect(first!.nodes.slice(1).every((n) => n.state === "locked")).toBe(true);
-    expect(first!.completedCount).toBe(0);
-    expect(first!.state).toBe("current");
-  });
-
-  test("mid-level currentDay marks completed/current/locked correctly", () => {
-    // currentDay 13 → L1 fully complete, L2 has 2 completed + day 13 current
-    const levels = buildPathway(13);
-    const l1 = levels[0]!;
-    const l2 = levels[1]!;
-    expect(l1.state).toBe("completed");
-    expect(l1.completedCount).toBe(DAYS_PER_LEVEL);
-    expect(l1.nodes.every((n) => n.state === "completed")).toBe(true);
-
-    expect(l2.state).toBe("current");
-    expect(l2.completedCount).toBe(2);
-    expect(l2.nodes[0]!.state).toBe("completed"); // day 11
-    expect(l2.nodes[1]!.state).toBe("completed"); // day 12
-    expect(l2.nodes[2]!.state).toBe("current"); // day 13
-    expect(l2.nodes[3]!.state).toBe("locked"); // day 14
-  });
-
-  test("exactly one node is current within the pathway range", () => {
-    const currents = buildPathway(27)
-      .flatMap((l) => l.nodes)
-      .filter((n) => n.state === "current");
-    expect(currents).toHaveLength(1);
-    expect(currents[0]!.day).toBe(27);
-  });
-
-  test("currentDay beyond the program completes every node", () => {
-    const levels = buildPathway(PATHWAY_MAX_DAY + 5);
+  test("does not derive completed or current nodes from day count (#587)", () => {
+    const levels = buildPathway();
     const allNodes = levels.flatMap((l) => l.nodes);
-    expect(allNodes.every((n) => n.state === "completed")).toBe(true);
-    expect(levels.every((l) => l.state === "completed")).toBe(true);
+    expect(allNodes.every((n) => n.state === "comingSoon")).toBe(true);
+    expect(levels.every((l) => l.state === "comingSoon")).toBe(true);
+    expect(levels.every((l) => l.completedCount === 0)).toBe(true);
+    expect(allNodes.some((n) => n.state === "completed")).toBe(false);
+    expect(allNodes.some((n) => n.state === "current")).toBe(false);
   });
 
-  test("currentDay exactly at the last day keeps it current", () => {
-    const last = buildPathway(PATHWAY_MAX_DAY)[TOTAL_LEVELS - 1]!;
-    expect(last.nodes[DAYS_PER_LEVEL - 1]!.state).toBe("current");
-    expect(last.state).toBe("current");
+  test("exposes coming-soon copy for tap affordance", () => {
+    expect(PATHWAY_COMING_SOON_MESSAGE).toBe("Lessons coming soon");
   });
 
-  test("clamps non-finite or sub-1 input to day 1", () => {
-    for (const input of [0, -5, Number.NaN, Number.POSITIVE_INFINITY]) {
-      const levels = buildPathway(input as number);
-      if (input === Number.POSITIVE_INFINITY) {
-        // Infinity is non-finite → clamped to 1
-        expect(levels[0]!.nodes[0]!.state).toBe("current");
-      } else {
-        expect(levels[0]!.nodes[0]!.state).toBe("current");
-      }
-    }
-  });
-
-  // MARK: - Shared cross-platform fixtures (#421 / #525)
+  // MARK: - Shared cross-platform fixtures (#421 / #525 / #587)
 
   test("shared pathway fixtures", () => {
     const fixture = loadSharedFixture<PathwayFixture>("pathway.json");
@@ -107,13 +64,14 @@ describe("buildPathway", () => {
     expect(TOTAL_LEVELS).toBe(fixture.totalLevels);
     expect(PATHWAY_MAX_DAY).toBe(fixture.pathwayMaxDay);
     expect([...LEVEL_NAMES]).toEqual(fixture.levelNames);
+    expect(PATHWAY_COMING_SOON_MESSAGE).toBe(fixture.comingSoonMessage);
 
     for (const testCase of fixture.nodeStateForDay) {
       expect(nodeStateForDay(testCase.day, testCase.currentDay)).toBe(testCase.expected);
     }
 
     for (const testCase of fixture.buildPathway) {
-      const levels = buildPathway(testCase.currentDay);
+      const levels = buildPathway();
 
       if (testCase.expectedLevelCount != null) {
         expect(levels).toHaveLength(testCase.expectedLevelCount);
@@ -124,36 +82,16 @@ describe("buildPathway", () => {
         expect(days).toEqual(testCase.expectedAllDays);
       }
 
-      if (testCase.expectedCurrentNodeCount != null) {
-        const currents = levels.flatMap((l) => l.nodes).filter((n) => n.state === "current");
-        expect(currents).toHaveLength(testCase.expectedCurrentNodeCount);
+      if (testCase.expectedAllNodesComingSoon === true) {
+        expect(levels.flatMap((l) => l.nodes).every((n) => n.state === "comingSoon")).toBe(true);
       }
 
-      if (testCase.expectedCurrentNodeDay != null) {
-        const currents = levels.flatMap((l) => l.nodes).filter((n) => n.state === "current");
-        expect(currents[0]!.day).toBe(testCase.expectedCurrentNodeDay);
+      if (testCase.expectedAllLevelsComingSoon === true) {
+        expect(levels.every((l) => l.state === "comingSoon")).toBe(true);
       }
 
-      if (testCase.expectedAllNodesCompleted === true) {
-        expect(levels.flatMap((l) => l.nodes).every((n) => n.state === "completed")).toBe(true);
-      }
-
-      if (testCase.expectedAllLevelsCompleted === true) {
-        expect(levels.every((l) => l.state === "completed")).toBe(true);
-      }
-
-      if (testCase.expectedLastLevelState != null) {
-        expect(levels[TOTAL_LEVELS - 1]!.state).toBe(testCase.expectedLastLevelState);
-      }
-
-      if (testCase.expectedLastNodeState != null) {
-        expect(levels[TOTAL_LEVELS - 1]!.nodes[DAYS_PER_LEVEL - 1]!.state).toBe(
-          testCase.expectedLastNodeState,
-        );
-      }
-
-      if (testCase.expectedFirstNodeState != null) {
-        expect(levels[0]!.nodes[0]!.state).toBe(testCase.expectedFirstNodeState);
+      if (testCase.expectedAllCompletedCountsZero === true) {
+        expect(levels.every((l) => l.completedCount === 0)).toBe(true);
       }
 
       for (const expectedLevel of testCase.expectedLevels ?? []) {

--- a/src/lib/pathway.ts
+++ b/src/lib/pathway.ts
@@ -1,11 +1,10 @@
 /**
- * Duolingo-style pathway derivation (#336, web v1).
+ * Duolingo-style pathway structure (#336, web v1).
  *
- * Levels and node states are derived purely from the user's `currentDay`; there
- * is no backend or migration. `currentDay` is the day the user is *on* (not yet
- * completed) — completing a standard sit advances it by one (see
- * `handleSessionComplete` in `src/app/app/page.tsx`). That gives the v1 unlock
- * rule: finishing a lesson unlocks the next.
+ * L1–L5 levels and node layout are fixed. Until real lesson content ships,
+ * every node is a coming-soon preview — node state is **not** derived from
+ * `currentDay` (#587). When lessons exist, `buildPathwayFromCompletions` (or
+ * similar) can drive `completed` / `current` / `locked` from actual progress.
  */
 
 /** Days that make up a single level. Five levels cover days 1–50. */
@@ -25,7 +24,10 @@ export const TOTAL_LEVELS = LEVEL_NAMES.length;
 /** Highest day represented in the pathway (L5, day 10). */
 export const PATHWAY_MAX_DAY = TOTAL_LEVELS * DAYS_PER_LEVEL;
 
-export type NodeState = "completed" | "current" | "locked";
+/** Copy shown when a pathway node is tapped before lessons ship. */
+export const PATHWAY_COMING_SOON_MESSAGE = "Lessons coming soon";
+
+export type NodeState = "completed" | "current" | "locked" | "comingSoon";
 
 export type PathwayNode = {
   /** 1-based day number this node represents. */
@@ -42,18 +44,13 @@ export type PathwayLevel = {
   nodes: PathwayNode[];
   /** Count of completed nodes within this level. */
   completedCount: number;
-  /**
-   * Level rollup state: `completed` when every node is done, `current` when the
-   * user's current day falls in this level, otherwise `locked`.
-   */
+  /** Level rollup state. */
   state: NodeState;
 };
 
 /**
  * Resolve a single day's node state relative to `currentDay`.
- * - day < currentDay  → completed
- * - day === currentDay → current
- * - day > currentDay  → locked
+ * Reserved for future real-lesson progression — not used by `buildPathway`.
  */
 export function nodeStateForDay(day: number, currentDay: number): NodeState {
   if (day < currentDay) return "completed";
@@ -62,41 +59,25 @@ export function nodeStateForDay(day: number, currentDay: number): NodeState {
 }
 
 /**
- * Build the full L1–L5 pathway for a given `currentDay`. Non-finite or sub-1
- * inputs are clamped to day 1 so the first node is always the current one.
+ * Build the L1–L5 pathway preview. Every node is `comingSoon` until lesson
+ * completions drive state (#587).
  */
-export function buildPathway(currentDay: number): PathwayLevel[] {
-  const day = Number.isFinite(currentDay) ? Math.max(1, Math.floor(currentDay)) : 1;
-
+export function buildPathway(): PathwayLevel[] {
   const levels: PathwayLevel[] = [];
   for (let level = 1; level <= TOTAL_LEVELS; level++) {
     const nodes: PathwayNode[] = [];
-    let completedCount = 0;
 
     for (let dayInLevel = 1; dayInLevel <= DAYS_PER_LEVEL; dayInLevel++) {
       const nodeDay = (level - 1) * DAYS_PER_LEVEL + dayInLevel;
-      const state = nodeStateForDay(nodeDay, day);
-      if (state === "completed") completedCount += 1;
-      nodes.push({ day: nodeDay, dayInLevel, state });
-    }
-
-    const levelStartDay = (level - 1) * DAYS_PER_LEVEL + 1;
-    const levelEndDay = level * DAYS_PER_LEVEL;
-    let state: NodeState;
-    if (day > levelEndDay) {
-      state = "completed";
-    } else if (day >= levelStartDay) {
-      state = "current";
-    } else {
-      state = "locked";
+      nodes.push({ day: nodeDay, dayInLevel, state: "comingSoon" });
     }
 
     levels.push({
       level,
       name: LEVEL_NAMES[level - 1]!,
       nodes,
-      completedCount,
-      state,
+      completedCount: 0,
+      state: "comingSoon",
     });
   }
 

--- a/src/lib/testing/sharedFixtures.ts
+++ b/src/lib/testing/sharedFixtures.ts
@@ -100,28 +100,24 @@ export type PathwayFixture = {
   totalLevels: number;
   pathwayMaxDay: number;
   levelNames: string[];
+  comingSoonMessage: string;
   nodeStateForDay: Array<{ day: number; currentDay: number; expected: "completed" | "current" | "locked" }>;
   buildPathway: Array<{
     name: string;
-    currentDay: number;
-    expectedCurrentNodeDay?: number;
-    expectedCurrentNodeCount?: number;
     expectedLevelCount?: number;
     expectedAllDays?: number[];
+    expectedAllNodesComingSoon?: boolean;
+    expectedAllLevelsComingSoon?: boolean;
+    expectedAllCompletedCountsZero?: boolean;
     expectedLevels?: Array<{
       level: number;
       name: string;
-      state: "completed" | "current" | "locked";
+      state: "completed" | "current" | "locked" | "comingSoon";
       completedCount: number;
-      firstNodeState?: "completed" | "current" | "locked";
-      lastNodeState?: "completed" | "current" | "locked";
-      nodeStates?: Array<"completed" | "current" | "locked">;
+      firstNodeState?: "completed" | "current" | "locked" | "comingSoon";
+      lastNodeState?: "completed" | "current" | "locked" | "comingSoon";
+      nodeStates?: Array<"completed" | "current" | "locked" | "comingSoon">;
     }>;
-    expectedAllNodesCompleted?: boolean;
-    expectedAllLevelsCompleted?: boolean;
-    expectedLastLevelState?: "completed" | "current" | "locked";
-    expectedLastNodeState?: "completed" | "current" | "locked";
-    expectedFirstNodeState?: "completed" | "current" | "locked";
   }>;
 };
 


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #587 by decoupling the L1–L5 pathway from `currentDay`. Until real lesson content ships, the pathway is a clickable coming-soon preview instead of showing fabricated completion (e.g. L1–L4 10/10 on a day-45 account).

## Changes

- **`buildPathway()`** (web + iOS shared): returns all nodes/levels as `comingSoon` with `completedCount: 0`; no longer accepts or uses `currentDay`
- **Web `Pathway.tsx`**: nodes are buttons; tap shows a brief "Lessons coming soon" status pill; level headers show "Coming soon" instead of `X/10`
- **iOS `PathwayView.swift` / `HomeView.swift`**: same preview UX with an alert on node tap; removed `currentDay` prop
- **`nodeStateForDay` / `Pathway.nodeState(forDay:)`** kept for future real-lesson progression
- Updated shared fixtures, unit tests, and parity checklist

## Test plan

- [x] `npm run test:unit -- src/lib/pathway.test.ts` (646 tests pass)
- [ ] Manual web: day-45 account → no completed checkmarks; tap node → "Lessons coming soon"
- [ ] Manual iOS: same behavior via alert on tap
- [ ] iOS shared tests (`PathwayTests`) — CI lane

## Notes

The Home day counter (`45 · DAY`) is unchanged; only pathway lesson semantics were removed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dea5b94d-abc3-4022-b688-64f233ad5999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dea5b94d-abc3-4022-b688-64f233ad5999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Show the lesson pathway as a coming-soon preview instead of fake progress**

### What Changed
- The lesson pathway no longer uses the current day to show completed, current, or locked lessons
- Every pathway node and level now appears as a coming-soon preview with zero completed lessons
- Tapping a pathway node now shows a “Lessons coming soon” message on web and iOS
- Level headers now show “Coming soon” instead of lesson counts

### Impact
`✅ No more fake lesson progress`
`✅ Clearer home screen preview`
`✅ Consistent coming-soon messaging on web and iOS`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
