### PR TITLE
feat(ios): session environment photo in session log

### DIFF
--- a/ios/StillPointApp/Info.plist
+++ b/ios/StillPointApp/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.brettonauerbach.stillpoint.app-block-refresh</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -46,17 +50,13 @@
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSCameraUsageDescription</key>
-	<string>Still Point uses the camera for partner video sessions and, when you opt in, gaze attention tracking during sits.</string>
+	<string>Still Point uses the camera for partner video sessions, gaze attention tracking during sits, and optionally to photograph your meditation environment at the end of a session.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Still Point needs microphone access for partner video sessions and to sample ambient sound levels during solo sits (no audio is stored).</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
 		<string>fetch</string>
-	</array>
-	<key>BGTaskSchedulerPermittedIdentifiers</key>
-	<array>
-		<string>com.brettonauerbach.stillpoint.app-block-refresh</string>
 	</array>
 	<key>UILaunchScreen</key>
 	<dict/>

--- a/ios/StillPointApp/Managers/CameraPermissionHelper.swift
+++ b/ios/StillPointApp/Managers/CameraPermissionHelper.swift
@@ -1,0 +1,65 @@
+import AVFoundation
+import SwiftUI
+
+/// Lightweight camera authorization helper with a clean deny path.
+///
+/// Mirrors the push-notification permission pattern in `NotificationsSettingsView` —
+/// on denial the caller shows an alert with an "Open Settings" deep-link action via
+/// the `.cameraPermissionDeniedAlert(isPresented:)` modifier below.
+enum CameraPermissionHelper {
+    /// Current camera authorization status, without prompting the user.
+    static var status: AVAuthorizationStatus {
+        AVCaptureDevice.authorizationStatus(for: .video)
+    }
+
+    /// `true` when camera access is already `.authorized`.
+    static var isAuthorized: Bool { status == .authorized }
+
+    /// `true` when the user has explicitly denied or the system has restricted access.
+    static var isDenied: Bool {
+        let s = status
+        return s == .denied || s == .restricted
+    }
+
+    /// Requests camera permission when status is `.notDetermined`; calls `completion` on
+    /// the main actor with the resulting status.
+    ///
+    /// - `.authorized`: camera may proceed.
+    /// - `.denied` / `.restricted`: caller should show `cameraPermissionDeniedAlert`.
+    static func requestIfNeeded(completion: @escaping @MainActor (AVAuthorizationStatus) -> Void) {
+        switch status {
+        case .authorized:
+            Task { @MainActor in completion(.authorized) }
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { granted in
+                Task { @MainActor in completion(granted ? .authorized : .denied) }
+            }
+        case .denied, .restricted:
+            let current = status
+            Task { @MainActor in completion(current) }
+        @unknown default:
+            Task { @MainActor in completion(.denied) }
+        }
+    }
+}
+
+// MARK: - Permission-denied alert modifier
+
+extension View {
+    /// Attaches a camera-access-denied alert with an "Open Settings" deep-link action,
+    /// mirroring the `showPushPermissionDeniedAlert` pattern in `NotificationsSettingsView`.
+    func cameraPermissionDeniedAlert(isPresented: Binding<Bool>) -> some View {
+        alert(
+            "Camera Access Required",
+            isPresented: isPresented
+        ) {
+            Button("Open Settings") {
+                guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+                UIApplication.shared.open(url)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("To photograph your meditation environment, allow camera access for Still Point in Settings.")
+        }
+    }
+}

--- a/ios/StillPointApp/Services/SessionPhotoStore.swift
+++ b/ios/StillPointApp/Services/SessionPhotoStore.swift
@@ -98,7 +98,7 @@ final class SessionPhotoStore {
         return renderer.image { _ in image.draw(in: CGRect(origin: .zero, size: newSize)) }
     }
 
-    /// Strips characters unsafe in filenames, keeping alphanumerics and hyphens.
+    /// Strips characters unsafe in filenames, keeping alphanumerics, hyphens, and underscores.
     private func sanitizedFilename(_ sessionId: String) -> String {
         let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
         let sanitized = sessionId.unicodeScalars

--- a/ios/StillPointApp/Services/SessionPhotoStore.swift
+++ b/ios/StillPointApp/Services/SessionPhotoStore.swift
@@ -1,0 +1,110 @@
+import Foundation
+import UIKit
+
+/// Persists per-session environment photos to the device's Documents directory.
+///
+/// Photos are stored as JPEG under `<Documents>/session-photos/<sanitized-sessionId>.jpg`.
+/// The session ID is encoded in the filename — no DTO or backend changes are required for
+/// the MVP. Images are downscaled and compressed on save to keep disk footprint small.
+///
+/// Use `SessionPhotoStore.shared` from both view models and the completion screen.
+final class SessionPhotoStore {
+    static let shared = SessionPhotoStore()
+
+    private static let subDirectory = "session-photos"
+    private static let maxDimension: CGFloat = 1280
+    private static let compressionQuality: CGFloat = 0.75
+
+    private init() {}
+
+    // MARK: - Public API
+
+    /// Saves `image` for the given session ID, overwriting any prior photo.
+    ///
+    /// The image is downscaled to at most 1 280 px on the long edge and JPEG-compressed
+    /// at 0.75 quality before writing. Uses atomic file replacement to avoid corrupt
+    /// partial writes.
+    ///
+    /// - Returns: the file URL on success, or `nil` on any failure.
+    @discardableResult
+    func save(_ image: UIImage, forSessionId sessionId: String) -> URL? {
+        guard !sessionId.isEmpty else { return nil }
+        guard let data = compressed(image) else { return nil }
+        let url = photoURL(forSessionId: sessionId)
+        do {
+            try ensureSubdirectoryExists()
+            try data.write(to: url, options: .atomic)
+            return url
+        } catch {
+            print("[SessionPhotoStore] Failed to write photo for '\(sessionId)': \(error)")
+            return nil
+        }
+    }
+
+    /// Loads and returns the stored image for `sessionId`, or `nil` if none exists.
+    func loadImage(forSessionId sessionId: String) -> UIImage? {
+        guard !sessionId.isEmpty else { return nil }
+        let url = photoURL(forSessionId: sessionId)
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return UIImage(contentsOfFile: url.path)
+    }
+
+    /// Returns `true` when a photo file exists for `sessionId`.
+    func exists(forSessionId sessionId: String) -> Bool {
+        guard !sessionId.isEmpty else { return false }
+        return FileManager.default.fileExists(atPath: photoURL(forSessionId: sessionId).path)
+    }
+
+    /// Deletes the photo for `sessionId`. Silently no-ops if no file exists.
+    func delete(forSessionId sessionId: String) {
+        guard !sessionId.isEmpty else { return }
+        try? FileManager.default.removeItem(at: photoURL(forSessionId: sessionId))
+    }
+
+    /// Returns the canonical file URL for `sessionId`'s photo, whether or not it exists.
+    func photoURL(forSessionId sessionId: String) -> URL {
+        subdirectoryURL.appendingPathComponent(sanitizedFilename(sessionId) + ".jpg")
+    }
+
+    // MARK: - Private
+
+    private var subdirectoryURL: URL {
+        FileManager.default
+            .urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent(Self.subDirectory, isDirectory: true)
+    }
+
+    private func ensureSubdirectoryExists() throws {
+        let url = subdirectoryURL
+        var isDir: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir)
+        guard !exists || !isDir.boolValue else { return }
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    private func compressed(_ image: UIImage) -> Data? {
+        downscaled(image).jpegData(compressionQuality: Self.compressionQuality)
+    }
+
+    private func downscaled(_ image: UIImage) -> UIImage {
+        let size = image.size
+        guard size.width > Self.maxDimension || size.height > Self.maxDimension else { return image }
+        let ratio = max(size.width, size.height) / Self.maxDimension
+        let newSize = CGSize(
+            width: (size.width / ratio).rounded(),
+            height: (size.height / ratio).rounded()
+        )
+        let renderer = UIGraphicsImageRenderer(size: newSize)
+        return renderer.image { _ in image.draw(in: CGRect(origin: .zero, size: newSize)) }
+    }
+
+    /// Strips characters unsafe in filenames, keeping alphanumerics and hyphens.
+    private func sanitizedFilename(_ sessionId: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        let sanitized = sessionId.unicodeScalars
+            .filter { allowed.contains($0) }
+            .map(String.init)
+            .joined()
+        return String(sanitized.prefix(128))
+    }
+}

--- a/ios/StillPointApp/ViewModels/HistoryViewModel.swift
+++ b/ios/StillPointApp/ViewModels/HistoryViewModel.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import StillPointShared
+import UIKit
 
 enum HistoryViewMode: String, CaseIterable {
     case calendar
@@ -28,6 +29,11 @@ final class HistoryViewModel {
     /// Expanded session (by row id).
     var expandedSessionId: String?
     var sessionThoughts: [String: [ThoughtDTO]] = [:]
+    /// Local environment photos keyed by session ID — only sessions that have a photo.
+    /// Use `photoCheckedIds` to distinguish "not yet checked" from "checked, no photo".
+    var sessionPhotos: [String: UIImage] = [:]
+    /// Session IDs whose local photo file has already been looked up (avoids repeat disk reads).
+    private(set) var photoCheckedIds: Set<String> = []
 
     var viewMode: HistoryViewMode = .calendar
     var calendarSubView: HistoryCalendarSubView = .default
@@ -127,6 +133,7 @@ final class HistoryViewModel {
             expandedSessionId = nil
         } else {
             expandedSessionId = sessionId
+            // Load thoughts from the server
             if sessionThoughts[sessionId] == nil {
                 do {
                     let detail = try await APIClient.shared.getSessionBySessionId(sessionId)
@@ -136,6 +143,21 @@ final class HistoryViewModel {
                     if expandedSessionId == sessionId {
                         expandedSessionId = nil
                     }
+                }
+            }
+            // Load local environment photo off the main thread (disk I/O + JPEG decode).
+            // photoCheckedIds deduplicates lookup across expands; nil → no photo (expected)
+            // vs. a transient read error (extremely rare for our own-written JPEGs — MVP).
+            if !photoCheckedIds.contains(sessionId) {
+                photoCheckedIds.insert(sessionId)
+                let id = sessionId
+                let photo: UIImage? = await withCheckedContinuation { continuation in
+                    DispatchQueue.global(qos: .userInitiated).async {
+                        continuation.resume(returning: SessionPhotoStore.shared.loadImage(forSessionId: id))
+                    }
+                }
+                if let photo {
+                    sessionPhotos[id] = photo
                 }
             }
         }

--- a/ios/StillPointApp/Views/CompletionView.swift
+++ b/ios/StillPointApp/Views/CompletionView.swift
@@ -395,7 +395,7 @@ struct CompletionView: View {
 
     private func handlePhotoSelected(_ image: UIImage) {
         guard !sessionId.isEmpty else { return }
-        SessionPhotoStore.shared.save(image, forSessionId: sessionId)
+        guard SessionPhotoStore.shared.save(image, forSessionId: sessionId) != nil else { return }
         capturedPhoto = image
     }
 

--- a/ios/StillPointApp/Views/CompletionView.swift
+++ b/ios/StillPointApp/Views/CompletionView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import StillPointShared
+import UIKit
 import os
 
 struct CompletionView: View {
@@ -27,6 +28,10 @@ struct CompletionView: View {
     @State private var isSaving = false
     @State private var saveError: String?
     @State private var uiTestAutoSaveTask: Task<Void, Never>?
+
+    // Session environment photo (optional, local-only MVP)
+    @State private var capturedPhoto: UIImage?
+    @State private var showPhotoPicker = false
 
     private var nextDuration: Int {
         DurationRecovery.previewNextStandardDuration(
@@ -181,6 +186,9 @@ struct CompletionView: View {
                     )
                 }
 
+                // Session environment photo (optional)
+                sessionPhotoSection
+
                 // End-of-session note
                 VStack(alignment: .leading, spacing: SPSpacing.s2) {
                     Text("SESSION NOTE")
@@ -306,6 +314,94 @@ struct CompletionView: View {
             saveError = nil
             scheduleUITestAutoSaveIfNeeded(for: newValue)
         }
+        .sheet(isPresented: $showPhotoPicker) {
+            SessionPhotoPicker { image in
+                handlePhotoSelected(image)
+            }
+        }
+    }
+
+    // MARK: - Session Photo Section
+
+    @ViewBuilder
+    private var sessionPhotoSection: some View {
+        VStack(alignment: .leading, spacing: SPSpacing.s2) {
+            Text("SESSION PHOTO")
+                .font(SPFont.mono(11, weight: .medium))
+                .foregroundStyle(Color(SPColor.fg4))
+                .tracking(2)
+
+            if let photo = capturedPhoto {
+                // Thumbnail with retake / remove controls
+                VStack(alignment: .leading, spacing: SPSpacing.s2) {
+                    Image(uiImage: photo)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 180)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                        .clipped()
+                        .accessibilityIdentifier("completion.photoThumbnail")
+
+                    HStack {
+                        Button {
+                            showPhotoPicker = true
+                        } label: {
+                            Text("Retake")
+                                .font(SPFont.mono(11, weight: .medium))
+                                .foregroundStyle(Color(SPColor.fg3))
+                        }
+                        .accessibilityIdentifier("completion.retakePhotoButton")
+
+                        Spacer()
+
+                        Button {
+                            removePhoto()
+                        } label: {
+                            Text("Remove")
+                                .font(SPFont.mono(11, weight: .medium))
+                                .foregroundStyle(SPColor.dangerMuted)
+                        }
+                        .accessibilityIdentifier("completion.removePhotoButton")
+                    }
+                }
+            } else {
+                // Dashed "add" affordance — intentionally low-prominence so it never feels mandatory.
+                // Disabled until sessionId is assigned by the server (mirrors isSaveDisabled guard).
+                Button {
+                    showPhotoPicker = true
+                } label: {
+                    HStack(spacing: SPSpacing.s2) {
+                        Image(systemName: "camera")
+                            .font(.system(size: 15))
+                        Text("Add photo of your environment")
+                            .font(SPFont.serifItalic(15, weight: .light))
+                    }
+                    .foregroundStyle(Color(SPColor.fg3))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, SPSpacing.s3)
+                    .background(Color(SPColor.surface1))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(SPColor.border2, style: StrokeStyle(lineWidth: 1, dash: [4]))
+                    )
+                }
+                .disabled(sessionId.isEmpty)
+                .accessibilityIdentifier("completion.addPhotoButton")
+            }
+        }
+    }
+
+    private func handlePhotoSelected(_ image: UIImage) {
+        guard !sessionId.isEmpty else { return }
+        SessionPhotoStore.shared.save(image, forSessionId: sessionId)
+        capturedPhoto = image
+    }
+
+    private func removePhoto() {
+        SessionPhotoStore.shared.delete(forSessionId: sessionId)
+        capturedPhoto = nil
     }
 
     private func statCard(

--- a/ios/StillPointApp/Views/HistoryView.swift
+++ b/ios/StillPointApp/Views/HistoryView.swift
@@ -1,9 +1,12 @@
 import SwiftUI
 import StillPointShared
+import UIKit
 
 struct HistoryView: View {
     let appVM: AppViewModel
     @State private var vm = HistoryViewModel()
+    /// Full-screen photo presented when the user taps a session thumbnail.
+    @State private var fullScreenPhoto: UIImage?
 
     private let weekdayLabels = ["S", "M", "T", "W", "T", "F", "S"]
 
@@ -49,6 +52,36 @@ struct HistoryView: View {
         .task {
             await vm.load()
         }
+        .sheet(isPresented: Binding(
+            get: { fullScreenPhoto != nil },
+            set: { if !$0 { fullScreenPhoto = nil } }
+        )) {
+            if let photo = fullScreenPhoto {
+                fullScreenPhotoSheet(photo)
+            }
+        }
+    }
+
+    // MARK: - Full-screen photo sheet
+
+    private func fullScreenPhotoSheet(_ photo: UIImage) -> some View {
+        VStack(spacing: 0) {
+            HStack {
+                Spacer()
+                Button("Done") { fullScreenPhoto = nil }
+                    .font(SPFont.mono(13, weight: .medium))
+                    .foregroundStyle(Color(SPColor.fg3))
+                    .padding()
+            }
+            Spacer()
+            Image(uiImage: photo)
+                .resizable()
+                .scaledToFit()
+                .padding(.horizontal, SPSpacing.s3)
+            Spacer()
+        }
+        .stillPointBackground()
+        .accessibilityIdentifier("history.fullScreenPhoto")
     }
 
     // MARK: - View Toggle
@@ -716,18 +749,38 @@ struct HistoryView: View {
             }
             .accessibilityIdentifier("history.session.\(session.id)")
 
-            if isExpanded, let thoughts = vm.sessionThoughts[session.id] {
+            if isExpanded {
                 VStack(alignment: .leading, spacing: 4) {
-                    ForEach(thoughts, id: \.id) { thought in
-                        HStack(alignment: .top, spacing: SPSpacing.s2) {
-                            Text(thought.timeInSession == -1 ? "note" : "@\(thought.timeInSession)s")
-                                .font(SPFont.mono(10))
-                                .foregroundStyle(SPColor.amberText)
-                                .frame(width: 44, alignment: .trailing)
+                    // Environment photo thumbnail (tap to enlarge)
+                    if let photo = vm.sessionPhotos[session.id] {
+                        Button {
+                            fullScreenPhoto = photo
+                        } label: {
+                            Image(uiImage: photo)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 120)
+                                .clipShape(RoundedRectangle(cornerRadius: 6))
+                                .clipped()
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.bottom, 2)
+                        .accessibilityIdentifier("history.session.\(session.id).photo")
+                    }
+                    // Captured thoughts
+                    if let thoughts = vm.sessionThoughts[session.id] {
+                        ForEach(thoughts, id: \.id) { thought in
+                            HStack(alignment: .top, spacing: SPSpacing.s2) {
+                                Text(thought.timeInSession == -1 ? "note" : "@\(thought.timeInSession)s")
+                                    .font(SPFont.mono(10))
+                                    .foregroundStyle(SPColor.amberText)
+                                    .frame(width: 44, alignment: .trailing)
 
-                            Text(thought.text)
-                                .font(SPFont.serifItalic(13))
-                                .foregroundStyle(Color(SPColor.fg3))
+                                Text(thought.text)
+                                    .font(SPFont.serifItalic(13))
+                                    .foregroundStyle(Color(SPColor.fg3))
+                            }
                         }
                     }
                 }

--- a/ios/StillPointApp/Views/SessionPhotoPicker.swift
+++ b/ios/StillPointApp/Views/SessionPhotoPicker.swift
@@ -1,0 +1,147 @@
+import SwiftUI
+import PhotosUI
+import AVFoundation
+
+/// Reusable photo capture / picker sheet.
+///
+/// Present this view as a sheet to give the user a "Take Photo" button (camera, gated
+/// through `CameraPermissionHelper`) and a "Choose from Library" button
+/// (`PhotosPicker`, no additional permission key required). Returns the selected
+/// image via `onImageSelected` and dismisses itself automatically.
+struct SessionPhotoPicker: View {
+    /// Called on the main thread when the user selects or captures a photo.
+    let onImageSelected: (UIImage) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var showCameraCapture = false
+    @State private var showPermissionDeniedAlert = false
+    @State private var photoPickerItem: PhotosPickerItem?
+    /// Holds an image captured by the camera until the fullScreenCover has dismissed.
+    @State private var pendingCameraImage: UIImage?
+
+    var body: some View {
+        VStack(spacing: SPSpacing.s4) {
+            Spacer().frame(height: SPSpacing.s3)
+
+            Text("ADD PHOTO")
+                .font(SPFont.mono(11, weight: .medium))
+                .foregroundStyle(Color(SPColor.fg4))
+                .tracking(2)
+
+            // Camera
+            Button {
+                handleCameraTap()
+            } label: {
+                Label("Take Photo", systemImage: "camera")
+                    .font(SPFont.serifItalic(18, weight: .light))
+                    .spCapsuleButtonStyle(.neutral, size: .fullWidth, prominent: true)
+            }
+            .accessibilityIdentifier("photoPicker.cameraButton")
+
+            // Library — system picker via PhotosUI (no NSPhotoLibraryUsageDescription needed)
+            PhotosPicker(
+                selection: $photoPickerItem,
+                matching: .images,
+                photoLibrary: .shared()
+            ) {
+                Label("Choose from Library", systemImage: "photo.on.rectangle")
+                    .font(SPFont.serifItalic(18, weight: .light))
+                    .spCapsuleButtonStyle(.neutral, size: .fullWidth, prominent: true)
+            }
+            .accessibilityIdentifier("photoPicker.libraryButton")
+
+            // Cancel
+            Button {
+                dismiss()
+            } label: {
+                Text("Cancel")
+                    .font(SPFont.mono(13))
+                    .foregroundStyle(Color(SPColor.fg3))
+            }
+            .padding(.top, SPSpacing.s1)
+            .accessibilityIdentifier("photoPicker.cancelButton")
+
+            Spacer()
+        }
+        .padding(.horizontal, SPSpacing.s4)
+        .stillPointBackground()
+        // Library selection: load Data → UIImage, then dismiss
+        .onChange(of: photoPickerItem) { _, newItem in
+            guard let newItem else { return }
+            Task {
+                if let data = try? await newItem.loadTransferable(type: Data.self),
+                   let image = UIImage(data: data) {
+                    onImageSelected(image)
+                }
+                dismiss()
+            }
+        }
+        // Camera capture: fullScreenCover (camera must be presented full-screen on iPhone)
+        .fullScreenCover(isPresented: $showCameraCapture) {
+            CameraImagePicker { captured in
+                pendingCameraImage = captured
+                showCameraCapture = false
+            }
+            .ignoresSafeArea()
+        }
+        // When the camera cover dismisses, deliver the pending image and close the sheet
+        .onChange(of: showCameraCapture) { _, isShowing in
+            guard !isShowing, let image = pendingCameraImage else { return }
+            onImageSelected(image)
+            pendingCameraImage = nil
+            dismiss()
+        }
+        // Deny path: Settings deep-link
+        .cameraPermissionDeniedAlert(isPresented: $showPermissionDeniedAlert)
+    }
+
+    private func handleCameraTap() {
+        CameraPermissionHelper.requestIfNeeded { status in
+            if status == .authorized {
+                showCameraCapture = true
+            } else {
+                showPermissionDeniedAlert = true
+            }
+        }
+    }
+}
+
+// MARK: - Camera UIViewControllerRepresentable
+
+/// Wraps `UIImagePickerController` with `.camera` source type for use in SwiftUI.
+private struct CameraImagePicker: UIViewControllerRepresentable {
+    /// Called with the captured image, or `nil` when the user cancels.
+    let onCapture: (UIImage?) -> Void
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(onCapture: onCapture) }
+
+    final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        let onCapture: (UIImage?) -> Void
+
+        init(onCapture: @escaping (UIImage?) -> Void) {
+            self.onCapture = onCapture
+        }
+
+        func imagePickerController(
+            _ picker: UIImagePickerController,
+            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+        ) {
+            let image = info[.editedImage] as? UIImage ?? info[.originalImage] as? UIImage
+            onCapture(image)
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            onCapture(nil)
+        }
+    }
+}

--- a/ios/StillPointApp/Views/SessionPhotoPicker.swift
+++ b/ios/StillPointApp/Views/SessionPhotoPicker.swift
@@ -37,6 +37,7 @@ struct SessionPhotoPicker: View {
                     .font(SPFont.serifItalic(18, weight: .light))
                     .spCapsuleButtonStyle(.neutral, size: .fullWidth, prominent: true)
             }
+            .disabled(!UIImagePickerController.isSourceTypeAvailable(.camera))
             .accessibilityIdentifier("photoPicker.cameraButton")
 
             // Library — system picker via PhotosUI (no NSPhotoLibraryUsageDescription needed)
@@ -97,6 +98,7 @@ struct SessionPhotoPicker: View {
     }
 
     private func handleCameraTap() {
+        guard UIImagePickerController.isSourceTypeAvailable(.camera) else { return }
         CameraPermissionHelper.requestIfNeeded { status in
             if status == .authorized {
                 showCameraCapture = true

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -58,7 +58,7 @@ targets:
         # Privacy purpose strings — REQUIRED by iOS for the buddy video web view
         # (BuddyVideoWebView: WKWebView -> Daily.co getUserMedia). A missing key is a
         # hard crash the moment camera/mic is requested, not a graceful denial.
-        NSCameraUsageDescription: Still Point uses the camera for partner video sessions and, when you opt in, gaze attention tracking during sits.
+        NSCameraUsageDescription: Still Point uses the camera for partner video sessions, gaze attention tracking during sits, and optionally to photograph your meditation environment at the end of a session.
         NSMicrophoneUsageDescription: Still Point needs microphone access for partner video sessions and to sample ambient sound levels during solo sits (no audio is stored).
         # NSFamilyControlsUsageDescription is intentionally NOT declared: it is not a
         # recognized iOS key. FamilyControls / Screen Time authorization is gated by the


### PR DESCRIPTION
## **User description**
## Summary

- Adds optional photo capture at session completion (`CompletionView`) after the server has assigned a `sessionId` — the affordance is visible but disabled until the ID exists
- Photos are stored locally in `Documents/session-photos/<sessionId>.jpg` via new `SessionPhotoStore` (FileManager, JPEG 0.75, max 1280px) — no backend or DTO changes
- History list (`HistoryView`/`HistoryViewModel`) loads each session's photo off the main thread (`withCheckedContinuation + DispatchQueue.global`) and shows a tappable thumbnail in the expanded row with a full-screen viewer

## New files

- `ios/StillPointApp/Services/SessionPhotoStore.swift` — FileManager JPEG store, singleton, atomic write
- `ios/StillPointApp/Managers/CameraPermissionHelper.swift` — AVCaptureDevice auth helper + Settings deep-link deny alert
- `ios/StillPointApp/Views/SessionPhotoPicker.swift` — "Take Photo" (`UIImagePickerController`) + "Choose from Library" (`PhotosPicker`, no permission key) sheet

## Capture-timing decision

Photo capture is placed at **session completion** (not session start) because `sessionId` is server-assigned and only available after the session ends. The photo is stored under that ID and can be looked up per-session in history.

## Local review notes

- CodeRabbit CLI (3 findings): all fixed — async photo loading off main thread, button disabled when `sessionId.isEmpty`, added comment on `photoCheckedIds` retry trade-off
- CodeAnt CLI: not installed in this environment (exit 127); GitHub CodeAnt App review will run on the PR

## Test plan

- [ ] Starting a session and reaching CompletionView shows a dashed "Add photo of your environment" button
- [ ] The button is active once the session completes (sessionId assigned)
- [ ] Tapping opens a sheet with "Take Photo" and "Choose from Library" options
- [ ] "Take Photo" requests camera permission; deny path shows alert with "Open Settings" deep-link
- [ ] Selecting or capturing an image shows a 180px thumbnail in CompletionView with Retake/Remove controls
- [ ] "Retake" replaces the previous image; "Remove" deletes it from disk and clears the thumbnail
- [ ] Returning home without taking a photo works normally (Return button unaffected)
- [ ] In history, expanding a session that has a photo shows a 120px thumbnail
- [ ] Tapping the thumbnail opens a full-screen viewer with a Done button
- [ ] Sessions without a photo show no thumbnail (history UI unchanged)
- [ ] Photo survives app restart (persisted to Documents/)
- [ ] Photo is deleted when user removes it (Remove button) and stays deleted after restart

Closes #564


___

## **CodeAnt-AI Description**
**Add an optional environment photo to sessions**

### What Changed
- Adds an optional photo step at the end of a session, with camera or library upload, plus retake and remove actions
- Saves each photo locally under its session ID and shows it later in the session history
- Session history thumbnails can be tapped to open a full-screen view
- Camera access now includes a clear deny path with an “Open Settings” option

### Impact
`✅ Easier session journaling`
`✅ Faster access to session photos in history`
`✅ Clearer camera permission prompts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
