### PR TITLE
feat(notifications): hourly missed-sit call dispatch (#640)

### DIFF
--- a/src/lib/notification-scheduler.test.ts
+++ b/src/lib/notification-scheduler.test.ts
@@ -12,11 +12,8 @@ const sendDailyReminderNotification = vi.fn();
 const sendMissADayNotification = vi.fn();
 const sendFailureReasonReminderNotification = vi.fn();
 
-const dbSelect = vi.fn(() => ({
-  from: vi.fn(() => ({
-    where: vi.fn(() => Promise.resolve(preferenceRows)),
-  })),
-}));
+const dbSelect = vi.fn();
+let callCandidateRows: Array<Record<string, unknown>> = [];
 
 vi.mock("@/db", () => ({
   db: {
@@ -27,10 +24,11 @@ vi.mock("@/db", () => ({
 }));
 
 vi.mock("@/db/schema", () => ({
-  notificationPreferences: { table: "notification_preferences" },
+  notificationPreferences: { table: "notification_preferences", callOptIn: "callOptIn" },
   notificationDispatches: { table: "notification_dispatches" },
   sessions: { table: "sessions" },
   failureReasons: { table: "failure_reasons" },
+  users: { table: "users", username: "username" },
 }));
 
 vi.mock("@/lib/notifications", () => ({
@@ -57,6 +55,12 @@ vi.mock("@/lib/notifications/failure-reason", () => ({
   hasFailureReasonForDate,
 }));
 
+const initiateMissedSitCall = vi.fn();
+
+vi.mock("@/lib/vapi", () => ({
+  initiateMissedSitCall,
+}));
+
 vi.mock("drizzle-orm", () => ({
   and: vi.fn((...args) => ({ and: args })),
   eq: vi.fn((left, right) => ({ left, right })),
@@ -80,6 +84,15 @@ describe("notification scheduler", () => {
     vi.clearAllMocks();
     vi.resetModules();
     preferenceRows = [basePrefs];
+    callCandidateRows = [];
+    dbSelect.mockImplementation(() => ({
+      from: vi.fn(() => ({
+        innerJoin: vi.fn(() => ({
+          where: vi.fn(() => Promise.resolve(callCandidateRows)),
+        })),
+        where: vi.fn(() => Promise.resolve(preferenceRows)),
+      })),
+    }));
     sendDailyReminderNotification.mockReset();
     sendMissADayNotification.mockReset();
     sendFailureReasonReminderNotification.mockReset();
@@ -92,6 +105,35 @@ describe("notification scheduler", () => {
     userCompletedSessionOnDate.mockResolvedValue(false);
     hasFailureReasonForDate.mockResolvedValue(false);
     loadUserStreak.mockResolvedValue(0);
+    initiateMissedSitCall.mockResolvedValue({ ok: true, callId: "call-1", attemptId: "attempt-1" });
+  });
+
+  test("listHourlyCallSlotMinutes returns hourly bounds inclusive", async () => {
+    const { listHourlyCallSlotMinutes } = await import("./notification-scheduler");
+    expect(listHourlyCallSlotMinutes("18:00", "21:00")).toEqual([18 * 60, 19 * 60, 20 * 60, 21 * 60]);
+  });
+
+  test("evaluateMissedSitCallDue matches hourly slot within cron window", async () => {
+    const { evaluateMissedSitCallDue } = await import("./notification-scheduler");
+    const result = evaluateMissedSitCallDue(18 * 60 + 2, "18:00", "21:00");
+    expect(result).toEqual({ due: true, slotMinutes: 18 * 60, dayOffset: 0 });
+  });
+
+  test("dispatchDueNotifications initiates missed-sit call when due", async () => {
+    callCandidateRows = [{
+      userId: "user-1",
+      callPhoneNumber: "+15551234567",
+      callWindowStart: "18:00",
+      callWindowStop: "21:00",
+      tz: "UTC",
+      username: "Alex",
+    }];
+
+    const { dispatchDueNotifications } = await import("./notification-scheduler");
+    const result = await dispatchDueNotifications(new Date("2026-05-29T18:02:00.000Z"));
+
+    expect(result.callsInitiated).toBe(1);
+    expect(initiateMissedSitCall).toHaveBeenCalled();
   });
 
   test("claimNotificationDispatch is idempotent on conflict", async () => {

--- a/src/lib/notification-scheduler.ts
+++ b/src/lib/notification-scheduler.ts
@@ -331,12 +331,15 @@ async function releaseMissedSitCallClaim(userId: string, windowKey: string): Pro
 }
 
 async function countDaysMissed(userId: string, anchorDateKey: string): Promise<number> {
-  let days = 0;
-  let dateKey = anchorDateKey;
+  if (await userCompletedSessionOnDate(userId, anchorDateKey)) {
+    return 0;
+  }
+  let days = 1;
+  let dateKey = addCalendarDays(anchorDateKey, -1);
   while (!(await userCompletedSessionOnDate(userId, dateKey))) {
     days += 1;
     dateKey = addCalendarDays(dateKey, -1);
-    if (days > 90) {
+    if (days >= 14) {
       break;
     }
   }
@@ -417,6 +420,7 @@ function addCalendarDays(dateKey: string, deltaDays: number): string {
 
 export async function dispatchDueNotifications(now: Date = new Date()): Promise<{
   scanned: number;
+  callCandidatesScanned: number;
   sent: number;
   skipped: number;
   missADaySent: number;
@@ -613,10 +617,6 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
       }
 
       const local = getLocalParts(now, prefs.tz);
-      if (await userCompletedSessionOnDate(prefs.userId, local.dateKey)) {
-        continue;
-      }
-
       const { due, slotMinutes, dayOffset } = evaluateMissedSitCallDue(
         local.minutesSinceMidnight,
         prefs.callWindowStart,
@@ -627,6 +627,10 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
       }
 
       const intendedDateKey = addCalendarDays(local.dateKey, dayOffset);
+      if (await userCompletedSessionOnDate(prefs.userId, intendedDateKey)) {
+        continue;
+      }
+
       const windowKey = missedSitCallWindowKey(intendedDateKey, slotMinutes);
       const claimed = await claimNotificationDispatch({
         userId: prefs.userId,
@@ -654,8 +658,6 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
         });
         if (result.ok) {
           callsInitiated += 1;
-        } else {
-          await releaseMissedSitCallClaim(prefs.userId, windowKey);
         }
       } catch (callError) {
         console.error(`Failed to initiate missed-sit call for user ${prefs.userId}:`, callError);
@@ -667,7 +669,8 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
   }
 
   return {
-    scanned: candidates.length + callCandidates.length,
+    scanned: candidates.length,
+    callCandidatesScanned: callCandidates.length,
     sent,
     skipped,
     missADaySent,

--- a/src/lib/notification-scheduler.ts
+++ b/src/lib/notification-scheduler.ts
@@ -1,6 +1,6 @@
 import { and, eq, or } from "drizzle-orm";
 import { db } from "@/db";
-import { notificationDispatches, notificationPreferences } from "@/db/schema";
+import { notificationDispatches, notificationPreferences, users } from "@/db/schema";
 import type { DailyReminderFrequency } from "@/lib/notification-preferences";
 import {
   hasMissADayDispatchForDate,
@@ -17,6 +17,9 @@ import {
   sendFailureReasonReminderNotification,
   sendMissADayNotification,
 } from "@/lib/notifications";
+import { initiateMissedSitCall } from "@/lib/vapi";
+
+export const MISSED_SIT_CALL_NOTIFICATION_TYPE = "missed_sit_call";
 
 /** Five-minute lookback for each cron tick. See docs/notifications.md § Scheduler
  *  for the DST spring-forward gap: a reminder inside the skipped local hour (e.g.
@@ -189,6 +192,54 @@ export function evaluateReminderDispatchWindow(
   return { due: true, dayOffset };
 }
 
+export function listHourlyCallSlotMinutes(windowStart: string, windowStop: string): number[] {
+  const start = parseReminderMinutes(windowStart);
+  const stop = parseReminderMinutes(windowStop);
+  const dayMinutes = 24 * 60;
+  const slots: number[] = [];
+
+  if (start === stop) {
+    return slots;
+  }
+  if (start < stop) {
+    for (let minute = start; minute <= stop; minute += 60) {
+      slots.push(minute);
+    }
+    return slots;
+  }
+
+  for (let minute = start; minute < dayMinutes; minute += 60) {
+    slots.push(minute);
+  }
+  for (let minute = 0; minute <= stop; minute += 60) {
+    slots.push(minute);
+  }
+  return slots;
+}
+
+export function missedSitCallWindowKey(dateKey: string, slotMinutes: number): string {
+  const hour = Math.floor(slotMinutes / 60);
+  return `${dateKey}T${String(hour).padStart(2, "0")}`;
+}
+
+export function evaluateMissedSitCallDue(
+  localMinutes: number,
+  windowStart: string,
+  windowStop: string,
+): { due: boolean; slotMinutes: number | null; dayOffset: 0 | -1 } {
+  for (const slotMinutes of listHourlyCallSlotMinutes(windowStart, windowStop)) {
+    const window = isWithinCronWindow(localMinutes, slotMinutes);
+    if (window.within) {
+      return {
+        due: true,
+        slotMinutes,
+        dayOffset: window.dayOffset,
+      };
+    }
+  }
+  return { due: false, slotMinutes: null, dayOffset: 0 };
+}
+
 function frequencyAllowsSend(
   frequency: DailyReminderFrequency,
   intendedDateKey: string,
@@ -265,6 +316,31 @@ async function releaseFailureReasonClaim(userId: string, windowKey: string): Pro
         eq(notificationDispatches.windowKey, windowKey),
       ),
     );
+}
+
+async function releaseMissedSitCallClaim(userId: string, windowKey: string): Promise<void> {
+  await db
+    .delete(notificationDispatches)
+    .where(
+      and(
+        eq(notificationDispatches.userId, userId),
+        eq(notificationDispatches.notificationType, MISSED_SIT_CALL_NOTIFICATION_TYPE),
+        eq(notificationDispatches.windowKey, windowKey),
+      ),
+    );
+}
+
+async function countDaysMissed(userId: string, anchorDateKey: string): Promise<number> {
+  let days = 0;
+  let dateKey = anchorDateKey;
+  while (!(await userCompletedSessionOnDate(userId, dateKey))) {
+    days += 1;
+    dateKey = addCalendarDays(dateKey, -1);
+    if (days > 90) {
+      break;
+    }
+  }
+  return days;
 }
 
 /**
@@ -345,6 +421,7 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
   skipped: number;
   missADaySent: number;
   failureReasonSent: number;
+  callsInitiated: number;
 }> {
   const candidates = await db
     .select()
@@ -364,6 +441,7 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
   let skipped = 0;
   let missADaySent = 0;
   let failureReasonSent = 0;
+  let callsInitiated = 0;
 
   for (const prefs of candidates) {
     try {
@@ -515,5 +593,85 @@ export async function dispatchDueNotifications(now: Date = new Date()): Promise<
     }
   }
 
-  return { scanned: candidates.length, sent, skipped, missADaySent, failureReasonSent };
+  const callCandidates = await db
+    .select({
+      userId: notificationPreferences.userId,
+      callPhoneNumber: notificationPreferences.callPhoneNumber,
+      callWindowStart: notificationPreferences.callWindowStart,
+      callWindowStop: notificationPreferences.callWindowStop,
+      tz: notificationPreferences.tz,
+      username: users.username,
+    })
+    .from(notificationPreferences)
+    .innerJoin(users, eq(notificationPreferences.userId, users.id))
+    .where(eq(notificationPreferences.callOptIn, true));
+
+  for (const prefs of callCandidates) {
+    try {
+      if (!prefs.callPhoneNumber || !prefs.callWindowStart || !prefs.callWindowStop) {
+        continue;
+      }
+
+      const local = getLocalParts(now, prefs.tz);
+      if (await userCompletedSessionOnDate(prefs.userId, local.dateKey)) {
+        continue;
+      }
+
+      const { due, slotMinutes, dayOffset } = evaluateMissedSitCallDue(
+        local.minutesSinceMidnight,
+        prefs.callWindowStart,
+        prefs.callWindowStop,
+      );
+      if (!due || slotMinutes === null) {
+        continue;
+      }
+
+      const intendedDateKey = addCalendarDays(local.dateKey, dayOffset);
+      const windowKey = missedSitCallWindowKey(intendedDateKey, slotMinutes);
+      const claimed = await claimNotificationDispatch({
+        userId: prefs.userId,
+        notificationType: MISSED_SIT_CALL_NOTIFICATION_TYPE,
+        windowKey,
+      });
+      if (!claimed) {
+        continue;
+      }
+
+      try {
+        const [currentStreak, daysMissed] = await Promise.all([
+          loadUserStreak(prefs.userId, intendedDateKey),
+          countDaysMissed(prefs.userId, intendedDateKey),
+        ]);
+        const result = await initiateMissedSitCall({
+          userId: prefs.userId,
+          phoneNumber: prefs.callPhoneNumber,
+          windowKey,
+          context: {
+            userName: prefs.username,
+            currentStreak,
+            daysMissed,
+          },
+        });
+        if (result.ok) {
+          callsInitiated += 1;
+        } else {
+          await releaseMissedSitCallClaim(prefs.userId, windowKey);
+        }
+      } catch (callError) {
+        console.error(`Failed to initiate missed-sit call for user ${prefs.userId}:`, callError);
+        await releaseMissedSitCallClaim(prefs.userId, windowKey);
+      }
+    } catch (error) {
+      console.error(`Missed-sit call scheduler error for user ${prefs.userId}:`, error);
+    }
+  }
+
+  return {
+    scanned: candidates.length + callCandidates.length,
+    sent,
+    skipped,
+    missADaySent,
+    failureReasonSent,
+    callsInitiated,
+  };
 }


### PR DESCRIPTION
## **User description**
## Summary
- Add pure hourly slot helpers and `evaluateMissedSitCallDue` in `notification-scheduler.ts`
- Dispatch `missed_sit_call` for opted-in users via `initiateMissedSitCall`, skipping users who sat today
- Expose `callsInitiated` in cron dispatch results

Closes #640

## Test plan
- [x] `npx vitest run src/lib/notification-scheduler.test.ts`

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
Dispatch hourly missed-sit reminder calls for opted-in users

### What Changed
- Users who opt in to phone reminders can receive a call during each hourly slot in their configured local-time window when they have not completed a sit
- Completed sits and previously handled hourly slots prevent duplicate calls
- Calls include the user's name, current streak, and consecutive missed-day count
- Scheduler results now report call candidates scanned and calls initiated
- Added coverage for hourly slot timing and missed-sit call dispatch

### Impact
`✅ Timely missed-sit calls`
`✅ Fewer duplicate reminder calls`
`✅ Personalized call context`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
