### PR TITLE
fix(ios): smoke test accepts tracking unlock explainer (#526)

### DIFF
--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -164,13 +164,16 @@ final class StillPointAppUITests: XCTestCase {
         let hyperfocusHold = app.staticTexts["session.hyperfocusHoldButton"]
         let secondaryChrome = app.otherElements["session.secondaryChromeMarker"]
         let completionRoot = app.otherElements["root.currentView.completion"]
-        // Session chrome can lag force-start on macos-26 Release simulators; allow
-        // either hold controls or an already-finished session (issue #496 flake).
+        let trackingExplainer = app.staticTexts["session.trackingUnlockExplainer"]
+        // #526: hold cluster hidden until tracking unlock on fresh install; accept
+        // unlock explainer or completion as valid session-ready chrome (#648 flake).
         let holdVisible = lightHold.waitForExistence(timeout: 10)
         let onCompletion = holdVisible ? false : completionRoot.waitForExistence(timeout: 10)
+        let onTrackingLocked = (!holdVisible && !onCompletion)
+            && trackingExplainer.waitForExistence(timeout: 8)
         XCTAssertTrue(
-            holdVisible || onCompletion,
-            "Hold control or completion screen did not appear"
+            holdVisible || onCompletion || onTrackingLocked,
+            "Session chrome (hold controls, tracking unlock explainer, or completion) did not appear"
         )
         if holdVisible {
             XCTAssertEqual(lightHold.value as? String, "inactive")


### PR DESCRIPTION
## **User description**
## Summary
- Builds 22/23 smoke gate failed: hold buttons hidden on fresh install per #526 progressive unlock.
- Smoke test now accepts `session.trackingUnlockExplainer` as valid session-ready chrome (alongside hold controls or completion).

## Test plan
- [x] Root cause confirmed in CI logs (timer present, hold absent, completion absent)
- [ ] CI green
- [ ] Post-merge: cut build 24 for TestFlight (#438)


Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Accept the tracking unlock explainer as a valid ready state in the iOS smoke test**

### What Changed
- The session smoke check now passes when the tracking unlock explainer is shown on a fresh install, not only when hold controls or completion are visible
- The failure message now includes the tracking unlock explainer as an expected session-ready screen
- Hold controls are still verified when they do appear

### Impact
`✅ Fewer false smoke test failures`
`✅ Stable fresh-install checks`
`✅ Less blocked CI on iOS session launch`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
