### PR TITLE
feat(web): offline PWA — app-shell cache, IndexedDB queue, Background Sync (#558)

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,18 @@
+{
+  "name": "Still Point",
+  "short_name": "Still Point",
+  "description": "Guided meditation practice for real, distractible days.",
+  "start_url": "/app/progress",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#0f1410",
+  "theme_color": "#0f1410",
+  "icons": [
+    {
+      "src": "/og.png",
+      "sizes": "724x724",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -33,6 +33,7 @@ const APP_SHELL_URLS = ["/app/progress", "/app", "/og.png", "/manifest.webmanife
 const SW_SUPPRESSION_CHANNEL = "stillpoint-session-suppression";
 const STATE_CACHE = "stillpoint-state-v1";
 const SUPPRESSION_STATE_URL = "https://still-point.internal/__session_suppression__";
+const OFFLINE_OWNER_STATE_URL = "https://still-point.internal/__offline_owner__";
 /** A suppress flag older than this is treated as inactive (self-heals a missed reset). */
 const SUPPRESS_TTL_MS = 10 * 60 * 1000;
 
@@ -140,12 +141,30 @@ async function postJson(url, body) {
   return res.json();
 }
 
+async function readOfflineOwnerUserId() {
+  try {
+    const cache = await caches.open(STATE_CACHE);
+    const cached = await cache.match(OFFLINE_OWNER_STATE_URL);
+    if (!cached) return null;
+    const data = await cached.json();
+    return typeof data.userId === "string" ? data.userId : null;
+  } catch {
+    return null;
+  }
+}
+
 async function flushOfflineQueueFromSw() {
+  const ownerUserId = await readOfflineOwnerUserId();
+  if (!ownerUserId) {
+    await notifyClientsToFlush();
+    return;
+  }
   const db = await openOfflineDb();
   try {
     const entries = await loadOfflineEntries(db);
     let changed = false;
     for (const entry of entries) {
+      if (entry.ownerUserId !== ownerUserId) continue;
       if (entry.sessionSynced && (!entry.thoughts || entry.thoughts.length === 0)) {
         continue;
       }
@@ -238,14 +257,24 @@ self.addEventListener("fetch", (event) => {
   if (isStaticAssetRequest(request)) {
     event.respondWith(
       caches.match(request).then((cached) => {
-        const networkFetch = fetch(request).then((response) => {
+        if (cached) {
+          void fetch(request)
+            .then((response) => {
+              if (response.ok) {
+                const copy = response.clone();
+                void caches.open(APP_SHELL_CACHE).then((cache) => cache.put(request, copy));
+              }
+            })
+            .catch(() => {});
+          return cached;
+        }
+        return fetch(request).then((response) => {
           if (response.ok) {
             const copy = response.clone();
             void caches.open(APP_SHELL_CACHE).then((cache) => cache.put(request, copy));
           }
           return response;
         });
-        return cached ?? networkFetch;
       }),
     );
   }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,13 @@
-/* Still Point Web Push service worker (#347). Served from site root. */
+/* Still Point service worker (#347 push, #431 suppression, #558 offline PWA). */
+
+/*
+ * Offline PWA (#558). Keep these in sync with src/lib/offlineSessionQueue/constants.ts.
+ */
+const OFFLINE_IDB_NAME = "stillpoint-offline-v1";
+const OFFLINE_IDB_STORE = "session-queue";
+const OFFLINE_SYNC_TAG = "stillpoint-session-sync";
+const APP_SHELL_CACHE = "stillpoint-app-shell-v1";
+const APP_SHELL_URLS = ["/app/progress", "/app", "/og.png", "/manifest.webmanifest"];
 
 /*
  * Suppress-during-session (#431). The app page relays the desired suppression
@@ -76,6 +85,180 @@ try {
 } catch {
   // BroadcastChannel unsupported: suppression simply never engages.
 }
+
+function openOfflineDb() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(OFFLINE_IDB_NAME, 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(OFFLINE_IDB_STORE)) {
+        db.createObjectStore(OFFLINE_IDB_STORE, { keyPath: "clientSessionId" });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("IndexedDB open failed"));
+  });
+}
+
+function loadOfflineEntries(db) {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(OFFLINE_IDB_STORE, "readonly");
+    const store = tx.objectStore(OFFLINE_IDB_STORE);
+    const request = store.getAll();
+    request.onsuccess = () => resolve(request.result ?? []);
+    request.onerror = () => reject(request.error ?? new Error("IndexedDB read failed"));
+  });
+}
+
+function saveOfflineEntries(db, entries) {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(OFFLINE_IDB_STORE, "readwrite");
+    const store = tx.objectStore(OFFLINE_IDB_STORE);
+    const clearRequest = store.clear();
+    clearRequest.onerror = () => reject(clearRequest.error ?? new Error("IndexedDB clear failed"));
+    clearRequest.onsuccess = () => {
+      for (const entry of entries) {
+        store.put(entry);
+      }
+    };
+    tx.oncomplete = () => resolve(undefined);
+    tx.onerror = () => reject(tx.error ?? new Error("IndexedDB write failed"));
+  });
+}
+
+async function postJson(url, body) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(text || `Request failed (${res.status})`);
+  }
+  return res.json();
+}
+
+async function flushOfflineQueueFromSw() {
+  const db = await openOfflineDb();
+  try {
+    const entries = await loadOfflineEntries(db);
+    let changed = false;
+    for (const entry of entries) {
+      if (entry.sessionSynced && (!entry.thoughts || entry.thoughts.length === 0)) {
+        continue;
+      }
+      if (!entry.sessionSynced) {
+        const data = await postJson("/api/sessions", entry.request);
+        entry.serverSessionId = data.session?.id ?? null;
+        entry.sessionSynced = true;
+        changed = true;
+      }
+      if (entry.serverSessionId && entry.thoughts?.length > 0) {
+        await postJson("/api/thoughts/batch", {
+          sessionId: entry.serverSessionId,
+          dayNumber: entry.request.dayNumber,
+          thoughts: entry.thoughts,
+        });
+        entry.thoughts = [];
+        changed = true;
+      }
+    }
+    if (changed) {
+      await saveOfflineEntries(db, entries);
+    }
+  } finally {
+    db.close();
+  }
+}
+
+async function notifyClientsToFlush() {
+  const windowClients = await clients.matchAll({ type: "window", includeUncontrolled: true });
+  for (const client of windowClients) {
+    client.postMessage({ type: "flush-offline-session-queue" });
+  }
+}
+
+function isStaticAssetRequest(request) {
+  const url = new URL(request.url);
+  return url.pathname.startsWith("/_next/static/")
+    || url.pathname.startsWith("/audio/")
+    || url.pathname === "/og.png"
+    || url.pathname === "/manifest.webmanifest";
+}
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(APP_SHELL_CACHE).then((cache) => cache.addAll(APP_SHELL_URLS)).then(() => self.skipWaiting()),
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key.startsWith("stillpoint-app-shell-") && key !== APP_SHELL_CACHE)
+          .map((key) => caches.delete(key)),
+      ),
+    ).then(() => self.clients.claim()),
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  if (request.method !== "GET") return;
+
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) return;
+  if (url.pathname.startsWith("/api/")) return;
+
+  if (request.mode === "navigate") {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          if (response.ok) {
+            const copy = response.clone();
+            void caches.open(APP_SHELL_CACHE).then((cache) => cache.put(request, copy));
+          }
+          return response;
+        })
+        .catch(async () => {
+          const cached = await caches.match(request);
+          if (cached) return cached;
+          const shell = await caches.match("/app/progress");
+          if (shell) return shell;
+          return caches.match("/app");
+        }),
+    );
+    return;
+  }
+
+  if (isStaticAssetRequest(request)) {
+    event.respondWith(
+      caches.match(request).then((cached) => {
+        const networkFetch = fetch(request).then((response) => {
+          if (response.ok) {
+            const copy = response.clone();
+            void caches.open(APP_SHELL_CACHE).then((cache) => cache.put(request, copy));
+          }
+          return response;
+        });
+        return cached ?? networkFetch;
+      }),
+    );
+  }
+});
+
+self.addEventListener("sync", (event) => {
+  if (event.tag !== OFFLINE_SYNC_TAG) return;
+  event.waitUntil(
+    flushOfflineQueueFromSw()
+      .then(() => notifyClientsToFlush())
+      .catch(() => notifyClientsToFlush()),
+  );
+});
 
 self.addEventListener("push", (event) => {
   let data = {};

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -21,6 +21,8 @@ import type { SessionType, Track } from "@/lib/constants";
 import { advanceProgression, advanceSecondTrackDay, isDualTrackEligible, sessionDurationForUser, type RecoveryFields } from "@/lib/duration";
 import { todayLocalIsoDate } from "@/lib/sessionCalendar";
 import { resetTrackingUnlockOnLogout, syncTrackingUnlockFromSessions } from "@/lib/trackingControlPrefs";
+import { getWebSessionSyncCoordinator } from "@/lib/offlineSessionQueue";
+import { PwaBootstrap } from "@/components/PwaBootstrap";
 
 /** Normalizes `User`'s optional recovery fields (absent on some legacy responses)
  *  into the non-optional shape `@/lib/duration` helpers expect. */
@@ -183,6 +185,10 @@ type Overlay = "session" | "breath" | "complete";
 
 type CompletionData = {
   sessionId: string | null;
+  /** #558: stable local key for offline end-note sync during completion. */
+  clientSessionId: string | null;
+  /** #558: true when the sit is queued locally and awaiting server sync. */
+  isPendingSync: boolean;
   dayNumber: number;
   sessionType: SessionType;
   /** #240: which daily track this completed sit belonged to. */
@@ -424,6 +430,7 @@ export default function StillPoint() {
     setOverlay(null);
     setUser(null);
     clearAccountScopedLocalState();
+    void getWebSessionSyncCoordinator().clearQueue().catch(() => {});
   };
 
   const handleBegin = (sessionType: SessionType = "standard", track: Track = "primary") => {
@@ -481,6 +488,8 @@ export default function StillPoint() {
     setBuddyCalendarMessage(null);
     setCompletionData({
       sessionId: data.sessionId,
+      clientSessionId: null,
+      isPendingSync: false,
       dayNumber: data.dayNumber,
       sessionType: "standard",
       // Buddy sits always count toward the primary track (#240).
@@ -513,66 +522,52 @@ export default function StillPoint() {
     mindStateLog: Array<{ time: number; state: string }>;
     thoughts: Array<{ timeInSession: number; text: string }>;
   }) => {
+    const clientSessionId = crypto.randomUUID();
     let savedSessionId: string | null = null;
+    let isPendingSync = false;
 
-    try {
-      // Save session
-      const sessionRes = await fetch("/api/sessions", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          dayNumber: data.dayNumber,
-          sessionType: data.sessionType,
-          track: data.track,
-          duration: data.duration,
-          bonusSeconds: data.bonusSeconds,
-          completed: data.completed,
-          actualTime: data.actualTime,
-          clearPercent: data.clearPercent,
-          thoughtCount: data.thoughtCount,
-          mindStateLog: data.mindStateLog,
-          sessionDate: todayLocalIsoDate(),
-        }),
-      });
+    if (user?.id) {
+      try {
+        const coordinator = getWebSessionSyncCoordinator();
+        const result = await coordinator.saveCompletedSession(
+          {
+            dayNumber: data.dayNumber,
+            sessionType: data.sessionType,
+            track: data.track,
+            duration: data.duration,
+            bonusSeconds: data.bonusSeconds,
+            completed: data.completed,
+            actualTime: data.actualTime,
+            clearPercent: data.clearPercent,
+            thoughtCount: data.thoughtCount,
+            mindStateLog: data.mindStateLog,
+            sessionDate: todayLocalIsoDate(),
+          },
+          clientSessionId,
+          user.id,
+          data.thoughts,
+        );
+        savedSessionId = result.sessionId;
+        isPendingSync = result.isPendingSync;
 
-      if (!sessionRes.ok) {
-        console.error("Failed to save session:", await sessionRes.text());
-      } else {
-        const sessionData = await sessionRes.json();
-        savedSessionId = sessionData.session?.id ?? null;
-
-        // Save thoughts if any
-        if (data.thoughts.length > 0 && savedSessionId) {
-          await fetch("/api/thoughts/batch", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              sessionId: savedSessionId,
-              dayNumber: data.dayNumber,
-              thoughts: data.thoughts,
-            }),
-          });
-        }
-
-        // Refresh local user state from the server (#238): whether this completed
-        // standard sit advances `currentDay` or steps a recovery ramp instead is
-        // decided server-side in POST /api/sessions, so re-fetch rather than
-        // optimistically guessing which one happened.
-        if (data.completed && data.sessionType === "standard") {
+        if (data.completed && data.sessionType === "standard" && !isPendingSync) {
           void api
             .me()
             .then(({ user: u }) => setUser(u))
             .catch(() => {});
-          // #240: refresh per-track completion badges for today.
+          void refreshTodayTracks();
+        } else if (data.completed && data.sessionType === "standard" && isPendingSync) {
           void refreshTodayTracks();
         }
+      } catch (error) {
+        console.error("Failed to save session:", error);
       }
-    } catch (error) {
-      console.error("Failed to save session:", error);
     }
 
     setCompletionData({
       sessionId: savedSessionId,
+      clientSessionId,
+      isPendingSync,
       dayNumber: data.dayNumber,
       sessionType: data.sessionType,
       track: data.track,
@@ -599,47 +594,34 @@ export default function StillPoint() {
     mindStateLog: Array<{ time: number; state: string }>;
     thoughts: Array<{ timeInSession: number; text: string }>;
   }) => {
-    try {
-      // Save abandoned session
-      const sessionRes = await fetch("/api/sessions", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          dayNumber: data.dayNumber,
-          sessionType: data.sessionType,
-          track: data.track,
-          duration: data.duration,
-          bonusSeconds: data.bonusSeconds,
-          completed: false,
-          actualTime: data.actualTime,
-          clearPercent: data.clearPercent,
-          thoughtCount: data.thoughtCount,
-          mindStateLog: data.mindStateLog,
-          sessionDate: todayLocalIsoDate(),
-        }),
-      });
-
-      if (sessionRes.ok) {
-        const sessionData = await sessionRes.json();
-
-        if (data.thoughts.length > 0 && sessionData.session?.id) {
-          await fetch("/api/thoughts/batch", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              sessionId: sessionData.session.id,
-              dayNumber: data.dayNumber,
-              thoughts: data.thoughts,
-            }),
-          });
-        }
+    if (user?.id) {
+      try {
+        const clientSessionId = crypto.randomUUID();
+        await getWebSessionSyncCoordinator().saveCompletedSession(
+          {
+            dayNumber: data.dayNumber,
+            sessionType: data.sessionType,
+            track: data.track,
+            duration: data.duration,
+            bonusSeconds: data.bonusSeconds,
+            completed: false,
+            actualTime: data.actualTime,
+            clearPercent: data.clearPercent,
+            thoughtCount: data.thoughtCount,
+            mindStateLog: data.mindStateLog,
+            sessionDate: todayLocalIsoDate(),
+          },
+          clientSessionId,
+          user.id,
+          data.thoughts,
+        );
+      } catch (error) {
+        console.error("Failed to save abandoned session:", error);
       }
-    } catch (error) {
-      console.error("Failed to save abandoned session:", error);
     }
 
     setOverlay(null);
-  }, []);
+  }, [user]);
 
   // #376: log a breath-counting session, mirroring iOS `completeBreathSession`
   // (#374). Empty sessions (entered then ended with no taps) are not logged.
@@ -658,25 +640,26 @@ export default function StillPoint() {
     if (breathSavingRef.current) return;
     breathSavingRef.current = true;
     try {
-      const res = await fetch("/api/sessions", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          dayNumber: user?.currentDay ?? 1,
-          sessionType: "breath",
-          duration: Math.max(result.elapsedSeconds, 1),
-          bonusSeconds: 0,
-          completed: true,
-          actualTime: result.elapsedSeconds,
-          clearPercent: 0,
-          thoughtCount: 0,
-          breathCount: result.breathCount,
-          mindStateLog: [],
-          sessionDate: todayLocalIsoDate(),
-        }),
-      });
-      if (!res.ok) {
-        console.error("Failed to save breath session: HTTP", res.status);
+      if (user?.id) {
+        const clientSessionId = crypto.randomUUID();
+        await getWebSessionSyncCoordinator().saveCompletedSession(
+          {
+            dayNumber: user.currentDay ?? 1,
+            sessionType: "breath",
+            duration: Math.max(result.elapsedSeconds, 1),
+            bonusSeconds: 0,
+            completed: true,
+            actualTime: result.elapsedSeconds,
+            clearPercent: 0,
+            thoughtCount: 0,
+            breathCount: result.breathCount,
+            mindStateLog: [],
+            sessionDate: todayLocalIsoDate(),
+          },
+          clientSessionId,
+          user.id,
+          [],
+        );
       }
     } catch (error) {
       console.error("Failed to save breath session:", error);
@@ -708,7 +691,9 @@ export default function StillPoint() {
 
   if (authError) {
     return (
-      <div style={{
+      <>
+        <PwaBootstrap ownerUserId={null} />
+        <div style={{
         minHeight: "100%", display: "flex", flexDirection: "column",
         alignItems: "center", justifyContent: "center",
         gap: "var(--s3)",
@@ -745,13 +730,16 @@ export default function StillPoint() {
           Retry
         </button>
       </div>
+      </>
     );
   }
 
   // Not logged in
   if (!user) {
     return (
-      <div style={{
+      <>
+        <PwaBootstrap ownerUserId={null} />
+        <div style={{
         minHeight: "100%", display: "flex", flexDirection: "column",
         alignItems: "center", justifyContent: "center",
         fontFamily: "var(--font-serif)",
@@ -759,6 +747,7 @@ export default function StillPoint() {
       }}>
         <AuthScreen onLogin={handleLogin} />
       </div>
+      </>
     );
   }
 
@@ -766,7 +755,9 @@ export default function StillPoint() {
 
   // Logged in
   return (
-    <div style={{
+    <>
+      <PwaBootstrap ownerUserId={user.id} />
+      <div style={{
       minHeight: "100%",
       display: "grid",
       gridTemplateRows: isImmersive ? "1fr" : "auto 1fr auto",
@@ -933,12 +924,29 @@ export default function StillPoint() {
               .then(({ user: u }) => setUser(u))
               .catch(() => {});
           }}
-          onSaveNote={completionData.sessionId ? async (text: string) => {
+          onSaveNote={completionData.clientSessionId && user ? async (text: string) => {
+            const coordinator = getWebSessionSyncCoordinator();
+            if (completionData.isPendingSync) {
+              await coordinator.appendEndNote(
+                completionData.clientSessionId!,
+                user.id,
+                text,
+              );
+              return;
+            }
+            const sessionId = completionData.sessionId
+              ?? (await coordinator.resolvedServerSessionId(
+                completionData.clientSessionId!,
+                user.id,
+              ));
+            if (!sessionId) {
+              throw new Error("Failed to save note");
+            }
             const res = await fetch("/api/thoughts/batch", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({
-                sessionId: completionData.sessionId,
+                sessionId,
                 dayNumber: completionData.dayNumber,
                 thoughts: [{ timeInSession: -1, text }],
               }),
@@ -947,7 +955,7 @@ export default function StillPoint() {
               throw new Error("Failed to save note");
             }
           } : undefined}
-          onSaveRatings={completionData.sessionId ? async (ratings) => {
+          onSaveRatings={completionData.sessionId && !completionData.isPendingSync ? async (ratings) => {
             await api.updateSessionRatings(completionData.sessionId!, ratings);
           } : undefined}
           compact={isMobile}
@@ -1030,5 +1038,6 @@ export default function StillPoint() {
         />
       )}
     </div>
+    </>
   );
 }

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -430,7 +430,9 @@ export default function StillPoint() {
     setOverlay(null);
     setUser(null);
     clearAccountScopedLocalState();
-    void getWebSessionSyncCoordinator().clearQueue().catch(() => {});
+    void getWebSessionSyncCoordinator().clearQueue().catch((error) => {
+      console.error("Failed to clear offline session queue on logout:", error);
+    });
   };
 
   const handleBegin = (sessionType: SessionType = "standard", track: Track = "primary") => {
@@ -561,6 +563,8 @@ export default function StillPoint() {
         }
       } catch (error) {
         console.error("Failed to save session:", error);
+        isPendingSync = true;
+        savedSessionId = clientSessionId;
       }
     }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,8 +6,13 @@ import "./globals.css";
 export const metadata: Metadata = {
   metadataBase: new URL("https://still-point.me"),
   title: "Still Point",
+  manifest: "/manifest.webmanifest",
   description:
     "Build steadier focus with a guided one-minute meditation practice designed for real, distractible days.",
+  appleWebApp: {
+    capable: true,
+    title: "Still Point",
+  },
   openGraph: {
     type: "website",
     images: [

--- a/src/components/PwaBootstrap.tsx
+++ b/src/components/PwaBootstrap.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { initWebPwaOffline } from "@/lib/offlineSessionQueue/pwaBootstrap";
+import { initWebPwaOffline, persistOfflineOwnerUserId } from "@/lib/offlineSessionQueue/pwaBootstrap";
 
 type PwaBootstrapProps = {
   ownerUserId: string | null;
@@ -15,6 +15,10 @@ export function PwaBootstrap({ ownerUserId }: PwaBootstrapProps) {
   useEffect(() => {
     return initWebPwaOffline(() => ownerUserIdRef.current);
   }, []);
+
+  useEffect(() => {
+    void persistOfflineOwnerUserId(ownerUserId);
+  }, [ownerUserId]);
 
   return null;
 }

--- a/src/components/PwaBootstrap.tsx
+++ b/src/components/PwaBootstrap.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { initWebPwaOffline } from "@/lib/offlineSessionQueue/pwaBootstrap";
+
+type PwaBootstrapProps = {
+  ownerUserId: string | null;
+};
+
+/** Registers the PWA service worker and reconnect flush hooks (#558). */
+export function PwaBootstrap({ ownerUserId }: PwaBootstrapProps) {
+  const ownerUserIdRef = useRef(ownerUserId);
+  ownerUserIdRef.current = ownerUserId;
+
+  useEffect(() => {
+    return initWebPwaOffline(() => ownerUserIdRef.current);
+  }, []);
+
+  return null;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -221,6 +221,8 @@ export const api = {
     thoughtCount: number;
     mindStateLog: Array<{ time: number; state: string }>;
     sessionDate: string;
+    /** #557/#558: client-generated UUID for offline idempotent create. */
+    clientSessionId?: string;
   }) =>
     request<{ session: Session }>("/api/sessions", { method: "POST", body: JSON.stringify(data) }),
 

--- a/src/lib/offlineSessionQueue/constants.ts
+++ b/src/lib/offlineSessionQueue/constants.ts
@@ -1,0 +1,4 @@
+/** IndexedDB + Background Sync identifiers (#558). Keep in sync with `public/sw.js`. */
+export const OFFLINE_IDB_NAME = "stillpoint-offline-v1";
+export const OFFLINE_IDB_STORE = "session-queue";
+export const OFFLINE_SYNC_TAG = "stillpoint-session-sync";

--- a/src/lib/offlineSessionQueue/idbStore.ts
+++ b/src/lib/offlineSessionQueue/idbStore.ts
@@ -1,0 +1,80 @@
+import { OFFLINE_IDB_NAME, OFFLINE_IDB_STORE } from "./constants";
+import { InMemoryOfflineSessionQueueStore, type OfflineSessionQueueStore } from "./queueStore";
+import type { PendingSessionEntry } from "./types";
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(OFFLINE_IDB_NAME, 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(OFFLINE_IDB_STORE)) {
+        db.createObjectStore(OFFLINE_IDB_STORE, { keyPath: "clientSessionId" });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("IndexedDB open failed"));
+  });
+}
+
+function runTransaction<T>(
+  mode: IDBTransactionMode,
+  fn: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T> {
+  return openDb().then(
+    (db) =>
+      new Promise<T>((resolve, reject) => {
+        const tx = db.transaction(OFFLINE_IDB_STORE, mode);
+        const store = tx.objectStore(OFFLINE_IDB_STORE);
+        const request = fn(store);
+        request.onsuccess = () => resolve(request.result as T);
+        request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed"));
+        tx.oncomplete = () => db.close();
+        tx.onerror = () => reject(tx.error ?? new Error("IndexedDB transaction failed"));
+      }),
+  );
+}
+
+export class IndexedDbOfflineSessionQueueStore implements OfflineSessionQueueStore {
+  async loadEntries(): Promise<PendingSessionEntry[]> {
+    if (typeof indexedDB === "undefined") {
+      return [];
+    }
+    try {
+      return await runTransaction("readonly", (store) => store.getAll());
+    } catch {
+      return [];
+    }
+  }
+
+  async saveEntries(entries: PendingSessionEntry[]): Promise<void> {
+    if (typeof indexedDB === "undefined") {
+      return;
+    }
+    await openDb().then(
+      (db) =>
+        new Promise<void>((resolve, reject) => {
+          const tx = db.transaction(OFFLINE_IDB_STORE, "readwrite");
+          const store = tx.objectStore(OFFLINE_IDB_STORE);
+          const clearRequest = store.clear();
+          clearRequest.onerror = () => reject(clearRequest.error ?? new Error("IndexedDB clear failed"));
+          clearRequest.onsuccess = () => {
+            for (const entry of entries) {
+              store.put(entry);
+            }
+          };
+          tx.oncomplete = () => {
+            db.close();
+            resolve();
+          };
+          tx.onerror = () => reject(tx.error ?? new Error("IndexedDB transaction failed"));
+        }),
+    );
+  }
+}
+
+export function defaultOfflineSessionQueueStore(): OfflineSessionQueueStore {
+  if (typeof indexedDB !== "undefined") {
+    return new IndexedDbOfflineSessionQueueStore();
+  }
+  return new InMemoryOfflineSessionQueueStore();
+}

--- a/src/lib/offlineSessionQueue/idbStore.ts
+++ b/src/lib/offlineSessionQueue/idbStore.ts
@@ -23,13 +23,26 @@ function runTransaction<T>(
   return openDb().then(
     (db) =>
       new Promise<T>((resolve, reject) => {
+        const closeDb = () => {
+          try {
+            db.close();
+          } catch {
+            // ignore close failures
+          }
+        };
         const tx = db.transaction(OFFLINE_IDB_STORE, mode);
         const store = tx.objectStore(OFFLINE_IDB_STORE);
         const request = fn(store);
         request.onsuccess = () => resolve(request.result as T);
-        request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed"));
-        tx.oncomplete = () => db.close();
-        tx.onerror = () => reject(tx.error ?? new Error("IndexedDB transaction failed"));
+        request.onerror = () => {
+          closeDb();
+          reject(request.error ?? new Error("IndexedDB request failed"));
+        };
+        tx.oncomplete = () => closeDb();
+        tx.onerror = () => {
+          closeDb();
+          reject(tx.error ?? new Error("IndexedDB transaction failed"));
+        };
       }),
   );
 }
@@ -53,20 +66,33 @@ export class IndexedDbOfflineSessionQueueStore implements OfflineSessionQueueSto
     await openDb().then(
       (db) =>
         new Promise<void>((resolve, reject) => {
+          const closeDb = () => {
+            try {
+              db.close();
+            } catch {
+              // ignore close failures
+            }
+          };
           const tx = db.transaction(OFFLINE_IDB_STORE, "readwrite");
           const store = tx.objectStore(OFFLINE_IDB_STORE);
           const clearRequest = store.clear();
-          clearRequest.onerror = () => reject(clearRequest.error ?? new Error("IndexedDB clear failed"));
+          clearRequest.onerror = () => {
+            closeDb();
+            reject(clearRequest.error ?? new Error("IndexedDB clear failed"));
+          };
           clearRequest.onsuccess = () => {
             for (const entry of entries) {
               store.put(entry);
             }
           };
           tx.oncomplete = () => {
-            db.close();
+            closeDb();
             resolve();
           };
-          tx.onerror = () => reject(tx.error ?? new Error("IndexedDB transaction failed"));
+          tx.onerror = () => {
+            closeDb();
+            reject(tx.error ?? new Error("IndexedDB transaction failed"));
+          };
         }),
     );
   }

--- a/src/lib/offlineSessionQueue/index.ts
+++ b/src/lib/offlineSessionQueue/index.ts
@@ -1,0 +1,23 @@
+export {
+  OFFLINE_IDB_NAME,
+  OFFLINE_IDB_STORE,
+  OFFLINE_SYNC_TAG,
+} from "./constants";
+export { IndexedDbOfflineSessionQueueStore, defaultOfflineSessionQueueStore } from "./idbStore";
+export { InMemoryOfflineSessionQueueStore, type OfflineSessionQueueStore } from "./queueStore";
+export {
+  WebSessionSyncCoordinator,
+  SessionSyncError,
+  alwaysFailingSessionSyncTransport,
+  getWebSessionSyncCoordinator,
+  provisionalSessionId,
+  requestBackgroundSync,
+  requestWithClientId,
+} from "./sessionSyncCoordinator";
+export { initWebPwaOffline, registerServiceWorker } from "./pwaBootstrap";
+export type {
+  CreateSessionPayload,
+  PendingSessionEntry,
+  PendingSessionThought,
+  SavedSessionResult,
+} from "./types";

--- a/src/lib/offlineSessionQueue/pwaBootstrap.ts
+++ b/src/lib/offlineSessionQueue/pwaBootstrap.ts
@@ -8,6 +8,21 @@ export async function registerServiceWorker(): Promise<ServiceWorkerRegistration
 
 let bootstrapStarted = false;
 
+export async function persistOfflineOwnerUserId(userId: string | null): Promise<void> {
+  if (typeof caches === "undefined") return;
+  try {
+    const cache = await caches.open("stillpoint-state-v1");
+    await cache.put(
+      "https://still-point.internal/__offline_owner__",
+      new Response(JSON.stringify({ userId }), {
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  } catch {
+    // Best-effort: foreground flush still has owner context.
+  }
+}
+
 /** Register the PWA service worker and wire reconnect flush (#558). */
 export function initWebPwaOffline(ownerUserIdProvider: () => string | null): () => void {
   if (typeof window === "undefined" || bootstrapStarted) {
@@ -45,6 +60,7 @@ export function initWebPwaOffline(ownerUserIdProvider: () => string | null): () 
   flushForCurrentUser();
 
   return () => {
+    bootstrapStarted = false;
     window.removeEventListener("online", onOnline);
     document.removeEventListener("visibilitychange", onVisibility);
     navigator.serviceWorker?.removeEventListener("message", onMessage);

--- a/src/lib/offlineSessionQueue/pwaBootstrap.ts
+++ b/src/lib/offlineSessionQueue/pwaBootstrap.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { getWebSessionSyncCoordinator } from "./sessionSyncCoordinator";
+
+export async function registerServiceWorker(): Promise<ServiceWorkerRegistration> {
+  return navigator.serviceWorker.register("/sw.js", { scope: "/" });
+}
+
+let bootstrapStarted = false;
+
+/** Register the PWA service worker and wire reconnect flush (#558). */
+export function initWebPwaOffline(ownerUserIdProvider: () => string | null): () => void {
+  if (typeof window === "undefined" || bootstrapStarted) {
+    return () => {};
+  }
+  bootstrapStarted = true;
+
+  void registerServiceWorker().catch(() => {});
+
+  const coordinator = getWebSessionSyncCoordinator();
+
+  const flushForCurrentUser = () => {
+    const ownerUserId = ownerUserIdProvider();
+    if (!ownerUserId) return;
+    void coordinator.flushPending(ownerUserId).catch(() => {});
+  };
+
+  const onOnline = () => flushForCurrentUser();
+  window.addEventListener("online", onOnline);
+
+  const onVisibility = () => {
+    if (document.visibilityState === "visible") {
+      flushForCurrentUser();
+    }
+  };
+  document.addEventListener("visibilitychange", onVisibility);
+
+  const onMessage = (event: MessageEvent) => {
+    if (event.data?.type === "flush-offline-session-queue") {
+      flushForCurrentUser();
+    }
+  };
+  navigator.serviceWorker?.addEventListener("message", onMessage);
+
+  flushForCurrentUser();
+
+  return () => {
+    window.removeEventListener("online", onOnline);
+    document.removeEventListener("visibilitychange", onVisibility);
+    navigator.serviceWorker?.removeEventListener("message", onMessage);
+  };
+}

--- a/src/lib/offlineSessionQueue/queueStore.ts
+++ b/src/lib/offlineSessionQueue/queueStore.ts
@@ -1,0 +1,18 @@
+import type { PendingSessionEntry } from "./types";
+
+export interface OfflineSessionQueueStore {
+  loadEntries(): Promise<PendingSessionEntry[]>;
+  saveEntries(entries: PendingSessionEntry[]): Promise<void>;
+}
+
+export class InMemoryOfflineSessionQueueStore implements OfflineSessionQueueStore {
+  private entries: PendingSessionEntry[] = [];
+
+  async loadEntries(): Promise<PendingSessionEntry[]> {
+    return [...this.entries];
+  }
+
+  async saveEntries(entries: PendingSessionEntry[]): Promise<void> {
+    this.entries = [...entries];
+  }
+}

--- a/src/lib/offlineSessionQueue/sessionSyncCoordinator.test.ts
+++ b/src/lib/offlineSessionQueue/sessionSyncCoordinator.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "vitest";
+import { InMemoryOfflineSessionQueueStore } from "./queueStore";
+import {
+  SessionSyncError,
+  WebSessionSyncCoordinator,
+  alwaysFailingSessionSyncTransport,
+  provisionalSessionId,
+  requestWithClientId,
+} from "./sessionSyncCoordinator";
+import type { SessionSyncTransport } from "./transport";
+
+const testOwnerUserId = "user-test-558";
+
+function baseRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    dayNumber: 1,
+    sessionType: "standard" as const,
+    duration: 60,
+    completed: true,
+    actualTime: 60,
+    clearPercent: 100,
+    thoughtCount: 0,
+    mindStateLog: [] as Array<{ time: number; state: string }>,
+    sessionDate: "2026-07-17",
+    ...overrides,
+  };
+}
+
+describe("WebSessionSyncCoordinator (#558)", () => {
+  test("saveCompletedSession enqueues when sync unavailable", async () => {
+    const store = new InMemoryOfflineSessionQueueStore();
+    const coordinator = new WebSessionSyncCoordinator(store, alwaysFailingSessionSyncTransport);
+    const clientSessionId = "550e8400-e29b-41d4-a716-446655440000";
+
+    const result = await coordinator.saveCompletedSession(
+      baseRequest(),
+      clientSessionId,
+      testOwnerUserId,
+      [],
+    );
+
+    expect(result.isPendingSync).toBe(true);
+    expect(result.sessionId).toBe(clientSessionId);
+    const entries = await store.loadEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.ownerUserId).toBe(testOwnerUserId);
+    expect(entries[0]!.sessionSynced).toBe(false);
+    expect(entries[0]!.request.clientSessionId).toBe(clientSessionId);
+  });
+
+  test("duplicate clientSessionId does not duplicate queue entries", async () => {
+    const store = new InMemoryOfflineSessionQueueStore();
+    const coordinator = new WebSessionSyncCoordinator(store, alwaysFailingSessionSyncTransport);
+    const clientSessionId = "550e8400-e29b-41d4-a716-446655440001";
+
+    await coordinator.saveCompletedSession(baseRequest(), clientSessionId, testOwnerUserId, []);
+    await coordinator.saveCompletedSession(baseRequest(), clientSessionId, testOwnerUserId, []);
+
+    expect(await store.loadEntries()).toHaveLength(1);
+  });
+
+  test("flushPending skips entries owned by another user", async () => {
+    const store = new InMemoryOfflineSessionQueueStore();
+    const coordinator = new WebSessionSyncCoordinator(store, alwaysFailingSessionSyncTransport);
+    const clientSessionId = "550e8400-e29b-41d4-a716-446655440002";
+
+    await coordinator.saveCompletedSession(baseRequest(), clientSessionId, "user-a", []);
+
+    const flushed = await coordinator.flushPending("user-b");
+    expect(flushed).toBe(0);
+    expect(await store.loadEntries()).toHaveLength(1);
+  });
+
+  test("provisionalSessionId uses clientSessionId", () => {
+    const clientSessionId = "550e8400-e29b-41d4-a716-446655440003";
+    expect(provisionalSessionId(clientSessionId)).toBe(clientSessionId);
+    expect(requestWithClientId(baseRequest({ sessionType: "quick" }), clientSessionId).clientSessionId)
+      .toBe(clientSessionId);
+  });
+
+  test("flushPending syncs queued session and thoughts with #557 idempotency key", async () => {
+    const store = new InMemoryOfflineSessionQueueStore();
+    const clientSessionId = "550e8400-e29b-41d4-a716-446655440004";
+    const createCalls: string[] = [];
+    const thoughtCalls: string[] = [];
+
+    const transport: SessionSyncTransport = {
+      createSession: async (payload) => {
+        createCalls.push(payload.clientSessionId);
+        return {
+          id: "server-session-1",
+          dayNumber: payload.dayNumber,
+          duration: payload.duration,
+          sessionType: payload.sessionType,
+          completed: payload.completed,
+          actualTime: payload.actualTime,
+          clearPercent: payload.clearPercent,
+          thoughtCount: payload.thoughtCount,
+          mindStateLog: payload.mindStateLog,
+          sessionDate: payload.sessionDate,
+          createdAt: "2026-07-17T12:00:00.000Z",
+        };
+      },
+      batchThoughts: async (data) => {
+        thoughtCalls.push(data.sessionId);
+      },
+    };
+
+    await new WebSessionSyncCoordinator(store, alwaysFailingSessionSyncTransport).saveCompletedSession(
+      baseRequest(),
+      clientSessionId,
+      testOwnerUserId,
+      [{ timeInSession: 10, text: "hello" }],
+    );
+
+    const flushed = await new WebSessionSyncCoordinator(store, transport).flushPending(testOwnerUserId);
+    expect(flushed).toBe(1);
+    expect(createCalls).toEqual([clientSessionId]);
+    expect(thoughtCalls).toEqual(["server-session-1"]);
+
+    const entries = await store.loadEntries();
+    expect(entries[0]!.sessionSynced).toBe(true);
+    expect(entries[0]!.thoughts).toHaveLength(0);
+  });
+
+  test("appendEndNote queues note for pending entry", async () => {
+    const store = new InMemoryOfflineSessionQueueStore();
+    const coordinator = new WebSessionSyncCoordinator(store, alwaysFailingSessionSyncTransport);
+    const clientSessionId = "550e8400-e29b-41d4-a716-446655440005";
+
+    await coordinator.saveCompletedSession(baseRequest(), clientSessionId, testOwnerUserId, []);
+    await coordinator.appendEndNote(clientSessionId, testOwnerUserId, "offline note");
+
+    const entries = await store.loadEntries();
+    expect(entries[0]!.thoughts).toEqual([{ timeInSession: -1, text: "offline note" }]);
+  });
+
+  test("appendEndNote rejects owner mismatch", async () => {
+    const store = new InMemoryOfflineSessionQueueStore();
+    const coordinator = new WebSessionSyncCoordinator(store, alwaysFailingSessionSyncTransport);
+    const clientSessionId = "550e8400-e29b-41d4-a716-446655440006";
+
+    await coordinator.saveCompletedSession(baseRequest(), clientSessionId, testOwnerUserId, []);
+
+    await expect(
+      coordinator.appendEndNote(clientSessionId, "other-user", "note"),
+    ).rejects.toThrow(SessionSyncError);
+  });
+});

--- a/src/lib/offlineSessionQueue/sessionSyncCoordinator.ts
+++ b/src/lib/offlineSessionQueue/sessionSyncCoordinator.ts
@@ -63,49 +63,51 @@ export class WebSessionSyncCoordinator {
       throw new SessionSyncError("missingOwnerUserId");
     }
 
-    const entries = await this.queueStore.loadEntries();
-    const existingIndex = entries.findIndex((entry) => entry.clientSessionId === clientSessionId);
+    return withQueueMutation(async () => {
+      const entries = await this.queueStore.loadEntries();
+      const existingIndex = entries.findIndex((entry) => entry.clientSessionId === clientSessionId);
 
-    if (existingIndex >= 0) {
-      const existing = entries[existingIndex]!;
-      if (existing.ownerUserId !== ownerUserId) {
-        throw new SessionSyncError("ownerMismatch");
+      if (existingIndex >= 0) {
+        const existing = entries[existingIndex]!;
+        if (existing.ownerUserId !== ownerUserId) {
+          throw new SessionSyncError("ownerMismatch");
+        }
+        if (existing.sessionSynced && existing.thoughts.length === 0 && existing.serverSessionId) {
+          return {
+            sessionId: existing.serverSessionId,
+            isPendingSync: false,
+            serverSessionId: existing.serverSessionId,
+          };
+        }
+      } else {
+        entries.push({
+          clientSessionId,
+          ownerUserId,
+          request: requestWithClientId(request, clientSessionId),
+          thoughts,
+          serverSessionId: null,
+          sessionSynced: false,
+          enqueuedAt: new Date().toISOString(),
+        });
+        await this.queueStore.saveEntries(entries);
+        await requestBackgroundSync();
       }
-      if (existing.sessionSynced && existing.thoughts.length === 0 && existing.serverSessionId) {
+
+      const synced = await this.flushEntry(clientSessionId, ownerUserId);
+      if (synced) {
         return {
-          sessionId: existing.serverSessionId,
+          sessionId: synced.serverSessionId!,
           isPendingSync: false,
-          serverSessionId: existing.serverSessionId,
+          serverSessionId: synced.serverSessionId,
         };
       }
-    } else {
-      entries.push({
-        clientSessionId,
-        ownerUserId,
-        request: requestWithClientId(request, clientSessionId),
-        thoughts,
-        serverSessionId: null,
-        sessionSynced: false,
-        enqueuedAt: new Date().toISOString(),
-      });
-      await this.queueStore.saveEntries(entries);
-      await requestBackgroundSync();
-    }
 
-    const synced = await this.flushEntry(clientSessionId, ownerUserId);
-    if (synced) {
       return {
-        sessionId: synced.serverSessionId!,
-        isPendingSync: false,
-        serverSessionId: synced.serverSessionId,
+        sessionId: provisionalSessionId(clientSessionId),
+        isPendingSync: true,
+        serverSessionId: null,
       };
-    }
-
-    return {
-      sessionId: provisionalSessionId(clientSessionId),
-      isPendingSync: true,
-      serverSessionId: null,
-    };
+    });
   }
 
   async appendEndNote(clientSessionId: string, ownerUserId: string, note: string): Promise<void> {
@@ -115,19 +117,21 @@ export class WebSessionSyncCoordinator {
       throw new SessionSyncError("missingOwnerUserId");
     }
 
-    const entries = await this.queueStore.loadEntries();
-    const index = entries.findIndex((entry) => entry.clientSessionId === clientSessionId);
-    if (index < 0) {
-      throw new SessionSyncError("entryNotFound");
-    }
-    if (entries[index]!.ownerUserId !== ownerUserId) {
-      throw new SessionSyncError("ownerMismatch");
-    }
+    return withQueueMutation(async () => {
+      const entries = await this.queueStore.loadEntries();
+      const index = entries.findIndex((entry) => entry.clientSessionId === clientSessionId);
+      if (index < 0) {
+        throw new SessionSyncError("entryNotFound");
+      }
+      if (entries[index]!.ownerUserId !== ownerUserId) {
+        throw new SessionSyncError("ownerMismatch");
+      }
 
-    entries[index]!.thoughts.push({ timeInSession: -1, text: trimmed });
-    await this.queueStore.saveEntries(entries);
-    await requestBackgroundSync();
-    await this.flushEntry(clientSessionId, ownerUserId);
+      entries[index]!.thoughts.push({ timeInSession: -1, text: trimmed });
+      await this.queueStore.saveEntries(entries);
+      await requestBackgroundSync();
+      await this.flushEntry(clientSessionId, ownerUserId);
+    });
   }
 
   async flushPending(ownerUserId: string): Promise<number> {
@@ -190,7 +194,8 @@ export class WebSessionSyncCoordinator {
         entry = entries[index]!;
       } catch (error) {
         if (isNetworkFailure(error)) return null;
-        throw error;
+        if (error && typeof error === "object" && "permanent" in error) throw error;
+        return null;
       }
     }
 
@@ -213,12 +218,14 @@ export class WebSessionSyncCoordinator {
           (item) => item.clientSessionId === clientSessionId && item.ownerUserId === ownerUserId,
         );
         if (index < 0) return entry;
+        if (entries[index]!.thoughts.length === 0) return entry;
         entries[index]!.thoughts = [];
         await this.queueStore.saveEntries(entries);
         entry = entries[index]!;
       } catch (error) {
         if (isNetworkFailure(error)) return null;
-        throw error;
+        if (error && typeof error === "object" && "permanent" in error) throw error;
+        return null;
       }
     }
 
@@ -227,6 +234,16 @@ export class WebSessionSyncCoordinator {
 }
 
 let sharedCoordinator: WebSessionSyncCoordinator | null = null;
+let queueMutation: Promise<unknown> = Promise.resolve();
+
+async function withQueueMutation<T>(fn: () => Promise<T>): Promise<T> {
+  const result = queueMutation.then(fn);
+  queueMutation = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
 
 export function getWebSessionSyncCoordinator(): WebSessionSyncCoordinator {
   if (!sharedCoordinator) {
@@ -240,12 +257,16 @@ export async function requestBackgroundSync(): Promise<void> {
     return;
   }
   try {
-    const registration = await navigator.serviceWorker.ready;
-    if ("sync" in registration) {
-      await (registration as ServiceWorkerRegistration & {
-        sync: { register: (tag: string) => Promise<void> };
-      }).sync.register(OFFLINE_SYNC_TAG);
+    const registration = await Promise.race([
+      navigator.serviceWorker.ready,
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), 2_000)),
+    ]);
+    if (!registration || !("sync" in registration)) {
+      return;
     }
+    await (registration as ServiceWorkerRegistration & {
+      sync: { register: (tag: string) => Promise<void> };
+    }).sync.register(OFFLINE_SYNC_TAG);
   } catch {
     // Background Sync is best-effort; foreground online flush covers unsupported browsers.
   }

--- a/src/lib/offlineSessionQueue/sessionSyncCoordinator.ts
+++ b/src/lib/offlineSessionQueue/sessionSyncCoordinator.ts
@@ -1,0 +1,258 @@
+import { OFFLINE_SYNC_TAG } from "./constants";
+import { defaultOfflineSessionQueueStore } from "./idbStore";
+import type { OfflineSessionQueueStore } from "./queueStore";
+import {
+  alwaysFailingSessionSyncTransport,
+  isNetworkFailure,
+  liveSessionSyncTransport,
+  type SessionSyncTransport,
+} from "./transport";
+import type {
+  CreateSessionPayload,
+  PendingSessionEntry,
+  PendingSessionThought,
+  SavedSessionResult,
+} from "./types";
+
+export class SessionSyncError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SessionSyncError";
+  }
+}
+
+function requestWithClientId(
+  request: Omit<CreateSessionPayload, "clientSessionId">,
+  clientSessionId: string,
+): CreateSessionPayload {
+  return { ...request, clientSessionId };
+}
+
+function provisionalSessionId(clientSessionId: string): string {
+  return clientSessionId;
+}
+
+export class WebSessionSyncCoordinator {
+  private readonly queueStore: OfflineSessionQueueStore;
+  private readonly transport: SessionSyncTransport;
+
+  constructor(
+    queueStore: OfflineSessionQueueStore = defaultOfflineSessionQueueStore(),
+    transport: SessionSyncTransport = liveSessionSyncTransport(),
+  ) {
+    this.queueStore = queueStore;
+    this.transport = transport;
+  }
+
+  async pendingCount(ownerUserId: string): Promise<number> {
+    const entries = await this.queueStore.loadEntries();
+    return entries.filter(
+      (entry) =>
+        entry.ownerUserId === ownerUserId
+        && (!entry.sessionSynced || entry.thoughts.length > 0),
+    ).length;
+  }
+
+  async saveCompletedSession(
+    request: Omit<CreateSessionPayload, "clientSessionId">,
+    clientSessionId: string,
+    ownerUserId: string,
+    thoughts: PendingSessionThought[],
+  ): Promise<SavedSessionResult> {
+    if (!ownerUserId) {
+      throw new SessionSyncError("missingOwnerUserId");
+    }
+
+    const entries = await this.queueStore.loadEntries();
+    const existingIndex = entries.findIndex((entry) => entry.clientSessionId === clientSessionId);
+
+    if (existingIndex >= 0) {
+      const existing = entries[existingIndex]!;
+      if (existing.ownerUserId !== ownerUserId) {
+        throw new SessionSyncError("ownerMismatch");
+      }
+      if (existing.sessionSynced && existing.thoughts.length === 0 && existing.serverSessionId) {
+        return {
+          sessionId: existing.serverSessionId,
+          isPendingSync: false,
+          serverSessionId: existing.serverSessionId,
+        };
+      }
+    } else {
+      entries.push({
+        clientSessionId,
+        ownerUserId,
+        request: requestWithClientId(request, clientSessionId),
+        thoughts,
+        serverSessionId: null,
+        sessionSynced: false,
+        enqueuedAt: new Date().toISOString(),
+      });
+      await this.queueStore.saveEntries(entries);
+      await requestBackgroundSync();
+    }
+
+    const synced = await this.flushEntry(clientSessionId, ownerUserId);
+    if (synced) {
+      return {
+        sessionId: synced.serverSessionId!,
+        isPendingSync: false,
+        serverSessionId: synced.serverSessionId,
+      };
+    }
+
+    return {
+      sessionId: provisionalSessionId(clientSessionId),
+      isPendingSync: true,
+      serverSessionId: null,
+    };
+  }
+
+  async appendEndNote(clientSessionId: string, ownerUserId: string, note: string): Promise<void> {
+    const trimmed = note.trim();
+    if (!trimmed) return;
+    if (!ownerUserId) {
+      throw new SessionSyncError("missingOwnerUserId");
+    }
+
+    const entries = await this.queueStore.loadEntries();
+    const index = entries.findIndex((entry) => entry.clientSessionId === clientSessionId);
+    if (index < 0) {
+      throw new SessionSyncError("entryNotFound");
+    }
+    if (entries[index]!.ownerUserId !== ownerUserId) {
+      throw new SessionSyncError("ownerMismatch");
+    }
+
+    entries[index]!.thoughts.push({ timeInSession: -1, text: trimmed });
+    await this.queueStore.saveEntries(entries);
+    await requestBackgroundSync();
+    await this.flushEntry(clientSessionId, ownerUserId);
+  }
+
+  async flushPending(ownerUserId: string): Promise<number> {
+    if (!ownerUserId) return 0;
+
+    const entries = await this.queueStore.loadEntries();
+    let syncedCount = 0;
+    for (const entry of entries) {
+      if (entry.ownerUserId !== ownerUserId) continue;
+      if (entry.sessionSynced && entry.thoughts.length === 0) continue;
+      const flushed = await this.flushEntry(entry.clientSessionId, ownerUserId);
+      if (flushed) syncedCount += 1;
+    }
+    return syncedCount;
+  }
+
+  async resolvedServerSessionId(clientSessionId: string, ownerUserId: string): Promise<string | null> {
+    const entry = (await this.queueStore.loadEntries()).find(
+      (item) => item.clientSessionId === clientSessionId && item.ownerUserId === ownerUserId,
+    );
+    return entry?.serverSessionId ?? null;
+  }
+
+  async pruneCompletedEntries(ownerUserId: string): Promise<void> {
+    if (!ownerUserId) return;
+    const entries = await this.queueStore.loadEntries();
+    const next = entries.filter(
+      (entry) =>
+        !(entry.ownerUserId === ownerUserId && entry.sessionSynced && entry.thoughts.length === 0),
+    );
+    if (next.length !== entries.length) {
+      await this.queueStore.saveEntries(next);
+    }
+  }
+
+  async clearQueue(): Promise<void> {
+    await this.queueStore.saveEntries([]);
+  }
+
+  private async flushEntry(
+    clientSessionId: string,
+    ownerUserId: string,
+  ): Promise<PendingSessionEntry | null> {
+    let entry = (await this.queueStore.loadEntries()).find(
+      (item) => item.clientSessionId === clientSessionId && item.ownerUserId === ownerUserId,
+    );
+    if (!entry) return null;
+
+    if (!entry.sessionSynced) {
+      try {
+        const session = await this.transport.createSession(entry.request);
+        const entries = await this.queueStore.loadEntries();
+        const index = entries.findIndex(
+          (item) => item.clientSessionId === clientSessionId && item.ownerUserId === ownerUserId,
+        );
+        if (index < 0) return null;
+        entries[index]!.serverSessionId = session.id;
+        entries[index]!.sessionSynced = true;
+        await this.queueStore.saveEntries(entries);
+        entry = entries[index]!;
+      } catch (error) {
+        if (isNetworkFailure(error)) return null;
+        throw error;
+      }
+    }
+
+    const serverSessionId = entry.serverSessionId;
+    if (!serverSessionId) return null;
+
+    entry = (await this.queueStore.loadEntries()).find(
+      (item) => item.clientSessionId === clientSessionId && item.ownerUserId === ownerUserId,
+    ) ?? entry;
+
+    if (entry.thoughts.length > 0) {
+      try {
+        await this.transport.batchThoughts({
+          sessionId: serverSessionId,
+          dayNumber: entry.request.dayNumber,
+          thoughts: entry.thoughts,
+        });
+        const entries = await this.queueStore.loadEntries();
+        const index = entries.findIndex(
+          (item) => item.clientSessionId === clientSessionId && item.ownerUserId === ownerUserId,
+        );
+        if (index < 0) return entry;
+        entries[index]!.thoughts = [];
+        await this.queueStore.saveEntries(entries);
+        entry = entries[index]!;
+      } catch (error) {
+        if (isNetworkFailure(error)) return null;
+        throw error;
+      }
+    }
+
+    return entry;
+  }
+}
+
+let sharedCoordinator: WebSessionSyncCoordinator | null = null;
+
+export function getWebSessionSyncCoordinator(): WebSessionSyncCoordinator {
+  if (!sharedCoordinator) {
+    sharedCoordinator = new WebSessionSyncCoordinator();
+  }
+  return sharedCoordinator;
+}
+
+export async function requestBackgroundSync(): Promise<void> {
+  if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
+    return;
+  }
+  try {
+    const registration = await navigator.serviceWorker.ready;
+    if ("sync" in registration) {
+      await (registration as ServiceWorkerRegistration & {
+        sync: { register: (tag: string) => Promise<void> };
+      }).sync.register(OFFLINE_SYNC_TAG);
+    }
+  } catch {
+    // Background Sync is best-effort; foreground online flush covers unsupported browsers.
+  }
+}
+
+export {
+  alwaysFailingSessionSyncTransport,
+  provisionalSessionId,
+  requestWithClientId,
+};

--- a/src/lib/offlineSessionQueue/transport.ts
+++ b/src/lib/offlineSessionQueue/transport.ts
@@ -1,0 +1,65 @@
+import type { Session } from "@/lib/api";
+import type { CreateSessionPayload, PendingSessionThought } from "./types";
+
+export type SessionSyncTransport = {
+  createSession: (payload: CreateSessionPayload) => Promise<Session>;
+  batchThoughts: (data: {
+    sessionId: string;
+    dayNumber: number;
+    thoughts: PendingSessionThought[];
+  }) => Promise<void>;
+};
+
+function isNetworkFailure(error: unknown): boolean {
+  return error instanceof TypeError;
+}
+
+export function liveSessionSyncTransport(): SessionSyncTransport {
+  return {
+    async createSession(payload) {
+      const res = await fetch("/api/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        const err = new Error(text || `Create session failed (${res.status})`);
+        if (res.status >= 500 || res.status === 408 || res.status === 429) {
+          throw err;
+        }
+        throw Object.assign(err, { permanent: true });
+      }
+      const data = await res.json();
+      return data.session as Session;
+    },
+    async batchThoughts(data) {
+      const res = await fetch("/api/thoughts/batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        const err = new Error(text || `Batch thoughts failed (${res.status})`);
+        if (res.status >= 500 || res.status === 408 || res.status === 429) {
+          throw err;
+        }
+        throw Object.assign(err, { permanent: true });
+      }
+    },
+  };
+}
+
+export const alwaysFailingSessionSyncTransport: SessionSyncTransport = {
+  createSession: async () => {
+    throw new TypeError("Network unavailable");
+  },
+  batchThoughts: async () => {
+    throw new TypeError("Network unavailable");
+  },
+};
+
+export { isNetworkFailure };

--- a/src/lib/offlineSessionQueue/transport.ts
+++ b/src/lib/offlineSessionQueue/transport.ts
@@ -11,7 +11,8 @@ export type SessionSyncTransport = {
 };
 
 function isNetworkFailure(error: unknown): boolean {
-  return error instanceof TypeError;
+  if (error instanceof TypeError) return true;
+  return Boolean(error && typeof error === "object" && "retryable" in error && (error as { retryable?: boolean }).retryable);
 }
 
 export function liveSessionSyncTransport(): SessionSyncTransport {
@@ -27,7 +28,7 @@ export function liveSessionSyncTransport(): SessionSyncTransport {
         const text = await res.text().catch(() => "");
         const err = new Error(text || `Create session failed (${res.status})`);
         if (res.status >= 500 || res.status === 408 || res.status === 429) {
-          throw err;
+          throw Object.assign(err, { retryable: true });
         }
         throw Object.assign(err, { permanent: true });
       }
@@ -45,7 +46,7 @@ export function liveSessionSyncTransport(): SessionSyncTransport {
         const text = await res.text().catch(() => "");
         const err = new Error(text || `Batch thoughts failed (${res.status})`);
         if (res.status >= 500 || res.status === 408 || res.status === 429) {
-          throw err;
+          throw Object.assign(err, { retryable: true });
         }
         throw Object.assign(err, { permanent: true });
       }

--- a/src/lib/offlineSessionQueue/types.ts
+++ b/src/lib/offlineSessionQueue/types.ts
@@ -1,0 +1,43 @@
+import type { SessionType, Track } from "@/lib/constants";
+
+/** Thought captured during or after a sit, queued for offline sync (#558). */
+export type PendingSessionThought = {
+  timeInSession: number;
+  text: string;
+};
+
+/** POST /api/sessions body with the #557 client idempotency key attached. */
+export type CreateSessionPayload = {
+  dayNumber: number;
+  sessionType: SessionType;
+  track?: Track;
+  duration: number;
+  bonusSeconds?: number;
+  completed: boolean;
+  actualTime: number;
+  clearPercent: number;
+  thoughtCount: number;
+  mindStateLog: Array<{ time: number; state: string }>;
+  attentionLog?: Array<{ time: number; state: string }> | null;
+  sessionDate: string;
+  breathCount?: number;
+  clientSessionId: string;
+};
+
+/** Durable local record of a completed sit awaiting server sync (#558). */
+export type PendingSessionEntry = {
+  clientSessionId: string;
+  /** Account that enqueued this sit — prevents cross-user replay after logout/login. */
+  ownerUserId: string;
+  request: CreateSessionPayload;
+  thoughts: PendingSessionThought[];
+  serverSessionId: string | null;
+  sessionSynced: boolean;
+  enqueuedAt: string;
+};
+
+export type SavedSessionResult = {
+  sessionId: string;
+  isPendingSync: boolean;
+  serverSessionId: string | null;
+};

--- a/src/lib/web-push-client.ts
+++ b/src/lib/web-push-client.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import { registerServiceWorker } from "@/lib/offlineSessionQueue/pwaBootstrap";
+
 export type NotificationPreferencesDto = {
   pushEnabled: boolean;
   dailyReminderEnabled: boolean;
@@ -45,10 +47,6 @@ function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
     output[i] = raw.charCodeAt(i);
   }
   return output;
-}
-
-async function registerServiceWorker(): Promise<ServiceWorkerRegistration> {
-  return navigator.serviceWorker.register("/sw.js", { scope: "/" });
 }
 
 export async function fetchVapidPublicKey(): Promise<string> {


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #558. Adds web-only offline PWA support, reusing the `clientSessionId` idempotency scheme from merged #557.

- **App shell caching**: extends `public/sw.js` with install/activate/fetch handlers for navigations and static assets while preserving push notification suppression (#431).
- **IndexedDB write queue**: `WebSessionSyncCoordinator` mirrors the iOS #557 outbox — local-first session save, thought batching, owner scoping, and dedupe by `clientSessionId`.
- **Auto-sync**: foreground flush on `online` / tab visibility; Background Sync tag `stillpoint-session-sync` in the service worker as a best-effort path when the tab is closed.
- **PWA installability**: `public/manifest.webmanifest` + layout metadata; `PwaBootstrap` registers the service worker on `/app`.

## Acceptance criteria

- [x] App shell loads offline (manifest + SW caching)
- [x] Complete a sit offline → queued in IndexedDB → auto-syncs on reconnect
- [x] Idempotent create shared with #557 (`clientSessionId` on every web write)
- [x] Existing push-suppression SW behavior preserved
- [x] v1 scope = writes + app-shell (no cached offline reads)

## Test plan

- [x] `npm ci`
- [x] `npm run test:unit` (includes new `sessionSyncCoordinator.test.ts`)
- [x] `npm run typecheck`
- [x] `npm run build:verify -- 3`
- [ ] Manual: DevTools offline → load app → complete sit → back online → syncs once
- [ ] Manual: verify install/PWA + push suppression still works
- [ ] e2e (Playwright): offline context → session queued → online → synced (#497 follow-up)

## Notes

- Ratings on the completion screen are disabled while a sit is pending sync (requires server session id).
- End-of-sit notes queue via `appendEndNote` when offline.
- Queue is cleared on logout to prevent cross-user replay.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec8eaffb-f678-40b8-97f5-d99b7b1272e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec8eaffb-f678-40b8-97f5-d99b7b1272e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Add offline PWA support for saving sessions and syncing them later**

### What Changed
- The app can now be installed as a PWA and opens as a standalone app with a manifest and Apple web app support
- Sessions, breath sits, and end notes can be saved while offline and are queued to sync automatically when the connection returns
- Offline completion now keeps the sit available for review, while ratings stay disabled until the session has a server record
- The offline queue is cleared on logout so one account's pending sits do not carry over to the next user
- The app shell and key assets are cached so the main app can still load without a network connection

### Impact
`✅ Installable mobile web app`
`✅ Fewer lost session saves when offline`
`✅ Faster recovery after reconnect`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
