### PR TITLE
ci: move e2e off PR path; gate release + nightly (#588)

### DIFF
--- a/.github/workflows/e2e-coverage-nudge.yml
+++ b/.github/workflows/e2e-coverage-nudge.yml
@@ -1,0 +1,59 @@
+name: E2E Coverage Nudge (advisory)
+
+# Non-blocking advisory when a PR touches user-facing surfaces without e2e updates
+# (#588). Mirrors auerbachb/skingod's e2e-coverage-nudge.yml — neutral signal,
+# not a merge gate.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
+jobs:
+  coverage-nudge:
+    name: e2e coverage nudge (advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Post coverage nudge
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/e2e/coverage-nudge.mjs
+
+      - name: Mark advisory check neutral
+        if: always()
+        uses: actions/github-script@60a0d83039c877a2a56125928565995e430d5472 # v7.0.1
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const sha = context.payload.pull_request?.head?.sha ?? context.sha;
+            if (!sha) {
+              core.info('No PR head SHA — skipping neutral check creation.');
+              return;
+            }
+            await github.rest.checks.create({
+              owner,
+              repo,
+              name: 'e2e coverage nudge (advisory)',
+              head_sha: sha,
+              status: 'completed',
+              conclusion: 'neutral',
+              output: {
+                title: 'E2E coverage nudge (advisory — does not gate merge)',
+                summary:
+                  'See workflow logs for UI paths touched without e2e spec updates. Comprehensive e2e runs nightly and on iOS release (#588).',
+              },
+            });

--- a/.github/workflows/e2e-coverage-nudge.yml
+++ b/.github/workflows/e2e-coverage-nudge.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Mark advisory check neutral
         if: always()
-        uses: actions/github-script@60a0d83039c877a2a56125928565995e430d5472 # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -1,15 +1,38 @@
 name: E2E iOS
 
+# As of #588 (SkinGod model), this workflow NO LONGER runs on `pull_request`.
+# Native iOS e2e (macOS XCTest smoke/critical) gates the TestFlight release path
+# via `ios-testflight-auto.yml` instead of blocking every PR. The Info.plist
+# sync guard moved to `infoplist-sync.yml` (required on every PR — #439/#588).
+#
+# Runs via:
+#   - `ios-testflight-auto.yml` — release:ios merge gate (#588)
+#   - `workflow_dispatch` — ad-hoc verification
+#   - `workflow_call` — reusable from other workflows
+#
+# Mirrors auerbachb/skingod#1402 / still-point #494 (mobile-web off PRs).
+
 on:
-  pull_request:
-    paths:
-      - "ios/**"
-      - "docs/testing/e2e-policy.md"
-      - ".github/workflows/e2e-ios.yml"
-      - "scripts/e2e/**"
-      - "package.json"
-      - "package-lock.json"
+  workflow_call:
+    inputs:
+      ref:
+        description: "Commit ref (SHA, branch, or tag) to check out and test"
+        type: string
+        required: true
+    secrets:
+      E2E_TEST_USER_EMAIL:
+        required: false
+      E2E_TEST_USER_PASSWORD:
+        required: false
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Commit ref to test. Defaults to the ref this run was dispatched from."
+        type: string
+        required: false
+
+permissions:
+  contents: read
 
 jobs:
   ios-e2e:
@@ -24,6 +47,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
       - name: Setup Node.js
@@ -98,48 +122,3 @@ jobs:
           path: ~/Library/Logs/DiagnosticReports/**
           if-no-files-found: ignore
           retention-days: 14
-
-  # Guards against project.yml <-> Info.plist drift. CI regenerates Info.plist via
-  # `xcodegen generate` before every build, so any key that lives only in the committed
-  # Info.plist (and not in project.yml's info.properties) is silently dropped from
-  # shipped builds. This job fails the PR if regeneration would change the committed
-  # Info.plist, forcing project.yml to stay the single source of truth. See issue #432.
-  infoplist-sync:
-    name: Info.plist in sync with project.yml
-    runs-on: macos-26
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Install XcodeGen
-        env:
-          HOMEBREW_NO_AUTO_UPDATE: "1"
-        run: |
-          for attempt in 1 2 3; do
-            if brew install xcodegen; then
-              exit 0
-            fi
-            if [[ "$attempt" -lt 3 ]]; then
-              sleep $((attempt * 10))
-            fi
-          done
-          echo "Failed to install xcodegen after 3 attempts."
-          exit 1
-
-      - name: Generate Xcode project
-        working-directory: ios
-        run: xcodegen generate
-
-      - name: Verify committed Info.plist matches XcodeGen output
-        run: |
-          if ! git diff --exit-code -- ios/StillPointApp/Info.plist; then
-            echo "::error::ios/StillPointApp/Info.plist is out of sync with ios/project.yml."
-            echo "CI regenerates Info.plist via 'xcodegen generate' before every build, so any key that"
-            echo "exists only in the committed Info.plist (not in project.yml info.properties) is DROPPED"
-            echo "from shipped builds. Fix: add the key(s) to ios/project.yml -> targets.StillPoint.info.properties,"
-            echo "then run 'cd ios && xcodegen generate' and commit the regenerated ios/StillPointApp/Info.plist."
-            exit 1
-          fi

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,0 +1,57 @@
+name: E2E PR Smoke (advisory)
+
+# Fast, optional web smoke on pull requests — does NOT gate merge (#588).
+# Mirrors auerbachb/skingod's e2e-smoke.yml: gives authors early signal without
+# the full smoke+critical suite that now runs nightly + at release.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pr-e2e-smoke:
+    name: pr-e2e-smoke (advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+    env:
+      E2E_BASE_URL: http://127.0.0.1:3000
+      E2E_WORKERS: "1"
+      E2E_REPEAT_EACH: "1"
+      E2E_RUN_ID: ${{ github.run_id }}
+      SEED_CONFIRM: still-point-nonprod
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run web smoke lane (advisory)
+        run: npm run e2e:web:smoke
+
+      - name: Upload advisory smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-e2e-smoke-advisory-artifacts
+          path: |
+            artifacts/e2e/web/**
+            playwright-report/**
+            test-results/**
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/e2e-web-nightly.yml
+++ b/.github/workflows/e2e-web-nightly.yml
@@ -1,0 +1,31 @@
+name: E2E Web Nightly
+
+# Scheduled comprehensive web e2e on `main` — off the PR critical path (#588).
+# Mirrors auerbachb/skingod's e2e-mobile-web-nightly.yml pattern: full smoke +
+# critical lanes run nightly so #497 P0 coverage stays exercised without blocking
+# every PR merge.
+
+on:
+  schedule:
+    - cron: "0 8 * * *" # 08:00 UTC nightly (~03:00-04:00 ET), after neon-preview-reset
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Commit ref to test. Defaults to main when scheduled."
+        type: string
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-web-nightly
+  cancel-in-progress: false
+
+jobs:
+  e2e-web:
+    name: nightly web e2e
+    uses: ./.github/workflows/e2e-web.yml
+    with:
+      ref: ${{ inputs.ref || 'main' }}
+    secrets: inherit

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -1,8 +1,29 @@
 name: E2E Web
 
+# As of #588 (SkinGod model), this workflow NO LONGER runs on `pull_request`.
+# Comprehensive web e2e gates release/nightly paths instead of blocking every
+# merge. PRs get fast required checks + optional advisory smoke/nudge workflows.
+#
+# Runs via:
+#   - `e2e-web-nightly.yml` — scheduled full dry-run on main (#588)
+#   - `workflow_dispatch` — ad-hoc verification
+#   - `workflow_call` — reusable from other workflows
+#
+# Supersedes #537 (which would have required web-e2e-smoke/critical on PRs).
+
 on:
-  pull_request:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Commit ref (SHA, branch, or tag) to check out and test"
+        type: string
+        required: false
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Commit ref to test. Defaults to the ref this run was dispatched from."
+        type: string
+        required: false
 
 permissions:
   contents: read
@@ -16,6 +37,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
       - name: Setup Node.js
@@ -47,6 +69,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
       - name: Setup Node.js
@@ -91,6 +114,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
       - name: Setup Node.js
@@ -148,6 +172,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
       - name: Check auth DB secrets

--- a/.github/workflows/infoplist-sync.yml
+++ b/.github/workflows/infoplist-sync.yml
@@ -1,0 +1,91 @@
+name: Info.plist sync
+
+# The `Info.plist in sync with project.yml` job is a REQUIRED status check on
+# `main` (#439, folded into #588). It must report on every PR — previously it
+# lived inside path-filtered `e2e-ios.yml`, which left non-iOS PRs stuck at
+# mergeStateStatus=BLOCKED forever (#442). Same no-op pattern as #463 /
+# ios-shared-tests.yml: run the real xcodegen diff on macOS when iOS plist
+# inputs changed; otherwise a cheap ubuntu no-op still satisfies the check.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changes:
+    name: detect Info.plist inputs
+    runs-on: ubuntu-latest
+    outputs:
+      ios: ${{ steps.filter.outputs.ios }}
+    steps:
+      - name: Detect changed paths
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # Fail safe toward MORE coverage when the diff is unknown.
+          if [ -z "${PR_NUMBER:-}" ]; then
+            echo "ios=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename' 2>/dev/null || true)"
+          if [ -z "$files" ] || printf '%s\n' "$files" | grep -qE '^(ios/project\.yml$|ios/StillPointApp/Info\.plist$|\.github/workflows/infoplist-sync\.yml$)'; then
+            echo "ios=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ios=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  infoplist-sync:
+    name: Info.plist in sync with project.yml
+    needs: changes
+    runs-on: ${{ needs.changes.outputs.ios == 'true' && 'macos-26' || 'ubuntu-latest' }}
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        if: needs.changes.outputs.ios == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install XcodeGen
+        if: needs.changes.outputs.ios == 'true'
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          for attempt in 1 2 3; do
+            if brew install xcodegen; then
+              exit 0
+            fi
+            if [[ "$attempt" -lt 3 ]]; then
+              sleep $((attempt * 10))
+            fi
+          done
+          echo "Failed to install xcodegen after 3 attempts."
+          exit 1
+
+      - name: Generate Xcode project
+        if: needs.changes.outputs.ios == 'true'
+        working-directory: ios
+        run: xcodegen generate
+
+      - name: Verify committed Info.plist matches XcodeGen output
+        if: needs.changes.outputs.ios == 'true'
+        run: |
+          if ! git diff --exit-code -- ios/StillPointApp/Info.plist; then
+            echo "::error::ios/StillPointApp/Info.plist is out of sync with ios/project.yml."
+            echo "CI regenerates Info.plist via 'xcodegen generate' before every build, so any key that"
+            echo "exists only in the committed Info.plist (not in project.yml info.properties) is DROPPED"
+            echo "from shipped builds. Fix: add the key(s) to ios/project.yml -> targets.StillPoint.info.properties,"
+            echo "then run 'cd ios && xcodegen generate' and commit the regenerated ios/StillPointApp/Info.plist."
+            exit 1
+          fi
+
+      - name: Skip (Info.plist inputs unchanged)
+        if: needs.changes.outputs.ios != 'true'
+        run: 'echo "Info.plist inputs unchanged on this PR — required check satisfied without macOS (issue #588 / #439)."'

--- a/.github/workflows/ios-testflight-auto.yml
+++ b/.github/workflows/ios-testflight-auto.yml
@@ -5,8 +5,9 @@ name: Auto TestFlight on merge
 # adapted for Still Point's self-hosted xcodebuild pipeline (skingod uses EAS).
 #
 # Flow:
-#   1. Run the mobile-web e2e suite (e2e-mobile.yml) against the merge commit.
-#   2. Only if it's green: read CURRENT_PROJECT_VERSION from ios/project.yml
+#   1. Run mobile-web e2e (e2e-mobile.yml) AND native iOS e2e (e2e-ios.yml) in
+#      parallel against the merge commit (#588 — both gate the release).
+#   2. Only if both are green: read CURRENT_PROJECT_VERSION from ios/project.yml
 #      at the merge commit.
 #   3. Increment it (build-number source of truth: the committed project.yml).
 #   4. Commit the bump back to main with [skip ci].
@@ -17,9 +18,9 @@ name: Auto TestFlight on merge
 # purpose (#494): the bump commit + tag push are themselves release side
 # effects, and this workflow only fires once per merged PR (no natural retry
 # trigger), so a failing e2e must prevent them too — not just skip the build
-# after a tag already exists. `tag`'s `if:` checks `needs.e2e.result ==
-# 'success'`; a failed OR skipped e2e run (no release:ios label) leaves `tag`
-# skipped and nothing is committed/tagged/built.
+# after a tag already exists. `tag`'s `if:` checks both e2e gates succeeded; a
+# failed OR skipped e2e run (no release:ios label) leaves `tag` skipped and
+# nothing is committed/tagged/built.
 #
 # The bump commit and tag are pushed with the default GITHUB_TOKEN. GitHub does
 # NOT start new workflow runs for GITHUB_TOKEN-authored pushes, so:
@@ -44,7 +45,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  e2e:
+  e2e-mobile:
     name: release e2e (mobile web)
     if: >-
       github.event.pull_request.merged == true &&
@@ -55,10 +56,23 @@ jobs:
       ref: ${{ github.event.pull_request.merge_commit_sha }}
     secrets: inherit
 
+  e2e-ios:
+    name: release e2e (native iOS)
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      contains(github.event.pull_request.labels.*.name, 'release:ios')
+    uses: ./.github/workflows/e2e-ios.yml
+    with:
+      ref: ${{ github.event.pull_request.merge_commit_sha }}
+    secrets: inherit
+
   tag:
     name: Bump build number and cut TestFlight tag
-    needs: e2e
-    if: needs.e2e.result == 'success'
+    needs: [e2e-mobile, e2e-ios]
+    if: >-
+      needs.e2e-mobile.result == 'success' &&
+      needs.e2e-ios.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -259,27 +259,36 @@ Automated code review on pull requests via [CodeRabbit](https://coderabbit.ai). 
 Cross-cutting web + iOS E2E standards (retries, deterministic waits, secrets/env guardrails, artifact policy, flake triage rubric, tags/lanes, visual+perf scope, merge gates, and reproducibility) are documented in:
 
 - [docs/testing/e2e-policy.md](docs/testing/e2e-policy.md)
+- [docs/testing/e2e-strategy.md](docs/testing/e2e-strategy.md)
 - [ios/E2E_RUNBOOK.md](ios/E2E_RUNBOOK.md)
 
 ## Merge gates (current)
 
-Branch protection on `main` requires **`typecheck`** and **`StillPointShared swift test`**. Issue #537 adds **`build`**, **`web-e2e-smoke`**, and **`web-e2e-critical`** — see [docs/testing/branch-protection.md](docs/testing/branch-protection.md) for the admin runbook and path-filter notes.
+Branch protection on `main` requires **`typecheck`** and **`StillPointShared swift test`**. Issue [#588](https://github.com/auerbachb/still-point/issues/588) adds the fast merge gate — **`unit-tests`** (#434), **`build`**, and **`Info.plist in sync with project.yml`** (#439) — and **removes e2e from required PR checks** (supersedes #537). See [docs/testing/branch-protection.md](docs/testing/branch-protection.md) and [docs/testing/e2e-strategy.md](docs/testing/e2e-strategy.md).
 
 What should be green before merge:
 
 - `typecheck` — full-project `tsc --noEmit` (includes test files)
+- `unit-tests` — Jest/unit suite (#434)
 - `StillPointShared swift test` — shared Swift parity suite (no-op pass when the package is unchanged; issue #463)
 - `build` — repeatable clean Next builds + design-token parity lint
-- `web-e2e-smoke` / `web-e2e-critical` — P0 Playwright lanes ([`e2e-policy.md`](docs/testing/e2e-policy.md))
+- `Info.plist in sync with project.yml` — XcodeGen drift guard (no-op when plist inputs unchanged; #439/#588)
 - `Vercel` — preview deployment completed successfully
 - `Vercel Agent Review` — Vercel's automated review completed
 - `Vercel Preview Comments` — preview comment bot completed
 - `CodeRabbit` — review completed with no blocking findings
 
+Advisory (do not require on `main`):
+
+- `pr-e2e-smoke (advisory)` — fast optional web smoke on PRs
+- `e2e coverage nudge (advisory)` — neutral reminder when UI changes lack e2e updates
+
+Comprehensive e2e (`web-e2e-smoke` / `web-e2e-critical`, native iOS lanes, mobile-web matrix) runs **nightly on main** and **gates iOS TestFlight releases** (`release:ios` label) — not on every PR.
+
 Notes:
 
 - The GitHub Actions workflows **Build & Upload to TestFlight** (`ios-v*-build*` tags) and **iOS App Store release (Fastlane)** (`ios-vMAJOR.MINOR.PATCH` tags) are **release-only** and are not pull-request merge gates.
-- Repo admins can apply the #537 check list with `node scripts/ci/sync-main-required-checks.mjs --apply` (dry-run first).
+- Repo admins can apply the #588 check list with `node scripts/ci/sync-main-required-checks.mjs --apply` (dry-run first; requires confirmation).
 
 ## Project structure
 

--- a/docs/testing/branch-protection.md
+++ b/docs/testing/branch-protection.md
@@ -1,35 +1,48 @@
-# Branch protection — required status checks (#537)
+# Branch protection — required status checks (#588)
 
 GitHub branch protection on `main` currently requires only:
 
 - `typecheck`
 - `StillPointShared swift test`
 
-This document lists the additional checks from issue #537 that should block merges once a repo admin applies them. Related follow-ups: #434 (`unit-tests`), #439 (Info.plist sync).
+This document lists the **fast PR merge gate** from issue #588, which **folds** #434 (`unit-tests`) and #439 (`Info.plist in sync with project.yml`) into a **single admin update**. It **supersedes #537** (which would have required `web-e2e-smoke` / `web-e2e-critical` on every PR).
 
-## Checks to add
+Comprehensive e2e (web + native iOS) runs **nightly** and on the **iOS TestFlight release path** instead — see [e2e-strategy.md](./e2e-strategy.md).
+
+## Checks to require (fast merge gate)
 
 | Status check name | Workflow | Job | Why merge-blocking |
 | --- | --- | --- | --- |
-| `build` | [Web Build](../../.github/workflows/web-build.yml) | `build` | Runs `npm run build:verify` (repeatable clean Next builds) **and** `npm run e2e:policy:design-tokens` (iOS ↔ web design-token parity from #420/PR #491). |
-| `web-e2e-smoke` | [E2E Web](../../.github/workflows/e2e-web.yml) | `web-e2e-smoke` | P0 smoke lane from the [#497 coverage matrix](./e2e-coverage-matrix.md). |
-| `web-e2e-critical` | [E2E Web](../../.github/workflows/e2e-web.yml) | `web-e2e-critical` | P0 critical lane; complements smoke on auth/session/settings paths. |
+| `typecheck` | [Unit Tests](../../.github/workflows/unit-tests.yml) | `typecheck` | Full-project `tsc --noEmit` (#396). |
+| `unit-tests` | [Unit Tests](../../.github/workflows/unit-tests.yml) | `unit-tests` | Jest/unit suite — #434. |
+| `build` | [Web Build](../../.github/workflows/web-build.yml) | `build` | `npm run build:verify` + design-token parity (#420). |
+| `StillPointShared swift test` | [iOS Shared Unit Tests](../../.github/workflows/ios-shared-tests.yml) | `swift-test` | Shared Swift parity; ubuntu no-op when unchanged (#463). |
+| `Info.plist in sync with project.yml` | [Info.plist sync](../../.github/workflows/infoplist-sync.yml) | `infoplist-sync` | XcodeGen drift guard — #439; split out of path-filtered e2e-ios (#588). |
 
-Do **not** add `e2e-policy` as a separate required check — both web E2E jobs already `need: e2e-policy`, so a policy failure blocks smoke/critical automatically.
+## Checks to **not** require (advisory / off-PR)
 
-## Path-filter trap (#442 / #463)
+| Check | Runs when | Notes |
+| --- | --- | --- |
+| `web-e2e-smoke` / `web-e2e-critical` | Nightly + `workflow_dispatch` | Full suite via [e2e-web.yml](../../.github/workflows/e2e-web.yml) / [e2e-web-nightly.yml](../../.github/workflows/e2e-web-nightly.yml). **Do not require on PRs** (#588). |
+| `ios-e2e-smoke` / `ios-e2e-critical` | `release:ios` merge gate | [e2e-ios.yml](../../.github/workflows/e2e-ios.yml) via [ios-testflight-auto.yml](../../.github/workflows/ios-testflight-auto.yml). |
+| `pr-e2e-smoke (advisory)` | Every PR (optional) | [e2e-smoke.yml](../../.github/workflows/e2e-smoke.yml) — `continue-on-error: true`. |
+| `e2e coverage nudge (advisory)` | Every PR (neutral) | [e2e-coverage-nudge.yml](../../.github/workflows/e2e-coverage-nudge.yml). |
+| `web-e2e-auth-db` | Nightly / dispatch | Skips when secrets unset; keep optional. |
+
+If #537 checks were previously applied, remove `web-e2e-smoke`, `web-e2e-critical`, and `e2e-policy` when syncing (#588).
+
+## Path-filter trap (#442 / #463 / #588)
 
 Only require checks that report a result on **every** pull request. Required checks that are path-filtered away leave PRs stuck at `mergeStateStatus=BLOCKED` forever.
 
 | Check | Runs on every PR? | Notes |
 | --- | --- | --- |
-| `build` | ✅ | `web-build.yml` has no path filter. |
-| `web-e2e-smoke` / `web-e2e-critical` | ✅ | `e2e-web.yml` runs on all PRs. |
-| `StillPointShared swift test` | ✅ | Uses a cheap ubuntu no-op when the package is unchanged (issue #463). |
-| `web-e2e-auth-db` | ⚠️ optional | Skips when secrets are unset; keep **optional** until secrets are guaranteed. |
-| `e2e-ios-*` | ❌ | Path-filtered to `ios/**`; do not require globally. |
+| `unit-tests` / `typecheck` / `build` | ✅ | No path filters. |
+| `StillPointShared swift test` | ✅ | Ubuntu no-op when package unchanged (#463). |
+| `Info.plist in sync with project.yml` | ✅ | Ubuntu no-op when plist inputs unchanged (#588 / #439). |
+| `web-e2e-*` / `ios-e2e-*` | ❌ | Off PR path — do not require globally. |
 
-## Apply (repo admin)
+## Apply (repo admin — requires confirmation)
 
 Dry-run the target list:
 
@@ -43,16 +56,18 @@ Apply (requires `gh auth` with admin rights on the repo):
 node scripts/ci/sync-main-required-checks.mjs --apply
 ```
 
-The script merges the #537 checks with the existing required set (`typecheck`, `StillPointShared swift test`) instead of replacing unrelated settings. Review the printed JSON before `--apply`.
+The script merges the #588 checks with the existing required set, removes deprecated e2e checks if present, and preserves unrelated settings (e.g. Vercel app checks). Review the printed list before `--apply`.
 
-Manual alternative: **Settings → Branches → `main` → Require status checks** and add the three check names above alongside the existing two.
+Manual alternative: **Settings → Branches → `main` → Require status checks** — add the five fast checks above; remove any e2e checks; keep existing Vercel/CodeRabbit checks.
 
 ## Verification
 
-After updating branch protection, open a no-op PR and confirm all five checks appear and complete:
+After updating branch protection, open a no-op PR and confirm all five fast checks appear and complete:
 
 1. `typecheck`
-2. `StillPointShared swift test`
+2. `unit-tests`
 3. `build`
-4. `web-e2e-smoke`
-5. `web-e2e-critical`
+4. `StillPointShared swift test`
+5. `Info.plist in sync with project.yml`
+
+Confirm full e2e workflows (`e2e-web`, `e2e-ios`) do **not** run on the PR, while advisory lanes (`pr-e2e-smoke`, coverage nudge) may appear without blocking merge.

--- a/docs/testing/e2e-coverage-matrix.md
+++ b/docs/testing/e2e-coverage-matrix.md
@@ -6,7 +6,7 @@ Published audit of user journeys across **web** (Playwright mobile web) and **iO
 
 | Tier | Meaning | CI lane |
 |------|---------|---------|
-| **P0** | Core retention path; regression blocks merge | `@smoke` / `@critical` (web PR lanes); iOS smoke/critical |
+| **P0** | Core retention path; regression blocks release / nightly audit | `@smoke` / `@critical` (web nightly + iOS release lanes) |
 | **P1** | High-value adjacent flows; covered in release or platform lanes | Full mobile web suite (`e2e-mobile.yml`); iOS critical where noted |
 | **P2** | Lower blast radius, manual QA, or unit/integration only | Tracked; no merge gate in v1 |
 

--- a/docs/testing/e2e-policy.md
+++ b/docs/testing/e2e-policy.md
@@ -213,26 +213,35 @@ from the `app_boot_seconds` metric above and from XCTest launch overhead.
 
 ## 11) PR merge gating policy
 
-For pull requests, required lanes:
+As of [#588](https://github.com/auerbachb/still-point/issues/588) (SkinGod model), **comprehensive e2e does not gate PR merges**. Required lanes are the fast checks documented in [branch-protection.md](./branch-protection.md):
 
-1. `web-e2e-smoke`
-2. `web-e2e-critical`
-3. `e2e-policy` (guard/secrets/no-sleep)
+1. `typecheck`
+2. `unit-tests` (#434)
+3. `build` (clean Next build + design-token parity)
+4. `StillPointShared swift test` (#463 no-op when unchanged)
+5. `Info.plist in sync with project.yml` (#439 — always-run workflow, #588)
 
-iOS E2E lanes are required for iOS test-plan changes and recommended otherwise; keep branch protection in sync with this policy ([branch-protection.md](./branch-protection.md)).
+PR advisory (non-blocking):
 
-### Release-time gating (mobile web + iOS TestFlight)
+- `pr-e2e-smoke (advisory)` — fast web smoke ([e2e-smoke.yml](../../.github/workflows/e2e-smoke.yml))
+- `e2e coverage nudge (advisory)` — neutral reminder when UI changes lack spec updates
+
+Issue [#537](https://github.com/auerbachb/still-point/issues/537) (require `web-e2e-smoke` / `web-e2e-critical` on PRs) is **superseded** by #588. Strategy overview: [e2e-strategy.md](./e2e-strategy.md).
+
+### Release-time gating (mobile web + native iOS TestFlight)
 
 As of [#494](https://github.com/auerbachb/still-point/issues/494) (mirroring [auerbachb/skingod#1402](https://github.com/auerbachb/skingod/issues/1402)), the mobile-web Playwright suite (`e2e-mobile.yml`, the 3-project cross-browser matrix) no longer runs on `pull_request` — it was the slowest, flakiest per-PR check, had no path filter, and blocked every PR regardless of relevance. It is now a reusable workflow (`workflow_call` + `workflow_dispatch` only) that runs:
 
-- as the first job of [`ios-testflight-auto.yml`](../../.github/workflows/ios-testflight-auto.yml) (the automatic PR-merge + `release:ios`-label release path) — the build-number bump + tag step only proceeds `if: needs.e2e.result == 'success'`, so a failing e2e run leaves nothing committed, tagged, or built;
+- as the first job of [`ios-testflight-auto.yml`](../../.github/workflows/ios-testflight-auto.yml) (the automatic PR-merge + `release:ios`-label release path) — the build-number bump + tag step only proceeds when **both** mobile-web and native iOS e2e succeed (#588);
 - on demand via `gh workflow run e2e-mobile.yml -f ref=<ref>` for ad-hoc verification.
 
 [`ios-testflight.yml`](../../.github/workflows/ios-testflight.yml) (the manual `ios-v*-build*` tag push, a break-glass escape hatch for shipping when e2e infra itself is down) intentionally does **not** call this gate.
 
-`e2e-ios.yml` (native XCTest smoke/critical) is unchanged by #494 — it stays path-filtered to `ios/**` on `pull_request`, matching skingod's analogous Maestro-lane precedent (PR-time signal, not release-gated).
+As of [#588](https://github.com/auerbachb/still-point/issues/588), native iOS e2e (`e2e-ios.yml` — XCTest smoke/critical) also moved off `pull_request` and gates the same `release:ios` TestFlight path alongside mobile-web e2e. Info.plist sync moved to [`infoplist-sync.yml`](../../.github/workflows/infoplist-sync.yml) as a fast required PR check.
 
-`e2e-web.yml` is also unchanged — web has no discrete "build" step to gate against (it auto-deploys to production on every merge to `main`), unlike iOS's TestFlight build. Revisit separately if that becomes painful.
+### Nightly web e2e (#588)
+
+Web has no discrete "build" step (production deploys on every merge to `main`), so comprehensive web e2e runs on a **nightly schedule** via [`e2e-web-nightly.yml`](../../.github/workflows/e2e-web-nightly.yml) (full smoke + critical + policy lanes on `main`) plus `workflow_dispatch`. This keeps [#497](./e2e-coverage-matrix.md) P0 coverage exercised without blocking PR merges.
 
 ## 12) Local runbook (single command per platform)
 

--- a/docs/testing/e2e-strategy.md
+++ b/docs/testing/e2e-strategy.md
@@ -1,0 +1,58 @@
+# E2E testing strategy (#588)
+
+Short strategy note for Still Point's CI e2e model — adapted from [auerbachb/skingod](https://github.com/auerbachb/skingod)'s e2e-flakiness / off-PR gating pattern ([#1402](https://github.com/auerbachb/skingod/issues/1402), [#1401](https://github.com/auerbachb/skingod/issues/1401)).
+
+## Why e2e is off the PR critical path
+
+Long-running e2e (Playwright web lanes, macOS XCTest) blocked every PR merge with high flake cost and low marginal safety versus running the same suites at **release** and **nightly**. Issue [#588](https://github.com/auerbachb/still-point/issues/588) moves comprehensive e2e off required PR checks while preserving coverage via gated + scheduled runs.
+
+## Where e2e runs
+
+| Suite | When | Blocks merge? | Workflow |
+| --- | --- | --- | --- |
+| **Web smoke + critical** | Nightly on `main` + `workflow_dispatch` | No | [e2e-web-nightly.yml](../../.github/workflows/e2e-web-nightly.yml) → [e2e-web.yml](../../.github/workflows/e2e-web.yml) |
+| **Mobile-web matrix** | `release:ios` PR merge → TestFlight auto path | No (PR); **yes (release)** | [ios-testflight-auto.yml](../../.github/workflows/ios-testflight-auto.yml) → [e2e-mobile.yml](../../.github/workflows/e2e-mobile.yml) |
+| **Native iOS smoke/critical** | `release:ios` PR merge → TestFlight auto path | No (PR); **yes (release)** | [ios-testflight-auto.yml](../../.github/workflows/ios-testflight-auto.yml) → [e2e-ios.yml](../../.github/workflows/e2e-ios.yml) |
+| **PR advisory smoke** | Every PR | No (`continue-on-error`) | [e2e-smoke.yml](../../.github/workflows/e2e-smoke.yml) |
+| **Coverage nudge** | Every PR | No (neutral check) | [e2e-coverage-nudge.yml](../../.github/workflows/e2e-coverage-nudge.yml) |
+
+Manual `ios-v*-build*` tags ([ios-testflight.yml](../../.github/workflows/ios-testflight.yml)) intentionally **skip** e2e — break-glass when infra is down ([#494](https://github.com/auerbachb/still-point/issues/494)).
+
+## What blocks PR merge (fast gate)
+
+Required status checks on `main` — see [branch-protection.md](./branch-protection.md):
+
+- `typecheck`, `unit-tests` (#434)
+- `build` (Next clean build + design-token parity)
+- `StillPointShared swift test` (#463 no-op pattern)
+- `Info.plist in sync with project.yml` (#439, split to always-run workflow)
+
+**Not required:** any `web-e2e-*` or `ios-e2e-*` job (#588 supersedes #537).
+
+## Coverage accountability
+
+- Journey matrix: [e2e-coverage-matrix.md](./e2e-coverage-matrix.md) (#497)
+- Retry / flake policy: [e2e-policy.md](./e2e-policy.md)
+- Nightly + release gates must still exercise P0 lanes — audit the matrix when moving specs between lanes.
+
+## Local verification
+
+```bash
+# Fast policy (also part of web-build required check via design tokens)
+npm run e2e:policy
+
+# Full web lanes (what nightly runs)
+E2E_BASE_URL=http://127.0.0.1:3000 npm run e2e:web:smoke
+E2E_BASE_URL=http://127.0.0.1:3000 npm run e2e:web:critical
+
+# iOS lanes (what release:ios gates)
+E2E_BASE_URL=http://127.0.0.1:3000 npm run e2e:ios:smoke
+E2E_BASE_URL=http://127.0.0.1:3000 npm run e2e:ios:critical
+```
+
+## Related issues
+
+- [#588](https://github.com/auerbachb/still-point/issues/588) — this strategy
+- [#537](https://github.com/auerbachb/still-point/issues/537) — superseded (would have required web e2e on PRs)
+- [#494](https://github.com/auerbachb/still-point/issues/494) — mobile-web off PRs (prior SkinGod step)
+- [#434](https://github.com/auerbachb/still-point/issues/434) / [#439](https://github.com/auerbachb/still-point/issues/439) — folded into branch protection sync

--- a/scripts/ci/sync-main-required-checks.mjs
+++ b/scripts/ci/sync-main-required-checks.mjs
@@ -1,28 +1,38 @@
 #!/usr/bin/env node
 /**
- * Sync required status checks on `main` for issue #537.
+ * Sync required status checks on `main` for issue #588.
  *
- * Adds `build`, `web-e2e-smoke`, and `web-e2e-critical` alongside the existing
- * required checks (`typecheck`, `StillPointShared swift test`). Does not remove
- * checks already configured unless they are superseded by this script's target
- * list (the script unions current + target).
+ * Sets the fast PR merge gate (folds #434 unit-tests + #439 Info.plist sync +
+ * #588 e2e-off-PR). Supersedes #537 (which would have required web-e2e lanes).
+ *
+ * Adds the target checks and removes deprecated e2e required checks if present.
+ * Preserves unrelated required checks (e.g. Vercel app checks).
  *
  * Usage:
  *   node scripts/ci/sync-main-required-checks.mjs --dry-run
  *   node scripts/ci/sync-main-required-checks.mjs --apply
+ *
+ * Requires explicit repo-admin confirmation before --apply (see branch-protection.md).
  */
 
 import { execFileSync } from "node:child_process";
 
 const BRANCH = "main";
 
-/** Checks that must stay required (existing + #537). */
+/** Fast checks that must stay required (#588, #434, #439). */
 const TARGET_CHECKS = [
   "typecheck",
-  "StillPointShared swift test",
+  "unit-tests",
   "build",
+  "StillPointShared swift test",
+  "Info.plist in sync with project.yml",
+];
+
+/** Deprecated e2e checks to remove when syncing (#588 supersedes #537). */
+const REMOVE_CHECKS = [
   "web-e2e-smoke",
   "web-e2e-critical",
+  "e2e-policy",
 ];
 
 function ghJson(args) {
@@ -69,8 +79,9 @@ function buildRequiredStatusChecksPayload(protection, mergedContexts) {
   return mergeRequiredStatusChecks(protection, mergedContexts);
 }
 
-function mergeChecks(existing, target) {
-  return [...new Set([...existing, ...target])].sort((a, b) => a.localeCompare(b));
+function mergeChecks(existing, target, remove) {
+  const filtered = existing.filter((ctx) => !remove.includes(ctx));
+  return [...new Set([...filtered, ...target])].sort((a, b) => a.localeCompare(b));
 }
 
 function main() {
@@ -95,7 +106,7 @@ function main() {
   }
 
   const existing = protection.required_status_checks?.contexts ?? [];
-  const merged = mergeChecks(existing, TARGET_CHECKS);
+  const merged = mergeChecks(existing, TARGET_CHECKS, REMOVE_CHECKS);
   const payload = buildRequiredStatusChecksPayload(protection, merged);
 
   console.log(`Branch: ${BRANCH}`);
@@ -104,14 +115,22 @@ function main() {
   console.log(`Target union (${merged.length}):`);
   for (const ctx of merged) console.log(`  - ${ctx}`);
 
+  const removed = existing.filter((ctx) => REMOVE_CHECKS.includes(ctx));
+  if (removed.length > 0) {
+    console.log("Will remove (deprecated e2e gates — #588):");
+    for (const ctx of removed) console.log(`  - ${ctx}`);
+  }
+
   const added = merged.filter((ctx) => !existing.includes(ctx));
-  if (added.length === 0) {
-    console.log("[branch-protection] Nothing to add — already in sync.");
+  if (added.length === 0 && removed.length === 0) {
+    console.log("[branch-protection] Nothing to change — already in sync.");
     return;
   }
 
-  console.log("Will add:");
-  for (const ctx of added) console.log(`  + ${ctx}`);
+  if (added.length > 0) {
+    console.log("Will add:");
+    for (const ctx of added) console.log(`  + ${ctx}`);
+  }
 
   if (dryRun) {
     console.log("[branch-protection] Dry run — re-run with --apply to write.");

--- a/scripts/e2e/coverage-nudge.mjs
+++ b/scripts/e2e/coverage-nudge.mjs
@@ -9,7 +9,7 @@ import { execFileSync } from "node:child_process";
 
 const UI_PATH_RE =
   /^(src\/(app|components|views|features)\/|ios\/StillPointApp\/Views\/|ios\/StillPointApp\/.*View\.swift$)/;
-const E2E_PATH_RE = /^(e2e\/|ios\/StillPointAppUITests\/|scripts\/e2e\/)/;
+const E2E_SPEC_PATH_RE = /^(e2e\/|ios\/StillPointAppUITests\/)/;
 
 function ghLines(args) {
   try {
@@ -38,12 +38,16 @@ function listChangedFiles() {
   const base = process.env.BASE_SHA?.trim();
   const head = process.env.HEAD_SHA?.trim();
   if (base && head) {
-    return execFileSync("git", ["diff", "--name-only", `${base}...${head}`], {
-      encoding: "utf8",
-    })
-      .split("\n")
-      .map((line) => line.trim())
-      .filter(Boolean);
+    try {
+      return execFileSync("git", ["diff", "--name-only", `${base}...${head}`], {
+        encoding: "utf8",
+      })
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean);
+    } catch {
+      return null;
+    }
   }
 
   return null;
@@ -57,7 +61,7 @@ function main() {
   }
 
   const uiFiles = files.filter((file) => UI_PATH_RE.test(file));
-  const e2eFiles = files.filter((file) => E2E_PATH_RE.test(file));
+  const e2eFiles = files.filter((file) => E2E_SPEC_PATH_RE.test(file));
 
   if (uiFiles.length === 0) {
     console.log("::notice::Coverage nudge: no user-facing surface changes detected.");

--- a/scripts/e2e/coverage-nudge.mjs
+++ b/scripts/e2e/coverage-nudge.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * Advisory PR coverage nudge (#588). When a PR touches user-facing surfaces
+ * without updating e2e specs, emit a notice so authors know to add/extend tests.
+ * This script always exits 0 — the workflow posts a neutral advisory, not a gate.
+ */
+
+import { execFileSync } from "node:child_process";
+
+const UI_PATH_RE =
+  /^(src\/(app|components|views|features)\/|ios\/StillPointApp\/Views\/|ios\/StillPointApp\/.*View\.swift$)/;
+const E2E_PATH_RE = /^(e2e\/|ios\/StillPointAppUITests\/|scripts\/e2e\/)/;
+
+function ghLines(args) {
+  try {
+    return execFileSync("gh", args, { encoding: "utf8" })
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function listChangedFiles() {
+  const prNumber = process.env.PR_NUMBER?.trim();
+  if (prNumber) {
+    const files = ghLines([
+      "api",
+      `repos/{owner}/{repo}/pulls/${prNumber}/files`,
+      "--paginate",
+      "--jq",
+      ".[].filename",
+    ]);
+    if (files && files.length > 0) return files;
+  }
+
+  const base = process.env.BASE_SHA?.trim();
+  const head = process.env.HEAD_SHA?.trim();
+  if (base && head) {
+    return execFileSync("git", ["diff", "--name-only", `${base}...${head}`], {
+      encoding: "utf8",
+    })
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+  }
+
+  return null;
+}
+
+function main() {
+  const files = listChangedFiles();
+  if (!files) {
+    console.log("::notice::Coverage nudge skipped — could not determine changed files.");
+    return;
+  }
+
+  const uiFiles = files.filter((file) => UI_PATH_RE.test(file));
+  const e2eFiles = files.filter((file) => E2E_PATH_RE.test(file));
+
+  if (uiFiles.length === 0) {
+    console.log("::notice::Coverage nudge: no user-facing surface changes detected.");
+    return;
+  }
+
+  if (e2eFiles.length > 0) {
+    console.log(
+      `::notice::Coverage nudge: ${uiFiles.length} UI file(s) changed and ${e2eFiles.length} e2e file(s) updated — thanks for keeping specs in sync.`,
+    );
+    return;
+  }
+
+  console.log("::warning::Coverage nudge: this PR touches user-facing code without e2e spec updates.");
+  console.log("Changed UI paths (sample):");
+  for (const file of uiFiles.slice(0, 12)) {
+    console.log(`  - ${file}`);
+  }
+  if (uiFiles.length > 12) {
+    console.log(`  … and ${uiFiles.length - 12} more`);
+  }
+  console.log(
+    "Consider adding or extending Playwright/XCUITest coverage. See docs/testing/e2e-coverage-matrix.md (#497).",
+  );
+  console.log(
+    "Comprehensive e2e still runs nightly on main and gates iOS TestFlight releases — this nudge is advisory only (#588).",
+  );
+}
+
+main();


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [#588](https://github.com/auerbachb/still-point/issues/588): adopt the SkinGod CI model by moving comprehensive e2e off the PR critical path and gating it to **release + nightly** instead. Folds [#434](https://github.com/auerbachb/still-point/issues/434) (`unit-tests`) and [#439](https://github.com/auerbachb/still-point/issues/439) (`Info.plist in sync with project.yml`) into a **single branch-protection update**, superseding [#537](https://github.com/auerbachb/still-point/issues/537).

## Workflow changes

| Change | Purpose |
| --- | --- |
| `infoplist-sync.yml` (new) | Required PR check with ubuntu no-op when plist inputs unchanged (#439 / path-filter trap) |
| `e2e-web.yml` / `e2e-ios.yml` | Remove `pull_request`; add `workflow_call` + `workflow_dispatch` |
| `e2e-web-nightly.yml` (new) | Scheduled full web e2e on `main` (08:00 UTC) |
| `e2e-smoke.yml` (new) | Fast advisory web smoke on PRs (`continue-on-error`) |
| `e2e-coverage-nudge.yml` (new) | Neutral advisory when UI changes lack e2e spec updates |
| `ios-testflight-auto.yml` | Gate `release:ios` on **both** mobile-web + native iOS e2e |

## Required PR checks (after admin apply)

- `typecheck`, `unit-tests`, `build`, `StillPointShared swift test`, `Info.plist in sync with project.yml`
- **Not required:** `web-e2e-smoke`, `web-e2e-critical`, `ios-e2e-*`

## Docs

- Rewrote `docs/testing/branch-protection.md` for #588
- Added `docs/testing/e2e-strategy.md`
- Updated `e2e-policy.md`, `README.md`, `e2e-coverage-matrix.md`
- Updated `scripts/ci/sync-main-required-checks.mjs` (adds fast checks, removes deprecated e2e checks)

## Admin follow-up (requires confirmation)

After merge, a repo admin should run:

```bash
node scripts/ci/sync-main-required-checks.mjs --dry-run
node scripts/ci/sync-main-required-checks.mjs --apply
```

See [docs/testing/branch-protection.md](docs/testing/branch-protection.md).

## Test plan

- [ ] Open a PR from this branch → full `e2e-web` / `e2e-ios` do **not** run; fast checks + advisory lanes appear
- [ ] `workflow_dispatch` on `e2e-web-nightly.yml` → full web suite runs
- [ ] Merge a `release:ios`-labeled PR → mobile-web + native iOS e2e gate TestFlight auto path
- [ ] Apply branch protection sync → five fast checks required; e2e checks removed if present

Closes #588. Resolves #434 and #439 via folded branch-protection sync. Supersedes #537.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23f95ce4-a096-4a74-9a5a-be4998388c49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23f95ce4-a096-4a74-9a5a-be4998388c49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Move full end-to-end checks off pull requests and keep PRs unblocked**

### What Changed
- Full web and iOS end-to-end tests no longer run as required PR checks; they now run nightly and on the iOS release path instead
- PRs now get a fast required gate for code checks plus a separate always-reported Info.plist sync check, so non-iOS changes no longer get stuck waiting on missing status checks
- PRs also show optional advisory smoke and coverage reminders when user-facing code changes without test updates
- iOS TestFlight releases now wait for both mobile-web and native iOS end-to-end checks before continuing

### Impact
`✅ Fewer blocked pull requests`
`✅ Faster merges for non-e2e changes`
`✅ Clearer coverage warnings on UI updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added advisory PR checks for web smoke testing and E2E coverage guidance; these checks do not block merges.
  * Added nightly comprehensive web E2E testing with optional manual runs.
  * Added an automated check to keep iOS configuration synchronized.

* **Updates**
  * Comprehensive web and native iOS E2E tests now run for scheduled or TestFlight release validation rather than every pull request.
  * Updated required PR checks and testing guidance to reflect the faster merge process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->