### PR TITLE
feat(web): before/after mood matrix on session recap (#472)

### DIFF
--- a/drizzle/sessions_mood_matrix_472_incremental.sql
+++ b/drizzle/sessions_mood_matrix_472_incremental.sql
@@ -1,0 +1,11 @@
+-- #472: before/after mood matrix on the completion screen. Stores per-mood
+-- before/after values (1–5) captured retrospectively at recap. Structure:
+-- { calm: { before: 3, after: 4 }, focus: { before: 2, after: 5 }, ... }
+-- Values are checked at the application layer (PATCH route) using the same
+-- 1–5 range pattern. Nullable until the user taps at least one box.
+-- Idempotent + safe to re-run (matches the runner contract in
+-- scripts/apply-migrations.ts). Do NOT edit after it is applied (the
+-- schema_migrations checksum ledger will reject a changed body).
+
+ALTER TABLE "sessions"
+ADD COLUMN IF NOT EXISTS "mood_matrix" jsonb;

--- a/src/app/api/sessions/by-session/[sessionId]/route.integration.test.ts
+++ b/src/app/api/sessions/by-session/[sessionId]/route.integration.test.ts
@@ -297,7 +297,7 @@ describe("PATCH /api/sessions/by-session/[sessionId] — mood matrix (#472)", ()
     expect(res.status).toBe(400);
   });
 
-  test("a later PATCH overwrites the stored moodMatrix", async () => {
+  test("a later PATCH merges with the stored moodMatrix", async () => {
     await PATCH(
       patchRequest(sessionId, { moodMatrix: { calm: { before: 1, after: 2 } } }),
       { params: Promise.resolve({ sessionId }) },
@@ -309,6 +309,9 @@ describe("PATCH /api/sessions/by-session/[sessionId] — mood matrix (#472)", ()
 
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json.session.moodMatrix).toEqual({ focus: { before: 4, after: 5 } });
+    expect(json.session.moodMatrix).toEqual({
+      calm: { before: 1, after: 2 },
+      focus: { before: 4, after: 5 },
+    });
   });
 });

--- a/src/app/api/sessions/by-session/[sessionId]/route.integration.test.ts
+++ b/src/app/api/sessions/by-session/[sessionId]/route.integration.test.ts
@@ -180,3 +180,135 @@ describe("PATCH /api/sessions/by-session/[sessionId] — ratings", () => {
     expect(res.status).toBe(401);
   });
 });
