### PR TITLE
feat(notifications): schema + preferences API for missed-sit calls (#638)

### DIFF
--- a/drizzle/notification_preferences_call_window_599_incremental.sql
+++ b/drizzle/notification_preferences_call_window_599_incremental.sql
@@ -1,0 +1,17 @@
+-- Missed-sit outbound call opt-in + window (#599 / #638). Off by default; phone,
+-- consent timestamp, and local call window stored on notification_preferences.
+
+ALTER TABLE "notification_preferences"
+  ADD COLUMN IF NOT EXISTS "call_opt_in" boolean DEFAULT false NOT NULL;
+
+ALTER TABLE "notification_preferences"
+  ADD COLUMN IF NOT EXISTS "call_phone_number" varchar(20);
+
+ALTER TABLE "notification_preferences"
+  ADD COLUMN IF NOT EXISTS "call_consent_at" timestamp with time zone;
+
+ALTER TABLE "notification_preferences"
+  ADD COLUMN IF NOT EXISTS "call_window_start" varchar(5);
+
+ALTER TABLE "notification_preferences"
+  ADD COLUMN IF NOT EXISTS "call_window_stop" varchar(5);

--- a/src/app/api/notifications/preferences/route.test.ts
+++ b/src/app/api/notifications/preferences/route.test.ts
@@ -31,6 +31,11 @@ vi.mock("@/db/schema", () => ({
     dailyReminderFrequency: "dailyReminderFrequency",
     quietHoursStart: "quietHoursStart",
     quietHoursEnd: "quietHoursEnd",
+    callOptIn: "callOptIn",
+    callPhoneNumber: "callPhoneNumber",
+    callConsentAt: "callConsentAt",
+    callWindowStart: "callWindowStart",
+    callWindowStop: "callWindowStop",
     tz: "tz",
     createdAt: "createdAt",
     updatedAt: "updatedAt",
@@ -67,9 +72,14 @@ const samplePrefs = {
   suppressDuringSession: false,
   dailyReminderTime: "09:00",
   dailyReminderFrequency: "daily" as const,
-  quietHoursStart: null,
-  quietHoursEnd: null,
-  tz: "America/New_York",
+    quietHoursStart: null,
+    quietHoursEnd: null,
+    callOptIn: false,
+    callPhoneNumber: null,
+    callConsentAt: null,
+    callWindowStart: null,
+    callWindowStop: null,
+    tz: "America/New_York",
   createdAt: new Date("2026-05-29T12:00:00.000Z"),
   updatedAt: new Date("2026-05-29T12:00:00.000Z"),
 };
@@ -195,6 +205,75 @@ describe("/api/notifications/preferences", () => {
 
     expect(response.status).toBe(400);
     expect(dbUpdate).not.toHaveBeenCalled();
+  });
+
+  test("PATCH rejects callOptIn without phone and window", async () => {
+    const { PATCH } = await import("./route");
+
+    const response = await PATCH(
+      new Request("http://test.local/api/notifications/preferences", {
+        method: "PATCH",
+        body: JSON.stringify({ callOptIn: true }),
+      }) as NextRequest,
+    );
+
+    expect(response.status).toBe(400);
+    expect(dbUpdate).not.toHaveBeenCalled();
+  });
+
+  test("PATCH sets consent timestamp when enabling call opt-in", async () => {
+    const { PATCH } = await import("./route");
+
+    const response = await PATCH(
+      new Request("http://test.local/api/notifications/preferences", {
+        method: "PATCH",
+        body: JSON.stringify({
+          callOptIn: true,
+          callPhoneNumber: "+15551234567",
+          callWindowStart: "09:00",
+          callWindowStop: "17:00",
+        }),
+      }) as NextRequest,
+    );
+
+    expect(response.status).toBe(200);
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callOptIn: true,
+        callPhoneNumber: "+15551234567",
+        callWindowStart: "09:00",
+        callWindowStop: "17:00",
+        callConsentAt: expect.any(Date),
+      }),
+    );
+  });
+
+  test("PATCH clears consent when opting out of calls", async () => {
+    getOrCreateNotificationPreferences.mockResolvedValue({
+      ...samplePrefs,
+      callOptIn: true,
+      callPhoneNumber: "+15551234567",
+      callWindowStart: "09:00",
+      callWindowStop: "17:00",
+      callConsentAt: new Date("2026-05-29T12:00:00.000Z"),
+    });
+
+    const { PATCH } = await import("./route");
+
+    const response = await PATCH(
+      new Request("http://test.local/api/notifications/preferences", {
+        method: "PATCH",
+        body: JSON.stringify({ callOptIn: false }),
+      }) as NextRequest,
+    );
+
+    expect(response.status).toBe(200);
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callOptIn: false,
+        callConsentAt: null,
+      }),
+    );
   });
 
   test("GET returns 401 when unauthenticated", async () => {

--- a/src/app/api/notifications/preferences/route.ts
+++ b/src/app/api/notifications/preferences/route.ts
@@ -9,6 +9,9 @@ import {
   isValidFrequency,
   isValidReminderTime,
   isValidTimezone,
+  isValidE164PhoneNumber,
+  isValidCallWindow,
+  callOptInRequirementsMet,
   asNotificationPreferencesRow,
   serializeNotificationPreferences,
 } from "@/lib/notification-preferences";
@@ -105,6 +108,41 @@ export const PATCH = withApiHandler("Notification preferences PATCH", async (req
     hasUpdate = true;
   }
 
+  if (typeof body.callOptIn === "boolean") {
+    updates.callOptIn = body.callOptIn;
+    hasUpdate = true;
+  }
+  if (body.callPhoneNumber === null) {
+    updates.callPhoneNumber = null;
+    hasUpdate = true;
+  } else if (typeof body.callPhoneNumber === "string") {
+    if (!isValidE164PhoneNumber(body.callPhoneNumber)) {
+      return NextResponse.json({ error: "callPhoneNumber must be E.164 format, e.g. +15551234567" }, { status: 400 });
+    }
+    updates.callPhoneNumber = body.callPhoneNumber;
+    hasUpdate = true;
+  }
+  if (body.callWindowStart === null) {
+    updates.callWindowStart = null;
+    hasUpdate = true;
+  } else if (typeof body.callWindowStart === "string") {
+    if (!isValidReminderTime(body.callWindowStart)) {
+      return NextResponse.json({ error: "callWindowStart must be HH:MM (24h)" }, { status: 400 });
+    }
+    updates.callWindowStart = body.callWindowStart;
+    hasUpdate = true;
+  }
+  if (body.callWindowStop === null) {
+    updates.callWindowStop = null;
+    hasUpdate = true;
+  } else if (typeof body.callWindowStop === "string") {
+    if (!isValidReminderTime(body.callWindowStop)) {
+      return NextResponse.json({ error: "callWindowStop must be HH:MM (24h)" }, { status: 400 });
+    }
+    updates.callWindowStop = body.callWindowStop;
+    hasUpdate = true;
+  }
+
   if (!hasUpdate) {
     return NextResponse.json({ error: "No supported preference fields provided" }, { status: 400 });
   }
@@ -118,7 +156,47 @@ export const PATCH = withApiHandler("Notification preferences PATCH", async (req
     );
   }
 
-  await getOrCreateNotificationPreferences(auth.user.userId);
+  const callStartTouched = Object.prototype.hasOwnProperty.call(updates, "callWindowStart");
+  const callStopTouched = Object.prototype.hasOwnProperty.call(updates, "callWindowStop");
+  if (callStartTouched !== callStopTouched) {
+    return NextResponse.json(
+      { error: "callWindowStart and callWindowStop must be updated together" },
+      { status: 400 },
+    );
+  }
+
+  const existing = await getOrCreateNotificationPreferences(auth.user.userId);
+  const mergedCallFields = {
+    callPhoneNumber: (updates.callPhoneNumber as string | null | undefined) ?? existing.callPhoneNumber,
+    callWindowStart: (updates.callWindowStart as string | null | undefined) ?? existing.callWindowStart,
+    callWindowStop: (updates.callWindowStop as string | null | undefined) ?? existing.callWindowStop,
+  };
+  const nextCallOptIn = typeof updates.callOptIn === "boolean" ? updates.callOptIn : existing.callOptIn;
+
+  if (callStartTouched && callStopTouched) {
+    const start = updates.callWindowStart as string | null;
+    const stop = updates.callWindowStop as string | null;
+    if (start !== null && stop !== null && !isValidCallWindow(start, stop)) {
+      return NextResponse.json(
+        { error: "callWindowStart and callWindowStop must differ and be valid HH:MM times" },
+        { status: 400 },
+      );
+    }
+  }
+
+  if (nextCallOptIn) {
+    if (!callOptInRequirementsMet(mergedCallFields)) {
+      return NextResponse.json(
+        { error: "callOptIn requires callPhoneNumber plus callWindowStart and callWindowStop" },
+        { status: 400 },
+      );
+    }
+    if (!existing.callOptIn) {
+      updates.callConsentAt = new Date();
+    }
+  } else if (existing.callOptIn || updates.callOptIn === false) {
+    updates.callConsentAt = null;
+  }
 
   const [updated] = await db
     .update(notificationPreferences)

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -83,6 +83,16 @@ export const notificationPreferences = pgTable("notification_preferences", {
   dailyReminderFrequency: varchar("daily_reminder_frequency", { length: 20 }).default("daily").notNull(),
   quietHoursStart: varchar("quiet_hours_start", { length: 5 }),
   quietHoursEnd: varchar("quiet_hours_end", { length: 5 }),
+  /** Opt-in (#599): outbound missed-sit voice call via Vapi. Off by default. */
+  callOptIn: boolean("call_opt_in").default(false).notNull(),
+  /** E.164 phone number for missed-sit calls, e.g. +15551234567 */
+  callPhoneNumber: varchar("call_phone_number", { length: 20 }),
+  /** When the user last opted in to missed-sit calls; cleared on opt-out. */
+  callConsentAt: timestamp("call_consent_at", { withTimezone: true }),
+  /** Local call window start as HH:MM (24h). */
+  callWindowStart: varchar("call_window_start", { length: 5 }),
+  /** Local call window stop as HH:MM (24h). */
+  callWindowStop: varchar("call_window_stop", { length: 5 }),
   /** IANA timezone, e.g. America/New_York */
   tz: varchar("tz", { length: 64 }).default("UTC").notNull(),
   createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),

--- a/src/lib/notification-preferences.test.ts
+++ b/src/lib/notification-preferences.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test } from "vitest";
 import {
   DEFAULT_NOTIFICATION_PREFERENCES,
   friendRequestNotificationsAllowed,
+  isValidE164PhoneNumber,
+  isValidCallWindow,
+  callOptInRequirementsMet,
 } from "./notification-preferences";
 
 describe("friendRequestNotificationsAllowed", () => {
@@ -30,5 +33,52 @@ describe("friendRequestNotificationsAllowed", () => {
 describe("suppressDuringSession default", () => {
   test("is opt-in (off by default)", () => {
     expect(DEFAULT_NOTIFICATION_PREFERENCES.suppressDuringSession).toBe(false);
+  });
+});
+
+describe("call preference defaults", () => {
+  test("missed-sit call opt-in is off by default", () => {
+    expect(DEFAULT_NOTIFICATION_PREFERENCES.callOptIn).toBe(false);
+    expect(DEFAULT_NOTIFICATION_PREFERENCES.callPhoneNumber).toBeNull();
+    expect(DEFAULT_NOTIFICATION_PREFERENCES.callConsentAt).toBeNull();
+    expect(DEFAULT_NOTIFICATION_PREFERENCES.callWindowStart).toBeNull();
+    expect(DEFAULT_NOTIFICATION_PREFERENCES.callWindowStop).toBeNull();
+  });
+});
+
+describe("isValidE164PhoneNumber", () => {
+  test("accepts valid E.164 numbers", () => {
+    expect(isValidE164PhoneNumber("+15551234567")).toBe(true);
+    expect(isValidE164PhoneNumber("+442079460123")).toBe(true);
+  });
+
+  test("rejects invalid numbers", () => {
+    expect(isValidE164PhoneNumber("5551234567")).toBe(false);
+    expect(isValidE164PhoneNumber("+0123456789")).toBe(false);
+    expect(isValidE164PhoneNumber("+1555")).toBe(false);
+  });
+});
+
+describe("isValidCallWindow", () => {
+  test("requires distinct HH:MM bounds", () => {
+    expect(isValidCallWindow("09:00", "17:00")).toBe(true);
+    expect(isValidCallWindow("09:00", "09:00")).toBe(false);
+    expect(isValidCallWindow("25:00", "17:00")).toBe(false);
+  });
+});
+
+describe("callOptInRequirementsMet", () => {
+  test("requires phone and window when opting in", () => {
+    expect(callOptInRequirementsMet({
+      callPhoneNumber: "+15551234567",
+      callWindowStart: "09:00",
+      callWindowStop: "17:00",
+    })).toBe(true);
+
+    expect(callOptInRequirementsMet({
+      callPhoneNumber: null,
+      callWindowStart: "09:00",
+      callWindowStop: "17:00",
+    })).toBe(false);
   });
 });

--- a/src/lib/notification-preferences.ts
+++ b/src/lib/notification-preferences.ts
@@ -16,6 +16,11 @@ export type NotificationPreferencesRow = {
   dailyReminderFrequency: DailyReminderFrequency;
   quietHoursStart: string | null;
   quietHoursEnd: string | null;
+  callOptIn: boolean;
+  callPhoneNumber: string | null;
+  callConsentAt: Date | null;
+  callWindowStart: string | null;
+  callWindowStop: string | null;
   tz: string;
   createdAt: Date;
   updatedAt: Date;
@@ -23,6 +28,7 @@ export type NotificationPreferencesRow = {
 
 const frequencyValues = new Set<DailyReminderFrequency>(["daily", "every_other", "weekly"]);
 const timePattern = /^([01]\d|2[0-3]):[0-5]\d$/;
+const e164Pattern = /^\+[1-9]\d{1,14}$/;
 
 export const DEFAULT_NOTIFICATION_PREFERENCES = {
   pushEnabled: false,
@@ -35,11 +41,44 @@ export const DEFAULT_NOTIFICATION_PREFERENCES = {
   dailyReminderFrequency: "daily" as DailyReminderFrequency,
   quietHoursStart: null as string | null,
   quietHoursEnd: null as string | null,
+  callOptIn: false,
+  callPhoneNumber: null as string | null,
+  callConsentAt: null as Date | null,
+  callWindowStart: null as string | null,
+  callWindowStop: null as string | null,
   tz: "UTC",
 };
 
 export function isValidReminderTime(value: string): boolean {
   return timePattern.test(value);
+}
+
+export function isValidE164PhoneNumber(value: string): boolean {
+  return e164Pattern.test(value) && value.length >= 8 && value.length <= 16;
+}
+
+export function isValidCallWindow(start: string, stop: string): boolean {
+  if (!isValidReminderTime(start) || !isValidReminderTime(stop)) {
+    return false;
+  }
+  return start !== stop;
+}
+
+export type CallPreferenceFields = Pick<
+  NotificationPreferencesRow,
+  "callOptIn" | "callPhoneNumber" | "callConsentAt" | "callWindowStart" | "callWindowStop"
+>;
+
+export function callOptInRequirementsMet(
+  fields: Pick<NotificationPreferencesRow, "callPhoneNumber" | "callWindowStart" | "callWindowStop">,
+): boolean {
+  return Boolean(
+    fields.callPhoneNumber
+      && fields.callWindowStart
+      && fields.callWindowStop
+      && isValidE164PhoneNumber(fields.callPhoneNumber)
+      && isValidCallWindow(fields.callWindowStart, fields.callWindowStop),
+  );
 }
 
 export function isValidTimezone(value: string): boolean {
@@ -77,6 +116,11 @@ export function serializeNotificationPreferences(row: NotificationPreferencesRow
     dailyReminderFrequency: row.dailyReminderFrequency,
     quietHoursStart: row.quietHoursStart,
     quietHoursEnd: row.quietHoursEnd,
+    callOptIn: row.callOptIn,
+    callPhoneNumber: row.callPhoneNumber,
+    callConsentAt: row.callConsentAt?.toISOString() ?? null,
+    callWindowStart: row.callWindowStart,
+    callWindowStop: row.callWindowStop,
     tz: row.tz,
     updatedAt: row.updatedAt.toISOString(),
   };


### PR DESCRIPTION
## Summary
- Add `callOptIn`, `callPhoneNumber`, `callConsentAt`, `callWindowStart`, and `callWindowStop` to `notification_preferences` (migration + Drizzle schema)
- Extend `notification-preferences.ts` with E.164 and call-window validators plus consent helpers
- Extend `PATCH/GET /api/notifications/preferences` with opt-in semantics (consent timestamp set on enable, cleared on disable)

Closes #638

## Test plan
- [x] `npx vitest run src/lib/notification-preferences.test.ts src/app/api/notifications/preferences/route.test.ts`
- [ ] Apply migration on preview DB
- [ ] Manual PATCH: opt-in requires phone + window; opt-out clears consent


Made with [Cursor](https://cursor.com)