### PR TITLE
fix(ios): AttentionTrackingManager.init() reads self.isSupported before super.init()

### DIFF
--- a/ios/StillPointApp/Managers/AttentionTrackingManager.swift
+++ b/ios/StillPointApp/Managers/AttentionTrackingManager.swift
@@ -131,8 +131,9 @@ final class AttentionTrackingManager: NSObject {
     private var startGeneration = 0
 
     override init() {
-        isSupported = ARFaceTrackingConfiguration.isSupported
-        status = isSupported ? .idle : .unsupported
+        let supported = ARFaceTrackingConfiguration.isSupported
+        isSupported = supported
+        status = supported ? .idle : .unsupported
         super.init()
         session.delegate = self
     }


### PR DESCRIPTION
## **User description**
## Summary
- `AttentionTrackingManager.init()`: `status = isSupported ? .idle : .unsupported` read `self.isSupported` before `super.init()` completed — Swift disallows this. Computed into a local `let supported` instead, used for both `isSupported` and `status` assignment before `super.init()`.
- Confirmed via grep this is the only `override init()` in `ios/StillPointApp`/`ios/StillPointShared`.

Closes #610

**Context:** same root cause as #608 — both bugs trace to PR #573's real-device ARKit branch, which the simulator-only smoke gate never compiles. Reviewed the full #573 diff and confirmed these two are the complete set of compile errors it introduced. Surfaced by TestFlight build 19 (tag `ios-v1.0.3-build19`, run [29837240519](https://github.com/auerbachb/still-point/actions/runs/29837240519)) — smoke gate passed, archive step failed on this error after #608's fix cleared the prior one.

**Local review:** CodeRabbit CLI back online, 0 findings.

## Test plan
- [x] `AttentionTrackingManager.init()` no longer reads any `self` property before `super.init()`
- [x] Confirmed sole `override init()` in the codebase (grep clean)
- [ ] PR merged to `main`
- [ ] Follow-up: `ios-v1.0.3-build20` tag pushed, workflow run green


___

## **CodeAnt-AI Description**
Fix app startup on iPhone when attention tracking is unavailable or supported

### What Changed
- The app now initializes attention tracking without reading its own state before startup finishes, preventing a build-time failure
- Support status and starting state are still set correctly for devices that can or cannot use face tracking

### Impact
`✅ Fewer iOS build failures`
`✅ Reliable startup on supported devices`
`✅ Clearer handling of unsupported face tracking`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
