### PR TITLE
fix(ios): widen smoke hold/completion wait for TestFlight build 22 retry

### DIFF
--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -164,17 +164,20 @@ final class StillPointAppUITests: XCTestCase {
         let hyperfocusHold = app.staticTexts["session.hyperfocusHoldButton"]
         let secondaryChrome = app.otherElements["session.secondaryChromeMarker"]
         let completionRoot = app.otherElements["root.currentView.completion"]
-        if lightHold.waitForExistence(timeout: 5) {
+        // Session chrome can lag force-start on macos-26 Release simulators; allow
+        // either hold controls or an already-finished session (issue #496 flake).
+        let holdVisible = lightHold.waitForExistence(timeout: 10)
+        let onCompletion = holdVisible ? false : completionRoot.waitForExistence(timeout: 10)
+        XCTAssertTrue(
+            holdVisible || onCompletion,
+            "Hold control or completion screen did not appear"
+        )
+        if holdVisible {
             XCTAssertEqual(lightHold.value as? String, "inactive")
-            XCTAssertTrue(hyperfocusHold.waitForExistence(timeout: 5))
+            XCTAssertTrue(hyperfocusHold.waitForExistence(timeout: 8))
             XCTAssertEqual(hyperfocusHold.value as? String, "inactive")
-            XCTAssertTrue(secondaryChrome.waitForExistence(timeout: 5))
-            waitForAccessibilityValue(secondaryChrome, "visible", timeout: 5)
-        } else {
-            XCTAssertTrue(
-                completionRoot.waitForExistence(timeout: 1),
-                "Expected active-session hold control or completion screen"
-            )
+            XCTAssertTrue(secondaryChrome.waitForExistence(timeout: 8))
+            waitForAccessibilityValue(secondaryChrome, "visible", timeout: 8)
         }
 
         if !completionRoot.exists {


### PR DESCRIPTION
## **User description**
## Summary
- TestFlight build 22 smoke gate failed: `testLaunchLoginCompleteSessionAndHistoryPersistence` asserted before session hold chrome rendered (5s hold wait + 1s completion fallback).
- Wait up to 10s for either hold controls or completion screen; use retriable failure message (`did not appear`) per #496 policy.

Relates to #438 TestFlight cut (build 22 failed smoke, not signing).

## Test plan
- [x] Logic review — extends existing waits; no app code change
- [ ] CI green on PR
- [ ] Post-merge: cut build 23 tag for TestFlight retry


Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
Make the iOS smoke test wait longer for session controls or completion

### What Changed
- The smoke test now gives the session screen more time to show either the hold controls or the completion screen before failing
- If the hold controls do appear, it now waits longer for the rest of the session chrome to become visible
- The failure message now clearly says when neither the hold controls nor the completion screen appears

### Impact
`✅ Fewer flaky TestFlight smoke failures`
`✅ More reliable iOS build validation`
`✅ Clearer smoke test failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
