### PR TITLE
fix(ios): scroll completion return button for smoke gate

### DIFF
--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -192,7 +192,8 @@ final class StillPointAppUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["completion.durationLabel"].exists)
 
         let returnButton = app.buttons["completion.returnButton"]
-        tapByStableCenter(returnButton, in: app)
+        scrollElementIntoVisibleFrame(returnButton, in: app)
+        XCTAssertTrue(tapByStableCenter(returnButton, in: app, timeout: 12))
         XCTAssertTrue(app.otherElements["root.currentView.home"].waitForExistence(timeout: 8))
 
         terminateAppReliably(app)

--- a/scripts/e2e/run-ios-tests.sh
+++ b/scripts/e2e/run-ios-tests.sh
@@ -224,6 +224,10 @@ is_retriable_failure() {
   if grep -q 'Field did not become keyboard first responder' "$log"; then
     return 0
   fi
+  # Completion-screen button frame settling flake (return button below fold).
+  if grep -q 'stable tappable frame' "$log"; then
+    return 0
+  fi
   # Simulator orientation confirmation timeouts in setUp/tearDown (macos-26
   # runners can stall on XCUIDevice.shared.orientation even before app launch).
   if grep -qE 'Failed to set device orientation:' "$log"; then


### PR DESCRIPTION
## **User description**
## Summary
- Build 24 smoke reached completion screen but `completion.returnButton` was off-screen (y≈1371).
- Scroll into visible frame before tap; mark stable-frame flake retriable.

## Test plan
- [ ] CI green
- [ ] Post-merge: cut build 25 (#438)


Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Keep the completion return button tappable in iOS smoke tests**

### What Changed
- The smoke test now scrolls the completion return button into view before tapping it, so the final screen can be exited reliably.
- Failures caused by the button not settling into a tappable position are now treated as retriable in iOS test runs.

### Impact
`✅ Fewer iOS smoke test failures`
`✅ More reliable completion-screen navigation`
`✅ Fewer false alarms from transient tap issues`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
