### PR TITLE
feat(web): last-used sign-in tag for email/password (#547)

### DIFF
--- a/src/components/AuthScreen.tsx
+++ b/src/components/AuthScreen.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { signIn } from "next-auth/react";
-import { loadLastAuthProvider, type OAuthProvider } from "@/lib/lastAuthProvider";
+import { loadLastAuthProvider, saveLastAuthProvider, type AuthProvider } from "@/lib/lastAuthProvider";
 
 type AuthScreenProps = {
   onLogin: (user: {
@@ -63,7 +63,7 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
   const [loading, setLoading] = useState(false);
   // Read in an effect (not the initializer) so server and first client
   // render agree — localStorage is only available after hydration.
-  const [lastProvider, setLastProvider] = useState<OAuthProvider | null>(null);
+  const [lastProvider, setLastProvider] = useState<AuthProvider | null>(null);
 
   useEffect(() => {
     setLastProvider(loadLastAuthProvider());
@@ -106,6 +106,7 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
         return;
       }
 
+      saveLastAuthProvider("password");
       onLogin(data.user);
     } catch {
       setError("Network error");
@@ -380,6 +381,7 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
             transition: "all 0.3s",
             marginTop: "var(--s1)",
             opacity: loading ? 0.5 : 1,
+            position: "relative",
           }}
           onMouseEnter={e => {
             if (!loading) {
@@ -391,8 +393,14 @@ export function AuthScreen({ onLogin }: AuthScreenProps) {
             e.currentTarget.style.borderColor = "var(--border-2)";
             e.currentTarget.style.background = "var(--surface-1)";
           }}
+          aria-label={
+            lastProvider === "password"
+              ? (mode === "login" ? "Enter (last used)" : "Begin the journey (last used)")
+              : undefined
+          }
         >
           {loading ? "..." : mode === "login" ? "Enter" : "Begin the journey"}
+          {lastProvider === "password" && <LastUsedTag onDark={false} />}
         </button>
         {mode === "login" && (
           <a

--- a/src/lib/lastAuthProvider.test.ts
+++ b/src/lib/lastAuthProvider.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { isOAuthProvider, loadLastAuthProvider, saveLastAuthProvider, STORAGE_KEY } from "./lastAuthProvider";
+import { isAuthProvider, isOAuthProvider, loadLastAuthProvider, saveLastAuthProvider, STORAGE_KEY } from "./lastAuthProvider";
 
 function stubBrowserStorage(initial: Record<string, string> = {}) {
   const store = new Map(Object.entries(initial));
@@ -30,6 +30,28 @@ describe("isOAuthProvider", () => {
     expect(isOAuthProvider(null)).toBe(false);
     expect(isOAuthProvider(undefined)).toBe(false);
   });
+
+  it("rejects 'password' (password is not an OAuth provider)", () => {
+    expect(isOAuthProvider("password")).toBe(false);
+  });
+});
+
+describe("isAuthProvider", () => {
+  it("accepts OAuth providers", () => {
+    expect(isAuthProvider("google")).toBe(true);
+    expect(isAuthProvider("apple")).toBe(true);
+  });
+
+  it("accepts 'password'", () => {
+    expect(isAuthProvider("password")).toBe(true);
+  });
+
+  it("rejects unknown values", () => {
+    expect(isAuthProvider("facebook")).toBe(false);
+    expect(isAuthProvider("")).toBe(false);
+    expect(isAuthProvider(null)).toBe(false);
+    expect(isAuthProvider(undefined)).toBe(false);
+  });
 });
 
 describe("loadLastAuthProvider", () => {
@@ -42,9 +64,14 @@ describe("loadLastAuthProvider", () => {
     expect(loadLastAuthProvider()).toBeNull();
   });
 
-  it("returns a stored valid provider", () => {
+  it("returns a stored valid OAuth provider", () => {
     stubBrowserStorage({ [STORAGE_KEY]: "google" });
     expect(loadLastAuthProvider()).toBe("google");
+  });
+
+  it("returns 'password' when stored", () => {
+    stubBrowserStorage({ [STORAGE_KEY]: "password" });
+    expect(loadLastAuthProvider()).toBe("password");
   });
 
   it("returns null for a tampered/unknown stored value", () => {
@@ -69,11 +96,18 @@ describe("saveLastAuthProvider", () => {
     expect(() => saveLastAuthProvider("google")).not.toThrow();
   });
 
-  it("persists the provider and round-trips through load", () => {
+  it("persists an OAuth provider and round-trips through load", () => {
     const store = stubBrowserStorage();
     saveLastAuthProvider("apple");
     expect(store.get(STORAGE_KEY)).toBe("apple");
     expect(loadLastAuthProvider()).toBe("apple");
+  });
+
+  it("persists 'password' and round-trips through load", () => {
+    const store = stubBrowserStorage();
+    saveLastAuthProvider("password");
+    expect(store.get(STORAGE_KEY)).toBe("password");
+    expect(loadLastAuthProvider()).toBe("password");
   });
 
   it("overwrites a previously stored provider", () => {

--- a/src/lib/lastAuthProvider.ts
+++ b/src/lib/lastAuthProvider.ts
@@ -2,24 +2,35 @@ export const OAUTH_PROVIDERS = ["google", "apple"] as const;
 
 export type OAuthProvider = (typeof OAUTH_PROVIDERS)[number];
 
+/** Widened union: OAuth providers + email/password. */
+export const AUTH_PROVIDERS = [...OAUTH_PROVIDERS, "password"] as const;
+
+export type AuthProvider = (typeof AUTH_PROVIDERS)[number];
+
 export const STORAGE_KEY = "stillpoint_last_auth_provider";
 
+/** Narrow guard: only OAuth providers (unchanged from #337). */
 export function isOAuthProvider(value: unknown): value is OAuthProvider {
   return typeof value === "string" && (OAUTH_PROVIDERS as readonly string[]).includes(value);
 }
 
-export function loadLastAuthProvider(): OAuthProvider | null {
+/** Broad guard: any supported auth provider, including "password". */
+export function isAuthProvider(value: unknown): value is AuthProvider {
+  return typeof value === "string" && (AUTH_PROVIDERS as readonly string[]).includes(value);
+}
+
+export function loadLastAuthProvider(): AuthProvider | null {
   if (typeof window === "undefined") return null;
 
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    return isOAuthProvider(raw) ? raw : null;
+    return isAuthProvider(raw) ? raw : null;
   } catch {
     return null;
   }
 }
 
-export function saveLastAuthProvider(provider: OAuthProvider): void {
+export function saveLastAuthProvider(provider: AuthProvider): void {
   if (typeof window === "undefined") return;
   try {
     localStorage.setItem(STORAGE_KEY, provider);


### PR DESCRIPTION
## **User description**
## Summary

Extends the last-used sign-in indicator (shipped for OAuth in #337) to also cover email/password.

- **`src/lib/lastAuthProvider.ts`**: introduces `AuthProvider` union type (`"google" | "apple" | "password"`), `AUTH_PROVIDERS` array, and `isAuthProvider` guard. `loadLastAuthProvider` / `saveLastAuthProvider` now accept the widened type. `OAuthProvider` type and `isOAuthProvider` guard are **unchanged** — OAuth capture in `LastAuthProviderCapture.tsx` and `oauth-complete/route.ts` is untouched.
- **`src/lib/lastAuthProvider.test.ts`**: adds coverage for `isAuthProvider`, persisting/loading `"password"`, and confirms `isOAuthProvider` rejects `"password"`.
- **`src/components/AuthScreen.tsx`**: imports `saveLastAuthProvider` and `AuthProvider`; updates `lastProvider` state type; calls `saveLastAuthProvider("password")` in `handleSubmit`'s shared success branch (covers both login and signup); adds `position: relative` to the submit button, renders `LastUsedTag onDark={false}` when `lastProvider === "password"`, and appends `(last used)` to the accessible label.

Closes #547

## Test plan

- [x] "Last used" tag appears on the email/password submit button after a successful email/password login
- [x] "Last used" tag appears on the email/password submit button after a successful email/password signup
- [x] Existing OAuth "last used" behavior from #337 is unchanged (Google and Apple buttons still show/hide the tag correctly)
- [x] Unit tests pass: `npm run test:unit` (666 tests, all green)
- [x] TypeScript clean: `npm run typecheck` (no errors)

## Local review

- **CodeRabbit CLI** (`coderabbit review --agent`): 0 findings — clean pass.
- **CodeAnt CLI**: not installed in this environment — skipped per cr-local-review.md timeout/fallback rule.


___

## **CodeAnt-AI Description**
**Show the last-used sign-in tag for email and password sign-ins**

### What Changed
- The “last used” sign-in indicator now appears after a successful email/password login or signup, not just after OAuth sign-ins
- The app now remembers password as a valid last-used sign-in option and restores it on return visits
- The submit button now includes the tag and announces it in its label for users relying on assistive tech

### Impact
`✅ Clearer sign-in choice`
`✅ Faster return sign-in`
`✅ Better sign-in feedback for screen readers`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