+
+describe("PATCH /api/sessions/by-session/[sessionId] — mood matrix (#472)", () => {
+  test("saves a full mood matrix and returns it in the session", async () => {
+    const matrix = {
+      calm:    { before: 2, after: 4 },
+      focus:   { before: 3, after: 5 },
+      energy:  { before: 1, after: 3 },
+      anxiety: { before: 4, after: 2 },
+      overall: { before: 3, after: 5 },
+    };
+
+    const res = await PATCH(
+      patchRequest(sessionId, { moodMatrix: matrix }),
+      { params: Promise.resolve({ sessionId }) },
+    );
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.session.moodMatrix).toEqual(matrix);
+
+    const [row] = await db.select().from(sessions).where(eq(sessions.id, sessionId));
+    expect(row!.moodMatrix).toEqual(matrix);
+  });
+
+  test("saves a partial mood matrix (subset of mood keys)", async () => {
+    const matrix = { calm: { before: 3, after: null } };
+
+    const res = await PATCH(
+      patchRequest(sessionId, { moodMatrix: matrix }),
+      { params: Promise.resolve({ sessionId }) },
+    );
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.session.moodMatrix).toEqual(matrix);
+  });
+
+  test("can combine moodMatrix and ratings in a single PATCH", async () => {
+    const res = await PATCH(
+      patchRequest(sessionId, {
+        focusRating: 7,
+        moodMatrix: { overall: { before: 2, after: 5 } },
+      }),
+      { params: Promise.resolve({ sessionId }) },
+    );
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.session.focusRating).toBe(7);
+    expect(json.session.moodMatrix).toEqual({ overall: { before: 2, after: 5 } });
+  });
+
+  test("rejects an unknown mood key with 400", async () => {
+    const res = await PATCH(
+      patchRequest(sessionId, { moodMatrix: { mood_unknown: { before: 3, after: 4 } } }),
+      { params: Promise.resolve({ sessionId }) },
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/Unknown mood key/);
+  });
+
+  test("rejects a mood value outside 1–5 with 400", async () => {
+    const res = await PATCH(
+      patchRequest(sessionId, { moodMatrix: { calm: { before: 6, after: 3 } } }),
+      { params: Promise.resolve({ sessionId }) },
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects a mood value of 0 with 400", async () => {
+    const res = await PATCH(
+      patchRequest(sessionId, { moodMatrix: { calm: { before: 0, after: 3 } } }),
+      { params: Promise.resolve({ sessionId }) },
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects a non-integer mood value with 400", async () => {
+    const res = await PATCH(
+      patchRequest(sessionId, { moodMatrix: { calm: { before: 2.5, after: 3 } } }),
+      { params: Promise.resolve({ sessionId }) },
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects a mood entry where both before and after are null with 400", async () => {
+    const res = await PATCH(
+      patchRequest(sessionId, { moodMatrix: { calm: { before: null, after: null } } }),
+      { params: Promise.resolve({ sessionId }) },
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects an empty moodMatrix object with 400", async () => {
+    const res = await PATCH(
+      patchRequest(sessionId, { moodMatrix: {} }),
+      { params: Promise.resolve({ sessionId }) },
+    );
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe("moodMatrix must have at least one mood entry");
+  });
+
+  test("rejects moodMatrix that is not an object with 400", async () => {
+    const res = await PATCH(
+      patchRequest(sessionId, { moodMatrix: [{ calm: 3 }] }),
+      { params: Promise.resolve({ sessionId }) },
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  test("a later PATCH overwrites the stored moodMatrix", async () => {
+    await PATCH(
+      patchRequest(sessionId, { moodMatrix: { calm: { before: 1, after: 2 } } }),
+      { params: Promise.resolve({ sessionId }) },
+    );
+    const res = await PATCH(
+      patchRequest(sessionId, { moodMatrix: { focus: { before: 4, after: 5 } } }),
+      { params: Promise.resolve({ sessionId }) },
+    );
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.session.moodMatrix).toEqual({ focus: { before: 4, after: 5 } });
+  });
+});

--- a/src/app/api/sessions/by-session/[sessionId]/route.ts
+++ b/src/app/api/sessions/by-session/[sessionId]/route.ts
@@ -10,8 +10,52 @@ type RouteContext = RouteParams<{ sessionId: string }>;
 
 const RATING_FIELDS = ["focusRating", "happinessRating"] as const;
 
+/** Valid mood keys for the before/after matrix (#472). */
+export const MOOD_MATRIX_KEYS = ["calm", "focus", "energy", "anxiety", "overall"] as const;
+export type MoodMatrixKey = (typeof MOOD_MATRIX_KEYS)[number];
+
 function isValidRating(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 10;
+}
+
+/** Mood matrix cells use a 1–5 scale (compact 5-box tap UI). */
+function isValidMoodValue(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 5;
+}
+
+function isValidMoodEntry(entry: unknown): entry is { before: number | null; after: number | null } {
+  if (entry === null || typeof entry !== "object" || Array.isArray(entry)) return false;
+  const e = entry as Record<string, unknown>;
+  const beforeOk = e.before === null || isValidMoodValue(e.before);
+  const afterOk = e.after === null || isValidMoodValue(e.after);
+  return beforeOk && afterOk && (e.before !== null || e.after !== null);
+}
+
+/** Validate a full moodMatrix payload object. Returns an error string or null. */
+function validateMoodMatrix(
+  value: unknown,
+): { validated: Record<string, { before: number | null; after: number | null }> } | { error: string } {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return { error: "moodMatrix must be a JSON object" };
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj);
+  if (keys.length === 0) {
+    return { error: "moodMatrix must have at least one mood entry" };
+  }
+  const validated: Record<string, { before: number | null; after: number | null }> = {};
+  for (const key of keys) {
+    if (!(MOOD_MATRIX_KEYS as readonly string[]).includes(key)) {
+      return { error: `Unknown mood key: ${key}` };
+    }
+    if (!isValidMoodEntry(obj[key])) {
+      return {
+        error: `Invalid mood entry for ${key}: each entry must have before/after (1-5 or null, at least one non-null)`,
+      };
+    }
+    validated[key] = obj[key] as { before: number | null; after: number | null };
+  }
+  return { validated };
 }
 
 export const GET = withApiHandler(
@@ -84,7 +128,11 @@ export const PATCH = withApiHandler(
     if (body === null || typeof body !== "object" || Array.isArray(body)) {
       return NextResponse.json({ error: "Request body must be a JSON object" }, { status: 400 });
     }
-    const updates: Partial<Record<(typeof RATING_FIELDS)[number], number>> = {};
+    const updates: Partial<
+      Record<(typeof RATING_FIELDS)[number], number> & {
+        moodMatrix: Record<string, { before: number | null; after: number | null }>;
+      }
+    > = {};
     const bodyObj = body as Record<string, unknown>;
 
     for (const field of RATING_FIELDS) {
@@ -93,6 +141,15 @@ export const PATCH = withApiHandler(
         return NextResponse.json({ error: `Invalid ${field}` }, { status: 400 });
       }
       updates[field] = bodyObj[field] as number;
+    }
+
+    // #472: mood matrix — validate and merge with existing session data.
+    if (bodyObj.moodMatrix !== undefined) {
+      const result = validateMoodMatrix(bodyObj.moodMatrix);
+      if ("error" in result) {
+        return NextResponse.json({ error: result.error }, { status: 400 });
+      }
+      updates.moodMatrix = result.validated;
     }
 
     if (Object.keys(updates).length === 0) {

--- a/src/app/api/sessions/by-session/[sessionId]/route.ts
+++ b/src/app/api/sessions/by-session/[sessionId]/route.ts
@@ -140,13 +140,27 @@ export const PATCH = withApiHandler(
       updates[field] = bodyObj[field] as number;
     }
 
-    // #472: mood matrix — validate and merge with existing session data.
+    // #472: mood matrix — validate incoming rows and merge with persisted data.
     if (bodyObj.moodMatrix !== undefined) {
       const result = validateMoodMatrix(bodyObj.moodMatrix);
       if ("error" in result) {
         return NextResponse.json({ error: result.error }, { status: 400 });
       }
-      updates.moodMatrix = result.validated;
+
+      const [existing] = await db
+        .select({ moodMatrix: sessions.moodMatrix })
+        .from(sessions)
+        .where(and(eq(sessions.id, sessionId), eq(sessions.userId, auth.user.userId)))
+        .limit(1);
+
+      if (!existing) {
+        return NextResponse.json({ error: "Session not found" }, { status: 404 });
+      }
+
+      const prior =
+        (existing.moodMatrix as Record<string, { before: number | null; after: number | null }> | null) ??
+        {};
+      updates.moodMatrix = { ...prior, ...result.validated };
     }
 
     if (Object.keys(updates).length === 0) {

--- a/src/app/api/sessions/by-session/[sessionId]/route.ts
+++ b/src/app/api/sessions/by-session/[sessionId]/route.ts
@@ -4,15 +4,12 @@ import { sessions, thoughts } from "@/db/schema";
 import { requireAuth } from "@/lib/api/requireAuth";
 import { RouteParams, withApiHandler } from "@/lib/api/withApiHandler";
 import { isUuid } from "@/lib/friends";
+import { MOOD_KEYS } from "@/lib/moodMatrix";
 import { eq, and, asc } from "drizzle-orm";
 
 type RouteContext = RouteParams<{ sessionId: string }>;
 
 const RATING_FIELDS = ["focusRating", "happinessRating"] as const;
-
-/** Valid mood keys for the before/after matrix (#472). */
-export const MOOD_MATRIX_KEYS = ["calm", "focus", "energy", "anxiety", "overall"] as const;
-export type MoodMatrixKey = (typeof MOOD_MATRIX_KEYS)[number];
 
 function isValidRating(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 10;
@@ -45,7 +42,7 @@ function validateMoodMatrix(
   }
   const validated: Record<string, { before: number | null; after: number | null }> = {};
   for (const key of keys) {
-    if (!(MOOD_MATRIX_KEYS as readonly string[]).includes(key)) {
+    if (!(MOOD_KEYS as readonly string[]).includes(key)) {
       return { error: `Unknown mood key: ${key}` };
     }
     if (!isValidMoodEntry(obj[key])) {

--- a/src/app/api/sessions/route.integration.test.ts
+++ b/src/app/api/sessions/route.integration.test.ts
@@ -29,7 +29,7 @@ const EXPECTED_SESSION_KEYS = [
 ].sort();
 
 /** Columns that must never reach the client from the history list. */
-const LEAKED_KEYS = ["userId", "clientSessionId", "focusRating", "happinessRating"] as const;
+const LEAKED_KEYS = ["userId", "clientSessionId", "focusRating", "happinessRating", "moodMatrix"] as const;
 
 /** Keys the iOS StatsDTO decodes; the stats object must carry all of them. */
 const REQUIRED_STATS_KEYS = [
@@ -64,6 +64,7 @@ async function seedSession() {
     // Set the PII / by-session-only columns so we can prove the projection drops them.
     focusRating: 7,
     happinessRating: 9,
+    moodMatrix: { calm: { before: 2, after: 4 } },
   });
 }
 

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -962,6 +962,9 @@ export default function StillPoint() {
           onSaveRatings={completionData.sessionId && !completionData.isPendingSync ? async (ratings) => {
             await api.updateSessionRatings(completionData.sessionId!, ratings);
           } : undefined}
+          onSaveMoodMatrix={completionData.sessionId && !completionData.isPendingSync ? async (matrix) => {
+            await api.updateSessionRatings(completionData.sessionId!, { moodMatrix: matrix });
+          } : undefined}
           compact={isMobile}
         />
       )}

--- a/src/components/CompletionScreen.tsx
+++ b/src/components/CompletionScreen.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { BLOCK_DURATION, type SessionType } from "@/lib/constants";
 import { RatingSlider } from "@/components/RatingSlider";
+import { MoodMatrix, type MoodMatrixValue, isMoodMatrixTouched, buildMoodMatrixPayload } from "@/components/MoodMatrix";
 
 type CompletionScreenProps = {
   dayNumber: number;
@@ -21,6 +22,9 @@ type CompletionScreenProps = {
    *  no persisted session to attach ratings to. Only touched slider values are
    *  included in the payload; untouched ones are omitted for partial-update. */
   onSaveRatings?: (ratings: { focusRating?: number; happinessRating?: number }) => Promise<void>;
+  /** #472: before/after mood matrix; omitted when there is no persisted session.
+   *  Payload only includes rows the user actually tapped. */
+  onSaveMoodMatrix?: (matrix: Record<string, { before: number | null; after: number | null }>) => Promise<void>;
   /** Tighten vertical spacing for narrow-viewport mobile layouts (#473). */
   compact?: boolean;
 };
@@ -39,6 +43,7 @@ export function CompletionScreen({
   onReturn,
   onSaveNote,
   onSaveRatings,
+  onSaveMoodMatrix,
   compact = false,
 }: CompletionScreenProps) {
   const [note, setNote] = useState("");
@@ -52,6 +57,11 @@ export function CompletionScreen({
   const [ratingsSaved, setRatingsSaved] = useState(false);
   const [savingRatings, setSavingRatings] = useState(false);
   const [ratingsSaveError, setRatingsSaveError] = useState(false);
+  // #472: mood matrix state
+  const [moodMatrix, setMoodMatrix] = useState<MoodMatrixValue>({});
+  const [moodMatrixSaved, setMoodMatrixSaved] = useState(false);
+  const [savingMoodMatrix, setSavingMoodMatrix] = useState(false);
+  const [moodMatrixSaveError, setMoodMatrixSaveError] = useState(false);
   const isQuick = sessionType === "quick";
   const nextBlocks = Math.ceil(nextDuration / BLOCK_DURATION);
   const distractionPercentDisplayed = Math.max(0, 100 - clearPercent);
@@ -321,6 +331,89 @@ export function CompletionScreen({
               >
                 {savingRatings ? "saving..." : ratingsSaveError ? "retry" : "save ratings"}
               </button>
+            </>
+          )}
+        </div>
+      )}
+
+      {/* Mood matrix (#472) */}
+      {onSaveMoodMatrix && (
+        <div style={{
+          width: "100%", maxWidth: "min(420px, calc(100vw - 40px))",
+          display: "flex", flexDirection: "column", alignItems: "center", gap: "14px",
+        }}>
+          <div style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "11px", color: "var(--fg-3)",
+            letterSpacing: "0.12em", textTransform: "uppercase",
+            alignSelf: "flex-start",
+          }}>
+            Mood Shift
+          </div>
+
+          {moodMatrixSaved ? (
+            <div style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "11px", color: "var(--accent-green-dim)",
+              letterSpacing: "0.09em",
+            }}>
+              mood saved
+            </div>
+          ) : (
+            <>
+              <MoodMatrix
+                value={moodMatrix}
+                onChange={setMoodMatrix}
+                disabled={savingMoodMatrix}
+              />
+              {moodMatrixSaveError && (
+                <div
+                  role="alert"
+                  aria-live="assertive"
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "11px", color: "var(--accent-danger)",
+                    letterSpacing: "0.09em",
+                  }}
+                >
+                  failed to save — tap to retry
+                </div>
+              )}
+              {isMoodMatrixTouched(moodMatrix) && (
+                <button
+                  type="button"
+                  onClick={async () => {
+                    setSavingMoodMatrix(true);
+                    try {
+                      setMoodMatrixSaveError(false);
+                      await onSaveMoodMatrix(buildMoodMatrixPayload(moodMatrix));
+                      setMoodMatrixSaved(true);
+                    } catch (err) {
+                      console.error("Failed to save mood matrix:", err);
+                      setMoodMatrixSaveError(true);
+                    } finally {
+                      setSavingMoodMatrix(false);
+                    }
+                  }}
+                  disabled={savingMoodMatrix}
+                  style={{
+                    background: "none",
+                    border: moodMatrixSaveError
+                      ? "1px solid var(--accent-danger-border)"
+                      : "1px solid var(--accent-green-border)",
+                    color: moodMatrixSaveError
+                      ? "var(--accent-danger)"
+                      : "var(--accent-green-text)",
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "11px", letterSpacing: "0.12em", textTransform: "uppercase",
+                    padding: "8px 24px", borderRadius: "20px",
+                    cursor: savingMoodMatrix ? "default" : "pointer",
+                    opacity: savingMoodMatrix ? 0.5 : 1,
+                  }}
+                >
+                  {savingMoodMatrix ? "saving..." : moodMatrixSaveError ? "retry" : "save mood"}
+                </button>
+              )}
             </>
           )}
         </div>

--- a/src/components/MoodMatrix.test.ts
+++ b/src/components/MoodMatrix.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Issue #472 — before/after mood matrix.
+ *
+ * Unit tests for the helper functions in MoodMatrix.tsx:
+ *   - isMoodMatrixTouched: detects whether any cell has been selected
+ *   - buildMoodMatrixPayload: strips untouched rows before sending to the API
+ */
+import { describe, expect, test } from "vitest";
+import {
+  isMoodMatrixTouched,
+  buildMoodMatrixPayload,
+  MOOD_KEYS,
+  type MoodMatrixValue,
+} from "@/lib/moodMatrix";
+
+describe("isMoodMatrixTouched", () => {
+  test("returns false for an empty matrix", () => {
+    expect(isMoodMatrixTouched({})).toBe(false);
+  });
+
+  test("returns false when all entries have null before and after", () => {
+    const value: MoodMatrixValue = {
+      calm: { before: null, after: null },
+      focus: { before: null, after: null },
+    };
+    expect(isMoodMatrixTouched(value)).toBe(false);
+  });
+
+  test("returns true when any before value is set", () => {
+    const value: MoodMatrixValue = {
+      calm: { before: 3, after: null },
+    };
+    expect(isMoodMatrixTouched(value)).toBe(true);
+  });
+
+  test("returns true when any after value is set", () => {
+    const value: MoodMatrixValue = {
+      energy: { before: null, after: 5 },
+    };
+    expect(isMoodMatrixTouched(value)).toBe(true);
+  });
+
+  test("returns true when both before and after are set on a single row", () => {
+    const value: MoodMatrixValue = {
+      overall: { before: 2, after: 4 },
+    };
+    expect(isMoodMatrixTouched(value)).toBe(true);
+  });
+
+  test("returns true when multiple rows are fully set", () => {
+    const value: MoodMatrixValue = {
+      calm: { before: 1, after: 2 },
+      focus: { before: 3, after: 4 },
+      energy: { before: 2, after: 3 },
+      anxiety: { before: 5, after: 2 },
+      overall: { before: 3, after: 5 },
+    };
+    expect(isMoodMatrixTouched(value)).toBe(true);
+  });
+});
+
+describe("buildMoodMatrixPayload", () => {
+  test("returns an empty object for an empty matrix", () => {
+    expect(buildMoodMatrixPayload({})).toEqual({});
+  });
+
+  test("strips rows where both before and after are null", () => {
+    const value: MoodMatrixValue = {
+      calm: { before: null, after: null },
+      focus: { before: 3, after: 5 },
+    };
+    const result = buildMoodMatrixPayload(value);
+    expect(result).not.toHaveProperty("calm");
+    expect(result).toHaveProperty("focus", { before: 3, after: 5 });
+  });
+
+  test("keeps rows where only before is set", () => {
+    const value: MoodMatrixValue = {
+      energy: { before: 2, after: null },
+    };
+    const result = buildMoodMatrixPayload(value);
+    expect(result).toHaveProperty("energy", { before: 2, after: null });
+  });
+
+  test("keeps rows where only after is set", () => {
+    const value: MoodMatrixValue = {
+      anxiety: { before: null, after: 1 },
+    };
+    const result = buildMoodMatrixPayload(value);
+    expect(result).toHaveProperty("anxiety", { before: null, after: 1 });
+  });
+
+  test("includes all five moods when fully populated", () => {
+    const value: MoodMatrixValue = {
+      calm:    { before: 2, after: 4 },
+      focus:   { before: 3, after: 5 },
+      energy:  { before: 1, after: 3 },
+      anxiety: { before: 4, after: 2 },
+      overall: { before: 3, after: 5 },
+    };
+    const result = buildMoodMatrixPayload(value);
+    expect(Object.keys(result)).toHaveLength(5);
+    for (const key of MOOD_KEYS) {
+      expect(result).toHaveProperty(key);
+    }
+  });
+
+  test("does not include keys not present in the source object", () => {
+    const value: MoodMatrixValue = {
+      calm: { before: 3, after: 4 },
+    };
+    const result = buildMoodMatrixPayload(value);
+    expect(Object.keys(result)).toEqual(["calm"]);
+  });
+
+  test("preserves null before/after rather than omitting them when the row is touched", () => {
+    const value: MoodMatrixValue = {
+      overall: { before: null, after: 5 },
+    };
+    const result = buildMoodMatrixPayload(value);
+    expect(result.overall).toEqual({ before: null, after: 5 });
+  });
+});

--- a/src/components/MoodMatrix.test.ts
+++ b/src/components/MoodMatrix.test.ts
@@ -1,7 +1,7 @@
 /**
  * Issue #472 — before/after mood matrix.
  *
- * Unit tests for the helper functions in MoodMatrix.tsx:
+ * Unit tests for the helper functions in @/lib/moodMatrix:
  *   - isMoodMatrixTouched: detects whether any cell has been selected
  *   - buildMoodMatrixPayload: strips untouched rows before sending to the API
  */

--- a/src/components/MoodMatrix.tsx
+++ b/src/components/MoodMatrix.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+/**
+ * #472: before/after mood matrix for the completion recap screen.
+ *
+ * Five mood rows (Calm, Focus, Energy, Anxiety, Overall) × two columns
+ * (Before | After) × five tap boxes (1 low → 5 high).
+ *
+ * Captured retrospectively: the user fills both columns at session end with
+ * no pre-session friction. Data is persisted via the sessions PATCH endpoint
+ * as `moodMatrix` (JSONB, 1–5 per cell).
+ *
+ * Pure helpers (isMoodMatrixTouched, buildMoodMatrixPayload, MOOD_KEYS, etc.)
+ * live in @/lib/moodMatrix so vitest (node mode, jsx:preserve) can test them
+ * without a JSX transform. They are re-exported here for convenience.
+ */
+
+import {
+  MOOD_KEYS,
+  MOOD_LABELS,
+  type MoodKey,
+  type MoodEntry,
+  type MoodMatrixValue,
+} from "@/lib/moodMatrix";
+
+// Re-export pure helpers so callers import from one place.
+export {
+  MOOD_KEYS,
+  MOOD_LABELS,
+  isMoodMatrixTouched,
+  buildMoodMatrixPayload,
+  type MoodKey,
+  type MoodEntry,
+  type MoodMatrixValue,
+} from "@/lib/moodMatrix";
+
+// ---------------------------------------------------------------------------
+// Internal sub-components
+// ---------------------------------------------------------------------------
+
+type MoodBoxProps = {
+  level: number; // 1–5
+  selected: boolean;
+  disabled: boolean;
+  onClick: () => void;
+  ariaLabel: string;
+};
+
+function MoodBox({ level, selected, disabled, onClick, ariaLabel }: MoodBoxProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      aria-pressed={selected}
+      style={{
+        width: "28px",
+        height: "28px",
+        borderRadius: "5px",
+        border: selected
+          ? "1px solid var(--accent-green-border)"
+          : "1px solid var(--border-1)",
+        background: selected
+          ? `rgba(74, 222, 128, ${0.08 + level * 0.07})`
+          : "var(--surface-1)",
+        cursor: disabled ? "default" : "pointer",
+        opacity: disabled ? 0.55 : 1,
+        transition: "background 0.12s, border-color 0.12s",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flexShrink: 0,
+        minWidth: 0,
+        padding: 0,
+      }}
+    >
+      {selected && (
+        <div
+          style={{
+            width: "10px",
+            height: "10px",
+            borderRadius: "2px",
+            background: `rgba(74, 222, 128, ${0.4 + level * 0.12})`,
+          }}
+        />
+      )}
+    </button>
+  );
+}
+
+type MoodRowProps = {
+  moodKey: MoodKey;
+  entry: MoodEntry;
+  disabled: boolean;
+  onChange: (key: MoodKey, entry: MoodEntry) => void;
+};
+
+function MoodRow({ moodKey, entry, disabled, onChange }: MoodRowProps) {
+  const label = MOOD_LABELS[moodKey];
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "60px 1fr 1fr",
+        gap: "6px",
+        alignItems: "center",
+      }}
+    >
+      {/* Mood label */}
+      <div
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: "10px",
+          color: "var(--fg-3)",
+          letterSpacing: "0.1em",
+          textTransform: "uppercase",
+          textAlign: "right",
+          paddingRight: "8px",
+        }}
+      >
+        {label}
+      </div>
+
+      {/* Before boxes */}
+      <div style={{ display: "flex", gap: "4px", justifyContent: "center" }}>
+        {([1, 2, 3, 4, 5] as const).map((level) => (
+          <MoodBox
+            key={level}
+            level={level}
+            selected={entry.before === level}
+            disabled={disabled}
+            onClick={() =>
+              onChange(moodKey, {
+                ...entry,
+                before: entry.before === level ? null : level,
+              })
+            }
+            ariaLabel={`${label} before: ${level}`}
+          />
+        ))}
+      </div>
+
+      {/* After boxes */}
+      <div style={{ display: "flex", gap: "4px", justifyContent: "center" }}>
+        {([1, 2, 3, 4, 5] as const).map((level) => (
+          <MoodBox
+            key={level}
+            level={level}
+            selected={entry.after === level}
+            disabled={disabled}
+            onClick={() =>
+              onChange(moodKey, {
+                ...entry,
+                after: entry.after === level ? null : level,
+              })
+            }
+            ariaLabel={`${label} after: ${level}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public component
+// ---------------------------------------------------------------------------
+
+type MoodMatrixProps = {
+  value: MoodMatrixValue;
+  onChange: (value: MoodMatrixValue) => void;
+  disabled?: boolean;
+};
+
+/** Renders the full before/after mood matrix with column headers. */
+export function MoodMatrix({ value, onChange, disabled = false }: MoodMatrixProps) {
+  function handleRowChange(key: MoodKey, entry: MoodEntry) {
+    onChange({ ...value, [key]: entry });
+  }
+
+  return (
+    <div style={{ width: "100%" }}>
+      {/* Column headers */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "60px 1fr 1fr",
+          gap: "6px",
+          marginBottom: "8px",
+        }}
+      >
+        <div />
+        <div
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "10px",
+            color: "var(--fg-4)",
+            letterSpacing: "0.14em",
+            textTransform: "uppercase",
+            textAlign: "center",
+          }}
+        >
+          Before
+        </div>
+        <div
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "10px",
+            color: "var(--fg-4)",
+            letterSpacing: "0.14em",
+            textTransform: "uppercase",
+            textAlign: "center",
+          }}
+        >
+          After
+        </div>
+      </div>
+
+      {/* Scale hint: low → high */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "60px 1fr 1fr",
+          gap: "6px",
+          marginBottom: "10px",
+        }}
+      >
+        <div />
+        {([0, 1] as const).map((col) => (
+          <div
+            key={col}
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              paddingInline: "2px",
+              fontFamily: "var(--font-mono)",
+              fontSize: "9px",
+              color: "var(--fg-4)",
+              letterSpacing: "0.05em",
+            }}
+          >
+            <span>low</span>
+            <span>high</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Mood rows */}
+      <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+        {MOOD_KEYS.map((key) => (
+          <MoodRow
+            key={key}
+            moodKey={key}
+            entry={value[key] ?? { before: null, after: null }}
+            disabled={disabled}
+            onChange={handleRowChange}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/db/atomic.ts
+++ b/src/db/atomic.ts
@@ -526,6 +526,7 @@ function mapSessionRow(row: Record<string, unknown>): typeof sessions.$inferSele
     sessionDate: String(row.session_date),
     focusRating: row.focus_rating == null ? null : Number(row.focus_rating),
     happinessRating: row.happiness_rating == null ? null : Number(row.happiness_rating),
+    moodMatrix: row.mood_matrix as typeof sessions.$inferSelect["moodMatrix"],
     createdAt: new Date(String(row.created_at)),
   };
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -394,6 +394,11 @@ export const sessions = pgTable("sessions", {
    *  by-session PATCH route from the CompletionScreen sliders. */
   focusRating: integer("focus_rating"),
   happinessRating: integer("happiness_rating"),
+  /** #472: before/after mood matrix captured retrospectively at the recap.
+   *  Shape: { [moodKey: string]: { before: number | null; after: number | null } }
+   *  where values are 1–5. Validated at the application layer (PATCH route).
+   *  Null until at least one matrix cell is saved. */
+  moodMatrix: jsonb("mood_matrix").$type<Record<string, { before: number | null; after: number | null }>>(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 }, (table) => ({
   userIdx: index("idx_sessions_user").on(table.userId, table.dayNumber),

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -75,6 +75,8 @@ export type Session = {
   /** #109: post-session self-report ratings (1-10), null until rated. */
   focusRating?: number | null;
   happinessRating?: number | null;
+  /** #472: before/after mood matrix (1–5 per cell), null until submitted. */
+  moodMatrix?: Record<string, { before: number | null; after: number | null }> | null;
 };
 
 export type Thought = {
@@ -243,10 +245,15 @@ export const api = {
   getSession: (dayNumber: number) =>
     request<{ session: Session; thoughts: Thought[] }>(`/api/sessions/${dayNumber}`),
 
-  /** #109: post-hoc ratings update from the CompletionScreen sliders. */
+  /** #109/#472: post-hoc ratings + mood-matrix update from the CompletionScreen. */
   updateSessionRatings: (
     sessionId: string,
-    data: { focusRating?: number; happinessRating?: number },
+    data: {
+      focusRating?: number;
+      happinessRating?: number;
+      /** #472: mood matrix payload — partial keys allowed. */
+      moodMatrix?: Record<string, { before: number | null; after: number | null }>;
+    },
   ) =>
     request<{ session: Session }>(`/api/sessions/by-session/${sessionId}`, {
       method: "PATCH",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,3 +1,5 @@
+import type { MoodMatrixPayload } from "@/lib/moodMatrix";
+
 export class ApiError extends Error {
   constructor(
     public status: number,
@@ -76,7 +78,7 @@ export type Session = {
   focusRating?: number | null;
   happinessRating?: number | null;
   /** #472: before/after mood matrix (1–5 per cell), null until submitted. */
-  moodMatrix?: Record<string, { before: number | null; after: number | null }> | null;
+  moodMatrix?: MoodMatrixPayload | null;
 };
 
 export type Thought = {
@@ -252,7 +254,7 @@ export const api = {
       focusRating?: number;
       happinessRating?: number;
       /** #472: mood matrix payload — partial keys allowed. */
-      moodMatrix?: Record<string, { before: number | null; after: number | null }>;
+      moodMatrix?: MoodMatrixPayload;
     },
   ) =>
     request<{ session: Session }>(`/api/sessions/by-session/${sessionId}`, {

--- a/src/lib/moodMatrix.ts
+++ b/src/lib/moodMatrix.ts
@@ -1,0 +1,42 @@
+/**
+ * #472: Pure helpers for the before/after mood matrix.
+ * Extracted from MoodMatrix.tsx so vitest (node mode, jsx:preserve) can import
+ * and test them without a JSX transform.
+ */
+
+export const MOOD_KEYS = ["calm", "focus", "energy", "anxiety", "overall"] as const;
+export type MoodKey = (typeof MOOD_KEYS)[number];
+
+export const MOOD_LABELS: Record<MoodKey, string> = {
+  calm: "Calm",
+  focus: "Focus",
+  energy: "Energy",
+  anxiety: "Anxiety",
+  overall: "Overall",
+};
+
+export type MoodEntry = { before: number | null; after: number | null };
+export type MoodMatrixValue = Partial<Record<MoodKey, MoodEntry>>;
+
+/** Returns true if the matrix contains at least one non-null cell. */
+export function isMoodMatrixTouched(value: MoodMatrixValue): boolean {
+  return MOOD_KEYS.some((k) => {
+    const e = value[k];
+    return e !== undefined && (e.before !== null || e.after !== null);
+  });
+}
+
+/** Strips un-touched rows (both before and after are null) to keep the
+ *  payload lean — rows where the user never tapped anything are omitted. */
+export function buildMoodMatrixPayload(
+  value: MoodMatrixValue,
+): Record<string, { before: number | null; after: number | null }> {
+  const out: Record<string, { before: number | null; after: number | null }> = {};
+  for (const key of MOOD_KEYS) {
+    const e = value[key];
+    if (e && (e.before !== null || e.after !== null)) {
+      out[key] = e;
+    }
+  }
+  return out;
+}

--- a/src/lib/moodMatrix.ts
+++ b/src/lib/moodMatrix.ts
@@ -17,6 +17,8 @@ export const MOOD_LABELS: Record<MoodKey, string> = {
 
 export type MoodEntry = { before: number | null; after: number | null };
 export type MoodMatrixValue = Partial<Record<MoodKey, MoodEntry>>;
+/** Persisted / API mood-matrix shape — only touched rows are present. */
+export type MoodMatrixPayload = Partial<Record<MoodKey, MoodEntry>>;
 
 /** Returns true if the matrix contains at least one non-null cell. */
 export function isMoodMatrixTouched(value: MoodMatrixValue): boolean {


### PR DESCRIPTION
## **User description**
## Summary

- Adds a **Before | After mood matrix** to the web completion/recap screen with five mood rows (Calm, Focus, Energy, Anxiety, Overall) and 5-point tap boxes per cell.
- Persists values via the existing `PATCH /api/sessions/by-session/[sessionId]` endpoint as `moodMatrix` JSONB (1–5 range-checked server-side).
- Keeps existing Focus/Happiness sliders and `focus_rating` / `happiness_rating` columns unchanged; mood matrix is by-session only (not exposed on history list).
- iOS parity tracked in #635 (web-first per PO spec).

Closes #472

## Test plan

- [x] `npx vitest run src/components/MoodMatrix.test.ts`
- [x] `npx vitest run src/app/api/sessions/by-session/[sessionId]/route.integration.test.ts`
- [x] `npx vitest run src/app/api/sessions/route.integration.test.ts` (moodMatrix not leaked on list)
- [x] `npm run typecheck`
- [ ] Manual: complete a session on web → recap shows Mood Shift matrix → tap Before/After boxes → Save mood → reload GET by-session confirms persistence
- [ ] Manual: Focus/Happiness sliders still save independently
- [ ] Manual: migration applies on deploy (`sessions_mood_matrix_472_incremental.sql`)

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Add a before/after mood matrix to session recap and save it with the session**

### What Changed
- The session recap now includes a five-row mood matrix for Calm, Focus, Energy, Anxiety, and Overall, with separate Before and After selections.
- Users can save mood changes from the recap screen, and only rows they touched are sent and stored.
- Saved mood matrix data loads with the session, and it stays out of the session history list.
- Session updates now accept mood matrix data together with the existing focus and happiness ratings.
- The recap save flow now works in production builds and deploys.

### Impact
`✅ Finer post-session mood tracking`
`✅ Fewer recap fields to fill`
`✅ Cleaner session history views`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
