### PR TITLE
feat(ios): flatten Thought Journal entry list (left-align, dividers)

### DIFF
--- a/ios/StillPointApp/Views/ThoughtJournalView.swift
+++ b/ios/StillPointApp/Views/ThoughtJournalView.swift
@@ -26,34 +26,44 @@ struct ThoughtJournalView: View {
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, SPSpacing.s3)
 
-                // Grouped thoughts
-                ForEach(vm.groupedThoughts, id: \.dayNumber) { group in
-                    VStack(alignment: .leading, spacing: SPSpacing.s2) {
-                        Text("DAY \(group.dayNumber)")
-                            .font(SPFont.mono(11, weight: .medium))
-                            .foregroundStyle(Color(SPColor.fg4))
-                            .tracking(2)
-
-                        ForEach(group.thoughts, id: \.id) { thought in
-                            HStack(alignment: .top, spacing: SPSpacing.s2) {
-                                Text(thought.timeInSession == -1 ? "note" : "@\(thought.timeInSession)s")
-                                    .font(SPFont.mono(11))
-                                    .foregroundStyle(SPColor.amberText)
-                                    .frame(width: 44, alignment: .trailing)
-
-                                Text(thought.text)
-                                    .font(SPFont.serifItalic(15))
-                                    .foregroundStyle(Color(SPColor.fg2))
+                // Grouped thoughts — a flat, left-aligned log: no cards, hairline
+                // dividers between date groups, tight vertical rhythm.
+                if !vm.groupedThoughts.isEmpty {
+                    VStack(alignment: .leading, spacing: 0) {
+                        ForEach(Array(vm.groupedThoughts.enumerated()), id: \.element.dayNumber) { index, group in
+                            // Thin hairline separating one date's entry from the
+                            // next — never above the first entry or below the last.
+                            if index > 0 {
+                                Rectangle()
+                                    .fill(SPColor.border1)
+                                    .frame(height: 1)
                             }
+
+                            VStack(alignment: .leading, spacing: SPSpacing.s2) {
+                                Text("DAY \(group.dayNumber)")
+                                    .font(SPFont.mono(11, weight: .medium))
+                                    .foregroundStyle(Color(SPColor.fg4))
+                                    .tracking(2)
+
+                                ForEach(group.thoughts, id: \.id) { thought in
+                                    HStack(alignment: .firstTextBaseline, spacing: SPSpacing.s2) {
+                                        Text(thought.timeInSession == -1 ? "note" : "@\(thought.timeInSession)s")
+                                            .font(SPFont.mono(11))
+                                            .foregroundStyle(SPColor.amberText)
+                                            .frame(width: 44, alignment: .leading)
+
+                                        Text(thought.text)
+                                            .font(SPFont.serifItalic(15))
+                                            .foregroundStyle(Color(SPColor.fg2))
+                                            .frame(maxWidth: .infinity, alignment: .leading)
+                                    }
+                                }
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.vertical, SPSpacing.s2)
                         }
                     }
-                    .padding(SPSpacing.s3)
-                    .background(SPColor.surface1)
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(SPColor.border1)
-                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
                 if vm.groupedThoughts.isEmpty && !vm.isLoading {

--- a/ios/StillPointApp/Views/ThoughtJournalView.swift
+++ b/ios/StillPointApp/Views/ThoughtJournalView.swift
@@ -5,7 +5,11 @@ struct ThoughtJournalView: View {
     @State private var vm = ThoughtJournalViewModel()
 
     var body: some View {
-        ScrollView {
+        // Compute the grouped collection once per render — it does a
+        // Dictionary grouping + sort + map, so avoid recomputing it per access.
+        let groups = vm.groupedThoughts
+
+        return ScrollView {
             VStack(spacing: SPSpacing.s5) {
                 Text("Thought Journal")
                     .font(SPFont.serifItalic(28, weight: .light))
@@ -28,12 +32,13 @@ struct ThoughtJournalView: View {
 
                 // Grouped thoughts — a flat, left-aligned log: no cards, hairline
                 // dividers between date groups, tight vertical rhythm.
-                if !vm.groupedThoughts.isEmpty {
+                if !groups.isEmpty {
                     VStack(alignment: .leading, spacing: 0) {
-                        ForEach(Array(vm.groupedThoughts.enumerated()), id: \.element.dayNumber) { index, group in
+                        ForEach(groups, id: \.dayNumber) { group in
                             // Thin hairline separating one date's entry from the
-                            // next — never above the first entry or below the last.
-                            if index > 0 {
+                            // next — rendered above every group except the first,
+                            // so there's none above the first or below the last.
+                            if group.dayNumber != groups[0].dayNumber {
                                 Rectangle()
                                     .fill(SPColor.border1)
                                     .frame(height: 1)
@@ -66,7 +71,7 @@ struct ThoughtJournalView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
-                if vm.groupedThoughts.isEmpty && !vm.isLoading {
+                if groups.isEmpty && !vm.isLoading {
                     Text("No thoughts captured yet")
                         .font(SPFont.serifItalic(15))
                         .foregroundStyle(Color(SPColor.fg4))


### PR DESCRIPTION
## **User description**
## Summary

Flattens the **Thought Journal** entry list on iOS so it reads like a clean, continuous log instead of a stack of cards.

Before, each date group rendered inside a rounded `surface1` card with a `border1` stroke, `s3` interior padding, and a wide `s5` gap between cards. The leading time tag was right-aligned in a fixed 44pt gutter, giving a ragged left edge. This change:

- **Drops the card** — removes the per-group `.background(SPColor.surface1)`, `.clipShape(RoundedRectangle)`, `.overlay(stroke)`, and interior `.padding(SPSpacing.s3)`. Each date group is now a flat, transparent block flush to the page's existing left margin.
- **Left-aligns the content** — flips the leading tag from `.frame(width: 44, alignment: .trailing)` to `.leading` and pins the note text to `.frame(maxWidth: .infinity, alignment: .leading)`, so the day label, tag, and note text form clean columns down the left edge (no drift toward center). Row alignment switches to `.firstTextBaseline` to match the web version.
- **Adds hairline dividers between date groups** — a single 1pt `SPColor.border1` rule (the low-opacity warm-white hairline, inset to the content width) separates each date's entry from the next, rendered only for `index > 0` so there's none above the first group or below the last.
- **Tightens vertical spacing** — a dedicated `VStack(spacing: 0)` plus `s2` vertical padding per group drops the between-group gap from ~64pt to ~25pt, so more of the journal is visible at once.

The centered header (title, "N thoughts captured", italic subtitle) and `ThoughtJournalViewModel` are untouched.

Closes #613

## Notes

- **Dark-mode only:** the app forces dark mode globally with non-adaptive `SPColor` values, so there is no light/dark divergence for the hairline — `border1` (warm off-white at 0.08 opacity) is the intended low-opacity divider in all cases.
- **Divider placement** is between date groups (matching the AC wording "separates each date's entry from the next"), not between individual thought rows.
- **Local review:** CodeRabbit CLI (v0.7.0) run locally; **CodeAnt CLI is not installed on this machine**, so its local pass was skipped — the CodeAnt GitHub App still reviews server-side.
- **Marketing screenshot follow-up (non-blocking):** the `16-thought-journal` App Store snapshot will look different after this change. It is not committed to the repo and `ios-screenshots.yml` is `workflow_dispatch`-only (not a per-PR check), so it does not gate this PR. Regenerate on-demand when refreshing store assets.

## Test plan

Code-verifiable (confirmed by inspection):

- [x] Entry rows no longer render a card/bubble background — the `surface1` background, `RoundedRectangle` clip, and stroke overlay are removed; each entry is a flat row.
- [x] Day label and note text are left-aligned — group `VStack(alignment: .leading)` in a full-width `.leading` container; tag `.frame(alignment: .leading)`; note text `.frame(maxWidth: .infinity, alignment: .leading)`.
- [x] A single 1pt `border1` hairline separates each date group from the next, with no divider above the first or below the last (`index > 0` guard).
- [x] Vertical spacing is tighter than the old card gaps (`s2` padding + `spacing: 0` vs. old `s5` gap + `s3` card padding).
- [x] Header block (title / count / subtitle) is unchanged and remains centered (header items untouched; outer `VStack` still center-aligned).

On-device visual confirmation (Journal tab):

- [ ] Entries render as a flat, left-aligned list with thin dividers and no bubbles.
- [ ] Scroll a journal with many entries (20+) → tight spacing, reads as one continuous column, dividers sit cleanly between date groups.
- [ ] Single-line ("DAY 44 — Morning session. Groggy") and multi-line notes both left-align correctly with consistent divider spacing.
- [ ] Header (title/count/subtitle) still centered and visually unchanged.
- [ ] Divider reads correctly against the (dark) background.


___

## **CodeAnt-AI Description**
**Flatten the Thought Journal list into a left-aligned log**

### What Changed
- Replaces each dated journal group card with a flat list separated by thin dividers
- Aligns the day label, time tag, and note text to the left so entries read in clean columns
- Tightens spacing between date groups so more thoughts fit on screen at once
- Keeps the empty-state message for when no thoughts have been captured

### Impact
`✅ Easier to scan journal entries`
`✅ More entries visible per screen`
`✅ Clearer reading flow`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
