### PR TITLE
fix(ios): ARError.errorCode vs .code type mismatch blocks archive build

### DIFF
--- a/ios/StillPointApp/Managers/AttentionTrackingManager.swift
+++ b/ios/StillPointApp/Managers/AttentionTrackingManager.swift
@@ -276,7 +276,7 @@ extension AttentionTrackingManager: ARSessionDelegate {
     nonisolated func session(_ session: ARSession, didFailWithError error: Error) {
         Task { @MainActor in
             guard self.isRunning else { return }
-            if let arError = error as? ARError, arError.errorCode == .cameraUnauthorized {
+            if let arError = error as? ARError, arError.code == .cameraUnauthorized {
                 self.status = .permissionDenied
             } else {
                 self.status = .failed


### PR DESCRIPTION
## **User description**
## Summary
- `AttentionTrackingManager.swift:279`: `arError.errorCode == .cameraUnauthorized` compared the raw `Int` NSError code (`.errorCode`, from `CustomNSError` conformance) against `.cameraUnauthorized` — an `ARError.Code` enum case. Changed to `arError.code`, which returns the typed `ARError.Code`.
- Confirmed via grep this is the only `ARError`/`.errorCode` usage in the codebase.

Closes #608

**Context:** second archive-only compile error found back-to-back while cutting a TestFlight build (see #603/#604). Introduced in #573. No regular PR CI check does a full `xcodebuild archive`, so this sat undetected on `main`. Surfaced by TestFlight build 18 (tag `ios-v1.0.3-build18`, run [29834793428](https://github.com/auerbachb/still-point/actions/runs/29834793428)) — smoke gate passed, archive step failed.

**Local review note:** CodeRabbit CLI still rate-limited from the prior fix; CodeAnt CLI not installed. Self-review: single property-name correction, verified against Apple's `ARError` API shape (`.code: ARError.Code` vs `.errorCode: Int`), confirmed sole occurrence via grep. This file lives in the main app target (not `StillPointShared`), so no local `swift build` verification was possible — relying on CI's Release-config smoke gate + archive build.

## Test plan
- [x] `AttentionTrackingManager.swift:279` uses `arError.code == .cameraUnauthorized`
- [x] Confirmed sole `ARError`/`errorCode` usage in the codebase (grep clean)
- [ ] PR merged to `main`
- [ ] Follow-up: `ios-v1.0.3-build19` tag pushed, workflow run green


___

## **CodeAnt-AI Description**
**Fix camera permission errors so the app builds and handles AR failures correctly**

### What Changed
- Camera access failures now use the correct AR error value, so the app can recognize when the camera is blocked by permissions.
- If AR session startup fails for another reason, the app still shows a generic failure message as before.

### Impact
`✅ Fewer archive build failures`
`✅ Correct camera permission handling`
`✅ Clearer AR failure states`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
