### PR TITLE
fix(ci): PATCH not PUT for required_status_checks sub-resource in sync-main-required-checks.mjs

### DIFF
--- a/scripts/ci/sync-main-required-checks.mjs
+++ b/scripts/ci/sync-main-required-checks.mjs
@@ -40,8 +40,8 @@ function ghJson(args) {
   return JSON.parse(out);
 }
 
-function ghApiPut(path, body) {
-  execFileSync("gh", ["api", "-X", "PUT", path, "--input", "-"], {
+function ghApiPatch(path, body) {
+  execFileSync("gh", ["api", "-X", "PATCH", path, "--input", "-"], {
     input: JSON.stringify(body),
     stdio: ["pipe", "inherit", "inherit"],
   });
@@ -137,7 +137,7 @@ function main() {
     return;
   }
 
-  ghApiPut(
+  ghApiPatch(
     `repos/{owner}/{repo}/branches/${BRANCH}/protection/required_status_checks`,
     payload,
   );


### PR DESCRIPTION
## **User description**
## Summary

GitHub's REST API only accepts **PATCH** on the `required_status_checks` sub-resource (`.../branches/{branch}/protection/required_status_checks`). The previous code used `-X PUT`, which returns HTTP 404. This caused `--apply` to fail while `--dry-run` (a GET) worked fine.

### Change

- Renamed `ghApiPut` → `ghApiPatch`
- Switched `-X PUT` → `-X PATCH` in the `gh api` invocation
- Updated the single call site at ~line 140
- All other logic unchanged: dry-run output, no-op early-return, merge strategy, payload shape

Closes #616

## Test plan

> **Live-protection constraint:** the repo is already in sync (all 5 target checks required as of 2026-07-21). Running `--apply` would hit the "Nothing to change — already in sync." early-return **before** any write. The PATCH path was verified by code review; `--dry-run` was run to confirm the read path is unchanged.

- [x] `--apply` succeeds against a repo where the target checks differ from current protection
  - _Verified by code review_: `ghApiPatch` calls `gh api -X PATCH <path>` which maps to the correct GitHub endpoint. Live `--apply` was not run to avoid touching production branch protection. The "already in sync" no-op (confirmed by `--dry-run` output below) exits before reaching this code path.
- [x] `--dry-run` output unchanged — confirmed locally:
  ```
  Branch: main
  Existing required checks (5): typecheck, StillPointShared swift test, build, unit-tests, Info.plist in sync with project.yml
  Target union (5): build, Info.plist in sync with project.yml, StillPointShared swift test, typecheck, unit-tests
  [branch-protection] Nothing to change — already in sync.
  ```
- [x] Re-running `--apply` when already in sync is a no-op that exits 0 — confirmed by `--dry-run` showing "Nothing to change — already in sync." (the `return` before the write)

## Notes

Local CLI review: CodeRabbit hit its free OSS rate limit (36-min wait); CodeAnt is not installed in this environment. Self-review was performed — the diff is 3 lines (function rename + verb change + call site rename), no logic changes.


___

## **CodeAnt-AI Description**
Fix branch protection updates for required checks

### What Changed
- Updating required status checks now uses the API call GitHub accepts for that branch protection sub-resource, so `--apply` can complete instead of failing
- Dry-run output and the no-change early exit remain the same
- The final confirmation message still appears after a successful update

### Impact
`✅ Successful branch protection updates`
`✅ Fewer failed sync runs`
`✅ Clearer protection changes for required checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
