### PR TITLE
fix(ios): warm audio engine when a sound is re-enabled mid-sit (#667)

### DIFF
--- a/ios/StillPointApp/ViewModels/BuddySessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/BuddySessionViewModel.swift
@@ -189,14 +189,34 @@ final class BuddySessionViewModel {
     // MARK: - Sound Preferences (#554)
 
     func toggleSound(_ keyPath: WritableKeyPath<AudioEngine.SoundPrefs, Bool>) {
+        let toggledKeyWasEnabled = soundPrefs[keyPath: keyPath]
         let voiceCountdownWasEnabled = soundPrefs.voiceCountdown
         soundPrefs[keyPath: keyPath].toggle()
         AudioEngine.savePrefs(soundPrefs)
-        if !voiceCountdownWasEnabled && soundPrefs.voiceCountdown {
+
+        let effects = SoundToggleLogic.effects(
+            toggledKeyWasEnabled: toggledKeyWasEnabled,
+            toggledKeyIsEnabled: soundPrefs[keyPath: keyPath],
+            voiceCountdownWasEnabled: voiceCountdownWasEnabled,
+            voiceCountdownIsEnabled: soundPrefs.voiceCountdown
+        )
+
+        if effects.warmUp {
+            // #667: this view model never warms the engine anywhere, so a buddy sit
+            // could leave the audio session inactive for its whole run. Reactivate on
+            // any off→on toggle so the re-enabled sound is audible.
+            AudioEngine.shared.warmUp()
+        }
+        if effects.preloadVoiceCountdown {
             AudioEngine.shared.preloadVoiceCountdown()
-        } else if voiceCountdownWasEnabled && !soundPrefs.voiceCountdown {
-            // Voice countdown was just disabled — stop any in-flight clip.
+        }
+        if effects.resetVoiceDedup {
+            // Voice countdown was just disabled — reset dedup state so re-enabling
+            // during the same remaining second announces correctly (#554).
             lastVoiceCountdownSec = 0
+        }
+        if effects.cancelVoiceCountdown {
+            // Stop any in-flight clip.
             AudioEngine.shared.cancelVoiceCountdownPlayback()
         }
     }

--- a/ios/StillPointApp/ViewModels/SessionViewModel.swift
+++ b/ios/StillPointApp/ViewModels/SessionViewModel.swift
@@ -256,16 +256,35 @@ final class SessionViewModel {
     }
 
     func toggleSound(_ keyPath: WritableKeyPath<AudioEngine.SoundPrefs, Bool>) {
+        let toggledKeyWasEnabled = soundPrefs[keyPath: keyPath]
         let voiceCountdownWasEnabled = soundPrefs.voiceCountdown
         soundPrefs[keyPath: keyPath].toggle()
         AudioEngine.savePrefs(soundPrefs)
-        if !voiceCountdownWasEnabled && soundPrefs.voiceCountdown {
+
+        let effects = SoundToggleLogic.effects(
+            toggledKeyWasEnabled: toggledKeyWasEnabled,
+            toggledKeyIsEnabled: soundPrefs[keyPath: keyPath],
+            voiceCountdownWasEnabled: voiceCountdownWasEnabled,
+            voiceCountdownIsEnabled: soundPrefs.voiceCountdown
+        )
+
+        if effects.warmUp {
+            // #667: `start()` only warms the engine when a sound is already on, so a
+            // sit begun with everything off leaves the audio session inactive.
+            // Reactivate it here so the re-enabled sound is audible at its next
+            // scheduled play point — no restart required.
+            AudioEngine.shared.warmUp()
+        }
+        if effects.preloadVoiceCountdown {
             // Voice countdown was just enabled — prime the buffer cache.
             AudioEngine.shared.preloadVoiceCountdown()
-        } else if voiceCountdownWasEnabled && !soundPrefs.voiceCountdown {
+        }
+        if effects.resetVoiceDedup {
             // Voice countdown was just disabled — reset dedup state so re-enabling
             // during the same remaining second announces correctly (#554).
             lastVoiceCountdownSec = 0
+        }
+        if effects.cancelVoiceCountdown {
             AudioEngine.shared.cancelVoiceCountdownPlayback()
         }
     }

--- a/ios/StillPointShared/Sources/StillPointShared/SoundToggleLogic.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/SoundToggleLogic.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Pure decision logic for the mid-session sound toggles (tick / chime / end / voice).
+///
+/// A sit can begin with every sound off, which leaves the shared audio session
+/// inactive — nothing ever called `AudioEngine.warmUp()`. Re-enabling a sound
+/// mid-sit then had nothing to play through and stayed silent for the rest of the
+/// session (#667). Any off→on transition must reactivate the audio session so the
+/// next scheduled sound is audible without restarting the sit.
+///
+/// Free of AVFoundation / UIKit so it compiles and runs under `swift test` on macOS.
+public enum SoundToggleLogic {
+
+    /// The audio side effects a single toggle requires.
+    public struct Effects: Equatable {
+        /// Reactivate the audio session so the next sound is audible (#667).
+        public let warmUp: Bool
+        /// Prime the voice-countdown buffer cache.
+        public let preloadVoiceCountdown: Bool
+        /// Stop any in-flight voice-countdown clip.
+        public let cancelVoiceCountdown: Bool
+        /// Clear the announced-second dedup so re-enabling during the same
+        /// remaining second announces correctly (#554).
+        public let resetVoiceDedup: Bool
+
+        public init(
+            warmUp: Bool,
+            preloadVoiceCountdown: Bool,
+            cancelVoiceCountdown: Bool,
+            resetVoiceDedup: Bool
+        ) {
+            self.warmUp = warmUp
+            self.preloadVoiceCountdown = preloadVoiceCountdown
+            self.cancelVoiceCountdown = cancelVoiceCountdown
+            self.resetVoiceDedup = resetVoiceDedup
+        }
+    }
+
+    /// Computes the side effects for one toggle.
+    ///
+    /// The toggled-key parameters describe whichever of the four sounds the user
+    /// tapped; the `voiceCountdown` parameters describe the voice pref before and
+    /// after the same toggle. When voice itself is the toggled key both pairs
+    /// carry the same values.
+    ///
+    /// - Parameters:
+    ///   - toggledKeyWasEnabled: Value of the toggled pref before the tap.
+    ///   - toggledKeyIsEnabled: Value of the toggled pref after the tap.
+    ///   - voiceCountdownWasEnabled: Value of `voiceCountdown` before the tap.
+    ///   - voiceCountdownIsEnabled: Value of `voiceCountdown` after the tap.
+    /// - Returns: The side effects the caller must apply, in `warmUp` →
+    ///   `preloadVoiceCountdown` → dedup-reset → cancel order.
+    public static func effects(
+        toggledKeyWasEnabled: Bool,
+        toggledKeyIsEnabled: Bool,
+        voiceCountdownWasEnabled: Bool,
+        voiceCountdownIsEnabled: Bool
+    ) -> Effects {
+        // #667: only an off→on transition needs the audio session reactivated.
+        // Turning a sound off must stay a pure preference write.
+        let didEnable = !toggledKeyWasEnabled && toggledKeyIsEnabled
+        let voiceDidEnable = !voiceCountdownWasEnabled && voiceCountdownIsEnabled
+        let voiceDidDisable = voiceCountdownWasEnabled && !voiceCountdownIsEnabled
+
+        return Effects(
+            warmUp: didEnable,
+            preloadVoiceCountdown: voiceDidEnable,
+            // #554: disabling voice stops the in-flight clip and clears the dedup
+            // so a re-enable inside the same remaining second still announces.
+            cancelVoiceCountdown: voiceDidDisable,
+            resetVoiceDedup: voiceDidDisable
+        )
+    }
+}

--- a/ios/StillPointShared/Tests/StillPointSharedTests/SoundToggleLogicTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/SoundToggleLogicTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+@testable import StillPointShared
+
+final class SoundToggleLogicTests: XCTestCase {
+
+    /// Convenience for the three non-voice sounds: the toggled key changes while
+    /// `voiceCountdown` stays put.
+    private func effectsForNonVoiceToggle(
+        wasEnabled: Bool,
+        voiceCountdown: Bool = false
+    ) -> SoundToggleLogic.Effects {
+        SoundToggleLogic.effects(
+            toggledKeyWasEnabled: wasEnabled,
+            toggledKeyIsEnabled: !wasEnabled,
+            voiceCountdownWasEnabled: voiceCountdown,
+            voiceCountdownIsEnabled: voiceCountdown
+        )
+    }
+
+    /// Convenience for the voice toggle itself: both pairs move together.
+    private func effectsForVoiceToggle(wasEnabled: Bool) -> SoundToggleLogic.Effects {
+        SoundToggleLogic.effects(
+            toggledKeyWasEnabled: wasEnabled,
+            toggledKeyIsEnabled: !wasEnabled,
+            voiceCountdownWasEnabled: wasEnabled,
+            voiceCountdownIsEnabled: !wasEnabled
+        )
+    }
+
+    // MARK: - warmUp (#667)
+
+    func testOffToOnTransitionWarmsUp() {
+        XCTAssertTrue(effectsForNonVoiceToggle(wasEnabled: false).warmUp)
+    }
+
+    func testOnToOffTransitionDoesNotWarmUp() {
+        XCTAssertFalse(effectsForNonVoiceToggle(wasEnabled: true).warmUp)
+    }
+
+    /// All four toggles route through the single `toggleSound` path, so one
+    /// decision function has to cover tick, chime, end, and voice alike.
+    func testEveryKeyWarmsUpOnEnableAndNotOnDisable() {
+        // tick / chime / end: voiceCountdown is untouched by the toggle.
+        for voiceState in [false, true] {
+            XCTAssertTrue(
+                effectsForNonVoiceToggle(wasEnabled: false, voiceCountdown: voiceState).warmUp,
+                "off→on must warm up (voiceCountdown = \(voiceState))"
+            )
+            XCTAssertFalse(
+                effectsForNonVoiceToggle(wasEnabled: true, voiceCountdown: voiceState).warmUp,
+                "on→off must not warm up (voiceCountdown = \(voiceState))"
+            )
+        }
+
+        // voice: the toggled key and voiceCountdown move together.
+        XCTAssertTrue(effectsForVoiceToggle(wasEnabled: false).warmUp)
+        XCTAssertFalse(effectsForVoiceToggle(wasEnabled: true).warmUp)
+    }
+
+    func testNoTransitionDoesNotWarmUp() {
+        // Defensive: identical before/after values are not an off→on transition.
+        let unchanged = SoundToggleLogic.effects(
+            toggledKeyWasEnabled: true,
+            toggledKeyIsEnabled: true,
+            voiceCountdownWasEnabled: true,
+            voiceCountdownIsEnabled: true
+        )
+        XCTAssertFalse(unchanged.warmUp)
+        XCTAssertFalse(unchanged.preloadVoiceCountdown)
+        XCTAssertFalse(unchanged.cancelVoiceCountdown)
+        XCTAssertFalse(unchanged.resetVoiceDedup)
+    }
+
+    // MARK: - Voice countdown (#554 behavior preserved)
+
+    func testVoiceOffToOnPreloadsAndDoesNotResetDedup() {
+        let effects = effectsForVoiceToggle(wasEnabled: false)
+        XCTAssertTrue(effects.preloadVoiceCountdown)
+        XCTAssertFalse(effects.cancelVoiceCountdown)
+        XCTAssertFalse(effects.resetVoiceDedup)
+    }
+
+    func testVoiceOnToOffCancelsAndResetsDedup() {
+        let effects = effectsForVoiceToggle(wasEnabled: true)
+        XCTAssertTrue(effects.cancelVoiceCountdown)
+        XCTAssertTrue(effects.resetVoiceDedup)
+        XCTAssertFalse(effects.preloadVoiceCountdown)
+    }
+
+    func testTogglingANonVoiceSoundLeavesVoiceEffectsUntouched() {
+        // Enabling tick while voice is already on must not re-preload or cancel it.
+        let whileVoiceOn = effectsForNonVoiceToggle(wasEnabled: false, voiceCountdown: true)
+        XCTAssertTrue(whileVoiceOn.warmUp)
+        XCTAssertFalse(whileVoiceOn.preloadVoiceCountdown)
+        XCTAssertFalse(whileVoiceOn.cancelVoiceCountdown)
+        XCTAssertFalse(whileVoiceOn.resetVoiceDedup)
+
+        // Disabling tick while voice is off must be a no-op beyond the pref write.
+        let whileVoiceOff = effectsForNonVoiceToggle(wasEnabled: true, voiceCountdown: false)
+        XCTAssertEqual(
+            whileVoiceOff,
+            SoundToggleLogic.Effects(
+                warmUp: false,
+                preloadVoiceCountdown: false,
+                cancelVoiceCountdown: false,
+                resetVoiceDedup: false
+            )
+        )
+    }
+
+    // MARK: - Rapid toggling
+
+    func testRapidOffOnOffOnSequenceWarmsOnlyOnEnables() {
+        // Simulates four fast taps on the same control starting from off.
+        var enabled = false
+        var warmUps = 0
+        for _ in 0..<4 {
+            let effects = effectsForNonVoiceToggle(wasEnabled: enabled)
+            if effects.warmUp { warmUps += 1 }
+            enabled.toggle()
+        }
+        // off→on, on→off, off→on, on→off ⇒ exactly two warm-ups.
+        XCTAssertEqual(warmUps, 2)
+    }
+}


### PR DESCRIPTION
## **User description**
Closes #667

## Problem

During a sit, turning a sound **off** worked immediately, but turning it back **on** did nothing — the sound stayed silent for the rest of that session, for all four toggles (tick, chime, end, voice). The preference itself persisted, so a relaunch showed the sound on and working, which made it look like a save bug rather than an audio bug.

## Root cause (iOS)

Exactly as predicted in the issue:

- `SessionViewModel.start()` calls `AudioEngine.shared.warmUp()` **only if at least one sound is already enabled** at session start.
- `toggleSound(_:)` saved the preference and handled voice-countdown preload/cancel, but **never warmed the engine**.

`warmUp()` is what reactivates the shared `AVAudioSession` (`setCategory` + `setActive(true)`). A sit begun with everything off — or one where the last enabled sound was toggled off — left the audio session inactive, so a re-enabled sound had nothing to play through. This answers the issue's open question: the `AVAudioSession` activation *is* the mechanism, and it lives inside `warmUp()`, so warming alone is sufficient.

`BuddySessionViewModel` never called `warmUp()` **anywhere**, so its buddy sits could run cold for their entire duration.

## Change

- **New `SoundToggleLogic` helper** (`ios/StillPointShared/Sources/StillPointShared/SoundToggleLogic.swift`) — a pure, stateless decision function returning the four side effects a toggle requires: `warmUp`, `preloadVoiceCountdown`, `cancelVoiceCountdown`, `resetVoiceDedup`. No `AVFoundation`/`UIKit`, so it runs under `swift test` on macOS. This follows the existing `VoiceCountdownLogic` / `SessionLogic` convention and makes the fix unit-testable without a new Xcode target or a protocol seam around the `AudioEngine.shared` singleton.
- **Both `toggleSound(_:)` paths** (`SessionViewModel`, `BuddySessionViewModel`) now route through the helper and call `AudioEngine.shared.warmUp()` on any off→on transition. All four toggles share this single path, which is consistent with the report that it failed for all of them.
- **Unit tests** (`SoundToggleLogicTests.swift`) covering off→on warm-up, on→off no-warm-up, every key, the voice-countdown cases, and a rapid four-tap sequence.

`start()`'s existing guard is left as-is deliberately: with the toggle now warming on off→on, the cold-start case is covered, and unconditionally activating the audio session for users who deliberately sit in silence would be an unrelated behavior change.

## Web: verified, no change needed

The failure **does not reproduce on web**, so per the AC this PR states that rather than changing it:

- `src/components/SessionView.tsx:790-796` — the toggle handler calls `unlockAudioContext()` on every off→on transition. That primes a 1-sample buffer *inside the user gesture* and then resumes the context (`src/lib/audio.ts:56-82`) — the exact analogue of the `warmUp()` iOS was missing.
- `src/components/BlockTimer.tsx:62-63` — `soundPrefsRef.current` is reassigned on every render, so the 50 ms tick loop reads prefs live; nothing is captured at session start.
- `src/lib/useVoiceCountdown.ts` — already preloads voice buffers on enable and cancels in-flight playback on disable, matching the iOS `#554` behavior.
- The dedup refs (`lastTickSecRef`, `lastVoiceSecRef`) only advance when a sound actually plays, so after a sound has been off they are stale and the next scheduled play point fires normally.

**Note on the CodeRabbit plan:** its Phase 2 proposed resetting `BlockTimer`'s `lastTickSecRef` / `lastVoiceSecRef` on an off→on toggle. I deliberately did not do this. The only residual gap it closes is a same-second re-enable being deferred to the next second — which is already "the next eligible second" per AC 5. Resetting would instead fire an immediate off-cadence tick and re-announce the current voice number mid-second, so rapid toggling would produce one extra tick per tap and stacked voice clips — a direct regression against AC 6 ("no audible glitch, restart, or duplicated sound when toggling rapidly"). Where the CR plan and the issue AC conflict, the AC wins.

## Test plan

- [x] Unit (iOS): `toggleSound` on an off→on transition triggers audio-engine warm-up; on an on→off transition it does not.
- [x] Toggling **off** remains immediate and does not regress.
- [x] Regression: normal sessions with sounds on from the start are unchanged.

Device-manual items moved to **Post-merge verification** below.

## Verification notes

- `SoundToggleLogicTests` runs in the `StillPointShared swift test` required check on CI (macOS runner with full Xcode).
- `swift test` could not be run locally: this machine has CommandLineTools only, no full Xcode, so the SwiftData `@Model` macro plugin in `Models/User.swift` fails to load. Pre-existing environment limitation, unrelated to this change. Locally verified instead with `swiftc -typecheck` on the new helper (clean) and `swiftc -parse` on the new test file and both edited view models (all clean).
- No web files changed, so `npm run test:unit` / `npm run typecheck` are unaffected.

**Phase B update (2026-08-26): the decision logic is now verified locally.** `SoundToggleLogic.swift` imports only `Foundation` and has no intra-package dependencies, so all 8 test cases from `SoundToggleLogicTests.swift` were reproduced verbatim as plain assertions against the real source file and executed with `swiftc`. Result: **PASS — 24/24 assertions across all 8 test cases.** This supersedes the typecheck/parse-only note above for the helper's behaviour. Still unproven locally: the XCTest target's own wiring/link (CommandLineTools ships neither `XCTest` nor the SwiftData macro plugin), which the `StillPointShared swift test` required check will confirm.

**Phase B blocker (2026-08-26): CI cannot run — GitHub Actions is in a `major_outage`** ([incident opened 15:11Z](https://www.githubstatus.com), impact critical, upstream Vitess issues with inbound traffic throttled). All five required contexts — `typecheck`, `StillPointShared swift test`, `build`, `unit-tests`, `Info.plist in sync with project.yml` — are **absent** on `4688aea`: the `unit-tests.yml` and `infoplist-sync.yml` runs ended in `startup_failure` with zero jobs, so they never created check-runs. The same `startup_failure` hit unrelated `main`-branch workflows, confirming infrastructure rather than a defect here. `gh run rerun` is rejected for `startup_failure` runs, so a fresh `pull_request` event is needed once Actions recovers — prefer close+reopen so HEAD stays `4688aea` and CodeAnt's approval is not invalidated.

> [!WARNING]
> Do not merge on a green-looking gate. Because the only check-runs currently present are four **non-required** ones (Cursor Bugbot, Graphite, Vercel x2), automated CI summaries can report "4/4 passed" while actual required coverage is zero. GitHub's own `mergeStateStatus: BLOCKED` is the accurate signal. All five required contexts must report success on the then-current HEAD before merge.

**Local review coverage:** cr-only — CodeRabbit CLI returned a verified clean pass (0 findings) across all four files. CodeAnt CLI returned `Access denied (403)` on two consecutive runs and was dropped for the session per `cr-local-review.md`; it emitted zero findings before dropping, so nothing is left unresolved or waived. The CodeAnt GitHub App is unaffected.

## Post-merge verification

Tracking issue: #681

- [ ] Re-enabling any of the four sounds (tick, chime, end, voice) mid-session produces audible output at the next scheduled play point, in the same session, with no app restart.
- [ ] Manual (iOS device): start a sit with all sounds off → enable tick → tick audible within one second; enable chime → chime audible at the next block boundary; enable end → completion sound plays; enable voice inside the final minute → next second is announced.
- [ ] Manual (iOS device): start a sit with sounds on → turn all off → turn one back on → audible.
- [ ] Re-enabling voice countdown mid-session still announces correctly on the next eligible second (the dedup reset from #554 is preserved).
- [ ] No audible glitch, restart, or duplicated sound when toggling rapidly.
- [ ] Manual (web): same matrix in the browser and in the installed PWA.

___

## **CodeAnt-AI Description**
Restore audio immediately when users turn sounds back on during an iOS sit

### What Changed
- Re-enabling any sound now reactivate the audio session, so tick, chime, end, and voice sounds play without restarting the sit
- Buddy sits receive the same audio recovery when a sound is enabled mid-session
- Voice countdown enabling, cancellation, and repeat-announcement behavior remain intact
- Added coverage for enable, disable, unchanged, and rapid-toggle scenarios

### Impact
`✅ Audible sounds after mid-sit re-enablement`
`✅ Working audio in buddy sits started with sounds off`
`✅ Preserved voice countdown behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


