### PR TITLE
feat(ios): missed-sit call settings UI (#641)

### DIFF
--- a/ios/StillPointApp/ViewModels/NotificationPreferencesViewModel.swift
+++ b/ios/StillPointApp/ViewModels/NotificationPreferencesViewModel.swift
@@ -142,35 +142,19 @@ final class NotificationPreferencesViewModel {
     func persistCallOptInToggle(enabled: Bool) async {
         callOptInEnabled = enabled
         if enabled {
-            await persist(
-                patch: NotificationPreferencesPatch(
-                    callOptIn: true,
-                    callPhoneNumber: .some(normalizedCallPhoneNumber()),
-                    callWindowStart: .some(formatHHMM(callWindowStartTime)),
-                    callWindowStop: .some(formatHHMM(callWindowStopTime))
-                )
-            )
-        } else {
-            await persist(patch: NotificationPreferencesPatch(callOptIn: false))
+            return
         }
+        await persist(patch: NotificationPreferencesPatch(callOptIn: false))
     }
 
-    func persistCallPhoneNumber() async {
+    func persistCallSettingsIfReady() async {
         guard callOptInEnabled else { return }
+        let phone = normalizedCallPhoneNumber()
+        guard phone.hasPrefix("+"), phone.count >= 8 else { return }
         await persist(
             patch: NotificationPreferencesPatch(
-                callPhoneNumber: .some(normalizedCallPhoneNumber()),
-                callWindowStart: .some(formatHHMM(callWindowStartTime)),
-                callWindowStop: .some(formatHHMM(callWindowStopTime))
-            )
-        )
-    }
-
-    func persistCallWindowTimes() async {
-        guard callOptInEnabled else { return }
-        await persist(
-            patch: NotificationPreferencesPatch(
-                callPhoneNumber: .some(normalizedCallPhoneNumber()),
+                callOptIn: true,
+                callPhoneNumber: .some(phone),
                 callWindowStart: .some(formatHHMM(callWindowStartTime)),
                 callWindowStop: .some(formatHHMM(callWindowStopTime))
             )
@@ -240,11 +224,11 @@ final class NotificationPreferencesViewModel {
 
     private func normalizedCallPhoneNumber() -> String {
         let trimmed = callPhoneNumber.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.hasPrefix("+") {
-            return trimmed
-        }
         let digits = trimmed.filter(\.isNumber)
         guard !digits.isEmpty else { return trimmed }
+        if trimmed.hasPrefix("+") {
+            return "+\(digits)"
+        }
         if digits.count == 10 {
             return "+1\(digits)"
         }

--- a/ios/StillPointApp/ViewModels/NotificationPreferencesViewModel.swift
+++ b/ios/StillPointApp/ViewModels/NotificationPreferencesViewModel.swift
@@ -13,6 +13,8 @@ final class NotificationPreferencesViewModel {
     var suppressDuringSession = false
     var dailyReminderFrequency: DailyReminderFrequency = .daily
     var quietHoursEnabled = false
+    var callOptInEnabled = false
+    var callPhoneNumber = ""
     var timezoneDisplay = "UTC"
 
     var isLoading = false
@@ -26,6 +28,8 @@ final class NotificationPreferencesViewModel {
     var reminderTime = Calendar.current.date(from: DateComponents(hour: 9, minute: 0)) ?? Date()
     var quietStartTime = Calendar.current.date(from: DateComponents(hour: 22, minute: 0)) ?? Date()
     var quietEndTime = Calendar.current.date(from: DateComponents(hour: 7, minute: 0)) ?? Date()
+    var callWindowStartTime = Calendar.current.date(from: DateComponents(hour: 18, minute: 0)) ?? Date()
+    var callWindowStopTime = Calendar.current.date(from: DateComponents(hour: 21, minute: 0)) ?? Date()
 
     func load() async {
         guard !isLoading else { return }
@@ -135,6 +139,44 @@ final class NotificationPreferencesViewModel {
         await persist(patch: NotificationPreferencesPatch(failureReasonReminderEnabled: enabled))
     }
 
+    func persistCallOptInToggle(enabled: Bool) async {
+        callOptInEnabled = enabled
+        if enabled {
+            await persist(
+                patch: NotificationPreferencesPatch(
+                    callOptIn: true,
+                    callPhoneNumber: .some(normalizedCallPhoneNumber()),
+                    callWindowStart: .some(formatHHMM(callWindowStartTime)),
+                    callWindowStop: .some(formatHHMM(callWindowStopTime))
+                )
+            )
+        } else {
+            await persist(patch: NotificationPreferencesPatch(callOptIn: false))
+        }
+    }
+
+    func persistCallPhoneNumber() async {
+        guard callOptInEnabled else { return }
+        await persist(
+            patch: NotificationPreferencesPatch(
+                callPhoneNumber: .some(normalizedCallPhoneNumber()),
+                callWindowStart: .some(formatHHMM(callWindowStartTime)),
+                callWindowStop: .some(formatHHMM(callWindowStopTime))
+            )
+        )
+    }
+
+    func persistCallWindowTimes() async {
+        guard callOptInEnabled else { return }
+        await persist(
+            patch: NotificationPreferencesPatch(
+                callPhoneNumber: .some(normalizedCallPhoneNumber()),
+                callWindowStart: .some(formatHHMM(callWindowStartTime)),
+                callWindowStop: .some(formatHHMM(callWindowStopTime))
+            )
+        )
+    }
+
     func persistTimezone(_ tz: String) async {
         timezoneDisplay = tz
         await persist(patch: NotificationPreferencesPatch(tz: tz))
@@ -186,6 +228,27 @@ final class NotificationPreferencesViewModel {
         if let end = dto.quietHoursEnd, let parsed = parseHHMM(end) {
             quietEndTime = parsed
         }
+        callOptInEnabled = dto.callOptIn
+        callPhoneNumber = dto.callPhoneNumber ?? ""
+        if let start = dto.callWindowStart, let parsed = parseHHMM(start) {
+            callWindowStartTime = parsed
+        }
+        if let stop = dto.callWindowStop, let parsed = parseHHMM(stop) {
+            callWindowStopTime = parsed
+        }
+    }
+
+    private func normalizedCallPhoneNumber() -> String {
+        let trimmed = callPhoneNumber.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("+") {
+            return trimmed
+        }
+        let digits = trimmed.filter(\.isNumber)
+        guard !digits.isEmpty else { return trimmed }
+        if digits.count == 10 {
+            return "+1\(digits)"
+        }
+        return "+\(digits)"
     }
 
     private func formatHHMM(_ date: Date) -> String {

--- a/ios/StillPointApp/Views/NotificationsSettingsView.swift
+++ b/ios/StillPointApp/Views/NotificationsSettingsView.swift
@@ -18,10 +18,14 @@ struct NotificationsSettingsView: View {
 
                     sectionHeader("Quiet hours")
                     quietHoursSection
+                }
+                .disabled(!notificationPrefs.pushEnabled || notificationPrefs.isSaving)
 
-                    sectionHeader("Missed-sit phone call")
-                    missedSitCallSection
+                sectionHeader("Missed-sit phone call")
+                missedSitCallSection
+                    .disabled(notificationPrefs.isSaving)
 
+                Group {
                     sectionHeader("Miss a day")
                     missADayToggle
 
@@ -249,7 +253,10 @@ struct NotificationsSettingsView: View {
                 .textInputAutocapitalization(.never)
                 .disabled(notificationPrefs.isSaving)
                 .onSubmit {
-                    Task { await notificationPrefs.persistCallPhoneNumber() }
+                    Task { await notificationPrefs.persistCallSettingsIfReady() }
+                }
+                .onChange(of: notificationPrefs.callPhoneNumber) { _, _ in
+                    Task { await notificationPrefs.persistCallSettingsIfReady() }
                 }
                 .accessibilityIdentifier("notifications.callPhoneNumberField")
 
@@ -264,7 +271,7 @@ struct NotificationsSettingsView: View {
             .font(SPFont.mono(13))
             .disabled(notificationPrefs.isSaving)
             .onChange(of: notificationPrefs.callWindowStartTime) { _, _ in
-                Task { await notificationPrefs.persistCallWindowTimes() }
+                Task { await notificationPrefs.persistCallSettingsIfReady() }
             }
             .accessibilityIdentifier("notifications.callWindowStartPicker")
 
@@ -279,7 +286,7 @@ struct NotificationsSettingsView: View {
             .font(SPFont.mono(13))
             .disabled(notificationPrefs.isSaving)
             .onChange(of: notificationPrefs.callWindowStopTime) { _, _ in
-                Task { await notificationPrefs.persistCallWindowTimes() }
+                Task { await notificationPrefs.persistCallSettingsIfReady() }
             }
             .accessibilityIdentifier("notifications.callWindowStopPicker")
 

--- a/ios/StillPointApp/Views/NotificationsSettingsView.swift
+++ b/ios/StillPointApp/Views/NotificationsSettingsView.swift
@@ -19,6 +19,9 @@ struct NotificationsSettingsView: View {
                     sectionHeader("Quiet hours")
                     quietHoursSection
 
+                    sectionHeader("Missed-sit phone call")
+                    missedSitCallSection
+
                     sectionHeader("Miss a day")
                     missADayToggle
 
@@ -213,6 +216,77 @@ struct NotificationsSettingsView: View {
                 Task { await notificationPrefs.persistQuietHoursTimes() }
             }
             .accessibilityIdentifier("notifications.quietHoursEndPicker")
+        }
+    }
+
+    @ViewBuilder
+    private var missedSitCallSection: some View {
+        Toggle(isOn: Binding(
+            get: { notificationPrefs.callOptInEnabled },
+            set: { newValue in
+                Task { await notificationPrefs.persistCallOptInToggle(enabled: newValue) }
+            }
+        )) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Phone call when you miss a sit")
+                    .font(SPFont.mono(13))
+                    .foregroundStyle(Color(SPColor.fg))
+                Text("A voice check-in if you haven't meditated by your chosen time")
+                    .font(SPFont.serif(13, weight: .light))
+                    .foregroundStyle(Color(SPColor.fg4))
+            }
+        }
+        .tint(SPColor.green)
+        .disabled(notificationPrefs.isSaving)
+        .accessibilityIdentifier("notifications.callOptInToggle")
+
+        if notificationPrefs.callOptInEnabled {
+            TextField("Phone number (+1…)", text: $notificationPrefs.callPhoneNumber)
+                .font(SPFont.mono(13))
+                .keyboardType(.phonePad)
+                .textContentType(.telephoneNumber)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .disabled(notificationPrefs.isSaving)
+                .onSubmit {
+                    Task { await notificationPrefs.persistCallPhoneNumber() }
+                }
+                .accessibilityIdentifier("notifications.callPhoneNumberField")
+
+            DatePicker(
+                "Call from",
+                selection: Binding(
+                    get: { notificationPrefs.callWindowStartTime },
+                    set: { notificationPrefs.callWindowStartTime = $0 }
+                ),
+                displayedComponents: .hourAndMinute
+            )
+            .font(SPFont.mono(13))
+            .disabled(notificationPrefs.isSaving)
+            .onChange(of: notificationPrefs.callWindowStartTime) { _, _ in
+                Task { await notificationPrefs.persistCallWindowTimes() }
+            }
+            .accessibilityIdentifier("notifications.callWindowStartPicker")
+
+            DatePicker(
+                "Call until",
+                selection: Binding(
+                    get: { notificationPrefs.callWindowStopTime },
+                    set: { notificationPrefs.callWindowStopTime = $0 }
+                ),
+                displayedComponents: .hourAndMinute
+            )
+            .font(SPFont.mono(13))
+            .disabled(notificationPrefs.isSaving)
+            .onChange(of: notificationPrefs.callWindowStopTime) { _, _ in
+                Task { await notificationPrefs.persistCallWindowTimes() }
+            }
+            .accessibilityIdentifier("notifications.callWindowStopPicker")
+
+            Text("By enabling, you consent to receive automated motivational check-in calls at the phone number above during your chosen window.")
+                .font(SPFont.serif(12, weight: .light))
+                .foregroundStyle(Color(SPColor.fg4))
+                .accessibilityIdentifier("notifications.callConsentCopy")
         }
     }
 

--- a/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/DTOs/DTOs.swift
@@ -785,6 +785,12 @@ public struct NotificationPreferencesDTO: Codable, Sendable, Equatable {
     public let dailyReminderFrequency: DailyReminderFrequency
     public let quietHoursStart: String?
     public let quietHoursEnd: String?
+    /// Opt-in (#599): outbound missed-sit voice call via Vapi.
+    public let callOptIn: Bool
+    public let callPhoneNumber: String?
+    public let callConsentAt: String?
+    public let callWindowStart: String?
+    public let callWindowStop: String?
     public let tz: String
     public let updatedAt: String?
 
@@ -799,6 +805,11 @@ public struct NotificationPreferencesDTO: Codable, Sendable, Equatable {
         dailyReminderFrequency: DailyReminderFrequency,
         quietHoursStart: String?,
         quietHoursEnd: String?,
+        callOptIn: Bool = false,
+        callPhoneNumber: String? = nil,
+        callConsentAt: String? = nil,
+        callWindowStart: String? = nil,
+        callWindowStop: String? = nil,
         tz: String,
         updatedAt: String? = nil
     ) {
@@ -812,6 +823,11 @@ public struct NotificationPreferencesDTO: Codable, Sendable, Equatable {
         self.dailyReminderFrequency = dailyReminderFrequency
         self.quietHoursStart = quietHoursStart
         self.quietHoursEnd = quietHoursEnd
+        self.callOptIn = callOptIn
+        self.callPhoneNumber = callPhoneNumber
+        self.callConsentAt = callConsentAt
+        self.callWindowStart = callWindowStart
+        self.callWindowStop = callWindowStop
         self.tz = tz
         self.updatedAt = updatedAt
     }
@@ -830,6 +846,11 @@ public struct NotificationPreferencesDTO: Codable, Sendable, Equatable {
         dailyReminderFrequency = try c.decode(DailyReminderFrequency.self, forKey: .dailyReminderFrequency)
         quietHoursStart = try c.decodeIfPresent(String.self, forKey: .quietHoursStart)
         quietHoursEnd = try c.decodeIfPresent(String.self, forKey: .quietHoursEnd)
+        callOptIn = try c.decodeIfPresent(Bool.self, forKey: .callOptIn) ?? false
+        callPhoneNumber = try c.decodeIfPresent(String.self, forKey: .callPhoneNumber)
+        callConsentAt = try c.decodeIfPresent(String.self, forKey: .callConsentAt)
+        callWindowStart = try c.decodeIfPresent(String.self, forKey: .callWindowStart)
+        callWindowStop = try c.decodeIfPresent(String.self, forKey: .callWindowStop)
         tz = try c.decode(String.self, forKey: .tz)
         updatedAt = try c.decodeIfPresent(String.self, forKey: .updatedAt)
     }
@@ -845,6 +866,11 @@ public struct NotificationPreferencesDTO: Codable, Sendable, Equatable {
         case dailyReminderFrequency
         case quietHoursStart
         case quietHoursEnd
+        case callOptIn
+        case callPhoneNumber
+        case callConsentAt
+        case callWindowStart
+        case callWindowStop
         case tz
         case updatedAt
     }
@@ -865,6 +891,10 @@ public struct NotificationPreferencesPatch: Encodable, Sendable {
     public var dailyReminderFrequency: DailyReminderFrequency?
     public var quietHoursStart: String??
     public var quietHoursEnd: String??
+    public var callOptIn: Bool?
+    public var callPhoneNumber: String??
+    public var callWindowStart: String??
+    public var callWindowStop: String??
     public var tz: String?
 
     public init(
@@ -878,6 +908,10 @@ public struct NotificationPreferencesPatch: Encodable, Sendable {
         dailyReminderFrequency: DailyReminderFrequency? = nil,
         quietHoursStart: String?? = nil,
         quietHoursEnd: String?? = nil,
+        callOptIn: Bool? = nil,
+        callPhoneNumber: String?? = nil,
+        callWindowStart: String?? = nil,
+        callWindowStop: String?? = nil,
         tz: String? = nil
     ) {
         self.pushEnabled = pushEnabled
@@ -890,6 +924,10 @@ public struct NotificationPreferencesPatch: Encodable, Sendable {
         self.dailyReminderFrequency = dailyReminderFrequency
         self.quietHoursStart = quietHoursStart
         self.quietHoursEnd = quietHoursEnd
+        self.callOptIn = callOptIn
+        self.callPhoneNumber = callPhoneNumber
+        self.callWindowStart = callWindowStart
+        self.callWindowStop = callWindowStop
         self.tz = tz
     }
 
@@ -919,6 +957,25 @@ public struct NotificationPreferencesPatch: Encodable, Sendable {
             case .some(let value): try c.encode(value, forKey: .quietHoursEnd)
             }
         }
+        if let callOptIn { try c.encode(callOptIn, forKey: .callOptIn) }
+        if let callPhoneNumber {
+            switch callPhoneNumber {
+            case .none: try c.encodeNil(forKey: .callPhoneNumber)
+            case .some(let value): try c.encode(value, forKey: .callPhoneNumber)
+            }
+        }
+        if let callWindowStart {
+            switch callWindowStart {
+            case .none: try c.encodeNil(forKey: .callWindowStart)
+            case .some(let value): try c.encode(value, forKey: .callWindowStart)
+            }
+        }
+        if let callWindowStop {
+            switch callWindowStop {
+            case .none: try c.encodeNil(forKey: .callWindowStop)
+            case .some(let value): try c.encode(value, forKey: .callWindowStop)
+            }
+        }
         if let tz { try c.encode(tz, forKey: .tz) }
     }
 
@@ -933,6 +990,10 @@ public struct NotificationPreferencesPatch: Encodable, Sendable {
         case dailyReminderFrequency
         case quietHoursStart
         case quietHoursEnd
+        case callOptIn
+        case callPhoneNumber
+        case callWindowStart
+        case callWindowStop
         case tz
     }
 }

--- a/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
@@ -578,6 +578,20 @@ actor UITestAPIStore {
         }
 
         let nextCallOptIn = patch.callOptIn ?? current.callOptIn
+        if nextCallOptIn {
+            guard let phone = callPhone,
+                  phone.hasPrefix("+"),
+                  phone.count >= 8,
+                  let start = callWindowStart,
+                  let stop = callWindowStop,
+                  start != stop else {
+                throw APIError(
+                    status: 400,
+                    message: "callOptIn requires callPhoneNumber plus callWindowStart and callWindowStop",
+                    code: "VALIDATION_ERROR"
+                )
+            }
+        }
         let nextCallConsentAt: String? = {
             if patch.callOptIn == true && !current.callOptIn {
                 return ISO8601DateFormatter().string(from: Date())

--- a/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
@@ -543,6 +543,9 @@ actor UITestAPIStore {
         let current = notificationPreferences
         var quietStart = current.quietHoursStart
         var quietEnd = current.quietHoursEnd
+        var callPhone = current.callPhoneNumber
+        var callWindowStart = current.callWindowStart
+        var callWindowStop = current.callWindowStop
         if let quietHoursStart = patch.quietHoursStart {
             switch quietHoursStart {
             case .none: quietStart = nil
@@ -555,6 +558,35 @@ actor UITestAPIStore {
             case .some(let value): quietEnd = value
             }
         }
+        if let callPhoneNumber = patch.callPhoneNumber {
+            switch callPhoneNumber {
+            case .none: callPhone = nil
+            case .some(let value): callPhone = value
+            }
+        }
+        if let callWindowStartPatch = patch.callWindowStart {
+            switch callWindowStartPatch {
+            case .none: callWindowStart = nil
+            case .some(let value): callWindowStart = value
+            }
+        }
+        if let callWindowStopPatch = patch.callWindowStop {
+            switch callWindowStopPatch {
+            case .none: callWindowStop = nil
+            case .some(let value): callWindowStop = value
+            }
+        }
+
+        let nextCallOptIn = patch.callOptIn ?? current.callOptIn
+        let nextCallConsentAt: String? = {
+            if patch.callOptIn == true && !current.callOptIn {
+                return ISO8601DateFormatter().string(from: Date())
+            }
+            if patch.callOptIn == false {
+                return nil
+            }
+            return current.callConsentAt
+        }()
 
         let next = NotificationPreferencesDTO(
             pushEnabled: patch.pushEnabled ?? current.pushEnabled,
@@ -567,6 +599,11 @@ actor UITestAPIStore {
             dailyReminderFrequency: patch.dailyReminderFrequency ?? current.dailyReminderFrequency,
             quietHoursStart: quietStart,
             quietHoursEnd: quietEnd,
+            callOptIn: nextCallOptIn,
+            callPhoneNumber: callPhone,
+            callConsentAt: nextCallConsentAt,
+            callWindowStart: callWindowStart,
+            callWindowStop: callWindowStop,
             tz: patch.tz ?? current.tz,
             updatedAt: current.updatedAt
         )

--- a/ios/StillPointShared/Tests/StillPointSharedTests/NotificationPreferencesCallOptInEncodingTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/NotificationPreferencesCallOptInEncodingTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import StillPointShared
+
+final class NotificationPreferencesCallOptInEncodingTests: XCTestCase {
+    func testPatchEncodesCallOptInFieldsWhenSet() throws {
+        let patch = NotificationPreferencesPatch(
+            callOptIn: true,
+            callPhoneNumber: .some("+15551234567"),
+            callWindowStart: .some("18:00"),
+            callWindowStop: .some("21:00")
+        )
+
+        let data = try JSONEncoder().encode(patch)
+        let jsonObject = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(jsonObject["callOptIn"] as? Bool, true)
+        XCTAssertEqual(jsonObject["callPhoneNumber"] as? String, "+15551234567")
+        XCTAssertEqual(jsonObject["callWindowStart"] as? String, "18:00")
+        XCTAssertEqual(jsonObject["callWindowStop"] as? String, "21:00")
+    }
+
+    func testDTODecodesCallOptInFields() throws {
+        let json = """
+        {
+            "pushEnabled": true,
+            "dailyReminderEnabled": false,
+            "missADayEnabled": false,
+            "friendRequestNotificationsEnabled": true,
+            "failureReasonReminderEnabled": false,
+            "suppressDuringSession": false,
+            "dailyReminderTime": "09:00",
+            "dailyReminderFrequency": "daily",
+            "quietHoursStart": null,
+            "quietHoursEnd": null,
+            "callOptIn": true,
+            "callPhoneNumber": "+15551234567",
+            "callConsentAt": "2026-06-25T12:00:00.000Z",
+            "callWindowStart": "18:00",
+            "callWindowStop": "21:00",
+            "tz": "America/New_York",
+            "updatedAt": "2026-06-25T12:00:00.000Z"
+        }
+        """.data(using: .utf8)!
+
+        let dto = try JSONDecoder().decode(NotificationPreferencesDTO.self, from: json)
+
+        XCTAssertTrue(dto.callOptIn)
+        XCTAssertEqual(dto.callPhoneNumber, "+15551234567")
+        XCTAssertEqual(dto.callWindowStart, "18:00")
+        XCTAssertEqual(dto.callWindowStop, "21:00")
+    }
+}


### PR DESCRIPTION
## **User description**
## Summary
- Extend `NotificationPreferencesDTO` / `NotificationPreferencesPatch` with call opt-in fields
- Add missed-sit call section to `NotificationsSettingsView` mirroring quiet-hours UX
- Persist via existing PATCH flow with phone normalization and consent copy

Closes #641

## Test plan
- [x] Added `NotificationPreferencesCallOptInEncodingTests`
- [ ] Manual: opt in, set phone + window, verify PATCH payload in network inspector


Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
Add missed-sit phone call settings to iOS notifications

### What Changed
- Users can opt in to an automated phone call when they miss a meditation session
- The settings include a phone number, call start and end times, and consent messaging
- Phone numbers are normalized and call preferences are saved and restored with notification settings
- Added coverage for saving and loading call opt-in details

### Impact
`✅ User-controlled missed-sit calls`
`✅ Configurable call windows`
`✅ Clearer consent before automated calls`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
