### PR TITLE
feat(vapi): client + call_attempts for missed-sit calls (#639)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,11 @@ AUTH_APPLE_ID=
 # Optional: set to exactly "true" to require friendship before buddy join (see README)
 # BUDDY_REQUIRE_FRIENDSHIP=
 
+# Vapi outbound missed-sit voice calls (#599). Required for live calls only; scheduler tests mock the client.
+# VAPI_API_KEY=
+# VAPI_ASSISTANT_ID=
+# VAPI_PHONE_NUMBER_ID=
+
 
 # Optional: public App Store URL for landing page badge (#199). Unset or empty = no badge shown.
 # NEXT_PUBLIC_APP_STORE_URL=

--- a/drizzle/call_attempts_599_incremental.sql
+++ b/drizzle/call_attempts_599_incremental.sql
@@ -1,0 +1,28 @@
+-- Outbound missed-sit call attempt log (#599 / #639). One row per scheduler-initiated call.
+
+CREATE TABLE IF NOT EXISTS "call_attempts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"vapi_call_id" varchar(64),
+	"phone_number" varchar(20) NOT NULL,
+	"window_key" varchar(32) NOT NULL,
+	"status" varchar(20) NOT NULL,
+	"error_message" varchar(500),
+	"created_at" timestamptz DEFAULT now() NOT NULL
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'call_attempts_user_id_users_id_fk'
+      AND conrelid = 'public.call_attempts'::regclass
+  ) THEN
+    ALTER TABLE "call_attempts"
+      ADD CONSTRAINT "call_attempts_user_id_users_id_fk"
+      FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "call_attempts_user_window_idx"
+  ON "call_attempts" USING btree ("user_id", "window_key");

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -111,6 +111,21 @@ export const notificationPreferences = pgTable("notification_preferences", {
   ),
 }));
 
+/** #599: log of outbound missed-sit Vapi call attempts. */
+export const callAttempts = pgTable("call_attempts", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  userId: uuid("user_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
+  vapiCallId: varchar("vapi_call_id", { length: 64 }),
+  phoneNumber: varchar("phone_number", { length: 20 }).notNull(),
+  /** Hour-granular dedup key, e.g. 2026-05-29T14 in the user's timezone. */
+  windowKey: varchar("window_key", { length: 32 }).notNull(),
+  status: varchar("status", { length: 20 }).notNull(),
+  errorMessage: varchar("error_message", { length: 500 }),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  userWindowIdx: index("call_attempts_user_window_idx").on(table.userId, table.windowKey),
+}));
+
 /** Idempotent send ledger: one row per user/type/window (#345). */
 export const notificationDispatches = pgTable("notification_dispatches", {
   id: uuid("id").primaryKey().defaultRandom(),
@@ -511,6 +526,7 @@ export const usersRelations = relations(users, ({ one, many }) => ({
     references: [notificationPreferences.userId],
   }),
   notificationDispatches: many(notificationDispatches),
+  callAttempts: many(callAttempts),
   failureReasons: many(failureReasons),
   oauthAccounts: many(oauthAccounts),
   googleOAuthToken: one(googleOAuthTokens, {
@@ -530,6 +546,10 @@ export const notificationPreferencesRelations = relations(notificationPreference
 
 export const notificationDispatchesRelations = relations(notificationDispatches, ({ one }) => ({
   user: one(users, { fields: [notificationDispatches.userId], references: [users.id] }),
+}));
+
+export const callAttemptsRelations = relations(callAttempts, ({ one }) => ({
+  user: one(users, { fields: [callAttempts.userId], references: [users.id] }),
 }));
 
 export const deviceTokensRelations = relations(deviceTokens, ({ one }) => ({

--- a/src/lib/vapi.test.ts
+++ b/src/lib/vapi.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const insertReturning = vi.fn();
+const insertValues = vi.fn(() => ({ returning: insertReturning }));
+const dbInsert = vi.fn(() => ({ values: insertValues }));
+
+vi.mock("@/db", () => ({
+  db: {
+    insert: dbInsert,
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  callAttempts: {
+    id: "id",
+  },
+}));
+
+describe("initiateMissedSitCall", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    delete process.env.VAPI_API_KEY;
+    delete process.env.VAPI_ASSISTANT_ID;
+    delete process.env.VAPI_PHONE_NUMBER_ID;
+    insertReturning.mockResolvedValue([{ id: "attempt-1" }]);
+  });
+
+  test("returns ok:false when Vapi env is missing", async () => {
+    const { initiateMissedSitCall } = await import("./vapi");
+    const fetchMock = vi.fn();
+
+    const result = await initiateMissedSitCall({
+      userId: "user-1",
+      phoneNumber: "+15551234567",
+      windowKey: "2026-05-29T14",
+      context: { userName: "Alex", currentStreak: 3, daysMissed: 1 },
+    }, fetchMock);
+
+    expect(result).toEqual({
+      ok: false,
+      reason: expect.stringContaining("Vapi not configured"),
+      attemptId: "attempt-1",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(dbInsert).toHaveBeenCalled();
+  });
+
+  test("posts Vapi payload with assistantOverrides.variableValues", async () => {
+    process.env.VAPI_API_KEY = "test-key";
+    process.env.VAPI_ASSISTANT_ID = "asst-123";
+    process.env.VAPI_PHONE_NUMBER_ID = "phone-456";
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ id: "call-789" }),
+    });
+
+    const { initiateMissedSitCall } = await import("./vapi");
+    const result = await initiateMissedSitCall({
+      userId: "user-1",
+      phoneNumber: "+15551234567",
+      windowKey: "2026-05-29T14",
+      context: { userName: "Alex", currentStreak: 5, daysMissed: 2 },
+    }, fetchMock);
+
+    expect(result).toEqual({ ok: true, callId: "call-789", attemptId: "attempt-1" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.vapi.ai/call",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-key",
+        }),
+        body: JSON.stringify({
+          assistantId: "asst-123",
+          phoneNumberId: "phone-456",
+          customer: { number: "+15551234567" },
+          assistantOverrides: {
+            variableValues: {
+              userName: "Alex",
+              currentStreak: "5",
+              daysMissed: "2",
+            },
+          },
+        }),
+      }),
+    );
+  });
+
+  test("returns ok:false when Vapi responds with error", async () => {
+    process.env.VAPI_API_KEY = "test-key";
+    process.env.VAPI_ASSISTANT_ID = "asst-123";
+    process.env.VAPI_PHONE_NUMBER_ID = "phone-456";
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ message: "invalid phone" }),
+    });
+
+    const { initiateMissedSitCall } = await import("./vapi");
+    const result = await initiateMissedSitCall({
+      userId: "user-1",
+      phoneNumber: "+15551234567",
+      windowKey: "2026-05-29T14",
+      context: { userName: "Alex", currentStreak: 0, daysMissed: 1 },
+    }, fetchMock);
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "invalid phone",
+      attemptId: "attempt-1",
+    });
+  });
+});
+
+describe("getVapiConfigStatus", () => {
+  test("reports missing env vars", async () => {
+    delete process.env.VAPI_API_KEY;
+    delete process.env.VAPI_ASSISTANT_ID;
+    delete process.env.VAPI_PHONE_NUMBER_ID;
+    vi.resetModules();
+    const { getVapiConfigStatus } = await import("./vapi");
+    expect(getVapiConfigStatus()).toEqual({
+      configured: false,
+      missing: ["VAPI_API_KEY", "VAPI_ASSISTANT_ID", "VAPI_PHONE_NUMBER_ID"],
+    });
+  });
+});

