### PR TITLE
fix(ios): correct inverted ARKit Z-axis sign in gaze classifier

### DIFF
--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -204,8 +204,16 @@ struct SessionView: View {
                 gazeTrackingRanThisSession = true
             }
             guard appVM.currentUser?.attentionTrackingEnabled == true else { return }
-            guard sessionInProgress, !vm.showIntroOverlay else { return }
-            presentAttentionStatusAlert(for: status)
+            // Surface permission/failure/unsupported alerts regardless of whether the
+            // session is still in progress; a status change at a session boundary would
+            // otherwise be silently swallowed by the sessionInProgress guard (#628).
+            guard !vm.showIntroOverlay else { return }
+            switch status {
+            case .unsupported, .permissionDenied, .failed:
+                presentAttentionStatusAlert(for: status)
+            case .idle, .running, .paused:
+                break
+            }
         }
         .onChange(of: appVM.keepScreenAwakeDuringSession) { _, _ in
             SessionIdleTimerController.syncLocalSession(

--- a/ios/StillPointShared/Sources/StillPointShared/AttentionTrackingLogic.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AttentionTrackingLogic.swift
@@ -6,9 +6,10 @@ public enum AttentionTrackingLogic {
     public static let sustainedThreshold: TimeInterval = 0.5
 
     /// Classify a raw `ARFaceAnchor.lookAtPoint` sample as attentive or away.
-    /// `lookAtPoint` is in face-anchor space: negative Z generally means toward the device.
+    /// `lookAtPoint` is in face-anchor space: positive Z means toward the device
+    /// (Apple-documented convention for ARFaceAnchor coordinate space).
     public static func classifyGaze(lookAtX: Float, lookAtY: Float, lookAtZ: Float) -> String {
-        let towardDevice = lookAtZ < -0.12
+        let towardDevice = lookAtZ > 0.12
         let centered = abs(lookAtX) < 0.18 && abs(lookAtY) < 0.18
         return (towardDevice && centered) ? "attentive" : "away"
     }

--- a/ios/StillPointShared/Tests/StillPointSharedTests/AttentionTrackingLogicTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/AttentionTrackingLogicTests.swift
@@ -3,19 +3,22 @@ import XCTest
 
 final class AttentionTrackingLogicTests: XCTestCase {
     func testClassifyGazeAttentiveWhenLookingAtDevice() {
+        // Positive Z = toward device (Apple-documented ARFaceAnchor convention).
         XCTAssertEqual(
-            AttentionTrackingLogic.classifyGaze(lookAtX: 0.02, lookAtY: -0.03, lookAtZ: -0.25),
+            AttentionTrackingLogic.classifyGaze(lookAtX: 0.02, lookAtY: -0.03, lookAtZ: 0.25),
             "attentive"
         )
     }
 
     func testClassifyGazeAwayWhenLookingOffScreen() {
+        // Toward device but X is too far off-center.
         XCTAssertEqual(
-            AttentionTrackingLogic.classifyGaze(lookAtX: 0.4, lookAtY: 0.0, lookAtZ: -0.25),
+            AttentionTrackingLogic.classifyGaze(lookAtX: 0.4, lookAtY: 0.0, lookAtZ: 0.25),
             "away"
         )
+        // Negative Z = gaze directed away from the device entirely.
         XCTAssertEqual(
-            AttentionTrackingLogic.classifyGaze(lookAtX: 0.0, lookAtY: 0.0, lookAtZ: 0.1),
+            AttentionTrackingLogic.classifyGaze(lookAtX: 0.0, lookAtY: 0.0, lookAtZ: -0.25),
             "away"
         )
     }


### PR DESCRIPTION
## **User description**
## Summary

- **Root cause:** `AttentionTrackingLogic.classifyGaze` used `lookAtZ < -0.12` (negative Z = toward device), but Apple's ARFaceAnchor coordinate space uses **positive Z** for toward-device. Attention was never detected because the condition was always false on real hardware.
- **Fix:** Flip to `lookAtZ > 0.12`, preserving the existing threshold magnitude. Update docstring to match Apple's convention.
- **Tests:** Updated `AttentionTrackingLogicTests` to encode the corrected convention (positive Z for attentive, negative Z for looking away). All 276 shared-package unit tests pass.
- **Harden SessionView:** Removed `sessionInProgress` gate from `onChange(of: attentionManager.status)` for failure states (`.unsupported`, `.permissionDenied`, `.failed`), so these alerts always surface to the user rather than being silently swallowed at session boundaries.

## Test plan

- [x] `classifyGaze(lookAtX: 0.02, lookAtY: -0.03, lookAtZ: 0.25)` returns `"attentive"` (corrected positive-Z convention)
- [x] `classifyGaze(lookAtX: 0.4, lookAtY: 0.0, lookAtZ: 0.25)` returns `"away"` (toward device but off-center X)
- [x] `classifyGaze(lookAtX: 0.0, lookAtY: 0.0, lookAtZ: -0.25)` returns `"away"` (looking away from device)
- [x] Threshold magnitude (0.12) unchanged — only direction flipped
- [x] `AttentionTrackingLogic.swift` docstring matches Apple-documented convention
- [x] `SessionView` surfaces `.permissionDenied`, `.failed`, `.unsupported` alerts regardless of `sessionInProgress`
- [x] No unrelated refactors (no shared camera-permission helper, no UIRequiredDeviceCapabilities, no threshold re-tuning)
- [x] All 276 `swift test` unit tests in `ios/StillPointShared` pass
- [ ] On-device gaze detection confirmed working — deferred to Issue #438 QA pass (ARKit face tracking does not run in simulator or CI)

## Local review notes

CodeRabbit CLI: rate-limited (free OSS cap, 34-min wait) — FAILED run, not a clean pass; noted per `cr-local-review.md` fallback. CodeAnt CLI: not installed. Self-review performed; no findings.

Closes #628


___

## **CodeAnt-AI Description**
**Fix gaze detection and show attention errors consistently**

### What Changed
- Gaze detection now treats positive Z as “looking toward the device,” so attention can be recognized correctly on iPhone and iPad.
- The gaze tests were updated to match the corrected direction and to cover both “looking at the device” and “looking away” cases.
- Permission, failure, and unsupported attention alerts now appear even when the session is ending, instead of being missed at the session boundary.

### Impact
`✅ Reliable gaze-based attention detection`
`✅ Clearer permission and device-support alerts`
`✅ Fewer missed attention errors at session end`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
