### PR TITLE
docs(ios): App Store submission runbook (#164)

### DIFF
--- a/docs/operations/ios-app-store-submission.md
+++ b/docs/operations/ios-app-store-submission.md
@@ -1,14 +1,94 @@
 # iOS App Store submission and delegation runbook
 
-Use this runbook after an iOS build has been uploaded to TestFlight and before clicking **Submit for Review** or **Add for Review** in App Store Connect. It turns issue #164 into a delegate-ready checklist with clear owners and evidence to capture.
+End-to-end checklist for **submitting the Still Point iOS app** and delegating work across Engineering, Product / App Store, and Account Holder lanes. Canonical home for issue #164.
 
-## Scope and handoff
+**Typical order:** upload a TestFlight build → validate in Connect → complete metadata and App Review materials → submit for review → track in #103.
 
-- **Engineering** owns tags, GitHub Actions, binary correctness, version/build values, and making sure the shipped app matches review notes.
-- **Product / App Store** owns screenshots, copy, age rating, review notes, the account-deletion recording, demo credentials, and release timing.
-- **Account Holder / Admin** owns Apple Developer and App Store Connect agreements, tax, and banking.
+For tag format, version bumps, and CI upload details, see [`ios/RELEASING.md`](../../ios/RELEASING.md). For positioning copy and parity notes, see [`ios/docs/app-store-metadata.md`](../../ios/docs/app-store-metadata.md). For what tooling automates vs what stays human-owned, see [Automation evidence log](./automation-evidence.md).
 
-Record submission status, reviewer notes, build strings, and final outcome in ops tracker #103. Use `ios/RELEASING.md` for tag format, build bumps, and CI upload details. Binary uploads use [`.github/workflows/ios-testflight.yml`](../../.github/workflows/ios-testflight.yml) (`ios-v*-build*` tags). App Store metadata + binary automation uses [`.github/workflows/ios-app-store-release.yml`](../../.github/workflows/ios-app-store-release.yml) (strict `ios-vMAJOR.MINOR.PATCH` tags) and Fastlane under `ios/fastlane/`.
+## Delegation split
+
+| Lane | Owns |
+|------|------|
+| **Engineering** | Tags, GitHub Actions green, binary correctness, `ios/project.yml` version/build values, signing secrets, and making sure the shipped app matches review notes. |
+| **Product / App Store** | Screenshots, copy, age rating, review notes + account-deletion recording, demo credentials, and release timing. |
+| **Account Holder / Admin** | Apple Developer and App Store Connect agreements, tax, banking, and ASC-only metadata edits (see [#314](https://github.com/auerbachb/still-point/issues/314) subtitle). |
+
+Record submission status, reviewer notes, build strings, and final outcome in ops tracker [#103](https://github.com/auerbachb/still-point/issues/103).
+
+## TestFlight upload paths
+
+Pick a path by intent. All TestFlight uploads share the reusable build workflow [`.github/workflows/ios-testflight-build.yml`](../../.github/workflows/ios-testflight-build.yml).
+
+| Path | Trigger | Workflow | Use when |
+|------|---------|----------|----------|
+| **Auto TestFlight** (recommended) | Merge a PR to `main` with the **`release:ios`** label | [`.github/workflows/ios-testflight-auto.yml`](../../.github/workflows/ios-testflight-auto.yml) → `ios-testflight-build.yml` | You want the merged code on TestFlight; build number auto-increments. |
+| **Manual TestFlight tag** (escape hatch) | Push `ios-v<marketing>-build<n>` (e.g. `ios-v1.0.3-build11`) | [`.github/workflows/ios-testflight.yml`](../../.github/workflows/ios-testflight.yml) → `ios-testflight-build.yml` | You need a specific commit/build by hand, or e2e infra blocked the auto path. |
+| **App Store release** | Push strict semver `ios-vMAJOR.MINOR.PATCH` (no `-build`; must match `MARKETING_VERSION`) | [`.github/workflows/ios-app-store-release.yml`](../../.github/workflows/ios-app-store-release.yml) | Shipping metadata + binary via Fastlane after TestFlight validation. |
+
+### Auto TestFlight (recommended)
+
+1. Add the **`release:ios`** label to the PR you want to ship.
+2. Merge to `main`. The auto workflow runs parallel e2e gates, increments `CURRENT_PROJECT_VERSION`, commits the bump with `[skip ci]`, tags `ios-v<MARKETING_VERSION>-build<n>`, and calls the reusable build/upload workflow.
+3. Build appears in TestFlight ~15–30 minutes after the workflow finishes. Record processed build number and timestamp in [`ios/QA_CHECKLIST.md`](../../ios/QA_CHECKLIST.md).
+
+`MARKETING_VERSION` is never auto-bumped — bump it in `ios/project.yml` in an ordinary PR when you want a new storefront version.
+
+### Manual TestFlight tag (escape hatch)
+
+1. Bump `CURRENT_PROJECT_VERSION` in [`ios/project.yml`](../../ios/project.yml) so it is strictly greater than the last upload.
+2. Commit, tag, and push: `git tag ios-v1.0.3-build11 && git push origin ios-v1.0.3-build11`.
+3. Confirm [Build & Upload to TestFlight](../../.github/workflows/ios-testflight.yml) is green and the build reaches **Ready to Test** in App Store Connect → **TestFlight**.
+
+### First-time TestFlight setup
+
+Before the first upload, the Account Holder should create an internal testing group in App Store Connect → **TestFlight** → **Internal Testing**, add testers, and enable **Automatic Distribution**. On the first build, answer the encryption questionnaire with **"None of the algorithms mentioned above"** — Still Point uses standard HTTPS only; `ITSAppUsesNonExemptEncryption` is `false` in `ios/project.yml`.
+
+## Code signing (CI)
+
+GitHub Actions holds distribution signing material as secrets (values never appear in logs or git). Both TestFlight and App Store release workflows import these on the macOS runner before `xcodebuild` / Fastlane `gym`.
+
+| Secret | Used for |
+|--------|----------|
+| `BUILD_CERTIFICATE_BASE64` | Distribution certificate (`.p12`) |
+| `P12_PASSWORD` | Certificate import password |
+| `BUILD_PROVISION_PROFILE_BASE64` | App Store provisioning profile (main app) |
+| `BUILD_PROVISION_PROFILE_EXTENSION_BASE64` | App extension profile (if applicable) |
+| `BUILD_PROVISION_PROFILE_WIDGET_BASE64` | Widget extension profile (if applicable) |
+| `APPSTORE_API_KEY_ID` | App Store Connect API key ID (`kid`) |
+| `APPSTORE_API_ISSUER_ID` | App Store Connect API issuer |
+| `APPSTORE_API_PRIVATE_KEY` | API private key (full `.p8` contents) |
+
+**Bundle ID:** `com.brettonauerbach.stillpoint` — certificate and provisioning profile must match.
+
+**Troubleshooting:**
+
+- **Signing error in CI:** verify certificate validity and that the provisioning profile bundle ID matches.
+- **Upload authentication error:** regenerate the App Store Connect API key and update GitHub secrets.
+- **Build number conflict:** `CURRENT_PROJECT_VERSION` must be unique per upload; re-uploads need a new TestFlight tag and incremented build number.
+- **`FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED`:** Account Holder must clear Agreements, Tax, and Banking in Apple Developer / App Store Connect before uploads succeed.
+
+The App Store release workflow maps `APPSTORE_*` secrets to Fastlane's `APP_STORE_CONNECT_API_*` environment names at runtime (see [`.github/workflows/ios-app-store-release.yml`](../../.github/workflows/ios-app-store-release.yml)).
+
+## App Store Connect metadata
+
+**Canonical repo strings** for English (U.S.) live under [`ios/fastlane/metadata/en-US/`](../../ios/fastlane/metadata/en-US/) and are uploaded by `deliver` on the App Store release path. Reconcile App Store Connect with those files before submission.
+
+| Field | Canonical value |
+|--------|------------------|
+| **Name** | Still Point |
+| **Subtitle** | `Meditate one minute at a time` (30 characters max; spell **meditate**, never `medite`) |
+| **Privacy Policy URL** | `https://still-point.me/privacy` |
+
+### Subtitle typo — ASC-only fix ([#314](https://github.com/auerbachb/still-point/issues/314))
+
+The repo-side subtitle is correct in [`ios/fastlane/metadata/en-US/subtitle.txt`](../../ios/fastlane/metadata/en-US/subtitle.txt) and [`ios/docs/app-store-metadata.md`](../../ios/docs/app-store-metadata.md). If the live App Store Connect subtitle still shows **"medite"**, the **Account Holder** must fix it directly in App Store Connect — it cannot be changed from the repo alone.
+
+While in ASC, also scan **Description**, **Keywords**, and **What's New** for the same typo. Track completion in #314.
+
+### Screenshots
+
+Regenerate candidates with [`ios-screenshots.yml`](../../.github/workflows/ios-screenshots.yml) (manual `workflow_dispatch`) or locally via `bundle exec fastlane screenshots`. Curate into [`ios/screenshots/selected/`](../../ios/screenshots/selected/) and upload with `bundle exec fastlane upload_app_store_screenshots`. See the *Regenerate candidate App Store screenshots* section in [`ios/RELEASING.md`](../../ios/RELEASING.md).
 
 ## AI-assisted dry run
 
@@ -21,84 +101,73 @@ npm run ios:app-store:dry-run
 The command reads `README.md`, `ios/RELEASING.md`, this runbook, `.github/workflows/ios-testflight.yml`, `.github/workflows/ios-app-store-release.yml`, `ios/PARITY_CHECKLIST.md`, `ios/QA_CHECKLIST.md`, and `ios/project.yml`. It writes `artifacts/ios-app-store-dry-run/summary.json`, `summary.md`, and `automation.log` with:
 
 - the intended `ios-v*` tag, marketing version, build number, bundle ID, workflow trigger, and release artifact placeholders;
-- a 38-item issue #242 checklist map across phases A-F, App Store Connect API readiness, submission execution, review follow-up, proof, and definition-of-done items;
+- a 38-item issue #242 checklist map across phases A–F, App Store Connect API readiness, submission execution, review follow-up, proof, and definition-of-done items;
 - App Store Connect API fallback paths and explicit human-owned gates.
 
 Set `APPSTORE_APP_ID`, `APPSTORE_API_KEY_ID`, `APPSTORE_API_ISSUER_ID`, and `APPSTORE_API_PRIVATE_KEY` to let the dry run query App Store Connect builds and version records. Add `-- --require-live` when a real submission must fail fast if live API validation cannot run. The script does not submit for review; submission remains blocked until the generated human gates are approved.
 
-## Automation scope
+## Release checklist (Phases A–F)
 
-The current pipeline already automates build/archive/upload to TestFlight through GitHub Actions. App Store Connect also has API coverage for many post-upload tasks, so future tooling can automate or prefill parts of this runbook instead of requiring every step to be pasted into the website.
+Assumes a **TestFlight build is already uploaded** and agreements are clear unless noted.
 
-Can be automated:
-
-- Create or locate the target App Store version.
-- Attach the processed TestFlight build to that version.
-- Read and update metadata, release notes, privacy policy URL, and review contact fields where App Store Connect API support exists.
-- Upload screenshots, app previews, and App Review attachments such as the account-deletion recording.
-- Submit the completed version for review and poll review/status transitions.
-
-Must stay human-owned:
-
-- Apple Developer and App Store Connect Agreements, Tax, and Banking must be clear for the account.
-- Screenshots, reviewer notes, demo credentials, age rating, export compliance, and release timing need a human owner unless a dedicated automation issue explicitly supplies approved source files and copy.
-- Rejections need human triage before engineering issues are created, even if status polling and reviewer-note capture are automated.
-
-## Phase A - Preconditions before submission
+### Phase A — Preconditions before submission
 
 | # | Check | Owner | Evidence / action |
 |---|-------|-------|-------------------|
-| 1 | [ ] **Apple Developer + App Store Connect:** all **Agreements, Tax, and Banking** are signed with no **Action required** items. | Account Holder / Admin | Screenshot or written confirmation from Apple Developer/App Store Connect. Uploads fail with `FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED` until this is clean. |
-| 2 | [ ] **GitHub Actions:** latest **Build & Upload to TestFlight** workflow for the intended `ios-v*` tag is green. | Engineering | Link the successful run for `.github/workflows/ios-testflight.yml`. |
-| 3 | [ ] **TestFlight:** intended build is visible in App Store Connect -> **TestFlight** and is not stuck **Processing** or marked **Invalid**. | Engineering | Capture App Store Connect build status and processing timestamp. |
-| 4 | [ ] **Version / build:** `ios/project.yml` `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` match the intended submission, and the build number is strictly greater than any prior upload for this app. | Engineering | Paste version/build values and compare against prior App Store Connect uploads. |
+| 1 | [ ] **Apple Developer + App Store Connect:** all **Agreements, Tax, and Banking** are signed with no **Action required** items. | Account Holder / Admin | Screenshot or written confirmation. Uploads fail with `FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED` until clean. |
+| 2 | [ ] **GitHub Actions:** latest **Build & Upload to TestFlight** workflow for the intended `ios-v*` tag is green. | Engineering | Link the successful run for [`.github/workflows/ios-testflight.yml`](../../.github/workflows/ios-testflight.yml) or [`.github/workflows/ios-testflight-auto.yml`](../../.github/workflows/ios-testflight-auto.yml). |
+| 3 | [ ] **TestFlight:** intended build is visible in App Store Connect → **TestFlight** and is not stuck **Processing** or marked **Invalid**. | Engineering | Capture build status and processing timestamp. |
+| 4 | [ ] **Version / build:** `ios/project.yml` `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` match the intended submission; build number is strictly greater than any prior upload. | Engineering | Paste version/build values; compare against prior Connect uploads. |
+| 5 | [ ] **Release-readiness artifacts:** [`ios/PARITY_CHECKLIST.md`](../../ios/PARITY_CHECKLIST.md) and [`ios/QA_CHECKLIST.md`](../../ios/QA_CHECKLIST.md) signed off for App Store path (required by `ios-app-store-release.yml`). | Engineering + Product | Required checkboxes checked before App Store tag push. |
 
-## Phase B - App Store version record
+### Phase B — App Store version record
 
 In App Store Connect, open the app and go to **Distribution** / **App Store** for the target version.
 
 | # | Check | Owner | Evidence / action |
 |---|-------|-------|-------------------|
-| 5 | [ ] **Create or open** the App Store version, for example `1.0.0`. | Product / App Store | Target version exists in App Store Connect. |
-| 6 | [ ] **Attach the build:** select the TestFlight build intended for this version. | Product / App Store + Engineering | Build number on the version page matches `CURRENT_PROJECT_VERSION`. |
-| 7 | [ ] **Screenshots:** all required iPhone sizes are present, plus iPad sizes if App Store Connect requires them. | Product / App Store | Screenshot slots show complete assets with no required-size warnings. |
-| 8 | [ ] **Metadata:** name, subtitle if used, description, keywords, support URL, and marketing URL if any are complete. | Product / App Store | Version page has no missing required metadata fields. |
-| 9 | [ ] **Privacy Policy URL:** set to `https://still-point.me/privacy`. | Product / App Store | URL field exactly matches project docs. |
-| 10 | [ ] **Age rating** questionnaire is complete. | Product / App Store | Age rating section has no incomplete status. |
-| 11 | [ ] **Export compliance** is complete or covered in app metadata as applicable. | Product / App Store + Engineering | Confirm export compliance section is accepted. The app sets `ITSAppUsesNonExemptEncryption` to `false` in `ios/project.yml`. |
-| 12 | [ ] **App Review contact** and phone are present if required. | Product / App Store | Review contact section is complete. |
+| 6 | [ ] **Create or open** the App Store version (e.g. `1.0.0`). | Product / App Store | Target version exists in App Store Connect. |
+| 7 | [ ] **Attach the build:** select the TestFlight build intended for this version. | Product / App Store + Engineering | Build number matches `CURRENT_PROJECT_VERSION`. |
+| 8 | [ ] **Screenshots:** all required iPhone sizes present; iPad sizes if required. | Product / App Store | No required-size warnings. |
+| 9 | [ ] **Metadata:** name, subtitle, description, keywords, support URL, marketing URL complete. Subtitle spells **meditate** ([#314](https://github.com/auerbachb/still-point/issues/314)). | Product / App Store | No missing required metadata fields. |
+| 10 | [ ] **Privacy Policy URL:** `https://still-point.me/privacy`. | Product / App Store | URL matches project docs. |
+| 11 | [ ] **Age rating** questionnaire complete. | Product / App Store | Age rating section has no incomplete status. |
+| 12 | [ ] **Export compliance** complete or covered in app metadata. | Product / App Store + Engineering | Export compliance accepted. App sets `ITSAppUsesNonExemptEncryption: false` in `ios/project.yml`. |
+| 13 | [ ] **App Review contact** and phone present if required. | Product / App Store | Review contact section complete. |
 
-## Phase C - App Review information
-
-| # | Check | Owner | Evidence / action |
-|---|-------|-------|-------------------|
-| 13 | [ ] **Notes for reviewer:** short and factual, including how to sign in and the exact account deletion path. Mention **Guideline 5.1.1(v)** if responding to that rejection thread. | Product / App Store + Engineering | Use the account deletion path from `ios/RELEASING.md`; verify the binary follows the same path. |
-| 14 | [ ] **Attachment:** screen recording from a physical iPhone showing sign-in -> **Settings** -> **Delete account** -> confirm -> signed out. | Product / App Store | Attach the recording to App Review Information and confirm it matches the submitted binary. |
-| 15 | [ ] **Demo credentials:** provide private review-field credentials if the app cannot be exercised without an existing account, or document a reliable signup path. | Product / App Store | Private review fields are populated or signup instructions are clear. |
-
-## Phase D - Submit
+### Phase C — App Review information
 
 | # | Check | Owner | Evidence / action |
 |---|-------|-------|-------------------|
-| 16 | [ ] Version page has the intended build attached and all App Store Connect warnings/blockers resolved. | Product / App Store + Engineering | Re-open the version page immediately before submission and confirm no blockers remain. |
-| 17 | [ ] Click **Submit for Review** or **Add for Review**; wording varies for first submit versus update. | Product / App Store | Capture submission timestamp in #103. |
-| 18 | [ ] Monitor status until **In Review** then **Approved** or **Rejected**. | Product / App Store | Post daily status in #103 while waiting. |
+| 14 | [ ] **Notes for reviewer:** short and factual — how to sign in and exact account deletion path. Mention **Guideline 5.1.1(v)** if responding to that rejection thread. | Product / App Store + Engineering | Path matches [`ios/RELEASING.md`](../../ios/RELEASING.md) and the submitted binary. |
+| 15 | [ ] **Attachment:** screen recording from a physical iPhone — sign-in → **Settings** → **Delete account** → confirm → signed out. | Product / App Store | Recording attached and matches the binary. |
+| 16 | [ ] **Demo credentials:** private review-field credentials or reliable signup path documented. | Product / App Store | Private fields populated or signup instructions clear. |
 
-## Phase E - If rejected
-
-| # | Check | Owner | Evidence / action |
-|---|-------|-------|-------------------|
-| 19 | [ ] Copy reviewer notes verbatim into #103 and link engineering issues per finding; keep implementation discussion out of #103. | Product / App Store | #103 contains exact reviewer language and links to follow-up issues. |
-| 20 | [ ] Fix code/config, bump iOS build, and push a new `ios-v*` tag or re-run CI per `ios/RELEASING.md`. | Engineering | New build number is strictly incremented and TestFlight upload is green. |
-| 21 | [ ] Attach the new build, update review notes and recording if the reviewed flow changed, then resubmit. | Product / App Store + Engineering | Version page references the replacement build and updated review materials. |
-
-## Phase F - If approved
+### Phase D — Submit
 
 | # | Check | Owner | Evidence / action |
 |---|-------|-------|-------------------|
-| 22 | [ ] Choose release strategy: manual release, automatic release, or phased rollout. | Product / App Store | Strategy is selected in App Store Connect. |
-| 23 | [ ] Add final #103 log entry with date, version + build, and outcome: shipped, held, or phased. | Product / App Store | #103 has final release outcome. |
-| 24 | [ ] Close #103 when submission tracking is complete per its definition of done. | Product / App Store | #103 is closed only after the submission lifecycle is complete. |
+| 17 | [ ] Version page has the intended build attached; all Connect warnings/blockers resolved. | Product / App Store + Engineering | Re-open version page immediately before submission. |
+| 18 | [ ] Click **Submit for Review** or **Add for Review** (wording varies for first submit vs update). | Product / App Store | Capture submission timestamp in #103. |
+| 19 | [ ] Monitor status until **In Review** → **Approved** or **Rejected**. | Product / App Store | Post daily status in #103 while waiting. |
+
+**Ops tracker:** [#103](https://github.com/auerbachb/still-point/issues/103) — paste reviewer notes, build strings, daily status.
+
+### Phase E — If rejected
+
+| # | Check | Owner | Evidence / action |
+|---|-------|-------|-------------------|
+| 20 | [ ] Copy reviewer notes verbatim into #103; link engineering issues per finding (keep implementation discussion out of #103). | Product / App Store | Exact reviewer language and follow-up issue links in #103. |
+| 21 | [ ] Fix code/config, bump iOS build, push new `ios-v*-build*` tag or re-run CI per [`ios/RELEASING.md`](../../ios/RELEASING.md). | Engineering | New build number strictly incremented; TestFlight upload green. |
+| 22 | [ ] Attach new build; update review notes and recording if the flow changed; resubmit. | Product / App Store + Engineering | Version page references replacement build and updated materials. |
+
+### Phase F — If approved
+
+| # | Check | Owner | Evidence / action |
+|---|-------|-------|-------------------|
+| 23 | [ ] Choose release strategy: manual, automatic, or phased rollout. | Product / App Store | Strategy selected in App Store Connect. |
+| 24 | [ ] Final #103 log entry — date, version + build, outcome (shipped / held / phased). | Product / App Store | #103 has final release outcome. |
+| 25 | [ ] Close #103 when submission tracking is complete per its definition of done. | Product / App Store | #103 closed only after lifecycle complete. |
 
 ## Reviewer notes template
 
@@ -115,10 +184,25 @@ Account deletion path for Guideline 5.1.1(v):
 5. Confirm the app returns to the signed-out screen.
 ```
 
+## GitHub Actions workflows (reference)
+
+| Workflow | File | Trigger |
+|----------|------|---------|
+| Auto TestFlight on merge | [`.github/workflows/ios-testflight-auto.yml`](../../.github/workflows/ios-testflight-auto.yml) | PR merged to `main` with `release:ios` label |
+| Manual TestFlight tag | [`.github/workflows/ios-testflight.yml`](../../.github/workflows/ios-testflight.yml) | Push `ios-v*-build*` tag |
+| Reusable build + upload | [`.github/workflows/ios-testflight-build.yml`](../../.github/workflows/ios-testflight-build.yml) | Called by auto and manual TestFlight paths |
+| App Store release (Fastlane) | [`.github/workflows/ios-app-store-release.yml`](../../.github/workflows/ios-app-store-release.yml) | Push `ios-vMAJOR.MINOR.PATCH` (no `-build`) |
+| Screenshot candidates | [`.github/workflows/ios-screenshots.yml`](../../.github/workflows/ios-screenshots.yml) | Manual `workflow_dispatch` |
+| iOS shared tests | [`.github/workflows/ios-shared-tests.yml`](../../.github/workflows/ios-shared-tests.yml) | PR / push (unit tests) |
+
+**Submit for review in CI:** `ios-app-store-release.yml` leaves `SUBMIT_FOR_REVIEW` unset, so `deliver` uses `submit_for_review: false` (upload only). Issue [#296](https://github.com/auerbachb/still-point/issues/296) can enable programmatic submission by setting `SUBMIT_FOR_REVIEW=1` when a release owner approves.
+
 ## Related links
 
-- Ops / submission log: #103
-- Submit / archive checklist (historical): #37
-- CI workflows: `.github/workflows/ios-testflight.yml`, `.github/workflows/ios-app-store-release.yml`
-- Release / tag / build docs: `ios/RELEASING.md`
+- Ops / submission log: [#103](https://github.com/auerbachb/still-point/issues/103)
+- Submit / archive checklist (historical): [#37](https://github.com/auerbachb/still-point/issues/37)
+- ASC subtitle fix (Account Holder): [#314](https://github.com/auerbachb/still-point/issues/314)
+- Release / tag / build docs: [`ios/RELEASING.md`](../../ios/RELEASING.md)
+- Metadata positioning: [`ios/docs/app-store-metadata.md`](../../ios/docs/app-store-metadata.md)
+- Automation evidence: [`docs/operations/automation-evidence.md`](./automation-evidence.md)
 - App Store Connect submission URL pattern: `https://appstoreconnect.apple.com/apps/<app-id>/distribution/reviewsubmissions/details/<submission-id>`

--- a/ios/docs/app-store-metadata.md
+++ b/ios/docs/app-store-metadata.md
@@ -2,9 +2,9 @@
 
 This file documents **positioning and parity** for App Store Connect. The **machine-deliverable** strings (name, subtitle, description, keywords, release notes, URLs, review notes) live under [`../fastlane/metadata/`](../fastlane/metadata/) as `deliver` locale files (`en-US` is canonical). Reconcile App Store Connect with those files when preparing a submission. If the live storefront differs, update ASC or the `fastlane/metadata` files (and this doc if narrative context changes) and note the change in release notes or the PR that touched copy.
 
-## Manual fix (issue #195)
+## Manual fix (issues #195, #314)
 
-The App Store **subtitle** must spell **meditate** correctly (not `medite`). In App Store Connect, open **Still Point Timer** → **App Information** / the target **version** → check **Subtitle**, **Description**, **Keywords**, and **What’s New** for the same typo.
+The App Store **subtitle** must spell **meditate** correctly (not `medite`). In App Store Connect, open **Still Point Timer** → **App Information** / the target **version** → check **Subtitle**, **Description**, **Keywords**, and **What's New** for the same typo. The repo-side strings are correct; the remaining ASC edit is tracked in [#314](https://github.com/auerbachb/still-point/issues/314) and the [submission runbook](../../docs/operations/ios-app-store-submission.md#subtitle-typo--asc-only-fix-314).
 
 ## App identity
 
@@ -35,7 +35,7 @@ These strings already ship on the marketing site and are safe references for **D
 
 ## Release notes
 
-Use the template in [`ios/RELEASING.md`](../RELEASING.md) (section *App Store metadata and release notes checklist*) for version-specific “What’s New” text; keep spelling consistent with this doc.
+Use the template in [`ios/RELEASING.md`](../RELEASING.md) (section *App Store metadata and release notes checklist*) for version-specific "What's New" text; keep spelling consistent with this doc.
 
 ## Related runbooks
 


### PR DESCRIPTION
## **User description**
## Summary

- Expands `docs/operations/ios-app-store-submission.md` into the canonical end-to-end runbook for issue #164: TestFlight upload paths (auto, manual tag, App Store release), CI code signing secrets, ASC metadata with #314 subtitle note, phased release checklist (A–F), and links to all iOS GitHub Actions workflows.
- Cross-links `ios/docs/app-store-metadata.md` to the runbook's #314 ASC-only subtitle fix section.

Closes #164

## Test plan

- [x] Runbook covers TestFlight flow (auto + manual + App Store release paths)
- [x] Runbook includes ASC metadata section with #314 subtitle (`medite` → `meditate`) note
- [x] Runbook documents CI signing secrets and troubleshooting
- [x] Runbook includes phased release checklist (A–F) with delegation split
- [x] Runbook links to `ios-testflight-auto.yml`, `ios-testflight.yml`, `ios-testflight-build.yml`, `ios-app-store-release.yml`, and `ios-screenshots.yml`
- [x] Cross-reference added in `ios/docs/app-store-metadata.md`

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Expand the iOS App Store submission runbook and link the subtitle fix**

### What Changed
- Turned the iOS submission guide into the main end-to-end runbook for TestFlight uploads, App Store review, rejection handling, and release follow-up
- Added a clear split of responsibilities for Engineering, Product / App Store, and Account Holder tasks, plus links to the related release, QA, metadata, and automation docs
- Documented the available TestFlight upload paths, CI signing requirements, App Store Connect metadata, screenshot flow, and the ASC-only subtitle fix tracked in #314
- Updated the metadata doc to point to the runbook and call out the correct “meditate” spelling note

### Impact
`✅ Clearer App Store submission handoff`
`✅ Fewer missed release steps`
`✅ Faster recovery from App Store review issues`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
