### PR TITLE
fix(notifications): surface missing APNs config instead of failing silently (#621)

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -56,6 +56,15 @@ Quiet hours: `quietHoursStart` and `quietHoursEnd` must be updated together (or 
 
 `POST|DELETE /api/device-token` (unchanged from #203).
 
+## Configuration
+
+The dispatcher needs provider credentials **in every environment that runs the cron** (Production, and any Preview that dispatches). APNs requires all four of `APNS_BUNDLE_ID`, `APNS_TEAM_ID`, `APNS_KEY_ID`, `APNS_PRIVATE_KEY`; Web Push requires the `WEB_PUSH_VAPID_*` set. Missing any APNs var makes `getApnsConfig()` throw before a request reaches Apple.
+
+Because a thrown provider-config error is caught per-token and never re-raised, a misconfigured environment fails **silently** — the cron still returns `200 {ok:true, sent:0}`. That left every scheduled iOS push undelivered for weeks (#621: `APNS_BUNDLE_ID` was simply unset in Production). Two guards now make that state visible:
+
+- `getApnsConfigStatus()` (`src/lib/apns.ts`) is a non-throwing presence check. `sendPushNotificationToUser` preflights it and, when unconfigured, logs one actionable line naming the missing vars and skips the send — the device token is left enabled (a config error is not an APNs rejection).
+- `/api/cron/dispatch-notifications` returns `apnsConfigured` (and `apnsMissing` when false) in its JSON, so the config state is visible at a glance instead of hidden behind a 200.
+
 ## Notification types
 
 | Type | Issue | `notification_type` | Deep link (iOS) | Preference gate |

--- a/src/app/api/cron/dispatch-notifications/route.test.ts
+++ b/src/app/api/cron/dispatch-notifications/route.test.ts
@@ -2,9 +2,14 @@ import type { NextRequest } from "next/server";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const dispatchDueNotifications = vi.fn();
+const getApnsConfigStatus = vi.fn(() => ({ configured: true, missing: [] as string[] }));
 
 vi.mock("@/lib/notification-scheduler", () => ({
   dispatchDueNotifications,
+}));
+
+vi.mock("@/lib/apns", () => ({
+  getApnsConfigStatus,
 }));
 
 describe("/api/cron/dispatch-notifications", () => {
@@ -12,6 +17,7 @@ describe("/api/cron/dispatch-notifications", () => {
     vi.clearAllMocks();
     vi.resetModules();
     dispatchDueNotifications.mockResolvedValue({ scanned: 0, sent: 0, skipped: 0 });
+    getApnsConfigStatus.mockReturnValue({ configured: true, missing: [] });
     delete process.env.CRON_SECRET;
   });
 
@@ -28,7 +34,7 @@ describe("/api/cron/dispatch-notifications", () => {
     vi.unstubAllEnvs();
   });
 
-  test("dispatches when authorized", async () => {
+  test("dispatches when authorized and reports APNs configured", async () => {
     vi.stubEnv("CRON_SECRET", "test-secret");
     dispatchDueNotifications.mockResolvedValue({ scanned: 2, sent: 1, skipped: 1 });
 
@@ -42,10 +48,43 @@ describe("/api/cron/dispatch-notifications", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       ok: true,
+      apnsConfigured: true,
       scanned: 2,
       sent: 1,
       skipped: 1,
     });
+    vi.unstubAllEnvs();
+  });
+
+  test("surfaces apnsConfigured:false and the missing vars when APNs is unconfigured (#621)", async () => {
+    vi.stubEnv("CRON_SECRET", "test-secret");
+    dispatchDueNotifications.mockResolvedValue({ scanned: 3, sent: 0, skipped: 3 });
+    getApnsConfigStatus.mockReturnValue({
+      configured: false,
+      missing: ["APNS_BUNDLE_ID", "APNS_TEAM_ID", "APNS_KEY_ID", "APNS_PRIVATE_KEY"],
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { GET } = await import("./route");
+    const response = await GET(
+      new Request("http://test.local/api/cron/dispatch-notifications", {
+        headers: { authorization: "Bearer test-secret" },
+      }) as NextRequest,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      apnsConfigured: false,
+      apnsMissing: ["APNS_BUNDLE_ID", "APNS_TEAM_ID", "APNS_KEY_ID", "APNS_PRIVATE_KEY"],
+      scanned: 3,
+      sent: 0,
+      skipped: 3,
+    });
+    expect(errorSpy).toHaveBeenCalledWith("dispatch-notifications: APNs is not configured", {
+      missing: ["APNS_BUNDLE_ID", "APNS_TEAM_ID", "APNS_KEY_ID", "APNS_PRIVATE_KEY"],
+    });
+    errorSpy.mockRestore();
     vi.unstubAllEnvs();
   });
 });

--- a/src/app/api/cron/dispatch-notifications/route.ts
+++ b/src/app/api/cron/dispatch-notifications/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { withApiHandler } from "@/lib/api/withApiHandler";
+import { getApnsConfigStatus } from "@/lib/apns";
 import { dispatchDueNotifications } from "@/lib/notification-scheduler";
 
 function isAuthorizedCron(request: NextRequest): boolean {
@@ -11,20 +12,29 @@ function isAuthorizedCron(request: NextRequest): boolean {
   return authHeader === `Bearer ${secret}`;
 }
 
-export const GET = withApiHandler("dispatch-notifications cron", async (request: NextRequest) => {
+async function runDispatch(request: NextRequest): Promise<NextResponse> {
   if (!isAuthorizedCron(request)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const result = await dispatchDueNotifications();
-  return NextResponse.json({ ok: true, ...result });
-});
 
-export const POST = withApiHandler("dispatch-notifications cron", async (request: NextRequest) => {
-  if (!isAuthorizedCron(request)) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  // Surface a misconfigured APNs environment in the cron's own output rather than
+  // burying it behind a 200 the way swallowed per-token send failures were (#621):
+  // this ran for weeks emitting sent:0 while APNS_BUNDLE_ID was simply unset.
+  const { configured: apnsConfigured, missing: apnsMissing } = getApnsConfigStatus();
+  if (!apnsConfigured) {
+    console.error("dispatch-notifications: APNs is not configured", { missing: apnsMissing });
   }
 
-  const result = await dispatchDueNotifications();
-  return NextResponse.json({ ok: true, ...result });
-});
+  return NextResponse.json({
+    ok: true,
+    apnsConfigured,
+    ...(apnsConfigured ? {} : { apnsMissing }),
+    ...result,
+  });
+}
+
+export const GET = withApiHandler("dispatch-notifications cron", runDispatch);
+
+export const POST = withApiHandler("dispatch-notifications cron", runDispatch);

--- a/src/lib/apns.test.ts
+++ b/src/lib/apns.test.ts
@@ -33,6 +33,7 @@ vi.mock("jose", async (importOriginal) => {
 });
 
 import {
+  getApnsConfigStatus,
   hashDeviceToken,
   isValidDeviceToken,
   resetApnsProviderTokenCacheForTests,
@@ -99,6 +100,51 @@ describe("apns helpers (#539)", () => {
 
   test("resetApnsProviderTokenCacheForTests clears cached provider JWT", () => {
     expect(() => resetApnsProviderTokenCacheForTests()).not.toThrow();
+  });
+});
+
+describe("getApnsConfigStatus (#621)", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  test("reports configured when all four APNs vars are present", () => {
+    process.env = {
+      ...originalEnv,
+      APNS_BUNDLE_ID: "com.example.stillpoint",
+      APNS_TEAM_ID: "TEAM123456",
+      APNS_KEY_ID: "KEY123456",
+      APNS_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----",
+    };
+    expect(getApnsConfigStatus()).toEqual({ configured: true, missing: [] });
+  });
+
+  test("lists every missing var and reports not configured", () => {
+    process.env = { ...originalEnv };
+    delete process.env.APNS_BUNDLE_ID;
+    delete process.env.APNS_TEAM_ID;
+    delete process.env.APNS_KEY_ID;
+    delete process.env.APNS_PRIVATE_KEY;
+    expect(getApnsConfigStatus()).toEqual({
+      configured: false,
+      missing: ["APNS_BUNDLE_ID", "APNS_TEAM_ID", "APNS_KEY_ID", "APNS_PRIVATE_KEY"],
+    });
+  });
+
+  test("treats an empty-string var as missing", () => {
+    process.env = {
+      ...originalEnv,
+      APNS_BUNDLE_ID: "com.example.stillpoint",
+      APNS_TEAM_ID: "TEAM123456",
+      APNS_KEY_ID: "KEY123456",
+      APNS_PRIVATE_KEY: "",
+    };
+    expect(getApnsConfigStatus()).toEqual({
+      configured: false,
+      missing: ["APNS_PRIVATE_KEY"],
+    });
   });
 });
 

--- a/src/lib/apns.ts
+++ b/src/lib/apns.ts
@@ -36,12 +36,36 @@ type ApnsConfig = {
 
 let cachedJwt: { token: string; expiresAt: number } | null = null;
 
+/** Environment variables required to authenticate with APNs (see docs/notifications.md).
+ *  Every environment that dispatches iOS push must set all four. */
+export const REQUIRED_APNS_ENV_VARS = [
+  "APNS_BUNDLE_ID",
+  "APNS_TEAM_ID",
+  "APNS_KEY_ID",
+  "APNS_PRIVATE_KEY",
+] as const;
+
 function getRequiredEnv(name: string): string {
   const value = process.env[name];
   if (!value) {
     throw new Error(`${name} is not set`);
   }
   return value;
+}
+
+/**
+ * Non-throwing check of the APNs provider configuration. Lets callers surface a
+ * misconfigured environment with a single actionable signal, instead of letting
+ * getApnsConfig() throw once per device token deep inside the send loop where a
+ * per-token catch swallows it — the failure mode that left every scheduled push
+ * silently undelivered behind a cron 200 (#621).
+ */
+export function getApnsConfigStatus(): { configured: boolean; missing: string[] } {
+  const missing = REQUIRED_APNS_ENV_VARS.filter((name) => {
+    const value = process.env[name];
+    return value === undefined || value === "";
+  });
+  return { configured: missing.length === 0, missing };
 }
 
 function getApnsConfig(): ApnsConfig {

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -8,6 +8,7 @@ const selectWhere = vi.fn();
 const selectFrom = vi.fn(() => ({ where: selectWhere }));
 const dbSelect = vi.fn(() => ({ from: selectFrom }));
 const sendApnsNotification = vi.fn();
+const getApnsConfigStatus = vi.fn(() => ({ configured: true, missing: [] as string[] }));
 
 vi.mock("@/db", () => ({
   db: {
@@ -30,6 +31,7 @@ vi.mock("@/db/schema", () => ({
 
 vi.mock("@/lib/apns", () => ({
   sendApnsNotification,
+  getApnsConfigStatus,
 }));
 
 const sendWebPushToUser = vi.fn();
@@ -49,6 +51,7 @@ describe("sendFriendRequestNotification", () => {
     tokenRows.length = 0;
     selectWhere.mockResolvedValue(tokenRows);
     sendApnsNotification.mockResolvedValue({ ok: true, status: 200 });
+    getApnsConfigStatus.mockReturnValue({ configured: true, missing: [] });
     sendWebPushToUser.mockResolvedValue({ delivered: false });
   });
 
@@ -116,6 +119,37 @@ describe("sendFriendRequestNotification", () => {
     });
 
     expect(updateSet).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
+  });
+
+  test("does not attempt an APNs send when APNs is not configured (#621)", async () => {
+    tokenRows.push({ id: "dt-1", token: "a".repeat(64), apnsEnvironment: "production" });
+    getApnsConfigStatus.mockReturnValue({
+      configured: false,
+      missing: ["APNS_BUNDLE_ID", "APNS_TEAM_ID", "APNS_KEY_ID", "APNS_PRIVATE_KEY"],
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { sendPushNotificationToUser } = await import("./notifications");
+
+      const result = await sendPushNotificationToUser({
+        recipientUserId: "recipient-id",
+        payload: { aps: { alert: { title: "Title", body: "Body" } } },
+      });
+
+      expect(result.delivered).toBe(false);
+      expect(sendApnsNotification).not.toHaveBeenCalled();
+      // Token stays enabled — a config error is not an APNs rejection.
+      expect(dbUpdate).not.toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith(
+        "APNs is not configured; skipping iOS push. Set the missing environment variables in this deployment.",
+        expect.objectContaining({
+          missing: ["APNS_BUNDLE_ID", "APNS_TEAM_ID", "APNS_KEY_ID", "APNS_PRIVATE_KEY"],
+          affectedTokens: 1,
+        }),
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   test("sends the daily reminder to APNs and Web Push", async () => {

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,7 +1,12 @@
 import { and, eq } from "drizzle-orm";
 import { db } from "@/db";
 import { deviceTokens } from "@/db/schema";
-import { type ApnsEnvironment, type ApnsPayload, sendApnsNotification } from "@/lib/apns";
+import {
+  type ApnsEnvironment,
+  type ApnsPayload,
+  getApnsConfigStatus,
+  sendApnsNotification,
+} from "@/lib/apns";
 import {
   buildDailyReminderPayload,
   buildDailyReminderWebPushPayload,
@@ -39,6 +44,20 @@ export async function sendPushNotificationToUser(params: {
     .where(and(eq(deviceTokens.userId, params.recipientUserId), eq(deviceTokens.enabled, true)));
 
   if (tokens.length === 0) {
+    return { delivered: false };
+  }
+
+  const apnsStatus = getApnsConfigStatus();
+  if (!apnsStatus.configured) {
+    // A missing APNs provider config makes getApnsConfig() throw once per token
+    // inside the loop below, where the per-token catch swallows it — so scheduled
+    // pushes fail silently behind a cron 200 (#621). Detect it up front and emit one
+    // loud, actionable line naming the vars to set, then stop rather than spamming
+    // stack traces. Tokens are left enabled (a config error is not an APNs rejection).
+    console.error(
+      "APNs is not configured; skipping iOS push. Set the missing environment variables in this deployment.",
+      { missing: apnsStatus.missing, affectedTokens: tokens.length },
+    );
     return { delivered: false };
   }
 


### PR DESCRIPTION
## **User description**
Closes #621

## Root cause — traced end-to-end (cron → scheduler → APNs → device)

Scheduled iOS pushes have **never** been delivered to **any** account because the **APNs provider env vars are unset in Vercel Production**. `getApnsConfig()` throws `APNS_BUNDLE_ID is not set` on the first `getRequiredEnv()` call — before any request reaches Apple. The throw is swallowed by the per-token `catch` in `sendPushNotificationToUser`, so the cron returns `200 {ok:true, sent:0}` and the failure hid for weeks.

**Evidence (this account = bretton.auerbach@gmail.com):**
- **Vercel prod logs:** cron runs every 5 min and matched this account at the 08:00 ET reminder (run at 12:00 UTC): `APNs notification error … Error: APNS_BUNDLE_ID is not set` on `/api/cron/dispatch-notifications`. Error cluster: first `2026-06-30` → last `2026-07-22` — environment-wide.
- **Prod DB:** `notification_preferences` correctly enabled (`push_enabled`, `daily_reminder_enabled`, `miss_a_day_enabled`; `08:00`, `America/New_York`, quiet `20:00–07:59`). Exactly **one** `device_tokens` row in the whole system — this account, `apns_environment=production`, `enabled=true`, `last_used_at=null`, registered `2026-07-22`. `notification_dispatches` empty for all users; global `MAX(last_used_at)` null ⇒ **no push has ever been accepted by APNs for anyone.**

Why the prior rounds didn't fix it: #440, #561 and PR #566 (quiet-hours) all repaired scheduler links that sit **upstream** of the throw, so none could ever produce a delivery. Quiet hours are not the blocker here — the `08:00` reminder lands one minute after the `07:59` quiet-end and the window math fires it.

## What this PR changes (make the silent failure loud + regression coverage)

- `src/lib/apns.ts` — non-throwing `getApnsConfigStatus()` presence check for the four `APNS_*` vars.
- `src/lib/notifications.ts` — `sendPushNotificationToUser` preflights the config; when unconfigured it logs **one** actionable line naming the missing vars and skips the send (the device token is left enabled — a config error is not an APNs rejection), instead of throwing once per token behind a swallowing catch.
- `src/app/api/cron/dispatch-notifications/route.ts` — response now includes `apnsConfigured` (and `apnsMissing` when false) and logs a distinct error, so a misconfig is visible at a glance instead of hidden behind a `200`. GET/POST refactored to a shared handler.
- Tests + `docs/notifications.md` configuration/failure-mode note.

This PR does **not** by itself deliver a push — it prevents the failure from being silent again. The actual delivery fix is operational ⤵

## ⚠️ Required operational fix (owner action — production secrets)

**Root cause refined:** neither `.p8` in the repo was an APNs key — `VKS77M2C6F` is the *Sign in with Apple* key and `T72VYL8K93` is the *App Store Connect API* key. The account had **no APNs push key at all**, so there was never anything to configure push with. A new APNs Auth Key ("Still Point APNs", **Key ID `55ZDZ93892`**) was created 2026-07-22.

Set these in Vercel **Production**, then ship a fresh deploy (still-point coerces env vars write-only and `vercel redeploy` self-cancels, so use `vercel deploy --prod --scope auerbachbs-projects` from clean `origin/main`):

- `APNS_BUNDLE_ID = com.brettonauerbach.stillpoint`
- `APNS_TEAM_ID = T5UU4BP6AV`
- `APNS_KEY_ID = 55ZDZ93892` — the newly created **APNs Auth Key** ("Still Point APNs").
- `APNS_PRIVATE_KEY = <contents of AuthKey_55ZDZ93892.p8>` (never paste the key value into issues/PRs/logs)

No new iOS/TestFlight build is required — permission is granted and the device token registered fine today; this is a server-only fix.

## Test plan

- [x] **Trace documented:** cron invocation → scheduler match → APNs accept → device, failing link identified (`APNS_BUNDLE_ID` unset in Production). Evidence above.
- [x] **Regression coverage:** `apns.test.ts` (`getApnsConfigStatus`), `notifications.test.ts` (unconfigured ⇒ single error, no send, token not disabled), `route.test.ts` (`apnsConfigured` surfaced). 23/23 green; `tsc --noEmit` clean.
- [x] **OS permission + APNs token verified for this device:** token present in prod DB (`enabled`, `production`), permission granted (token would not exist otherwise); #387 denied-state alert correctly does not apply (permission not denied).
- [ ] **Real push received on the physical device** at the configured reminder time (screenshot / user confirmation) — **blocked on the operational fix above.**
- [ ] **Every enabled category delivers** (daily reminder + miss-a-day) — verify after env vars ship: `device_tokens.last_used_at` becomes non-null and a `daily_reminder` row appears in `notification_dispatches`.
- [x] **TestFlight build:** not required — server-only fix (no iOS changes).

## Local review notes
- CodeRabbit CLI reviewed the diff: 1 minor finding (test spy restore via `try/finally`) — fixed. The confirm-clean re-run hit the free-OSS hourly rate limit; the GitHub-side CodeRabbit review here is authoritative.
- CodeAnt CLI is not installed locally; the CodeAnt GitHub App review on this PR covers it.


___

## **CodeAnt-AI Description**
**Show APNs setup problems instead of letting iOS pushes fail silently**

### What Changed
- Scheduled iOS pushes now stop early when APNs credentials are missing, and the app logs one clear message naming the missing environment variables.
- The notification cron now reports whether APNs is configured, and includes the missing variables in its JSON response when it is not.
- Device tokens are no longer marked invalid just because the APNs setup is missing.
- Added coverage for the missing-configuration case so the silent failure does not return.

### Impact
`✅ Clearer iOS push failure messages`
`✅ Fewer silent notification outages`
`✅ Easier APNs setup checks in cron runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

