### PR TITLE
test(ios): account deletion flow UI test

### DIFF
--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -332,6 +332,7 @@ struct SettingsView: View {
                     .spCapsuleButtonStyle(.danger, size: .fullWidth)
                 }
                 .disabled(isDeletingAccount)
+                .accessibilityIdentifier("settings.deleteAccountButton")
                 .confirmationDialog(
                     "Delete your account?",
                     isPresented: $showDeleteAccountDialog,

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -447,6 +447,54 @@ final class StillPointAppUITests: XCTestCase {
         XCTAssertTrue(app.textFields["auth.emailField"].waitForExistence(timeout: 5))
     }
 
+    /// Account deletion flow: authenticated user navigates to Settings, taps Delete Account,
+    /// confirms through the two-step dialog, and lands on the unauthenticated auth screen.
+    ///
+    /// **Canonical path:** Native flow — SettingsView "Delete Account" button →
+    /// confirmation dialog ("Continue") → final alert ("Delete Account") → `didLogout()` →
+    /// auth screen. The UITestAPIStore mock handles the deletion in-process (no real
+    /// network call) — non-production semantics are guaranteed by the mock store.
+    ///
+    /// **Local run command:**
+    /// ```
+    /// bash scripts/e2e/run-ios-tests.sh critical
+    /// # or for this test only:
+    /// xcodebuild test \
+    ///   -project ios/StillPoint.xcodeproj \
+    ///   -scheme StillPoint \
+    ///   -destination "platform=iOS Simulator,name=iPhone 17,OS=latest" \
+    ///   -only-testing:"StillPointAppUITests/StillPointAppUITests/testAccountDeletionFlow"
+    /// ```
+    @MainActor
+    func testAccountDeletionFlow() throws {
+        let app = makeApp(seedAuthenticated: true, resetStore: true)
+        app.launch()
+
+        waitForRoot("home", in: app, failureMessage: "Home screen did not appear", assertColdStart: false)
+        openTab(identifier: "tab.settings", in: app, waitingFor: app.staticTexts["settings.title"])
+
+        let deleteAccountButton = app.buttons["settings.deleteAccountButton"]
+        XCTAssertTrue(deleteAccountButton.waitForExistence(timeout: 5))
+        scrollElementIntoVisibleFrame(deleteAccountButton, in: app)
+        tapByStableCenter(deleteAccountButton, in: app)
+
+        // Step 1: Confirmation dialog — "Delete your account?"
+        let continueButton = app.buttons["Continue"]
+        XCTAssertTrue(continueButton.waitForExistence(timeout: 5), "Account deletion confirmation dialog did not appear")
+        continueButton.tap()
+
+        // Step 2: Final alert — "Final confirmation"
+        let finalDeleteButton = app.alerts.firstMatch.buttons["Delete Account"]
+        XCTAssertTrue(finalDeleteButton.waitForExistence(timeout: 5), "Final account deletion alert did not appear")
+        finalDeleteButton.tap()
+
+        XCTAssertTrue(
+            app.otherElements["root.currentView.auth"].waitForExistence(timeout: 15),
+            "Auth screen should appear after account deletion"
+        )
+        XCTAssertTrue(app.textFields["auth.emailField"].waitForExistence(timeout: 5))
+    }
+
     @MainActor
     func testGuidedExerciseOverlayOpensAndStartsExercise() throws {
         let app = makeApp(

--- a/scripts/e2e/run-ios-tests.sh
+++ b/scripts/e2e/run-ios-tests.sh
@@ -102,6 +102,7 @@ resolve_test_target() {
       echo "StillPointAppUITests/StillPointAppUITests/testLaunchLoginCompleteSessionAndHistoryPersistence"
       ;;
     critical)
+      echo "StillPointAppUITests/StillPointAppUITests/testAccountDeletionFlow"
       echo "StillPointAppUITests/StillPointAppUITests/testHistoryAndSettingsNavigationSmoke"
       echo "StillPointAppUITests/StillPointAppUITests/testJournalAndBoardTabsReachable"
       echo "StillPointAppUITests/StillPointAppUITests/testLaunchOfflineShowsUserVisibleMessage"


### PR DESCRIPTION
## **User description**
## Summary

- Adds `testAccountDeletionFlow` to `StillPointAppUITests` — authenticated user navigates to Settings, taps Delete Account, confirms through the two-step dialog, and lands on the unauthenticated auth screen
- Adds `.accessibilityIdentifier("settings.deleteAccountButton")` to the delete account button in `SettingsView` so XCTest can locate it reliably
- Registers the test in the critical lane in `scripts/e2e/run-ios-tests.sh`

Closes #156

## Design notes

**Canonical path: native flow.** The deletion UI is entirely native SwiftUI (`SettingsView` → `confirmationDialog` → `.alert` → `APIClient.deleteAccount()`). No Safari/web view involved.

**Mock backend:** `UITestAPIStore.deleteAccount()` already existed and correctly sets `isAuthenticated = false`, clears sessions/thoughts/failureReasons, and persists state. No shared code changes were needed.

**Non-production semantics:** guaranteed by the `SP_UI_TEST_MODE` launch environment — the mock store is used in place of all real network calls.

**Local CLI review note:** CodeRabbit CLI returned a rate-limit error (free OSS limit); CodeAnt CLI is not installed on this machine. Self-review was performed in lieu — changes are minimal (1 accessibility identifier line, 48-line test, 1 run-script line).

## Test plan

- [x] `testAccountDeletionFlow` runs on iOS Simulator without failure:
  - App launches authenticated and reaches home screen
  - Navigating to Settings tab shows the Settings view
  - "Delete Account" button is scrolled into view and tappable
  - Tapping it presents the "Delete your account?" confirmation dialog with a "Continue" destructive button
  - Tapping "Continue" presents the "Final confirmation" alert with a "Delete Account" destructive button
  - Tapping "Delete Account" in the alert completes deletion and transitions to the auth screen (`root.currentView.auth`)
  - The login email field (`auth.emailField`) is visible confirming unauthenticated state
- [x] Test is included in the critical lane: `bash scripts/e2e/run-ios-tests.sh critical`
- [x] No regression in `testLogoutReturnsToAuthScreen` (shares the same Settings navigation pattern)

**Run command:**
```bash
bash scripts/e2e/run-ios-tests.sh critical
# or single test:
xcodebuild test \
  -project ios/StillPoint.xcodeproj \
  -scheme StillPoint \
  -destination "platform=iOS Simulator,name=iPhone 17,OS=latest" \
  -only-testing:"StillPointAppUITests/StillPointAppUITests/testAccountDeletionFlow"
```


___

## **CodeAnt-AI Description**
**Add UI coverage for the account deletion flow**

### What Changed
- Added an iOS UI test that signs in, opens Settings, deletes the account through the two-step confirmation flow, and verifies the app returns to the auth screen
- Made the Delete Account button easier for the test runner to find
- Included the new deletion flow test in the critical iOS test run

### Impact
`✅ Account deletion stays covered in UI tests`
`✅ Fewer regressions in the delete-account flow`
`✅ Critical iOS runs now check account deletion`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
