### PR TITLE
chore: hygiene batch — log ignore, e2e:policy tokens, reverse token lint, os.Logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 *.pem
 
 # debug
+*.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/ios/StillPointShared/Sources/StillPointShared/AuthTokenStore.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AuthTokenStore.swift
@@ -1,9 +1,14 @@
 import Foundation
 import Security
+import os
 
 enum AuthTokenStore {
     private static let account = "sp-auth-token"
     private static let service = "still-point.auth"
+    private static let log = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.brettonauerbach.stillpoint",
+        category: "keychain"
+    )
 
     @discardableResult
     static func save(_ token: String) -> Bool {
@@ -75,6 +80,6 @@ enum AuthTokenStore {
 
     private static func logKeychainFailure(operation: String, status: OSStatus) {
         let message = SecCopyErrorMessageString(status, nil) as String? ?? "Unknown Keychain error"
-        print("AuthTokenStore \(operation) failed (\(status)): \(message)")
+        log.error("AuthTokenStore \(operation, privacy: .public) failed (\(status, privacy: .public)): \(message, privacy: .public)")
     }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "e2e:policy:no-sleep": "node scripts/e2e/check-no-naked-sleep.mjs",
     "e2e:policy:secrets": "node scripts/e2e/check-test-secrets.mjs",
     "e2e:policy:design-tokens": "node scripts/e2e/check-design-tokens.mjs",
-    "e2e:policy": "E2E_BASE_URL=${E2E_BASE_URL:-http://127.0.0.1:3000} npm run e2e:policy:no-sleep && npm run e2e:policy:secrets && E2E_BASE_URL=${E2E_BASE_URL:-http://127.0.0.1:3000} npm run e2e:guard",
+    "e2e:policy": "E2E_BASE_URL=${E2E_BASE_URL:-http://127.0.0.1:3000} npm run e2e:policy:no-sleep && npm run e2e:policy:secrets && E2E_BASE_URL=${E2E_BASE_URL:-http://127.0.0.1:3000} npm run e2e:guard && npm run e2e:policy:design-tokens",
     "e2e:setup-web-user": "tsx scripts/e2e/setup-web-user.ts",
     "ios:app-store:dry-run": "node scripts/ios-app-store-dry-run.mjs",
     "e2e:web:smoke": "E2E_BASE_URL=${E2E_BASE_URL:-http://127.0.0.1:3000} npm run e2e:guard && node scripts/e2e/run-playwright-lane.mjs smoke @smoke 1",

--- a/scripts/e2e/check-design-tokens.mjs
+++ b/scripts/e2e/check-design-tokens.mjs
@@ -67,6 +67,12 @@ const CSS_ONLY_VARS = new Set([
   "--nav-h",
 ]);
 
+/** iOS-only SPColor tokens that intentionally have no web counterpart. */
+const SPCOLOR_ONLY = new Set(/** @type {string[]} */ ([]));
+
+/** iOS-only SPSpacing tokens that intentionally have no web counterpart. */
+const SPSPACING_ONLY = new Set(/** @type {string[]} */ ([]));
+
 const SHARED_CSS_VARS = new Set([
   ...Object.values(SHARED_COLOR_MAP).map((entry) => entry.css),
   ...Object.values(SHARED_SPACING_MAP).map((entry) => entry.css),
@@ -321,6 +327,24 @@ function main() {
     );
   }
 
+  for (const swiftName of Object.keys(swiftColors)) {
+    if (SHARED_COLOR_MAP[swiftName] != null || SPCOLOR_ONLY.has(swiftName)) {
+      continue;
+    }
+    violations.push(
+      `Unexpected Swift token SPColor.${swiftName} is neither shared nor listed as platform-specific`
+    );
+  }
+
+  for (const swiftName of Object.keys(swiftSpacing)) {
+    if (SHARED_SPACING_MAP[swiftName] != null || SPSPACING_ONLY.has(swiftName)) {
+      continue;
+    }
+    violations.push(
+      `Unexpected Swift token SPSpacing.${swiftName} is neither shared nor listed as platform-specific`
+    );
+  }
+
   if (violations.length > 0) {
     console.error("Design token parity check failed:");
     for (const violation of violations) {
@@ -336,7 +360,7 @@ function main() {
   const sharedColorCount = Object.keys(SHARED_COLOR_MAP).length;
   const sharedSpacingCount = Object.keys(SHARED_SPACING_MAP).length;
   console.log(
-    `Design token parity check passed (${sharedColorCount} shared colors, ${sharedSpacingCount} shared spacing values, ${CSS_ONLY_VARS.size} web-only CSS tokens).`
+    `Design token parity check passed (${sharedColorCount} shared colors, ${sharedSpacingCount} shared spacing values, ${CSS_ONLY_VARS.size} web-only CSS tokens, ${SPCOLOR_ONLY.size + SPSPACING_ONLY.size} iOS-only tokens).`
   );
 }
 


### PR DESCRIPTION
## **User description**
## Summary

Four independent hygiene fixes from the 2026-07-02 review (Issue #542):

- **`.gitignore`**: Add `*.log` catch-all to debug block; `err.log` was absent from the worktree checkout (untracked file, not present in fresh clone).
- **`package.json`**: Add `e2e:policy:design-tokens` to the `e2e:policy` umbrella chain so local runs and `e2e-web.yml` (which calls the umbrella) enforce token parity. `web-build.yml`'s dedicated standalone step is left intact per design choice 2.
- **`check-design-tokens.mjs`**: Add symmetric iOS→web orphan check — `SPCOLOR_ONLY`/`SPSPACING_ONLY` allow-lists (empty; all current tokens are shared) and reverse loops that flag any SPColor/SPSpacing token missing from `SHARED_COLOR_MAP`/`SHARED_SPACING_MAP`.
- **`AuthTokenStore.swift`**: Replace `print()` in `logKeychainFailure` with `os.Logger` (category `keychain`), following the `APIClient.swift` pattern. Subsystem derived from `Bundle.main.bundleIdentifier` (target-agnostic). All values marked `privacy: .public`; no token values are logged.

Closes #542

## Test plan

- [x] `.gitignore` contains `*.log` in the debug block; `err.log` is absent from the repo (was untracked, removed or never present in this checkout).
- [x] `npm run e2e:policy` now includes the design-tokens check: running it locally produces a `Design token parity check passed (…)` line after the other policy checks.
- [x] `e2e-web.yml` picks up the token check transitively via the umbrella (no new step added); `web-build.yml` retains its explicit standalone `npm run e2e:policy:design-tokens` step before `build:verify`.
- [x] Adding a new SPColor token to `DesignTokens.swift` without a `SHARED_COLOR_MAP` entry causes `check-design-tokens.mjs` to exit 1 with "Unexpected Swift token SPColor.X is neither shared nor listed as platform-specific" (verified locally with a temporary mutation).
- [x] `AuthTokenStore.swift` Keychain failures log via `os.Logger` (category `keychain`) with no token values in the message; the `logKeychainFailure` helper no longer calls `print()`.

## Notes

Local CLI review: CodeRabbit hit OSS rate limit twice (dropped); CodeAnt not installed on this machine (dropped). Self-review performed — all changes are minimal, pattern-matched, and linter-verified.


___

## **CodeAnt-AI Description**
**Catch token mismatches earlier and log keychain errors safely**

### What Changed
- The design-token check now flags iOS tokens that do not have a web match, so shared token drift is caught in both directions.
- The main policy check now includes the design-token parity check, so local policy runs stop when token sets are out of sync.
- Keychain save and clear failures now go through structured logging instead of plain text output, with app and error details logged safely.

### Impact
`✅ Fewer cross-platform token mismatches`
`✅ Earlier policy failures for design-token drift`
`✅ Clearer keychain error logs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>