### PR TITLE
docs: refresh parity/QA checklists and README project structure (#541)

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,31 +299,58 @@ src/
     layout.tsx               # global styles, metadata
     globals.css              # keyframes (fadeIn, breathe, pulse)
     api/
-      auth/                  # signup, login, logout, me
-      sessions/              # CRUD for meditation sessions
-      thoughts/              # batch insert + list thoughts
+      account/               # account management (password reset, deletion)
+      auth/                  # signup, login, logout, me, OAuth (Google, Apple)
       board/                 # public leaderboard
-      settings/              # toggle public visibility
+      buddy/                 # buddy-session create/join/start/leave + video token
+      cron/                  # scheduled jobs (notification dispatch, cleanup)
+      device-token/          # iOS APNs token registration
+      failure-reasons/       # failure-reason log (missed-sit capture)
+      friends/               # friend requests, accept/reject, list
+      notifications/         # notification preferences + web-push subscriptions
+      sessions/              # CRUD for meditation sessions
+      settings/              # user settings (public toggle, attention tracking, etc.)
+      thoughts/              # batch insert + list thoughts
+      track/                 # post-session rating track endpoint
   components/
-    AuthScreen.tsx           # login/signup form
-    HomeView.tsx             # day counter, begin button, FAQ
+    AuthScreen.tsx           # login/signup form (email, Google, Apple)
+    HomeView.tsx             # day counter, begin button, pathway preview
     SessionView.tsx          # timer orchestrator + auto-hide controls
     BlockTimer.tsx           # visual block grid + countdown + 60s bar
     MindStateBar.tsx         # green/amber timeline bar
     ThoughtCapture.tsx       # thought input during thinking state
-    CompletionScreen.tsx     # stats + session note input
-    HistoryView.tsx          # session history with bar charts
+    CompletionScreen.tsx     # stats + session note + rating input
+    HistoryView.tsx          # calendar-first history: month grid, mind-state trends, year-in-review
     ThoughtJournal.tsx       # all captured thoughts by day
     PublicBoard.tsx          # practitioners leaderboard
-    SettingsView.tsx         # account + public toggle
+    SettingsView.tsx         # account, public toggle, notification prefs
+    BuddySessionHub.tsx      # buddy session lobby + controls
+    BuddyCalendarView.tsx    # unified + per-buddy session calendar
+    FriendsView.tsx          # friend search, requests, list
+    Pathway.tsx              # L1–L5 lesson pathway preview
+    GuidedExerciseOverlay.tsx # guided breath/movement/insight exercises
+    RatingSlider.tsx         # post-session quality rating
+    WebNotificationSettings.tsx # web push opt-in + failure-reason reminder
+    # … plus buddy/, layout, and utility components
   db/
-    schema.ts                # Drizzle schema (users, sessions, thoughts)
+    schema.ts                # Drizzle schema: users, sessions, thoughts, device_tokens,
+                             #   friendships, friendRequests, buddySessions, buddySessionParticipants,
+                             #   oauthAccounts, notificationPreferences, failureReasons, and more
     index.ts                 # database connection
   lib/
     auth.ts                  # JWT + bcrypt helpers
     api.ts                   # typed fetch wrapper
     audio.ts                 # Web Audio API sound synthesis
     constants.ts             # BASE_DURATION, INCREMENT, BLOCK_DURATION
+    apns.ts                  # Apple Push Notification Service helpers
+    web-push.ts              # VAPID web push helpers
+    daily.ts                 # Daily.co video room + meeting token helpers
+    buddySession.ts          # buddy session logic + friendship gate
+    email.ts                 # Resend password-reset email helpers
+    pathway.ts               # L1–L5 lesson pathway logic
+    guidedExercise.ts        # guided exercise content + sequencing
+    notification-scheduler.ts # push notification scheduling logic
+    # … plus history aggregation, OAuth, friend, and other helpers
   middleware.ts              # route protection
 ```
 
@@ -335,6 +362,11 @@ src/
 | **sessions** | One per completed or abandoned sitting | dayNumber, duration, clearPercent, thoughtCount, mindStateLog, sessionDate |
 | **thoughts** | Captured during sessions or as end-of-session notes | sessionId, dayNumber, timeInSession, text |
 | **device_tokens** | iOS APNs registration targets | userId, platform, tokenHash, apnsEnvironment, enabled |
+| **friendships** + **friend_requests** | Mutual friend graph and pending invitations | requesterId, addresseeId, status |
+| **buddy_sessions** + **buddy_session_participants** | Shared sits, participant state, and Daily.co video rooms | hostId, roomName, status, dailyRoomName |
+| **oauth_accounts** | Linked OAuth provider accounts (Google, Apple) | userId, provider, providerAccountId |
+| **notification_preferences** | Per-user push notification settings | userId, failureReasonReminderEnabled, etc. |
+| **failure_reasons** | Logged missed-sit reasons | userId, sessionDate, reason |
 
 Thoughts with `timeInSession >= 0` were captured mid-session. Thoughts with `timeInSession = -1` are end-of-session journal notes.
 

--- a/ios/PARITY_CHECKLIST.md
+++ b/ios/PARITY_CHECKLIST.md
@@ -23,17 +23,22 @@ Release owner: iOS release DRI
 | Account deletion flow | Implemented | Implemented | ✅ Complete | iOS Settings includes two-step destructive confirmation. |
 | Aphorisms pre-session inspiration toggle (#88) | Implemented | Implemented | ✅ Complete | Shared quote list in `StillPointShared/Aphorisms.swift` mirrors `src/lib/aphorisms.ts`; both clients toggle via `PATCH /api/settings`. |
 | Failure-reason reminder + log-reason capture (#441 / web PR #466) | Implemented | Implemented | ✅ Complete | iOS exposes `failureReasonReminderEnabled` in Notifications settings, handles `stillpoint://log-reason?date=…`, and captures notes via `/api/failure-reasons`. |
+| Miss-a-day recovery ramp (#481 / #511) | Implemented | Implemented | ✅ Complete | Shared ramp logic in `StillPointShared/DurationRecovery.swift`; applied in `AppViewModel.swift`, `SessionViewModel.swift`, `HomeView.swift`, and `CompletionView.swift`. |
+| ARKit gaze attention tracking (#512) | Not applicable — web | Implemented (iOS-only) | ✅ Intentional iOS-only | TrueDepth/ARKit hardware requirement; consent-gated toggle in `SettingsView.swift`; core manager is `AttentionTrackingManager.swift`. Web has no camera-during-session equivalent by design — not a parity defect. |
 
 ## Known parity gaps (critical + non-critical)
 
 | Gap | Severity | Decision | Owner | Target date | Tracking notes |
 |---|---|---|---|---|---|
-| Dedicated **Friends management UI** (search users, request/accept/reject/cancel, remove friend) exists on web (`FriendsView.tsx`) but not in iOS tabs. | Critical | Deferred for this release candidate (buddy core flow remains functional without in-app friend graph controls). | Mobile platform owner (@ios-release) | 2026-05-01 | Add iOS Friends tab + friend-request flows using existing API endpoints before next social feature milestone. |
+| Dedicated **Friends management UI** (search users, request/accept/reject/cancel, remove friend) exists on web (`FriendsView.tsx`) but not in iOS tabs. | Critical | Deferred for this release candidate (buddy core flow remains functional without in-app friend graph controls). | Mobile platform owner (@ios-release) | TBD (overdue from 2026-05-01; re-plan before next social feature milestone) | Add iOS Friends tab + friend-request flows using existing API endpoints before next social feature milestone. |
 | Marketing-only web homepage demo embed / App Store badge behavior has no iOS equivalent screen. | Non-critical | Explicitly out of scope for native parity. | Product (@product) | 2026-05-08 | Keep web-only marketing surfaces documented; no native action required. |
+| **Guided exercises (#517)** — branching breath/movement/insight exercises layered on the core timer. Web: `GuidedExerciseOverlay.tsx` + `src/lib/guidedExercise.ts`. | Non-critical | Deferred post-1.0; add to iOS feature roadmap. | Mobile platform owner (@ios-release) | TBD | No iOS surface exists. Part of June–July batch (#519–#529). |
+| **Session ratings (#479)** — post-session quality slider. Web: `RatingSlider.tsx` + `/api/track`. | Non-critical | Deferred post-1.0. | Mobile platform owner (@ios-release) | TBD | No iOS surface exists. |
+| **Last-used tag (#394)** — surfacing a "last used N days ago" indicator. Not built on either platform (net-new). | Non-critical | Not yet designed — add to backlog. | Product (@product) | TBD | Distinct from the auth-provider last-used sign-in tag (row above, #337/#528). `LastAuthProviderCapture.tsx` / `StillPointShared/LastAuthProvider.swift` handle a different feature. |
 
 ## Release gate decision (Issue #210)
 
 - [x] Feature parity checklist between iOS and web is completed.
 - [x] All critical parity gaps are fixed or explicitly deferred with owner/date.
 
-The current release candidate is allowed to ship with the deferred critical gap above because it does not block session completion, account safety, or backend data integrity.
+The current release candidate is allowed to ship with the deferred critical gap above because it does not block session completion, account safety, or backend data integrity. The June–July batch (#519–#529) added additional non-critical web-only gaps (guided exercises, session ratings) and one net-new unbuilt item (last-used tag #394); none of these block the release gate.

--- a/ios/QA_CHECKLIST.md
+++ b/ios/QA_CHECKLIST.md
@@ -1,7 +1,7 @@
 # iOS Release Candidate QA Checklist (Issue #210)
 
-Release candidate: 1.0.3 (10)
-Last updated: 2026-04-27
+Release candidate: 1.0.3 (17)
+Last updated: 2026-07-21
 QA owner: iOS QA DRI
 
 ## 1) Smoke + regression pass
@@ -19,6 +19,8 @@ QA owner: iOS QA DRI
 | Buddy create/join/start | Two participants can create, join, ready, and start | ✅ Pass | Deep-link invite join path validated. |
 | Buddy leave/cancel + personal completion save | Exit/cancel behavior and personal save remain correct | ✅ Pass | Session teardown and return navigation verified. |
 | Delete account safety flow | Two-step confirmation then sign-out/auth screen | ✅ Pass | Matches App Review guideline flow in `RELEASING.md`. |
+| **Camera/mic permission regression (#433)** | Buddy-video WKWebView `getUserMedia` grant succeeds; gaze-tracking camera consent is shown on first `attentionTrackingEnabled` toggle | ⬜ | `BuddyVideoWebView.swift` (getUserMedia path); `SettingsView.swift` (gaze toggle); `NSCameraUsageDescription` + `NSMicrophoneUsageDescription` in `ios/project.yml`. |
+| **Deep-link routing regression (#433)** | Push-tap and `stillpoint://buddy/…` invite links open the correct screen on cold start and from background | ⬜ | `.onOpenURL` in `RootView.swift`; custom-scheme `stillpoint://` only — no universal-links/associated-domains path exists. |
 
 ## 2) Platform checks
 
@@ -28,10 +30,11 @@ QA owner: iOS QA DRI
 | Foreground/background resume | ✅ Pass | Session state is preserved on short background transitions. |
 | Network offline handling | ✅ Pass | API errors surface user-readable messaging for critical paths. |
 | Light/dark appearance sanity | ✅ Pass | Core screens remain legible and themed correctly. |
+| **Background-audio regression (#433)** | ⬜ | Timer tick/chime stays audible while backgrounded; resume does not crash. `UIBackgroundModes: [audio]` in `ios/project.yml`; `.playback`/interruption handling in `StillPointShared/AudioEngine.swift` (includes `#262` crash-avoidance guard). |
 
 ## 3) Release metadata + submission readiness
 
-- [x] `ios/project.yml` versioning finalized: `MARKETING_VERSION = 1.0.3`, `CURRENT_PROJECT_VERSION = 10`.
+- [x] `ios/project.yml` versioning finalized: `MARKETING_VERSION = 1.0.3`, `CURRENT_PROJECT_VERSION = 17`.
 - [x] App Store release notes finalized for this build (see `ios/RELEASING.md`).
 - [x] App Store metadata checklist finalized (privacy policy URL, support URL, account deletion review notes).
 - [x] App Store submission automation dry-run evidence can be generated with `npm run ios:app-store:dry-run`.
@@ -39,12 +42,12 @@ QA owner: iOS QA DRI
   - Live ASC validation requires `APPSTORE_APP_ID` plus the App Store Connect API key environment variables.
 - [ ] Build submitted to App Store review in App Store Connect.
   - Owner: iOS release DRI
-  - Target date: 2026-04-29 (after TestFlight smoke test for this build passes)
+  - Target date: TBD (re-evaluate after build 17 TestFlight smoke test passes)
   - Completion evidence: attach App Store Connect submission timestamp and build number in PR comment.
 
 ## Release gate decision (Issue #210)
 
-- [x] Regression/QA pass for release candidate is completed.
+- [ ] Regression/QA pass for release candidate is completed. (Re-opened: camera/mic, deep-link, and background-audio regression checks added for build 17 — see §1 and §2 above.)
 - [x] App Store metadata/versioning/release notes are finalized.
 - [ ] Updated iOS build is submitted to App Store by end of week.
 


### PR DESCRIPTION
## **User description**
Closes #541

## Summary

Refreshes three stale drift-tracking docs to reflect the June–July feature batch and current code state. No source files changed.

### ios/PARITY_CHECKLIST.md
- Added **Recovery ramp (#481 / #511)** as ✅ Complete on both platforms — verified via `StillPointShared/DurationRecovery.swift` (+ `SessionViewModel.swift`, `AppViewModel.swift`, `HomeView.swift`, `CompletionView.swift`).
- Added **ARKit gaze attention tracking (#512)** as intentional iOS-only — verified via `AttentionTrackingManager.swift` and `SettingsView.swift` gaze toggle.
- Added known-gap rows for **Guided exercises (#517)** (web: `GuidedExerciseOverlay.tsx`, no iOS surface) and **Session ratings (#479)** (web: `RatingSlider.tsx`, no iOS surface).
- Added **Last-used tag (#394)** as unbuilt/net-new on both platforms — clearly distinguished from the auth-provider last-used tag (#337/#528) already in the checklist.
- Updated stale Friends-management-UI target date (was 2026-05-01, now TBD overdue).
- Extended release gate rationale to acknowledge the June–July batch (#519–#529).

Not added as separate rows (already covered in existing "Progress/history view" row notes): month grid (#504), year-in-review (#516), mind-state trends (#513) — confirmed implemented via `HistoryMonthGrid.swift`, `HistoryView.swift`, `HistoryMindStateTrends.swift`.

### ios/QA_CHECKLIST.md
- Corrected build number from `1.0.3 (10)` → `1.0.3 (17)` per `ios/project.yml` `CURRENT_PROJECT_VERSION: 17` (issue text saying "15" was itself stale; orchestrator note predicted 16 — actual is 17).
- Added three **#433 regression check rows**:
  - Camera/mic permission — cites `BuddyVideoWebView.swift`, `SettingsView.swift` gaze toggle, and `NSCameraUsageDescription`/`NSMicrophoneUsageDescription` in `ios/project.yml`.
  - Deep-link routing — cites `.onOpenURL` in `RootView.swift`; notes no universal-links path exists.
  - Background-audio — cites `UIBackgroundModes: [audio]` in `ios/project.yml` and `.playback`/interruption handling in `StillPointShared/AudioEngine.swift` (#262 guard).
- Unchecked the QA gate (`[x]` → `[ ]`) while the three new regression checks remain unverified (per CodeRabbit major finding).
- Updated stale App Store submission target date (was 2026-04-29).

### README.md
- Expanded `api/` from 5 dirs to all 13 real directories with purpose comments (verified via `ls src/app/api/`).
- Expanded `components/` and `lib/` to represent current surface.
- Added 5 additional tables to the Database schema table (friendships, friend_requests, buddy_sessions, buddy_session_participants, oauth_accounts, notification_preferences, failure_reasons) — verified via `grep pgTable src/db/schema.ts`.
- Merge gates section was **already accurate** (verified via `gh api repos/auerbachb/still-point/branches/main/protection` — only `typecheck` and `StillPointShared swift test` are enforced). No change needed there.

## Local review outcome

- **CodeRabbit** (`coderabbit review --agent --type uncommitted`): First pass completed; returned 3 findings (1 major: QA gate checked while regressions unchecked; 2 minor: stale dates). All three fixed. Second pass hit OSS free-tier rate limit (37 min wait) — CR unavailable for clean re-run.
- **CodeAnt**: Not installed in this environment.
- **Self-review performed** per `cr-local-review.md` fallback: all code citations verified against actual files; no inaccuracies found.

## Test plan

- [x] `ios/PARITY_CHECKLIST.md`: Recovery ramp row cites `StillPointShared/DurationRecovery.swift` — file exists on this branch.
- [x] `ios/PARITY_CHECKLIST.md`: ARKit gaze row cites `AttentionTrackingManager.swift` and `SettingsView.swift` — both confirmed present.
- [x] `ios/QA_CHECKLIST.md`: Header shows `1.0.3 (17)` — matches `CURRENT_PROJECT_VERSION: 17` in `ios/project.yml`.
- [x] `ios/QA_CHECKLIST.md`: Three #433 regression rows added with concrete file citations; QA gate is unchecked.
- [x] `README.md`: All 13 API directories listed match `ls src/app/api/` output.
- [x] `README.md`: Database schema table lists additional tables present in `src/db/schema.ts`.
- [x] No source files modified — only `ios/PARITY_CHECKLIST.md`, `ios/QA_CHECKLIST.md`, `README.md`.


___

## **CodeAnt-AI Description**
Refresh the iOS parity, QA, and project structure docs to match the current release state

### What Changed
- Added completed parity coverage for miss-a-day recovery ramp and marked ARKit gaze tracking as an intentional iOS-only feature
- Updated the parity checklist with current unresolved gaps for guided exercises, session ratings, and the last-used tag, and moved the Friends gap target date to overdue
- Reopened the iOS QA gate for build 17 by adding missing regression checks for camera/mic permission, deep-link routing, and background audio
- Expanded the README project map to reflect the current app areas, screens, APIs, database tables, and helper modules

### Impact
`✅ Clearer release readiness tracking`
`✅ Fewer stale parity claims`
`✅ Less QA drift during app store submission`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>