### PR TITLE
chore(ios): sync build number to 21 after TestFlight cut

### DIFF
--- a/ios/project.yml
+++ b/ios/project.yml
@@ -87,7 +87,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint
         MARKETING_VERSION: "1.0.3"
-        CURRENT_PROJECT_VERSION: 17
+        CURRENT_PROJECT_VERSION: 21
         # Native Google Sign-In client IDs (#344). Empty by default so no real
         # client ID is committed; override per environment / in CI signing config.
         # GID_CLIENT_ID:           iOS OAuth client ID (xxxxx.apps.googleusercontent.com)
@@ -129,7 +129,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint.monitor
         MARKETING_VERSION: "1.0.3"
-        CURRENT_PROJECT_VERSION: 17
+        CURRENT_PROJECT_VERSION: 21
         DEVELOPMENT_TEAM: T5UU4BP6AV
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]: StillPointMonitor/StillPointMonitor.entitlements
@@ -159,7 +159,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint.widget
         MARKETING_VERSION: "1.0.3"
-        CURRENT_PROJECT_VERSION: 17
+        CURRENT_PROJECT_VERSION: 21
         DEVELOPMENT_TEAM: T5UU4BP6AV
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]: StillPointWidget/StillPointWidget.entitlements


### PR DESCRIPTION
## **User description**
## Summary

Housekeeping PR to sync `CURRENT_PROJECT_VERSION` in `ios/project.yml` from **17 → 21** after the TestFlight build 21 cut.

- Build 21 tag (`ios-v1.0.3-build21`) was already pushed and the TestFlight upload workflow is running/completed separately.
- This build includes the mood matrix work and parity updates from the cut branch.
- No functional code changes — version metadata only.

Closes nothing — housekeeping only.

## Test plan

- [ ] Verify `CURRENT_PROJECT_VERSION` is `21` for StillPoint, StillPointMonitor, and StillPointWidget targets in `ios/project.yml`
- [ ] Confirm CI passes on this PR

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
Update the iOS build number for the current release cut

### What Changed
- Raised the build number from 17 to 21 for the app, monitor extension, and widget
- Kept the app version the same while aligning all iOS targets to the new TestFlight build

### Impact
`✅ New TestFlight uploads use the latest build number`
`✅ Fewer version conflicts across iOS targets`
`✅ Clearer release tracking for the current cut`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
