### PR TITLE
fix(ios): AudioEngine player init — unblock TestFlight build 22

### DIFF
--- a/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/AudioEngine.swift
@@ -292,6 +292,7 @@ public final class AudioEngine: @unchecked Sendable {
             player = existing
         } else {
             let node = AVAudioPlayerNode()
+            player = node
             voicePlayerNode = node
             engine.attach(node)
             engine.connect(node, to: engine.mainMixerNode, format: buffer.format)

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -87,7 +87,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint
         MARKETING_VERSION: "1.0.3"
-        CURRENT_PROJECT_VERSION: 17
+        CURRENT_PROJECT_VERSION: 21
         # Native Google Sign-In client IDs (#344). Empty by default so no real
         # client ID is committed; override per environment / in CI signing config.
         # GID_CLIENT_ID:           iOS OAuth client ID (xxxxx.apps.googleusercontent.com)
@@ -129,7 +129,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint.monitor
         MARKETING_VERSION: "1.0.3"
-        CURRENT_PROJECT_VERSION: 17
+        CURRENT_PROJECT_VERSION: 21
         DEVELOPMENT_TEAM: T5UU4BP6AV
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]: StillPointMonitor/StillPointMonitor.entitlements
@@ -159,7 +159,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint.widget
         MARKETING_VERSION: "1.0.3"
-        CURRENT_PROJECT_VERSION: 17
+        CURRENT_PROJECT_VERSION: 21
         DEVELOPMENT_TEAM: T5UU4BP6AV
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]: StillPointWidget/StillPointWidget.entitlements


### PR DESCRIPTION
## **User description**
## Summary
- Fix Swift compile error blocking TestFlight build 21: assign `player = node` in `_doPlayVoiceBuffer` else branch (`AudioEngine.swift:302`).
- Sync `CURRENT_PROJECT_VERSION` to 21 across iOS targets (supersedes #643).
- Unblocks TestFlight build 22 after merge + tag cut.

**Root cause:** Build 21 ([workflow run 30038036014](https://github.com/auerbachb/still-point/actions/runs/30038036014)) failed during Release archive with:
```
AudioEngine.swift:302:9: error: constant 'player' used before being initialized
```

## Test plan
- [x] `cd ios/StillPointShared && swift test` — 288/288 passed locally
- [ ] CI: `StillPointShared swift test`
- [ ] CI: `typecheck`, `unit-tests`, `build`
- [ ] Post-merge: tag `ios-v1.0.3-build22` to trigger TestFlight upload

Supersedes #643 (build sync only).

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Fix voice playback initialization and unblock the iOS build**

### What Changed
- Voice playback now initializes the audio player correctly before scheduling audio, preventing the app from failing during build or playback setup.
- The iOS app, monitor extension, and widget version numbers were updated together to build 21 so the release can be packaged and uploaded consistently.

### Impact
`✅ Fewer iOS release build failures`
`✅ Unblocked TestFlight uploads`
`✅ Consistent versioning across iOS targets`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
