### PR TITLE
test(ios): signup happy-path UI test

### DIFF
--- a/ios/StillPointApp/Views/AuthView.swift
+++ b/ios/StillPointApp/Views/AuthView.swift
@@ -34,6 +34,7 @@ struct AuthView: View {
                     toggleButton("Sign Up", isSelected: vm.isSignUp) {
                         withAnimation { vm.isSignUp = true }
                     }
+                    .accessibilityIdentifier("auth.signUpToggleButton")
                 }
                 .background(SPColor.surface1)
                 .clipShape(Capsule())

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -44,6 +44,67 @@ final class StillPointAppUITests: XCTestCase {
         )
     }
 
+    /// Signup happy path: unique per-run credentials, sign up toggle, full form submission,
+    /// assert authenticated home shell appears.
+    ///
+    /// **Credential uniqueness:** email and username are prefixed with the first 8 hex characters
+    /// of a per-run UUID so repeated simulator runs never collide in the mock backend.
+    /// The mock `UITestAPIStore.signup()` accepts any well-formed credentials and does not
+    /// persist state between process launches, so real-server uniqueness is not required here.
+    ///
+    /// **Local run command:**
+    /// ```
+    /// bash scripts/e2e/run-ios-tests.sh critical
+    /// # or for this test only:
+    /// xcodebuild test \
+    ///   -project ios/StillPoint.xcodeproj \
+    ///   -scheme StillPoint \
+    ///   -destination "platform=iOS Simulator,name=iPhone 17,OS=latest" \
+    ///   -only-testing:"StillPointAppUITests/StillPointAppUITests/testSignupHappyPath"
+    /// ```
+    @MainActor
+    func testSignupHappyPath() throws {
+        // Unique per-run credentials via UUID prefix (hex a–f, 0–9; satisfies username regex).
+        let uniqueId = String(UUID().uuidString.prefix(8)).lowercased()
+        let email = "signup.\(uniqueId)@stillpoint.test"
+        let username = "sp_\(uniqueId)" // 11 chars, matches ^[a-zA-Z0-9_]+$
+        let password = "testPass8!"
+
+        let app = makeApp(seedAuthenticated: false, resetStore: true)
+        app.launch()
+
+        waitForRoot("auth", in: app, failureMessage: "Auth screen did not appear", assertColdStart: false)
+
+        // Switch to Sign Up mode
+        let signUpToggle = app.buttons["auth.signUpToggleButton"]
+        XCTAssertTrue(signUpToggle.waitForExistence(timeout: 5), "Sign Up toggle did not appear")
+        tapByStableCenter(signUpToggle, in: app)
+
+        // Fill signup form
+        let emailField = app.textFields["auth.emailField"]
+        XCTAssertTrue(emailField.waitForExistence(timeout: 5))
+        emailField.tapAndType(email, in: app)
+
+        let usernameField = app.textFields["auth.usernameField"]
+        XCTAssertTrue(usernameField.waitForExistence(timeout: 5), "Username field did not appear after switching to Sign Up mode")
+        usernameField.tapAndType(username, in: app)
+
+        let passwordField = app.secureTextFields["auth.passwordField"]
+        XCTAssertTrue(passwordField.waitForExistence(timeout: 5))
+        passwordField.tapAndType(password, in: app)
+
+        dismissKeyboardIfPresent(in: app)
+
+        let submitButton = app.buttons["auth.submitButton"]
+        XCTAssertTrue(submitButton.waitForExistence(timeout: 5))
+        tapByStableCenter(submitButton, in: app)
+
+        XCTAssertTrue(
+            app.otherElements["root.currentView.home"].waitForExistence(timeout: 25),
+            "Authenticated home shell did not appear after signup"
+        )
+    }
+
     @MainActor
     func testLaunchLoginCompleteSessionAndHistoryPersistence() throws {
         let app = makeApp(

--- a/scripts/e2e/run-ios-tests.sh
+++ b/scripts/e2e/run-ios-tests.sh
@@ -107,6 +107,7 @@ resolve_test_target() {
       echo "StillPointAppUITests/StillPointAppUITests/testLaunchOfflineShowsUserVisibleMessage"
       echo "StillPointAppUITests/StillPointAppUITests/testLogoutReturnsToAuthScreen"
       echo "StillPointAppUITests/StillPointAppUITests/testPasswordResetEntryIsDiscoverable"
+      echo "StillPointAppUITests/StillPointAppUITests/testSignupHappyPath"
       echo "StillPointAppUITests/StillPointAppUITests/testSettingsUsernameConflictShowsTakenMessage"
       echo "StillPointAppUITests/StillPointAppUITests/testSettingsUsernameInlineEditSucceeds"
       echo "StillPointAppUITests/StillPointAppUITests/testSettingsUsernameValidationError"


### PR DESCRIPTION
## **User description**
## Summary

- Adds `auth.signUpToggleButton` accessibility identifier to the Sign Up toggle in `AuthView` so XCTest can locate it reliably without index-based queries
- Adds `testSignupHappyPath` to `StillPointAppUITests`: taps Sign Up toggle, fills email/username/password with UUID-prefixed unique-per-run credentials, asserts `root.currentView.home` appears after mock signup succeeds
- Registers the new test in the `critical` lane of `run-ios-tests.sh` (grouped with other auth-path tests)

Closes #155

## Design notes

**Mock backend:** All existing iOS UI tests run against `UITestAPIStore` (the in-memory fake in `StillPointShared`). `UITestAPIStore.signup()` accepts any well-formed credentials and immediately returns success, so no real server is involved. The test runs entirely on-simulator with `SP_UI_TEST_MODE=1`.

**Unique per-run credentials:** Email and username are prefixed with the first 8 hex characters of a per-run `UUID` (e.g. `signup.a3f7c2d1@stillpoint.test`, username `sp_a3f7c2d1`). This documents the intended CI behaviour (each run is independent) without requiring real-server deduplication.

**CI execution:** Per the E2E iOS policy (#588), this test runs on the `critical` lane via `ios-testflight-auto.yml` (TestFlight release gate) and `workflow_dispatch`, not on every PR.

## Local run command

```bash
# Full critical lane (includes testSignupHappyPath):
bash scripts/e2e/run-ios-tests.sh critical

# This test only:
xcodebuild test \
  -project ios/StillPoint.xcodeproj \
  -scheme StillPoint \
  -destination "platform=iOS Simulator,name=iPhone 17,OS=latest" \
  -only-testing:"StillPointAppUITests/StillPointAppUITests/testSignupHappyPath"
```

Note: local `xcodebuild` requires Xcode 16 or earlier (objectVersion 77 is not parsed by Xcode 26 locally — see `project_ios_local_xcodebuild_broken.md`). CI runs on `macos-26` runners which do support it.

## Local review notes

- CodeRabbit CLI: rate-limited (free OSS cap); noted per `cr-local-review.md` fallback
- CodeAnt CLI: not installed on this host
- Self-review: clean — all three file changes verified against codebase conventions

## Test plan

- [x] `auth.signUpToggleButton` accessibility identifier added to Sign Up toggle in `AuthView.swift`, matching `auth.*` identifier convention used throughout the file
- [x] `testSignupHappyPath` generates unique per-run credentials via `UUID().uuidString.prefix(8)` (documented in test docstring)
- [x] Test fills email (`auth.emailField`), username (`auth.usernameField`), password (`auth.passwordField`) — all identifiers verified against `AuthView.swift`
- [x] Test asserts `root.currentView.home` visible after signup — matches the assertion used by `testLaunchLoginCompleteSessionAndHistoryPersistence`
- [x] `testSignupHappyPath` added to `critical` lane in `run-ios-tests.sh` with correct target path `StillPointAppUITests/StillPointAppUITests/testSignupHappyPath`
- [x] No changes to `project.yml`, `Info.plist`, or `StillPointShared` — infoplist-sync CI check unaffected
- [x] UI test execution is nightly/release-gated (not PR-path); local run command documented above


___

## **CodeAnt-AI Description**
**Add a signup happy-path iOS UI test**

### What Changed
- Added a new iOS UI test that opens Sign Up, fills out the signup form with unique credentials, submits it, and checks that the authenticated home screen appears
- Made the Sign Up toggle easier to find in UI tests so the signup flow can be exercised reliably
- Included the new test in the critical iOS test run

### Impact
`✅ Signup flow covered in critical iOS checks`
`✅ Fewer false failures in signup UI tests`
`✅ More reliable release gating for new accounts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
