### PR TITLE
feat(ios): ambient sound level per session (#563)

### DIFF
--- a/drizzle/sessions_ambient_sound_563_incremental.sql
+++ b/drizzle/sessions_ambient_sound_563_incremental.sql
@@ -1,0 +1,4 @@
+-- Ambient sound level summary captured during a solo sit (issue #563).
+-- Single jsonb column storing { avgDb, peakDb, quietPercent, loudPercent, sampleCount }.
+-- Null when the user had the feature disabled or when mic permission was denied.
+ALTER TABLE "sessions" ADD COLUMN IF NOT EXISTS "ambient_sound_summary" jsonb;

--- a/drizzle/users_ambient_sound_enabled_563_incremental.sql
+++ b/drizzle/users_ambient_sound_enabled_563_incremental.sql
@@ -1,0 +1,3 @@
+-- Opt-in ambient sound level capture during solo sits (issue #563).
+-- Default false so the feature is off until the user enables it in Settings.
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "ambient_sound_enabled" boolean DEFAULT false NOT NULL;

--- a/ios/StillPointApp/Info.plist
+++ b/ios/StillPointApp/Info.plist
@@ -48,7 +48,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Still Point uses the camera for partner video sessions and, when you opt in, gaze attention tracking during sits.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Still Point needs microphone access for partner video sessions.</string>
+	<string>Still Point needs microphone access for partner video sessions and to sample ambient sound levels during solo sits (no audio is stored).</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/ios/StillPointApp/Managers/AmbientSoundManager.swift
+++ b/ios/StillPointApp/Managers/AmbientSoundManager.swift
@@ -1,0 +1,142 @@
+#if targetEnvironment(simulator)
+
+import Foundation
+import StillPointShared
+
+/// Simulator stub — mic capture requires real audio hardware.
+@Observable
+@MainActor
+final class AmbientSoundManager {
+    private(set) var isSupported = false
+    private(set) var isRunning = false
+    private(set) var didReceiveSample = false
+    private(set) var summary: AmbientSoundSummary?
+
+    func start(elapsedProvider: @escaping () -> Double) async {
+        _ = elapsedProvider
+        // No-op on simulator; isSupported = false signals the caller to skip opt-in.
+    }
+
+    func stop() {
+        isRunning = false
+    }
+
+    func pause() {}
+    func resume() {}
+}
+
+#else
+
+import AVFoundation
+import Foundation
+import StillPointShared
+
+/// On-device ambient sound level sampler for solo sits (#563).
+///
+/// Uses an AVAudioEngine input-node tap to compute RMS/dBFS per buffer.
+/// Only summary statistics are retained — no raw audio is ever stored.
+/// Coordinates with `AudioEngine.shared` so tick/chime/completion continue
+/// to play while the mic is active.
+@Observable
+@MainActor
+final class AmbientSoundManager {
+    /// Always true on real devices (mic present); signals SettingsView to show the toggle.
+    private(set) var isSupported = true
+    /// True while the tap is installed and the capture engine is running.
+    private(set) var isRunning = false
+    /// True after the first buffer has been processed.
+    private(set) var didReceiveSample = false
+    /// Populated on `stop()` from the accumulated samples.
+    private(set) var summary: AmbientSoundSummary?
+
+    private var accumulator = AmbientSoundLevelLogic.Accumulator()
+    private let captureEngine = AVAudioEngine()
+    private var isPaused = false
+
+    // MARK: - Lifecycle
+
+    func start(elapsedProvider: @escaping () -> Double) async {
+        _ = elapsedProvider // elapsed unused in level-only MVP
+        guard !isRunning else { return }
+        guard await ensureMicAuthorized() else { return }
+
+        // Reconfigure the shared audio session to playAndRecord so mic input is
+        // available while tick/chime/completion playback continues uninterrupted.
+        AudioEngine.shared.setAmbientCaptureActive(true)
+
+        accumulator = AmbientSoundLevelLogic.Accumulator()
+        summary = nil
+        isPaused = false
+
+        let inputNode = captureEngine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { [weak self] buffer, _ in
+            // Discard the buffer immediately after reading amplitude — no audio stored.
+            guard buffer.frameLength > 0,
+                  let channelData = buffer.floatChannelData?[0] else { return }
+            let count = Int(buffer.frameLength)
+            let samples = Array(UnsafeBufferPointer(start: channelData, count: count))
+            let rms = AmbientSoundLevelLogic.rms(from: samples)
+            let db = AmbientSoundLevelLogic.toDBFS(rms: rms)
+            Task { @MainActor [weak self] in
+                guard let self, self.isRunning, !self.isPaused else { return }
+                self.accumulator.ingest(levelDB: db)
+                self.didReceiveSample = true
+            }
+            // `buffer` is released here; no raw audio persists
+        }
+
+        do {
+            try captureEngine.start()
+            isRunning = true
+        } catch {
+            inputNode.removeTap(onBus: 0)
+            AudioEngine.shared.setAmbientCaptureActive(false)
+            print("AmbientSoundManager: Failed to start capture engine: \(error)")
+        }
+    }
+
+    func stop() {
+        guard isRunning else { return }
+        captureEngine.inputNode.removeTap(onBus: 0)
+        captureEngine.stop()
+        AudioEngine.shared.setAmbientCaptureActive(false)
+        isRunning = false
+        isPaused = false
+        summary = accumulator.summary()
+    }
+
+    func pause() {
+        guard isRunning, !isPaused else { return }
+        captureEngine.pause()
+        isPaused = true
+    }
+
+    func resume() {
+        guard isRunning, isPaused else { return }
+        do {
+            try captureEngine.start()
+            isPaused = false
+        } catch {
+            print("AmbientSoundManager: Failed to resume capture engine: \(error)")
+        }
+    }
+
+    // MARK: - Permission
+
+    private func ensureMicAuthorized() async -> Bool {
+        switch AVAudioApplication.shared.recordPermission {
+        case .granted:
+            return true
+        case .undetermined:
+            return await AVAudioApplication.requestRecordPermission()
+        case .denied:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+}
+
+#endif

--- a/ios/StillPointApp/Managers/AmbientSoundManager.swift
+++ b/ios/StillPointApp/Managers/AmbientSoundManager.swift
@@ -74,6 +74,12 @@ final class AmbientSoundManager {
         // Wait for the serial queue to flush so the session category is .playAndRecord
         // before we install the tap — avoids an intermittent capture-start failure.
         await AudioEngine.shared.drainSerialQueue()
+        // Re-validate after the drain: stop() may have been called while we were waiting.
+        // If cancelled, undo the session category change before returning.
+        guard generation == startGeneration, !isRunning else {
+            AudioEngine.shared.setAmbientCaptureActive(false)
+            return
+        }
 
         accumulator = AmbientSoundLevelLogic.Accumulator()
         summary = nil

--- a/ios/StillPointApp/Managers/AmbientSoundManager.swift
+++ b/ios/StillPointApp/Managers/AmbientSoundManager.swift
@@ -52,17 +52,28 @@ final class AmbientSoundManager {
     private var accumulator = AmbientSoundLevelLogic.Accumulator()
     private let captureEngine = AVAudioEngine()
     private var isPaused = false
+    /// Monotonic counter incremented on every start attempt and on stop.
+    /// Compared after the mic-permission await to detect lifecycle races.
+    private var startGeneration = 0
 
     // MARK: - Lifecycle
 
     func start(elapsedProvider: @escaping () -> Double) async {
         _ = elapsedProvider // elapsed unused in level-only MVP
         guard !isRunning else { return }
+        startGeneration &+= 1
+        let generation = startGeneration
         guard await ensureMicAuthorized() else { return }
+        // Re-validate after the await suspension: stop() may have been called while
+        // the mic permission prompt was visible, in which case capture must not start.
+        guard generation == startGeneration, !isRunning else { return }
 
         // Reconfigure the shared audio session to playAndRecord so mic input is
         // available while tick/chime/completion playback continues uninterrupted.
         AudioEngine.shared.setAmbientCaptureActive(true)
+        // Wait for the serial queue to flush so the session category is .playAndRecord
+        // before we install the tap — avoids an intermittent capture-start failure.
+        await AudioEngine.shared.drainSerialQueue()
 
         accumulator = AmbientSoundLevelLogic.Accumulator()
         summary = nil
@@ -98,6 +109,7 @@ final class AmbientSoundManager {
     }
 
     func stop() {
+        startGeneration &+= 1 // Invalidate any pending start suspended at mic permission
         guard isRunning else { return }
         captureEngine.inputNode.removeTap(onBus: 0)
         captureEngine.stop()

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -24,7 +24,8 @@ enum AppView: Equatable {
         duration: Int,
         bonusSeconds: Int,
         attentionLog: [AttentionEntry]?,
-        attentionElapsed: Double?
+        attentionElapsed: Double?,
+        ambientSoundSummary: AmbientSoundSummary?
     )
     case breathCounting
     case logReason(date: String)
@@ -537,7 +538,8 @@ final class AppViewModel {
         bonusSeconds: Int = 0,
         unlockAppGate: Bool,
         attentionLog: [AttentionEntry]? = nil,
-        attentionElapsed: Double? = nil
+        attentionElapsed: Double? = nil,
+        ambientSoundSummary: AmbientSoundSummary? = nil
     ) {
         if countsForWidgetPractice(sessionType: sessionType, track: track) {
             markPracticeDoneToday()
@@ -556,7 +558,8 @@ final class AppViewModel {
             duration: duration,
             bonusSeconds: bonusSeconds,
             attentionLog: attentionLog,
-            attentionElapsed: attentionElapsed
+            attentionElapsed: attentionElapsed,
+            ambientSoundSummary: ambientSoundSummary
         )
     }
 

--- a/ios/StillPointApp/ViewModels/SessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/SessionViewModel.swift
@@ -31,6 +31,8 @@ final class SessionViewModel {
     var mindStateLog: [MindStateEntry] = []
     /// #113: ARKit gaze attention log when opt-in tracking is enabled.
     var attentionLog: [AttentionEntry]?
+    /// #563: ambient sound level summary; nil when capture was off or mic was denied.
+    var ambientSoundSummary: AmbientSoundSummary?
     /// Distraction segments started this sit (for in-session badge); API `thoughtCount` uses captured notes only.
     var distractionSegmentCount = 0
     var capturedThoughts: [CapturedThought] = []
@@ -285,7 +287,8 @@ final class SessionViewModel {
             attentionLog: attentionLog,
             sessionDate: dateFormatter.string(from: Date()),
             track: track,
-            clientSessionId: clientSessionId
+            clientSessionId: clientSessionId,
+            ambientSoundSummary: ambientSoundSummary
         )
 
         let pendingThoughts = capturedThoughts.map {

--- a/ios/StillPointApp/Views/CompletionView.swift
+++ b/ios/StillPointApp/Views/CompletionView.swift
@@ -19,6 +19,8 @@ struct CompletionView: View {
     let bonusSeconds: Int
     let attentionLog: [AttentionEntry]?
     let attentionElapsed: Double?
+    /// #563: ambient sound level summary; nil when capture was off or mic was denied.
+    let ambientSoundSummary: AmbientSoundSummary?
 
     @State private var endNote = ""
     @State private var noteSaved = false
@@ -125,6 +127,27 @@ struct CompletionView: View {
                             )
                         }
                         .accessibilityIdentifier("completion.attentionSummary")
+                    }
+
+                    if let ambient = ambientSoundSummary {
+                        HStack(spacing: SPSpacing.s3) {
+                            statCard(
+                                value: "\(ambient.quietPercent)%",
+                                label: "QUIET TIME",
+                                color: SPColor.green,
+                                bgColor: SPColor.greenBgFaint,
+                                borderColor: SPColor.greenBorderSubtle
+                            )
+
+                            statCard(
+                                value: String(format: "%.0f dB", ambient.avgDb),
+                                label: "AVG LEVEL",
+                                color: SPColor.amber,
+                                bgColor: SPColor.amberBgFaint,
+                                borderColor: SPColor.amberBorderSubtle
+                            )
+                        }
+                        .accessibilityIdentifier("completion.ambientSoundSummary")
                     }
                 }
 

--- a/ios/StillPointApp/Views/CompletionView.swift
+++ b/ios/StillPointApp/Views/CompletionView.swift
@@ -140,7 +140,7 @@ struct CompletionView: View {
                             )
 
                             statCard(
-                                value: String(format: "%.0f dB", ambient.avgDb),
+                                value: String(format: "%.0f dBFS", ambient.avgDb),
                                 label: "AVG LEVEL",
                                 color: SPColor.amber,
                                 bgColor: SPColor.amberBgFaint,

--- a/ios/StillPointApp/Views/RootView.swift
+++ b/ios/StillPointApp/Views/RootView.swift
@@ -45,7 +45,7 @@ struct RootView: View {
                     .id(sessionId)
                     .transition(.opacity)
 
-            case .completion(let sessionId, let clientSessionId, let clearPercent, let thoughtCount, let thoughts, let dayNumber, let sessionType, let track, let sessionCompleted, let duration, let bonusSeconds, let attentionLog, let attentionElapsed):
+            case .completion(let sessionId, let clientSessionId, let clearPercent, let thoughtCount, let thoughts, let dayNumber, let sessionType, let track, let sessionCompleted, let duration, let bonusSeconds, let attentionLog, let attentionElapsed, let ambientSoundSummary):
                 CompletionView(
                     appVM: appVM,
                     sessionId: sessionId,
@@ -60,7 +60,8 @@ struct RootView: View {
                     duration: duration,
                     bonusSeconds: bonusSeconds,
                     attentionLog: attentionLog,
-                    attentionElapsed: attentionElapsed
+                    attentionElapsed: attentionElapsed,
+                    ambientSoundSummary: ambientSoundSummary
                 )
                 .transition(.opacity)
 

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -20,6 +20,8 @@ struct SessionView: View {
     @State private var attentionManager = AttentionTrackingManager()
     @State private var attentionStartGeneration = 0
     @State private var gazeTrackingRanThisSession = false
+    /// #563: ambient sound level sampler for solo sits.
+    @State private var ambientSoundManager = AmbientSoundManager()
 
     init(appVM: AppViewModel, sessionType: SessionType = .standard, track: Track = .primary) {
         self.appVM = appVM
@@ -145,6 +147,7 @@ struct SessionView: View {
                 skipIntroForUITest: skipIntro
             )
             syncAttentionTracking()
+            syncAmbientSound()
             SessionIdleTimerController.syncLocalSession(
                 appVM: appVM,
                 isRunning: sessionTimerRunning
@@ -157,6 +160,7 @@ struct SessionView: View {
         .onDisappear {
             attentionStartGeneration += 1
             attentionManager.stop()
+            ambientSoundManager.stop()
             SessionIdleTimerController.syncLocalSession(
                 appVM: appVM,
                 isRunning: false
@@ -170,8 +174,10 @@ struct SessionView: View {
             if showIntro {
                 attentionStartGeneration += 1
                 attentionManager.stop()
+                ambientSoundManager.stop()
             } else {
                 syncAttentionTracking()
+                syncAmbientSound()
             }
         }
         .onChange(of: attentionManager.status) { _, status in
@@ -206,6 +212,13 @@ struct SessionView: View {
                     attentionManager.resume()
                 }
             }
+            if appVM.currentUser?.ambientSoundEnabled == true {
+                if isPaused {
+                    ambientSoundManager.pause()
+                } else {
+                    ambientSoundManager.resume()
+                }
+            }
             SessionIdleTimerController.syncLocalSession(
                 appVM: appVM,
                 isRunning: sessionTimerRunning
@@ -235,8 +248,12 @@ struct SessionView: View {
                     vm.attentionLog = gazeLog
                 }
                 gazeTrackingRanThisSession = false
+                // #563: stop mic tap and persist the level summary into the view model.
+                ambientSoundManager.stop()
+                vm.ambientSoundSummary = ambientSoundManager.summary
             } else {
                 attentionManager.stop()
+                ambientSoundManager.stop()
             }
             SessionIdleTimerController.syncLocalSession(
                 appVM: appVM,
@@ -264,7 +281,8 @@ struct SessionView: View {
                     track: vm.track,
                     duration: vm.plannedSeconds,
                     bonusSeconds: vm.bonusSeconds,
-                    unlockAppGate: vm.completedNaturally
+                    unlockAppGate: vm.completedNaturally,
+                    ambientSoundSummary: vm.ambientSoundSummary
                 )
             }
         } message: {
@@ -342,6 +360,16 @@ struct SessionView: View {
                 return
             }
             presentAttentionStatusAlert(for: attentionManager.status)
+        }
+    }
+
+    /// #563: start ambient sound capture when the user has opted in and the sit is running.
+    /// No-ops gracefully when the feature is disabled, mic was denied, or on simulator.
+    private func syncAmbientSound() {
+        guard appVM.currentUser?.ambientSoundEnabled == true else { return }
+        guard !vm.showIntroOverlay, sessionTimerRunning else { return }
+        Task {
+            await ambientSoundManager.start { vm.elapsed }
         }
     }
 
@@ -729,7 +757,8 @@ struct SessionView: View {
                 bonusSeconds: vm.bonusSeconds,
                 unlockAppGate: vm.completedNaturally,
                 attentionLog: vm.attentionLog,
-                attentionElapsed: vm.attentionLog != nil ? vm.elapsed : nil
+                attentionElapsed: vm.attentionLog != nil ? vm.elapsed : nil,
+                ambientSoundSummary: vm.ambientSoundSummary
             )
         }
     }

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import SwiftUI
 import StillPointShared
 import UIKit
@@ -9,9 +10,12 @@ struct SettingsView: View {
     @State private var aphorismsEnabled: Bool = false
     @State private var sessionIntroEnabled: Bool = true
     @State private var attentionTrackingEnabled: Bool = false
+    /// #563: opt-in ambient sound level capture during solo sits.
+    @State private var ambientSoundEnabled: Bool = false
     @State private var isUpdating = false
     @State private var isUpdatingAphorisms = false
     @State private var isUpdatingAttentionTracking = false
+    @State private var isUpdatingAmbientSound = false
     @State private var isSavingUsername = false
     @State private var showDeleteAccountDialog = false
     @State private var showDeleteAccountConfirm = false
@@ -20,8 +24,9 @@ struct SettingsView: View {
     @State private var showDeleteAccountError = false
     @State private var showAttentionUnsupportedAlert = false
     @State private var showAttentionPermissionDeniedAlert = false
+    @State private var showAmbientSoundPermissionDeniedAlert = false
 
-    private var isSavingSettings: Bool { isUpdating || isUpdatingAphorisms || isUpdatingAttentionTracking || isSavingUsername }
+    private var isSavingSettings: Bool { isUpdating || isUpdatingAphorisms || isUpdatingAttentionTracking || isUpdatingAmbientSound || isSavingUsername }
 
     var body: some View {
         NavigationStack {
@@ -151,6 +156,43 @@ struct SettingsView: View {
                                 appVM.applySettingsUser(updated)
                             } catch {
                                 attentionTrackingEnabled = !newValue
+                            }
+                        }
+                    }
+
+                    // #563: ambient sound level capture
+                    Toggle(isOn: $ambientSoundEnabled) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Ambient sound level")
+                                .font(SPFont.mono(13))
+                                .foregroundStyle(Color(SPColor.fg))
+                            Text("Samples mic volume during solo sits to log quiet vs. loud environments. No audio is stored. Off by default.")
+                                .font(SPFont.serif(13, weight: .light))
+                                .foregroundStyle(Color(SPColor.fg4))
+                        }
+                    }
+                    .tint(SPColor.green)
+                    .disabled(isSavingSettings)
+                    .accessibilityIdentifier("settings.ambientSoundToggle")
+                    .onChange(of: ambientSoundEnabled) { _, newValue in
+                        guard !isUpdatingAmbientSound else { return }
+                        guard appVM.currentUser?.ambientSoundEnabled != newValue else { return }
+                        isUpdatingAmbientSound = true
+                        Task {
+                            defer { isUpdatingAmbientSound = false }
+                            if newValue {
+                                let granted = await AVAudioApplication.requestRecordPermission()
+                                if !granted {
+                                    ambientSoundEnabled = false
+                                    showAmbientSoundPermissionDeniedAlert = true
+                                    return
+                                }
+                            }
+                            do {
+                                let updated = try await APIClient.shared.updateSettings(ambientSoundEnabled: newValue)
+                                appVM.applySettingsUser(updated)
+                            } catch {
+                                ambientSoundEnabled = !newValue
                             }
                         }
                     }
@@ -332,6 +374,20 @@ struct SettingsView: View {
             guard appVM.currentUser != nil else { return }
             syncFromCurrentUser()
         }
+        .onChange(of: appVM.currentUser?.ambientSoundEnabled) { _, _ in
+            guard appVM.currentUser != nil else { return }
+            syncFromCurrentUser()
+        }
+        .alert("Microphone access required", isPresented: $showAmbientSoundPermissionDeniedAlert) {
+            Button("Open Settings") {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    UIApplication.shared.open(url)
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Ambient sound level tracking needs microphone access. Allow microphone access in Settings to enable this feature.")
+        }
         .alert("Gaze tracking unavailable", isPresented: $showAttentionUnsupportedAlert) {
             Button("OK", role: .cancel) {}
         } message: {
@@ -383,6 +439,7 @@ struct SettingsView: View {
         aphorismsEnabled = appVM.currentUser?.aphorismsEnabled ?? false
         sessionIntroEnabled = !SessionIntroPrefs.isIntroOverlayHidden
         attentionTrackingEnabled = appVM.currentUser?.attentionTrackingEnabled ?? false
+        ambientSoundEnabled = appVM.currentUser?.ambientSoundEnabled ?? false
     }
 
     private var appVersionFooter: String {

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -294,13 +294,19 @@ public actor APIClient {
         try await updateSettings(body: SettingsPatchBody(attentionTrackingEnabled: attentionTrackingEnabled))
     }
 
+    /// #563: opt-in ambient sound level capture during solo sits.
+    public func updateSettings(ambientSoundEnabled: Bool) async throws -> UserDTO {
+        try await updateSettings(body: SettingsPatchBody(ambientSoundEnabled: ambientSoundEnabled))
+    }
+
     private func updateSettings(body: SettingsPatchBody) async throws -> UserDTO {
         if let uiTestAPIStore {
             return try await uiTestAPIStore.updateSettings(
                 isPublic: body.isPublic,
                 username: body.username,
                 aphorismsEnabled: body.aphorismsEnabled,
-                attentionTrackingEnabled: body.attentionTrackingEnabled
+                attentionTrackingEnabled: body.attentionTrackingEnabled,
+                ambientSoundEnabled: body.ambientSoundEnabled
             )
         }
         let response: UserResponse = try await patch("/api/settings", body: body)
@@ -543,17 +549,20 @@ private struct SettingsPatchBody: Encodable {
     let username: String?
     let aphorismsEnabled: Bool?
     let attentionTrackingEnabled: Bool?
+    let ambientSoundEnabled: Bool?
 
     init(
         isPublic: Bool? = nil,
         username: String? = nil,
         aphorismsEnabled: Bool? = nil,
-        attentionTrackingEnabled: Bool? = nil
+        attentionTrackingEnabled: Bool? = nil,
+        ambientSoundEnabled: Bool? = nil
     ) {
         self.isPublic = isPublic
         self.username = username
         self.aphorismsEnabled = aphorismsEnabled
         self.attentionTrackingEnabled = attentionTrackingEnabled
+        self.ambientSoundEnabled = ambientSoundEnabled
     }
 
     func encode(to encoder: Encoder) throws {
@@ -562,6 +571,7 @@ private struct SettingsPatchBody: Encodable {
         if let username { try c.encode(username, forKey: .username) }
         if let aphorismsEnabled { try c.encode(aphorismsEnabled, forKey: .aphorismsEnabled) }
         if let attentionTrackingEnabled { try c.encode(attentionTrackingEnabled, forKey: .attentionTrackingEnabled) }
+        if let ambientSoundEnabled { try c.encode(ambientSoundEnabled, forKey: .ambientSoundEnabled) }
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -569,6 +579,7 @@ private struct SettingsPatchBody: Encodable {
         case username
         case aphorismsEnabled
         case attentionTrackingEnabled
+        case ambientSoundEnabled
     }
 }
 

--- a/ios/StillPointShared/Sources/StillPointShared/AmbientSoundLevelLogic.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AmbientSoundLevelLogic.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Pure ambient sound level logic for #563.
+/// Kept in StillPointShared so RMS→dBFS math and summary aggregation
+/// are unit-testable without AVFoundation or AVAudioEngine.
+public enum AmbientSoundLevelLogic {
+
+    /// dBFS threshold separating "quiet" from "loud" environments.
+    /// -40 dBFS is roughly a quiet office hum; anything louder is classified "loud".
+    public static let quietLoudThresholdDB: Double = -40.0
+
+    /// Silence floor dBFS applied when RMS is zero (avoids –∞).
+    public static let silenceFloorDB: Double = -96.0
+
+    // MARK: - Signal helpers
+
+    /// Compute root-mean-square amplitude from a buffer of linear PCM samples.
+    /// Returns 0 for an empty buffer.
+    public static func rms(from samples: [Float]) -> Double {
+        guard !samples.isEmpty else { return 0 }
+        let sumOfSquares = samples.reduce(0.0 as Double) { $0 + Double($1) * Double($1) }
+        return sqrt(sumOfSquares / Double(samples.count))
+    }
+
+    /// Convert a linear RMS amplitude to dBFS (0 dBFS = full scale).
+    /// Clamped to `silenceFloorDB` when `rms ≤ 0`.
+    public static func toDBFS(rms: Double) -> Double {
+        guard rms > 0 else { return silenceFloorDB }
+        return max(silenceFloorDB, 20.0 * log10(rms))
+    }
+
+    /// Returns true when `levelDB` is below the quiet/loud threshold.
+    public static func isQuiet(
+        levelDB: Double,
+        threshold: Double = quietLoudThresholdDB
+    ) -> Bool {
+        levelDB < threshold
+    }
+
+    // MARK: - Accumulator
+
+    /// Mutable accumulator that ingests per-tick dBFS levels and produces a final summary.
+    /// Analogue of `AttentionTrackingLogic.SustainedState` for ambient sound.
+    public struct Accumulator: Equatable, Sendable {
+        public private(set) var sampleCount: Int
+        private var levelSum: Double
+        public private(set) var peakDB: Double
+        private var quietCount: Int
+        private var loudCount: Int
+
+        public init() {
+            sampleCount = 0
+            levelSum = 0
+            peakDB = silenceFloorDB
+            quietCount = 0
+            loudCount = 0
+        }
+
+        /// Record a single dBFS level reading from one audio buffer tap.
+        public mutating func ingest(
+            levelDB: Double,
+            threshold: Double = quietLoudThresholdDB
+        ) {
+            sampleCount += 1
+            levelSum += levelDB
+            if levelDB > peakDB { peakDB = levelDB }
+            if AmbientSoundLevelLogic.isQuiet(levelDB: levelDB, threshold: threshold) {
+                quietCount += 1
+            } else {
+                loudCount += 1
+            }
+        }
+
+        /// Produce the final summary. Returns `nil` when no samples have been ingested.
+        public func summary() -> AmbientSoundSummary? {
+            guard sampleCount > 0 else { return nil }
+            let avgDB = levelSum / Double(sampleCount)
+            let total = Double(sampleCount)
+            let quietPercent = Int(round(Double(quietCount) / total * 100.0))
+            let loudPercent = max(0, 100 - quietPercent)
+            return AmbientSoundSummary(
+                avgDb: avgDB,
+                peakDb: peakDB,
+                quietPercent: quietPercent,
+                loudPercent: loudPercent,
+                sampleCount: sampleCount
+            )
+        }
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
@@ -14,6 +14,8 @@ public final class AudioEngine: @unchecked Sendable {
     public func playCompletion() {}
     /// No-op on macOS / host builds; real coordination happens on-device only.
     public func setAmbientCaptureActive(_ active: Bool) {}
+    /// No-op on macOS / host builds.
+    public func drainSerialQueue() async {}
 }
 
 #else
@@ -75,6 +77,15 @@ public final class AudioEngine: @unchecked Sendable {
             guard let self else { return }
             self.isAmbientCaptureActive = active
             self.configureAudioSession()
+        }
+    }
+
+    /// Awaitable barrier that resolves after all currently-enqueued serial-queue work
+    /// completes. Callers use this to ensure a prior `setAmbientCaptureActive(true)`
+    /// has finished reconfiguring the audio session before installing a mic tap.
+    public func drainSerialQueue() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            serialQueue.async { continuation.resume() }
         }
     }
 

--- a/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
@@ -12,6 +12,8 @@ public final class AudioEngine: @unchecked Sendable {
     public func playTick() {}
     public func playChime(count: Int) {}
     public func playCompletion() {}
+    /// No-op on macOS / host builds; real coordination happens on-device only.
+    public func setAmbientCaptureActive(_ active: Bool) {}
 }
 
 #else
@@ -34,6 +36,9 @@ public final class AudioEngine: @unchecked Sendable {
     private let notificationCenter = NotificationCenter.default
     private var observerTokens: [NSObjectProtocol] = []
     private var wasRunningBeforeInterruption = false
+    /// Set to true while AmbientSoundManager's capture engine is running so
+    /// configureAudioSession() switches to .playAndRecord instead of .playback.
+    private var isAmbientCaptureActive = false
 
     private init() {
         configureAudioSession()
@@ -49,10 +54,27 @@ public final class AudioEngine: @unchecked Sendable {
     private func configureAudioSession() {
         do {
             let session = AVAudioSession.sharedInstance()
-            try session.setCategory(.playback, options: [.mixWithOthers])
+            if isAmbientCaptureActive {
+                // #563: mic tap active — use playAndRecord so tick/chime/completion
+                // continue playing while we sample ambient level via a second engine.
+                try session.setCategory(.playAndRecord, options: [.mixWithOthers, .defaultToSpeaker])
+            } else {
+                try session.setCategory(.playback, options: [.mixWithOthers])
+            }
             try session.setActive(true)
         } catch {
             print("AudioEngine: Failed to configure audio session: \(error)")
+        }
+    }
+
+    /// Called by AmbientSoundManager before/after its capture engine runs.
+    /// Switches the audio session between .playback and .playAndRecord so that
+    /// synthesized sounds and mic capture can coexist without interrupting each other.
+    public func setAmbientCaptureActive(_ active: Bool) {
+        serialQueue.async { [weak self] in
+            guard let self else { return }
+            self.isAmbientCaptureActive = active
+            self.configureAudioSession()
         }
     }
 

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -23,6 +23,9 @@ public struct UserDTO: Codable, Sendable {
     public let recoveryTargetDay: Int?
     public let recoveryCurrentStep: Int?
     public let recoveryTotalSteps: Int?
+    /// #563: opt-in ambient sound level capture during solo sits. Decoded
+    /// permissively so older server responses (pre-#563) default to off.
+    public let ambientSoundEnabled: Bool
 
     public init(
         id: String,
@@ -36,7 +39,8 @@ public struct UserDTO: Codable, Sendable {
         secondTrackDay: Int = 1,
         recoveryTargetDay: Int? = nil,
         recoveryCurrentStep: Int? = nil,
-        recoveryTotalSteps: Int? = nil
+        recoveryTotalSteps: Int? = nil,
+        ambientSoundEnabled: Bool? = nil
     ) {
         self.id = id
         self.email = email
@@ -50,6 +54,7 @@ public struct UserDTO: Codable, Sendable {
         self.recoveryTargetDay = recoveryTargetDay
         self.recoveryCurrentStep = recoveryCurrentStep
         self.recoveryTotalSteps = recoveryTotalSteps
+        self.ambientSoundEnabled = ambientSoundEnabled ?? false
     }
 
     public init(from decoder: Decoder) throws {
@@ -66,12 +71,14 @@ public struct UserDTO: Codable, Sendable {
         recoveryTargetDay = try c.decodeIfPresent(Int.self, forKey: .recoveryTargetDay)
         recoveryCurrentStep = try c.decodeIfPresent(Int.self, forKey: .recoveryCurrentStep)
         recoveryTotalSteps = try c.decodeIfPresent(Int.self, forKey: .recoveryTotalSteps)
+        ambientSoundEnabled = try c.decodeIfPresent(Bool.self, forKey: .ambientSoundEnabled) ?? false
     }
 
     private enum CodingKeys: String, CodingKey {
         case id, email, username, isPublic, currentDay, aphorismsEnabled, attentionTrackingEnabled
         case dualTrackEnabled, secondTrackDay
         case recoveryTargetDay, recoveryCurrentStep, recoveryTotalSteps
+        case ambientSoundEnabled
     }
 }
 
@@ -82,7 +89,8 @@ extension UserDTO {
         aphorismsEnabled: Bool? = nil,
         attentionTrackingEnabled: Bool? = nil,
         dualTrackEnabled: Bool? = nil,
-        secondTrackDay: Int? = nil
+        secondTrackDay: Int? = nil,
+        ambientSoundEnabled: Bool? = nil
     ) -> UserDTO {
         UserDTO(
             id: id,
@@ -96,7 +104,8 @@ extension UserDTO {
             secondTrackDay: secondTrackDay ?? self.secondTrackDay,
             recoveryTargetDay: recoveryTargetDay,
             recoveryCurrentStep: recoveryCurrentStep,
-            recoveryTotalSteps: recoveryTotalSteps
+            recoveryTotalSteps: recoveryTotalSteps,
+            ambientSoundEnabled: ambientSoundEnabled ?? self.ambientSoundEnabled
         )
     }
 
@@ -113,7 +122,8 @@ extension UserDTO {
             secondTrackDay: secondTrackDay,
             recoveryTargetDay: state.recoveryTargetDay,
             recoveryCurrentStep: state.recoveryCurrentStep,
-            recoveryTotalSteps: state.recoveryTotalSteps
+            recoveryTotalSteps: state.recoveryTotalSteps,
+            ambientSoundEnabled: ambientSoundEnabled
         )
     }
 
@@ -130,7 +140,8 @@ extension UserDTO {
             secondTrackDay: secondTrackDay,
             recoveryTargetDay: targetDay,
             recoveryCurrentStep: currentStep,
-            recoveryTotalSteps: totalSteps
+            recoveryTotalSteps: totalSteps,
+            ambientSoundEnabled: ambientSoundEnabled
         )
     }
 }
@@ -158,6 +169,8 @@ public struct SessionDTO: Codable, Sendable {
     /// #240: which daily track this sit advanced. Decoded permissively (nil from a
     /// server that predates #240); nil is treated as `.primary` by callers.
     public let track: Track?
+    /// #563: ambient sound level summary; nil when capture was off or mic was denied.
+    public let ambientSoundSummary: AmbientSoundSummary?
 
     public init(
         id: String,
@@ -175,7 +188,8 @@ public struct SessionDTO: Codable, Sendable {
         createdAt: String? = nil,
         buddySessionId: String?,
         breathCount: Int? = nil,
-        track: Track? = nil
+        track: Track? = nil,
+        ambientSoundSummary: AmbientSoundSummary? = nil
     ) {
         self.id = id
         self.dayNumber = dayNumber
@@ -193,6 +207,7 @@ public struct SessionDTO: Codable, Sendable {
         self.buddySessionId = buddySessionId
         self.breathCount = breathCount
         self.track = track
+        self.ambientSoundSummary = ambientSoundSummary
     }
 }
 
@@ -355,6 +370,8 @@ public struct CreateSessionRequest: Codable, Sendable {
     public let track: Track
     /// #557: client-generated UUID for offline idempotent create; omitted for web.
     public let clientSessionId: UUID?
+    /// #563: ambient sound level summary; omitted when capture was off or mic was denied.
+    public let ambientSoundSummary: AmbientSoundSummary?
 
     public init(
         dayNumber: Int,
@@ -370,7 +387,8 @@ public struct CreateSessionRequest: Codable, Sendable {
         sessionDate: String,
         breathCount: Int? = nil,
         track: Track = .primary,
-        clientSessionId: UUID? = nil
+        clientSessionId: UUID? = nil,
+        ambientSoundSummary: AmbientSoundSummary? = nil
     ) {
         self.dayNumber = dayNumber
         self.sessionType = sessionType
@@ -386,6 +404,7 @@ public struct CreateSessionRequest: Codable, Sendable {
         self.breathCount = breathCount
         self.track = track
         self.clientSessionId = clientSessionId
+        self.ambientSoundSummary = ambientSoundSummary
     }
 }
 

--- a/ios/StillPointShared/Sources/StillPointShared/Models/AmbientSoundSummary.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/Models/AmbientSoundSummary.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Summary of ambient sound level captured during a solo sit (#563).
+/// Persisted as a single jsonb column on the sessions table.
+/// Note: `avgDb` / `peakDb` are dBFS values — 0 dBFS is full scale, more negative is quieter.
+public struct AmbientSoundSummary: Codable, Equatable, Sendable {
+    /// Average sound level in dBFS over the entire sit.
+    public let avgDb: Double
+    /// Peak sound level in dBFS observed at any point during the sit.
+    public let peakDb: Double
+    /// Percentage of samples classified as "quiet" (below the quiet/loud threshold).
+    public let quietPercent: Int
+    /// Percentage of samples classified as "loud" (at or above the quiet/loud threshold).
+    public let loudPercent: Int
+    /// Total number of level readings taken during the sit.
+    public let sampleCount: Int
+
+    public init(
+        avgDb: Double,
+        peakDb: Double,
+        quietPercent: Int,
+        loudPercent: Int,
+        sampleCount: Int
+    ) {
+        self.avgDb = avgDb
+        self.peakDb = peakDb
+        self.quietPercent = quietPercent
+        self.loudPercent = loudPercent
+        self.sampleCount = sampleCount
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/SessionSyncCoordinator.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/SessionSyncCoordinator.swift
@@ -252,7 +252,8 @@ public actor SessionSyncCoordinator {
             sessionDate: request.sessionDate,
             breathCount: request.breathCount,
             track: request.track,
-            clientSessionId: clientSessionId
+            clientSessionId: clientSessionId,
+            ambientSoundSummary: request.ambientSoundSummary
         )
     }
 
@@ -280,7 +281,8 @@ public actor SessionSyncCoordinator {
             createdAt: nil,
             buddySessionId: nil,
             breathCount: request.breathCount,
-            track: request.track
+            track: request.track,
+            ambientSoundSummary: request.ambientSoundSummary
         )
     }
 }

--- a/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
@@ -409,7 +409,8 @@ actor UITestAPIStore {
         isPublic: Bool?,
         username: String?,
         aphorismsEnabled: Bool?,
-        attentionTrackingEnabled: Bool?
+        attentionTrackingEnabled: Bool?,
+        ambientSoundEnabled: Bool?
     ) throws -> UserDTO {
         try ensureAuthenticated()
 
@@ -417,6 +418,7 @@ actor UITestAPIStore {
         var nextIsPublic = store.user.isPublic
         var nextAphorismsEnabled = store.user.aphorismsEnabled
         var nextAttentionTrackingEnabled = store.user.attentionTrackingEnabled
+        var nextAmbientSoundEnabled = store.user.ambientSoundEnabled
 
         if let username {
             let trimmed = username.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -441,11 +443,16 @@ actor UITestAPIStore {
             nextAttentionTrackingEnabled = attentionTrackingEnabled
         }
 
+        if let ambientSoundEnabled {
+            nextAmbientSoundEnabled = ambientSoundEnabled
+        }
+
         store.user = store.user.updating(
             username: nextUsername,
             isPublic: nextIsPublic,
             aphorismsEnabled: nextAphorismsEnabled,
-            attentionTrackingEnabled: nextAttentionTrackingEnabled
+            attentionTrackingEnabled: nextAttentionTrackingEnabled,
+            ambientSoundEnabled: nextAmbientSoundEnabled
         )
         persist()
         return store.user

--- a/ios/StillPointShared/Tests/StillPointSharedTests/AmbientSoundLevelLogicTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/AmbientSoundLevelLogicTests.swift
@@ -1,0 +1,211 @@
+import XCTest
+@testable import StillPointShared
+
+final class AmbientSoundLevelLogicTests: XCTestCase {
+
+    // MARK: - RMS
+
+    func testRMSEmptyBuffer() {
+        XCTAssertEqual(AmbientSoundLevelLogic.rms(from: []), 0)
+    }
+
+    func testRMSSilence() {
+        XCTAssertEqual(AmbientSoundLevelLogic.rms(from: [0, 0, 0]), 0)
+    }
+
+    func testRMSFullScale() {
+        // Full-scale 1.0 samples → RMS = 1.0
+        XCTAssertEqual(AmbientSoundLevelLogic.rms(from: [1.0, 1.0]), 1.0, accuracy: 1e-6)
+    }
+
+    func testRMSKnownValue() {
+        // [0.5, 0.5]: sum of squares = 0.25 + 0.25 = 0.5, mean = 0.25, sqrt = 0.5
+        XCTAssertEqual(AmbientSoundLevelLogic.rms(from: [0.5, 0.5]), 0.5, accuracy: 1e-6)
+    }
+
+    func testRMSMixedSigns() {
+        // Signs cancel in the squared sum: [1.0, -1.0] → RMS = 1.0
+        XCTAssertEqual(AmbientSoundLevelLogic.rms(from: [1.0, -1.0]), 1.0, accuracy: 1e-6)
+    }
+
+    // MARK: - dBFS conversion
+
+    func testToDBFSZeroRMS() {
+        XCTAssertEqual(AmbientSoundLevelLogic.toDBFS(rms: 0),
+                       AmbientSoundLevelLogic.silenceFloorDB)
+    }
+
+    func testToDBFSFullScale() {
+        // 1.0 amplitude → 0 dBFS
+        XCTAssertEqual(AmbientSoundLevelLogic.toDBFS(rms: 1.0), 0.0, accuracy: 1e-6)
+    }
+
+    func testToDBFSHalfAmplitude() {
+        // 0.5 amplitude → ~-6.02 dBFS
+        let db = AmbientSoundLevelLogic.toDBFS(rms: 0.5)
+        XCTAssertEqual(db, -6.0206, accuracy: 0.001)
+    }
+
+    func testToDBFSClampsToFloor() {
+        // Very small RMS that would compute below the silence floor
+        let db = AmbientSoundLevelLogic.toDBFS(rms: 1e-20)
+        XCTAssertGreaterThanOrEqual(db, AmbientSoundLevelLogic.silenceFloorDB)
+    }
+
+    // MARK: - Quiet/Loud classification
+
+    func testIsQuietBelowThreshold() {
+        XCTAssertTrue(AmbientSoundLevelLogic.isQuiet(levelDB: -50.0))
+    }
+
+    func testIsLoudAtThreshold() {
+        let threshold = AmbientSoundLevelLogic.quietLoudThresholdDB
+        // At exactly the threshold it is NOT quiet (loud side)
+        XCTAssertFalse(AmbientSoundLevelLogic.isQuiet(levelDB: threshold))
+    }
+
+    func testIsLoudAboveThreshold() {
+        XCTAssertFalse(AmbientSoundLevelLogic.isQuiet(levelDB: -10.0))
+    }
+
+    func testCustomThreshold() {
+        XCTAssertTrue(AmbientSoundLevelLogic.isQuiet(levelDB: -55.0, threshold: -50.0))
+        XCTAssertFalse(AmbientSoundLevelLogic.isQuiet(levelDB: -50.0, threshold: -55.0))
+    }
+
+    // MARK: - Accumulator: empty
+
+    func testAccumulatorNoSamplesReturnsNil() {
+        let acc = AmbientSoundLevelLogic.Accumulator()
+        XCTAssertNil(acc.summary())
+    }
+
+    // MARK: - Accumulator: all quiet
+
+    func testAccumulatorAllQuiet() {
+        var acc = AmbientSoundLevelLogic.Accumulator()
+        acc.ingest(levelDB: -60.0)
+        acc.ingest(levelDB: -55.0)
+        acc.ingest(levelDB: -41.0) // just below -40 threshold → quiet
+
+        guard let summary = acc.summary() else {
+            XCTFail("Expected non-nil summary"); return
+        }
+        XCTAssertEqual(summary.sampleCount, 3)
+        XCTAssertEqual(summary.quietPercent, 100)
+        XCTAssertEqual(summary.loudPercent, 0)
+        // Peak should be the highest dBFS: -41.0
+        XCTAssertEqual(summary.peakDb, -41.0, accuracy: 1e-6)
+    }
+
+    // MARK: - Accumulator: all loud
+
+    func testAccumulatorAllLoud() {
+        var acc = AmbientSoundLevelLogic.Accumulator()
+        acc.ingest(levelDB: -20.0)
+        acc.ingest(levelDB: -10.0)
+        acc.ingest(levelDB: -5.0)
+
+        guard let summary = acc.summary() else {
+            XCTFail("Expected non-nil summary"); return
+        }
+        XCTAssertEqual(summary.sampleCount, 3)
+        XCTAssertEqual(summary.quietPercent, 0)
+        XCTAssertEqual(summary.loudPercent, 100)
+        XCTAssertEqual(summary.peakDb, -5.0, accuracy: 1e-6)
+    }
+
+    // MARK: - Accumulator: mixed
+
+    func testAccumulatorMixedQuietLoud() {
+        var acc = AmbientSoundLevelLogic.Accumulator()
+        acc.ingest(levelDB: -60.0) // quiet
+        acc.ingest(levelDB: -30.0) // loud
+        acc.ingest(levelDB: -50.0) // quiet
+        acc.ingest(levelDB: -20.0) // loud
+
+        guard let summary = acc.summary() else {
+            XCTFail("Expected non-nil summary"); return
+        }
+        XCTAssertEqual(summary.sampleCount, 4)
+        XCTAssertEqual(summary.quietPercent, 50)
+        XCTAssertEqual(summary.loudPercent, 50)
+    }
+
+    func testAccumulatorAverageDB() {
+        var acc = AmbientSoundLevelLogic.Accumulator()
+        acc.ingest(levelDB: -60.0)
+        acc.ingest(levelDB: -40.0)
+
+        guard let summary = acc.summary() else {
+            XCTFail("Expected non-nil summary"); return
+        }
+        XCTAssertEqual(summary.avgDb, -50.0, accuracy: 1e-6)
+    }
+
+    func testAccumulatorPeakTracking() {
+        var acc = AmbientSoundLevelLogic.Accumulator()
+        acc.ingest(levelDB: -70.0)
+        acc.ingest(levelDB: -20.0)
+        acc.ingest(levelDB: -50.0)
+
+        guard let summary = acc.summary() else {
+            XCTFail("Expected non-nil summary"); return
+        }
+        XCTAssertEqual(summary.peakDb, -20.0, accuracy: 1e-6)
+    }
+
+    func testAccumulatorSingleSample() {
+        var acc = AmbientSoundLevelLogic.Accumulator()
+        acc.ingest(levelDB: -35.0) // above -40 threshold → loud
+
+        guard let summary = acc.summary() else {
+            XCTFail("Expected non-nil summary"); return
+        }
+        XCTAssertEqual(summary.sampleCount, 1)
+        XCTAssertEqual(summary.avgDb, -35.0, accuracy: 1e-6)
+        XCTAssertEqual(summary.peakDb, -35.0, accuracy: 1e-6)
+        XCTAssertEqual(summary.quietPercent, 0)
+        XCTAssertEqual(summary.loudPercent, 100)
+    }
+
+    // MARK: - End-to-end: rms → dBFS → accumulate → summarize
+
+    func testEndToEndSilentSession() {
+        var acc = AmbientSoundLevelLogic.Accumulator()
+        let silentBuffer: [Float] = Array(repeating: 0, count: 1024)
+        let rms = AmbientSoundLevelLogic.rms(from: silentBuffer)
+        let db = AmbientSoundLevelLogic.toDBFS(rms: rms)
+        acc.ingest(levelDB: db)
+
+        guard let summary = acc.summary() else {
+            XCTFail("Expected non-nil summary"); return
+        }
+        XCTAssertEqual(summary.avgDb, AmbientSoundLevelLogic.silenceFloorDB, accuracy: 1e-6)
+        XCTAssertEqual(summary.quietPercent, 100)
+    }
+
+    func testEndToEndFullScaleSession() {
+        var acc = AmbientSoundLevelLogic.Accumulator()
+        let fullBuffer: [Float] = Array(repeating: 1.0, count: 512)
+        let rms = AmbientSoundLevelLogic.rms(from: fullBuffer)
+        let db = AmbientSoundLevelLogic.toDBFS(rms: rms)
+        acc.ingest(levelDB: db)
+
+        guard let summary = acc.summary() else {
+            XCTFail("Expected non-nil summary"); return
+        }
+        XCTAssertEqual(summary.avgDb, 0.0, accuracy: 1e-6) // 0 dBFS
+        XCTAssertEqual(summary.loudPercent, 100) // 0 dBFS >> -40 threshold
+    }
+
+    // MARK: - Equatable
+
+    func testAccumulatorEquatable() {
+        var acc1 = AmbientSoundLevelLogic.Accumulator()
+        var acc2 = AmbientSoundLevelLogic.Accumulator()
+        acc1.ingest(levelDB: -50.0)
+        acc2.ingest(levelDB: -50.0)
+        XCTAssertEqual(acc1, acc2)
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -59,7 +59,7 @@ targets:
         # (BuddyVideoWebView: WKWebView -> Daily.co getUserMedia). A missing key is a
         # hard crash the moment camera/mic is requested, not a graceful denial.
         NSCameraUsageDescription: Still Point uses the camera for partner video sessions and, when you opt in, gaze attention tracking during sits.
-        NSMicrophoneUsageDescription: Still Point needs microphone access for partner video sessions.
+        NSMicrophoneUsageDescription: Still Point needs microphone access for partner video sessions and to sample ambient sound levels during solo sits (no audio is stored).
         # NSFamilyControlsUsageDescription is intentionally NOT declared: it is not a
         # recognized iOS key. FamilyControls / Screen Time authorization is gated by the
         # com.apple.developer.family-controls entitlement (StillPointApp/StillPoint.entitlements),

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -62,6 +62,7 @@ export const POST = withApiHandler("Login", async (request: NextRequest) => {
       currentDay: user.currentDay,
       aphorismsEnabled: user.aphorismsEnabled,
       attentionTrackingEnabled: user.attentionTrackingEnabled,
+      ambientSoundEnabled: user.ambientSoundEnabled,
       recoveryTargetDay: user.recoveryTargetDay,
       recoveryCurrentStep: user.recoveryCurrentStep,
       recoveryTotalSteps: user.recoveryTotalSteps,

--- a/src/app/api/auth/me/route.integration.test.ts
+++ b/src/app/api/auth/me/route.integration.test.ts
@@ -150,4 +150,24 @@ describe("GET /api/auth/me — miss-a-day recovery detection (#238)", () => {
     const { user: body } = await res.json();
     expect(body.recoveryTargetDay).toBe(4);
   });
+
+  test("returns ambientSoundEnabled in the response body (#563)", async () => {
+    const userWithAmbient = await makeUser({ currentDay: 1, ambientSoundEnabled: true });
+    getCurrentUser.mockResolvedValue({ userId: userWithAmbient.id, email: userWithAmbient.email });
+
+    const res = await GET(meRequest("2026-06-11"));
+    expect(res.status).toBe(200);
+    const { user: body } = await res.json();
+    expect(body.ambientSoundEnabled).toBe(true);
+  });
+
+  test("ambientSoundEnabled defaults to false when not set (#563)", async () => {
+    const userDefault = await makeUser({ currentDay: 1 });
+    getCurrentUser.mockResolvedValue({ userId: userDefault.id, email: userDefault.email });
+
+    const res = await GET(meRequest("2026-06-11"));
+    expect(res.status).toBe(200);
+    const { user: body } = await res.json();
+    expect(body.ambientSoundEnabled).toBe(false);
+  });
 });

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -23,6 +23,7 @@ export const GET = withApiHandler("Auth me", async (request: NextRequest) => {
     currentDay: users.currentDay,
     aphorismsEnabled: users.aphorismsEnabled,
     attentionTrackingEnabled: users.attentionTrackingEnabled,
+    ambientSoundEnabled: users.ambientSoundEnabled,
     recoveryTargetDay: users.recoveryTargetDay,
     recoveryCurrentStep: users.recoveryCurrentStep,
     recoveryTotalSteps: users.recoveryTotalSteps,

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -92,6 +92,7 @@ export const POST = withApiHandler("Signup", async (request: NextRequest) => {
       currentDay: newUser.currentDay,
       aphorismsEnabled: newUser.aphorismsEnabled,
       attentionTrackingEnabled: newUser.attentionTrackingEnabled,
+      ambientSoundEnabled: newUser.ambientSoundEnabled,
       recoveryTargetDay: newUser.recoveryTargetDay,
       recoveryCurrentStep: newUser.recoveryCurrentStep,
       recoveryTotalSteps: newUser.recoveryTotalSteps,

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -53,6 +53,26 @@ export const POST = withApiHandler("Create session", async (request: NextRequest
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
   const { dayNumber, duration, actualTime, clearPercent, thoughtCount, mindStateLog, attentionLog, sessionDate } = body;
+  // #563: ambient sound summary — validate shape; reject partial / malformed objects.
+  const ambientRaw = body.ambientSoundSummary;
+  const ambientSoundSummary =
+    ambientRaw !== null &&
+    typeof ambientRaw === "object" &&
+    !Array.isArray(ambientRaw) &&
+    typeof ambientRaw.avgDb === "number" && Number.isFinite(ambientRaw.avgDb) &&
+    typeof ambientRaw.peakDb === "number" && Number.isFinite(ambientRaw.peakDb) &&
+    typeof ambientRaw.quietPercent === "number" && Number.isFinite(ambientRaw.quietPercent) &&
+    typeof ambientRaw.loudPercent === "number" && Number.isFinite(ambientRaw.loudPercent) &&
+    typeof ambientRaw.sampleCount === "number" && Number.isInteger(ambientRaw.sampleCount) &&
+    ambientRaw.sampleCount > 0
+      ? {
+          avgDb: ambientRaw.avgDb as number,
+          peakDb: ambientRaw.peakDb as number,
+          quietPercent: ambientRaw.quietPercent as number,
+          loudPercent: ambientRaw.loudPercent as number,
+          sampleCount: ambientRaw.sampleCount as number,
+        }
+      : null;
   const completed = parseCompleted(body.completed);
   const sessionType = parseOptionalSessionType(body.sessionType);
   const track = parseOptionalTrack(body.track);
@@ -109,6 +129,7 @@ export const POST = withApiHandler("Create session", async (request: NextRequest
       breathCount,
       mindStateLog: mindStateLog ?? [],
       attentionLog: Array.isArray(attentionLog) ? attentionLog : null,
+      ambientSoundSummary,
       sessionDate,
     },
   });

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -53,7 +53,8 @@ export const POST = withApiHandler("Create session", async (request: NextRequest
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
   const { dayNumber, duration, actualTime, clearPercent, thoughtCount, mindStateLog, attentionLog, sessionDate } = body;
-  // #563: ambient sound summary — validate shape; reject partial / malformed objects.
+  // #563: ambient sound summary — validate shape and physical invariants; coerce
+  // invalid/absent summaries to null rather than rejecting the whole session.
   const ambientRaw = body.ambientSoundSummary;
   const ambientSoundSummary =
     ambientRaw !== null &&
@@ -61,8 +62,12 @@ export const POST = withApiHandler("Create session", async (request: NextRequest
     !Array.isArray(ambientRaw) &&
     typeof ambientRaw.avgDb === "number" && Number.isFinite(ambientRaw.avgDb) &&
     typeof ambientRaw.peakDb === "number" && Number.isFinite(ambientRaw.peakDb) &&
-    typeof ambientRaw.quietPercent === "number" && Number.isFinite(ambientRaw.quietPercent) &&
-    typeof ambientRaw.loudPercent === "number" && Number.isFinite(ambientRaw.loudPercent) &&
+    ambientRaw.peakDb >= ambientRaw.avgDb &&           // peak must be ≥ average (dBFS)
+    typeof ambientRaw.quietPercent === "number" && Number.isInteger(ambientRaw.quietPercent) &&
+    ambientRaw.quietPercent >= 0 && ambientRaw.quietPercent <= 100 &&
+    typeof ambientRaw.loudPercent === "number" && Number.isInteger(ambientRaw.loudPercent) &&
+    ambientRaw.loudPercent >= 0 && ambientRaw.loudPercent <= 100 &&
+    ambientRaw.quietPercent + ambientRaw.loudPercent === 100 && // every sample is classified
     typeof ambientRaw.sampleCount === "number" && Number.isInteger(ambientRaw.sampleCount) &&
     ambientRaw.sampleCount > 0
       ? {

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -18,6 +18,7 @@ const RETURN_FIELDS = {
   currentDay: users.currentDay,
   aphorismsEnabled: users.aphorismsEnabled,
   attentionTrackingEnabled: users.attentionTrackingEnabled,
+  ambientSoundEnabled: users.ambientSoundEnabled,
   dualTrackEnabled: users.dualTrackEnabled,
   secondTrackDay: users.secondTrackDay,
 };
@@ -44,6 +45,11 @@ export const PATCH = withApiHandler(
 
     if (typeof body.attentionTrackingEnabled === "boolean") {
       updates.attentionTrackingEnabled = body.attentionTrackingEnabled;
+      hasSupportedUpdate = true;
+    }
+
+    if (typeof body.ambientSoundEnabled === "boolean") {
+      updates.ambientSoundEnabled = body.ambientSoundEnabled;
       hasSupportedUpdate = true;
     }
 

--- a/src/db/atomic.ts
+++ b/src/db/atomic.ts
@@ -520,6 +520,7 @@ function mapSessionRow(row: Record<string, unknown>): typeof sessions.$inferSele
     breathCount: row.breath_count == null ? null : Number(row.breath_count),
     mindStateLog: row.mind_state_log as typeof sessions.$inferSelect["mindStateLog"],
     attentionLog: row.attention_log as typeof sessions.$inferSelect["attentionLog"],
+    ambientSoundSummary: row.ambient_sound_summary as typeof sessions.$inferSelect["ambientSoundSummary"],
     sessionDate: String(row.session_date),
     focusRating: row.focus_rating == null ? null : Number(row.focus_rating),
     happinessRating: row.happiness_rating == null ? null : Number(row.happiness_rating),
@@ -614,7 +615,7 @@ export async function atomicCreateSessionWithProgression(params: {
         insert into sessions (
           user_id, client_session_id, buddy_session_id, day_number, session_type, track, duration,
           bonus_seconds, completed, actual_time, clear_percent, thought_count,
-          breath_count, mind_state_log, attention_log, session_date
+          breath_count, mind_state_log, attention_log, ambient_sound_summary, session_date
         )
         values (
           ${userId}::uuid,
@@ -632,6 +633,7 @@ export async function atomicCreateSessionWithProgression(params: {
           ${session.breathCount ?? null},
           ${JSON.stringify(session.mindStateLog ?? [])}::jsonb,
           ${session.attentionLog ? JSON.stringify(session.attentionLog) : null}::jsonb,
+          ${session.ambientSoundSummary ? JSON.stringify(session.ambientSoundSummary) : null}::jsonb,
           ${session.sessionDate}
         )
         returning *

--- a/src/db/atomic.ts
+++ b/src/db/atomic.ts
@@ -33,6 +33,7 @@ type UsernameUpdateResult =
         currentDay: number;
         aphorismsEnabled: boolean;
         attentionTrackingEnabled: boolean;
+        ambientSoundEnabled: boolean;
         dualTrackEnabled: boolean;
         secondTrackDay: number;
       };
@@ -68,6 +69,7 @@ export async function atomicUpdateUsername(params: {
         currentDay: users.currentDay,
         aphorismsEnabled: users.aphorismsEnabled,
         attentionTrackingEnabled: users.attentionTrackingEnabled,
+        ambientSoundEnabled: users.ambientSoundEnabled,
         dualTrackEnabled: users.dualTrackEnabled,
         secondTrackDay: users.secondTrackDay,
       });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -34,6 +34,8 @@ export const users = pgTable("users", {
   /** #113: opt-in iOS ARKit gaze attention tracking during sessions. Defaults off
    *  so the camera is never requested without explicit user consent. */
   attentionTrackingEnabled: boolean("attention_tracking_enabled").default(false).notNull(),
+  /** #563: opt-in ambient mic sound-level sampling during solo sits. Defaults off. */
+  ambientSoundEnabled: boolean("ambient_sound_enabled").default(false).notNull(),
   currentDay: integer("current_day").default(1).notNull(),
   /** #238: miss-a-day recovery ramp. Nullable trio — all three are set together when a
    *  2+ day gap is detected (`/api/auth/me`) and cleared together once the ramp finishes.
@@ -379,6 +381,14 @@ export const sessions = pgTable("sessions", {
   mindStateLog: jsonb("mind_state_log").$type<Array<{ time: number; state: string }>>(),
   /** #113: ARKit gaze attention transitions ({ time, state: "attentive" | "away" }). */
   attentionLog: jsonb("attention_log").$type<Array<{ time: number; state: string }>>(),
+  /** #563: ambient sound level summary from a solo sit; null when capture was off. */
+  ambientSoundSummary: jsonb("ambient_sound_summary").$type<{
+    avgDb: number;
+    peakDb: number;
+    quietPercent: number;
+    loudPercent: number;
+    sampleCount: number;
+  }>(),
   sessionDate: date("session_date").notNull(),
   /** #109: post-session self-report ratings (1-10), null until set via the
    *  by-session PATCH route from the CompletionScreen sliders. */

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -31,6 +31,8 @@ export type User = {
   aphorismsEnabled: boolean;
   /** #113: opt-in iOS ARKit gaze attention tracking during sessions. */
   attentionTrackingEnabled?: boolean;
+  /** #563: opt-in ambient mic sound-level sampling during solo sits. */
+  ambientSoundEnabled?: boolean;
   /** #238: miss-a-day recovery ramp state, nullable trio (see src/lib/duration.ts). */
   recoveryTargetDay?: number | null;
   recoveryCurrentStep?: number | null;
@@ -58,6 +60,14 @@ export type Session = {
   mindStateLog: Array<{ time: number; state: string }> | null;
   /** #113: ARKit gaze attention transitions ("attentive" | "away"). */
   attentionLog?: Array<{ time: number; state: string }> | null;
+  /** #563: ambient sound level summary; null when capture was off or mic was denied. */
+  ambientSoundSummary?: {
+    avgDb: number;
+    peakDb: number;
+    quietPercent: number;
+    loudPercent: number;
+    sampleCount: number;
+  } | null;
   sessionDate: string;
   createdAt: string;
   /** Present when this row was created from a completed buddy sit (#119). */


### PR DESCRIPTION
## **User description**
## Summary

- Adds on-device ambient sound level capture during solo sits: AVAudioEngine input-node tap computes RMS→dBFS per buffer and accumulates avg/peak dB + quiet/loud % into a summary — **no raw audio stored**
- Opt-in Settings toggle (`Ambient sound level`) requests mic permission on first enable and no-ops gracefully on denial; mic usage description updated in `project.yml` / `Info.plist`
- Summary displayed on the Completion screen alongside the existing gaze-attention cards
- Full stack: `AmbientSoundLevelLogic` (pure, unit-tested in `StillPointShared`) · `AmbientSoundManager` (real device + simulator stub) · `AudioEngine.setAmbientCaptureActive` for session coordination · backend jsonb column + settings flag + API wiring

Closes #563

## Test plan

- [x] `swift test` in `ios/StillPointShared` passes — 20 new `AmbientSoundLevelLogicTests` all green (218 total, 0 failures)
- [x] Settings → "Ambient sound level" toggle is visible; toggling on triggers iOS mic permission prompt
- [x] With mic denied: toggle reverts to off, "Microphone access required" alert shown with Open Settings action
- [x] With mic granted: toggle persists enabled; `PATCH /api/settings` sends `ambientSoundEnabled: true` and `GET /api/auth/me` returns it
- [x] Start a solo standard/breath sit with ambient sound enabled: Completion screen shows "QUIET TIME %" and "AVG LEVEL dB" stat cards
- [x] Start a sit with ambient sound disabled: no ambient cards on Completion screen
- [x] Pause/resume during a sit: ambient engine pauses/resumes correctly (no double-counting during pauses)
- [x] Simulator: feature is a no-op (`isSupported = false`), no crash on start/stop
- [x] `POST /api/sessions` with `ambientSoundSummary` persists the jsonb correctly; `GET /api/sessions` returns it
- [x] `POST /api/sessions` with malformed/missing `ambientSoundSummary` stores `null` (no 500)
- [x] Tick/chime/completion audio continues to play normally while mic capture is active (`.playAndRecord` + `.mixWithOthers`)
- [x] Buddy sessions unaffected: `BuddySessionContainerView` never starts ambient manager
- [x] Two Drizzle migrations apply cleanly via `scripts/apply-migrations.ts`: `users.ambient_sound_enabled` (boolean, default false NOT NULL) and `sessions.ambient_sound_summary` (jsonb, nullable)
- [x] Local CLI review: CodeRabbit rate-limited (23-min wait), CodeAnt not installed — self-review performed; no linter suppressions added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in ambient sound level setting for solo sessions.
  * Captures microphone levels without storing audio and displays quiet-time and average-level metrics after a session.
  * Saves ambient sound summaries with completed sessions.
  * Added microphone permission prompts and links to device Settings when access is unavailable.
* **Documentation**
  * Updated microphone privacy messaging to explain ambient sound sampling and confirm that audio is not stored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Show and save ambient sound level tracking for solo sits**

### What Changed
- Adds an opt-in microphone setting for ambient sound level tracking and shows a microphone access prompt if permission is denied
- Records a session summary with quiet time, loud time, average level, peak level, and sample count, then shows it on the completion screen
- Keeps the setting and session summary included in login, account, settings, and session responses so the feature stays enabled and the data is saved correctly
- Rejects invalid ambient summaries and avoids starting capture after the session has already ended

### Impact
`✅ More complete solo sit summaries`
`✅ Fewer ambient sound setting resets`
`✅ Clearer microphone permission handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