--- a/src/lib/vapi.ts
+++ b/src/lib/vapi.ts
@@ -1,0 +1,147 @@
+import "server-only";
+import { db } from "@/db";
+import { callAttempts } from "@/db/schema";
+
+export const REQUIRED_VAPI_ENV_VARS = [
+  "VAPI_API_KEY",
+  "VAPI_ASSISTANT_ID",
+  "VAPI_PHONE_NUMBER_ID",
+] as const;
+
+const VAPI_CALL_URL = "https://api.vapi.ai/call";
+
+export type MissedSitCallContext = {
+  userName: string;
+  currentStreak: number;
+  daysMissed: number;
+};
+
+export type InitiateMissedSitCallParams = {
+  userId: string;
+  phoneNumber: string;
+  windowKey: string;
+  context: MissedSitCallContext;
+};
+
+export type InitiateMissedSitCallResult =
+  | { ok: true; callId: string; attemptId: string }
+  | { ok: false; reason: string; attemptId?: string };
+
+export function getVapiConfigStatus(): { configured: boolean; missing: string[] } {
+  const missing = REQUIRED_VAPI_ENV_VARS.filter((name) => !process.env[name]);
+  return { configured: missing.length === 0, missing: [...missing] };
+}
+
+export async function logCallAttempt(params: {
+  userId: string;
+  phoneNumber: string;
+  windowKey: string;
+  status: "initiated" | "failed";
+  vapiCallId?: string | null;
+  errorMessage?: string | null;
+}): Promise<string> {
+  const [row] = await db
+    .insert(callAttempts)
+    .values({
+      userId: params.userId,
+      phoneNumber: params.phoneNumber,
+      windowKey: params.windowKey,
+      status: params.status,
+      vapiCallId: params.vapiCallId ?? null,
+      errorMessage: params.errorMessage ?? null,
+    })
+    .returning({ id: callAttempts.id });
+
+  return row.id;
+}
+
+export async function initiateMissedSitCall(
+  params: InitiateMissedSitCallParams,
+  fetchImpl: typeof fetch = fetch,
+): Promise<InitiateMissedSitCallResult> {
+  const { configured, missing } = getVapiConfigStatus();
+  if (!configured) {
+    const reason = `Vapi not configured (missing: ${missing.join(", ")})`;
+    const attemptId = await logCallAttempt({
+      userId: params.userId,
+      phoneNumber: params.phoneNumber,
+      windowKey: params.windowKey,
+      status: "failed",
+      errorMessage: reason,
+    });
+    return { ok: false, reason, attemptId };
+  }
+
+  const payload = {
+    assistantId: process.env.VAPI_ASSISTANT_ID,
+    phoneNumberId: process.env.VAPI_PHONE_NUMBER_ID,
+    customer: {
+      number: params.phoneNumber,
+    },
+    assistantOverrides: {
+      variableValues: {
+        userName: params.context.userName,
+        currentStreak: String(params.context.currentStreak),
+        daysMissed: String(params.context.daysMissed),
+      },
+    },
+  };
+
+  try {
+    const response = await fetchImpl(VAPI_CALL_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${process.env.VAPI_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const body = await response.json().catch(() => ({})) as { id?: string; message?: string };
+
+    if (!response.ok) {
+      const reason = body.message ?? `Vapi call failed (${response.status})`;
+      const attemptId = await logCallAttempt({
+        userId: params.userId,
+        phoneNumber: params.phoneNumber,
+        windowKey: params.windowKey,
+        status: "failed",
+        errorMessage: reason,
+      });
+      return { ok: false, reason, attemptId };
+    }
+
+    const callId = body.id;
+    if (!callId) {
+      const reason = "Vapi call response missing id";
+      const attemptId = await logCallAttempt({
+        userId: params.userId,
+        phoneNumber: params.phoneNumber,
+        windowKey: params.windowKey,
+        status: "failed",
+        errorMessage: reason,
+      });
+      return { ok: false, reason, attemptId };
+    }
+
+    const attemptId = await logCallAttempt({
+      userId: params.userId,
+      phoneNumber: params.phoneNumber,
+      windowKey: params.windowKey,
+      status: "initiated",
+      vapiCallId: callId,
+    });
+
+    return { ok: true, callId, attemptId };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : "Vapi call request failed";
+    const attemptId = await logCallAttempt({
+      userId: params.userId,
+      phoneNumber: params.phoneNumber,
+      windowKey: params.windowKey,
+      status: "failed",
+      errorMessage: reason,
+    });
+    return { ok: false, reason, attemptId };
+  }
+}

--- a/src/lib/vapi.ts
+++ b/src/lib/vapi.ts
@@ -9,6 +9,7 @@ export const REQUIRED_VAPI_ENV_VARS = [
 ] as const;
 
 const VAPI_CALL_URL = "https://api.vapi.ai/call";
+const VAPI_REQUEST_TIMEOUT_MS = 10_000;
 
 export type MissedSitCallContext = {
   userName: string;
@@ -95,6 +96,7 @@ export async function initiateMissedSitCall(
         "Content-Type": "application/json",
       },
       body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(VAPI_REQUEST_TIMEOUT_MS),
     });
 
     const body = await response.json().catch(() => ({})) as { id?: string; message?: string };
@@ -124,15 +126,19 @@ export async function initiateMissedSitCall(
       return { ok: false, reason, attemptId };
     }
 
-    const attemptId = await logCallAttempt({
-      userId: params.userId,
-      phoneNumber: params.phoneNumber,
-      windowKey: params.windowKey,
-      status: "initiated",
-      vapiCallId: callId,
-    });
-
-    return { ok: true, callId, attemptId };
+    try {
+      const attemptId = await logCallAttempt({
+        userId: params.userId,
+        phoneNumber: params.phoneNumber,
+        windowKey: params.windowKey,
+        status: "initiated",
+        vapiCallId: callId,
+      });
+      return { ok: true, callId, attemptId };
+    } catch (logError) {
+      console.error("Vapi call placed but call_attempts insert failed:", logError);
+      return { ok: true, callId };
+    }
   } catch (error) {
     const reason = error instanceof Error ? error.message : "Vapi call request failed";
     const attemptId = await logCallAttempt({

--- a/src/lib/vapi.ts
+++ b/src/lib/vapi.ts
@@ -25,7 +25,7 @@ export type InitiateMissedSitCallParams = {
 };
 
 export type InitiateMissedSitCallResult =
-  | { ok: true; callId: string; attemptId: string }
+  | { ok: true; callId: string; attemptId?: string }
   | { ok: false; reason: string; attemptId?: string };
 
 export function getVapiConfigStatus(): { configured: boolean; missing: string[] } {


### PR DESCRIPTION
## **User description**
## Summary
- Add `src/lib/vapi.ts` with `initiateMissedSitCall()` posting to Vapi `/call` and `assistantOverrides.variableValues`
- Add `call_attempts` table + migration for outbound call logging
- Document `VAPI_*` env placeholders in `.env.example` (no secrets)

Closes #639

## Test plan
- [x] `npx vitest run src/lib/vapi.test.ts`
- [ ] Apply migration on preview DB

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
Enable and track outbound missed-sit voice calls through Vapi

### What Changed
- Missed-sit calls can include the user's phone number, name, current streak, and missed-day count
- Calls are recorded as initiated or failed, with provider IDs and clear failure reasons
- Missing configuration, provider errors, invalid responses, network failures, and requests exceeding 10 seconds return actionable results instead of hanging or throwing
- A successful call remains successful even if recording the attempt fails
- Added configuration status reporting, environment placeholders, database storage, and coverage for successful and failed call scenarios

### Impact
`✅ Personalized missed-sit voice calls`
`✅ Trackable call outcomes`
`✅ Fewer hung call requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
