### PR TITLE
fix(ios): widget streak derived from history, stop wiping the week (#671)

### DIFF
--- a/.claude/scripts/ac-gate.sh
+++ b/.claude/scripts/ac-gate.sh
@@ -204,13 +204,7 @@ while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
   if printf '%s' "$line" | grep -qE '^[[:space:]]{0,3}##[[:space:]]'; then
     # Strip leading indent, the '##' marker, surrounding whitespace. Case is
     # preserved: the exemption heading is matched case-sensitively below.
-    # CommonMark also allows an optional closing sequence ('## Test Plan ##'):
-    # a run of '#' preceded by whitespace at end of line. Leaving it attached
-    # made the heading text 'Test Plan ##', so the line fell through to the
-    # '*)' default (STATE=other) and its unchecked boxes escaped Stage 1
-    # entirely. The leading-whitespace requirement keeps '## C#' intact, which
-    # CommonMark treats as content rather than a closing sequence.
-    heading="$(printf '%s' "$line" | sed -E 's/^[[:space:]]{0,3}##[[:space:]]+//; s/[[:space:]]+#+[[:space:]]*$//; s/[[:space:]]*$//')"
+    heading="$(printf '%s' "$line" | sed -E 's/^[[:space:]]{0,3}##[[:space:]]+//; s/[[:space:]]*$//')"
 
     # Case-insensitive match for in-scope sections
     heading_lower="$(printf '%s' "$heading" | tr 'A-Z' 'a-z')"

--- a/.claude/scripts/ac-gate.sh
+++ b/.claude/scripts/ac-gate.sh
@@ -279,7 +279,7 @@ while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
     heading="$(printf '%s' "$line" | sed -E 's/^[[:space:]]{0,3}#{1,2}[[:space:]]+//; s/[[:space:]]+#+[[:space:]]*$//; s/[[:space:]]*$//')"
 
     # Case-insensitive match for in-scope sections
-    heading_lower="$(printf '%s' "$heading" | tr 'A-Z' 'a-z')"
+    heading_lower="$(printf '%s' "$heading" | tr '[:upper:]' '[:lower:]')"
 
     case "$heading_lower" in
       "acceptance criteria")
@@ -317,7 +317,15 @@ while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
   # `+ [ ]` as task-list items exactly like `- [ ]`, so matching only `-` let an
   # unchecked criterion written with either of the other two markers through the
   # gate unseen — the same silent-bypass class as the heading handling above.
-  if printf '%s' "$line" | grep -qE '^[[:space:]]*[-*+][[:space:]]\[ \]'; then
+  #
+  # The gap after the marker is 1-4 whitespace, not exactly 1. CommonMark lets a
+  # list item's content be indented up to four columns past its marker, so
+  # '-  [ ] item' renders as a real checkbox on GitHub; requiring a single space
+  # let that form bypass the gate. Four is the upper bound on purpose: at five
+  # the content becomes an indented code block relative to the marker and no
+  # longer renders as a task item, so matching further would fail PRs over
+  # inert sample text.
+  if printf '%s' "$line" | grep -qE '^[[:space:]]*[-*+][[:space:]]{1,4}\[ \]'; then
     case "$STATE" in
       ac|testplan|malformed_postmerge)
         HAS_UNCHECKED_INSCOPE=1

--- a/.claude/scripts/ac-gate.sh
+++ b/.claude/scripts/ac-gate.sh
@@ -177,6 +177,10 @@ HAS_UNCHECKED_INSCOPE=0
 HAS_UNCHECKED_EXEMPT=0
 TRACKING_ISSUE=""
 PENDING_SECTIONS=""
+# Open fenced-code block, if any: the fence character (` or ~) and its length.
+# Empty FENCE_CHAR means "not inside a fence". See the fence guard in the loop.
+FENCE_CHAR=""
+FENCE_LEN=0
 
 # Records a completed postmerge section that carried unchecked boxes, so Stage 2
 # can validate it. Called before any state transition away from "postmerge", and
@@ -195,6 +199,42 @@ _commit_postmerge() {
 while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
   # Strip CRLF (defensive: body from gh may carry Windows line endings)
   line="${raw_line%$'\r'}"
+
+  # --- fenced code blocks are inert ---
+  # Everything below treats the body as prose. Without fence tracking a PR could
+  # paste a fenced *example* containing '## Post-merge verification' and a
+  # 'Tracking issue: #N' line, which the parser would honour as a real exemption
+  # region -- shifting genuine unchecked criteria that follow the fence into the
+  # exempt state and passing a gate that should fail. Since the gate is a
+  # required check, that is a bypass, so fenced content is skipped entirely:
+  # no headings, no task items, no tracking-issue lines.
+  #
+  # CommonMark: a fence opens with 3+ backticks or tildes, indented at most 3
+  # spaces, optionally followed by an info string. It closes with the same
+  # character, at least as long, and no trailing content. Backtick fences may
+  # not carry a backtick in the info string; tilde fences may carry anything.
+  if [[ -z "$FENCE_CHAR" ]]; then
+    if [[ "$line" =~ ^[[:space:]]{0,3}('```'+|'~~~'+)(.*)$ ]]; then
+      _marker="${BASH_REMATCH[1]}"
+      _info="${BASH_REMATCH[2]}"
+      # A backtick fence's info string cannot contain a backtick (CommonMark),
+      # so '``` ``` ```' inline-code prose does not open a block.
+      if [[ "${_marker:0:1}" != '`' || "$_info" != *'`'* ]]; then
+        FENCE_CHAR="${_marker:0:1}"
+        FENCE_LEN="${#_marker}"
+      fi
+    fi
+    [[ -n "$FENCE_CHAR" ]] && continue
+  else
+    if [[ "$line" =~ ^[[:space:]]{0,3}([\`~]+)[[:space:]]*$ ]]; then
+      _marker="${BASH_REMATCH[1]}"
+      if [[ "${_marker:0:1}" == "$FENCE_CHAR" && "${#_marker}" -ge "$FENCE_LEN" ]]; then
+        FENCE_CHAR=""
+        FENCE_LEN=0
+      fi
+    fi
+    continue
+  fi
 
   # --- section heading detection (level 1 and 2) ---
   # Markdown allows up to three leading spaces before the marker and arbitrary

--- a/.claude/scripts/ac-gate.sh
+++ b/.claude/scripts/ac-gate.sh
@@ -181,6 +181,8 @@ PENDING_SECTIONS=""
 # Empty FENCE_CHAR means "not inside a fence". See the fence guard in the loop.
 FENCE_CHAR=""
 FENCE_LEN=0
+# Single-quoted so the backticks are literal and never command-substituted.
+_FENCE_OPEN_RE='^[[:space:]]{0,3}(`{3,}|~{3,})(.*)$'
 
 # Records a completed postmerge section that carried unchecked boxes, so Stage 2
 # can validate it. Called before any state transition away from "postmerge", and
@@ -210,11 +212,24 @@ while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
   # no headings, no task items, no tracking-issue lines.
   #
   # CommonMark: a fence opens with 3+ backticks or tildes, indented at most 3
-  # spaces, optionally followed by an info string. It closes with the same
-  # character, at least as long, and no trailing content. Backtick fences may
-  # not carry a backtick in the info string; tilde fences may carry anything.
+  # spaces, optionally followed by an info string. It closes with a run of the
+  # SAME character, at least as long as the opener, and nothing else on the
+  # line. Backtick fences may not carry a backtick in the info string; tilde
+  # fences may carry anything.
+  #
+  # The closing run is matched against the OPEN fence character specifically,
+  # never a combined '[`~]+' class. A combined class validated only the first
+  # character and the total length, so a mixed run such as '~~~```' closed a
+  # tilde fence -- which CommonMark does not allow, and which re-opens the
+  # laundering bypass by ending the block early and turning the rest of the
+  # sample back into "real" content.
+  #
+  # Both runs use an explicit {3,} / {FENCE_LEN,} quantifier. A repeated
+  # literal ('```'+) does match three-or-more, since the '+' binds only to the
+  # final backtick, but it reads as though it meant multiples of three; the
+  # quantifier says what is meant.
   if [[ -z "$FENCE_CHAR" ]]; then
-    if [[ "$line" =~ ^[[:space:]]{0,3}('```'+|'~~~'+)(.*)$ ]]; then
+    if [[ "$line" =~ $_FENCE_OPEN_RE ]]; then
       _marker="${BASH_REMATCH[1]}"
       _info="${BASH_REMATCH[2]}"
       # A backtick fence's info string cannot contain a backtick (CommonMark),
@@ -226,12 +241,11 @@ while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
     fi
     [[ -n "$FENCE_CHAR" ]] && continue
   else
-    if [[ "$line" =~ ^[[:space:]]{0,3}([\`~]+)[[:space:]]*$ ]]; then
-      _marker="${BASH_REMATCH[1]}"
-      if [[ "${_marker:0:1}" == "$FENCE_CHAR" && "${#_marker}" -ge "$FENCE_LEN" ]]; then
-        FENCE_CHAR=""
-        FENCE_LEN=0
-      fi
+    # Same character, at least as long as the opener, nothing trailing.
+    _close_re="^[[:space:]]{0,3}${FENCE_CHAR}{${FENCE_LEN},}[[:space:]]*$"
+    if [[ "$line" =~ $_close_re ]]; then
+      FENCE_CHAR=""
+      FENCE_LEN=0
     fi
     continue
   fi

--- a/.claude/scripts/ac-gate.sh
+++ b/.claude/scripts/ac-gate.sh
@@ -278,8 +278,13 @@ while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
     # indent handling above was added to close.
     heading="$(printf '%s' "$line" | sed -E 's/^[[:space:]]{0,3}#{1,2}[[:space:]]+//; s/[[:space:]]+#+[[:space:]]*$//; s/[[:space:]]*$//')"
 
-    # Case-insensitive match for in-scope sections
-    heading_lower="$(printf '%s' "$heading" | tr '[:upper:]' '[:lower:]')"
+    # Case-insensitive match for in-scope sections.
+    # ASCII ranges deliberately, not '[:upper:]'/'[:lower:]' (shellcheck
+    # SC2018/SC2019): the headings matched below are fixed ASCII keywords, and
+    # locale-aware folding would map 'I' to a dotless 'ı' under a Turkish
+    # locale, so '## ACCEPTANCE CRITERIA' would stop matching. ASCII folding
+    # keeps the gate locale-independent, which matters for a CI check.
+    heading_lower="$(printf '%s' "$heading" | LC_ALL=C tr 'A-Z' 'a-z')"
 
     case "$heading_lower" in
       "acceptance criteria")

--- a/.claude/scripts/ac-gate.sh
+++ b/.claude/scripts/ac-gate.sh
@@ -202,9 +202,18 @@ while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
   # go unrecognised, so its unchecked boxes bypassed the gate entirely — and it
   # diverged from ac-checkboxes.sh, which accepts the indented forms.
   if printf '%s' "$line" | grep -qE '^[[:space:]]{0,3}##[[:space:]]'; then
-    # Strip leading indent, the '##' marker, surrounding whitespace. Case is
-    # preserved: the exemption heading is matched case-sensitively below.
-    heading="$(printf '%s' "$line" | sed -E 's/^[[:space:]]{0,3}##[[:space:]]+//; s/[[:space:]]*$//')"
+    # Strip leading indent, the '##' marker, surrounding whitespace, and any
+    # optional ATX closing sequence. Case is preserved: the exemption heading is
+    # matched case-sensitively below.
+    #
+    # The closing-hash strip requires at least one space before the run of '#'
+    # because that is what makes it a *closing sequence* rather than heading
+    # text: CommonMark renders '## Test Plan ##' identically to '## Test Plan',
+    # but '## C#' is a heading whose text really does end in '#'. Without this,
+    # '## Test Plan ##' fell through to the "other" state and its unchecked
+    # boxes bypassed the gate entirely — the same class of silent bypass the
+    # indent handling above was added to close.
+    heading="$(printf '%s' "$line" | sed -E 's/^[[:space:]]{0,3}##[[:space:]]+//; s/[[:space:]]+#+[[:space:]]*$//; s/[[:space:]]*$//')"
 
     # Case-insensitive match for in-scope sections
     heading_lower="$(printf '%s' "$heading" | tr 'A-Z' 'a-z')"

--- a/.claude/scripts/ac-gate.sh
+++ b/.claude/scripts/ac-gate.sh
@@ -196,13 +196,22 @@ while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
   # Strip CRLF (defensive: body from gh may carry Windows line endings)
   line="${raw_line%$'\r'}"
 
-  # --- level-2 heading detection ---
+  # --- section heading detection (level 1 and 2) ---
   # Markdown allows up to three leading spaces before the marker and arbitrary
   # whitespace after it. Accepting only '^## ' let an indented '## Test Plan'
   # go unrecognised, so its unchecked boxes bypassed the gate entirely — and it
   # diverged from ac-checkboxes.sh, which accepts the indented forms.
-  if printf '%s' "$line" | grep -qE '^[[:space:]]{0,3}##[[:space:]]'; then
-    # Strip leading indent, the '##' marker, surrounding whitespace, and any
+  #
+  # Level 1 counts as a section boundary too. Matching '##' alone meant a level-1
+  # heading did not end the current section: a body with '## Test plan' followed
+  # by '# Notes' stayed in the testplan state, so unchecked boxes under Notes
+  # were failed as in-scope Test Plan items. '#{1,2}' also lets a level-1
+  # '# Acceptance criteria' open a section, which is the gate's intent.
+  # Level 3+ must NOT match, because sub-headings inside a section are expected;
+  # '#{1,2}[[:space:]]' excludes them naturally, since for '### Foo' the third
+  # '#' is not whitespace.
+  if printf '%s' "$line" | grep -qE '^[[:space:]]{0,3}#{1,2}[[:space:]]'; then
+    # Strip leading indent, the heading marker, surrounding whitespace, and any
     # optional ATX closing sequence. Case is preserved: the exemption heading is
     # matched case-sensitively below.
     #
@@ -213,7 +222,7 @@ while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
     # '## Test Plan ##' fell through to the "other" state and its unchecked
     # boxes bypassed the gate entirely — the same class of silent bypass the
     # indent handling above was added to close.
-    heading="$(printf '%s' "$line" | sed -E 's/^[[:space:]]{0,3}##[[:space:]]+//; s/[[:space:]]+#+[[:space:]]*$//; s/[[:space:]]*$//')"
+    heading="$(printf '%s' "$line" | sed -E 's/^[[:space:]]{0,3}#{1,2}[[:space:]]+//; s/[[:space:]]+#+[[:space:]]*$//; s/[[:space:]]*$//')"
 
     # Case-insensitive match for in-scope sections
     heading_lower="$(printf '%s' "$heading" | tr 'A-Z' 'a-z')"

--- a/.claude/scripts/ac-gate.sh
+++ b/.claude/scripts/ac-gate.sh
@@ -250,7 +250,11 @@ while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
   fi
 
   # --- unchecked box detection (`- [ ]` with optional leading whitespace) ---
-  if printf '%s' "$line" | grep -qE '^[[:space:]]*-[[:space:]]\[ \]'; then
+  # All three CommonMark bullet markers count. GitHub renders `* [ ]` and
+  # `+ [ ]` as task-list items exactly like `- [ ]`, so matching only `-` let an
+  # unchecked criterion written with either of the other two markers through the
+  # gate unseen — the same silent-bypass class as the heading handling above.
+  if printf '%s' "$line" | grep -qE '^[[:space:]]*[-*+][[:space:]]\[ \]'; then
     case "$STATE" in
       ac|testplan|malformed_postmerge)
         HAS_UNCHECKED_INSCOPE=1

--- a/.claude/scripts/pr-issue-ref.sh
+++ b/.claude/scripts/pr-issue-ref.sh
@@ -145,8 +145,44 @@ if ! BODY="$(gh pr view "$PR_NUM" --json body --jq '.body // ""' 2>"$GH_STDERR")
   exit 4
 fi
 
+# Drop fenced code blocks from a Markdown body, so documentation *examples* are
+# not read as real closing references. ac-gate.sh treats fenced content as inert;
+# without the same treatment here a prose sample such as a fenced "Closes #123"
+# would be returned as a genuine closing reference, and the gate would then
+# classify a valid deferred tracking issue #123 as self-referential and fail a PR
+# that is actually well-formed. Same CommonMark rules as ac-gate.sh: 3+ backticks
+# or tildes, indented at most three spaces, closing only on a run of the same
+# character at least as long with nothing trailing.
+_strip_fenced_blocks() {
+  local line fence_char="" fence_len=0 marker info close_re
+  local open_re='^[[:space:]]{0,3}(`{3,}|~{3,})(.*)$'
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%$'\r'}"
+    if [[ -z "$fence_char" ]]; then
+      if [[ "$line" =~ $open_re ]]; then
+        marker="${BASH_REMATCH[1]}"
+        info="${BASH_REMATCH[2]}"
+        if [[ "${marker:0:1}" != '`' || "$info" != *'`'* ]]; then
+          fence_char="${marker:0:1}"
+          fence_len="${#marker}"
+          continue
+        fi
+      fi
+      printf '%s\n' "$line"
+    else
+      close_re="^[[:space:]]{0,3}${fence_char}{${fence_len},}[[:space:]]*$"
+      if [[ "$line" =~ $close_re ]]; then
+        fence_char=""
+        fence_len=0
+      fi
+    fi
+  done
+}
+
 # --- extract issue number(s) ---
 if [[ "$ALL_MODE" -eq 1 ]]; then
+  # Examples inside fenced blocks are not closing references (see above).
+  BODY="$(printf '%s\n' "$BODY" | _strip_fenced_blocks)"
   # --all mode: collect every closing reference that targets the current repository.
   #
   # Pass 1: bare `#N` form. The leading `(^|[^[:alnum:]_])` is a left word-boundary.

--- a/.claude/scripts/pr-issue-ref.sh
+++ b/.claude/scripts/pr-issue-ref.sh
@@ -179,10 +179,16 @@ _strip_fenced_blocks() {
   done
 }
 
+# Examples inside fenced blocks are not closing references in EITHER mode (see
+# above). Stripped once here rather than inside the --all branch: the default
+# path ran its own matcher against the raw body, so a fenced `Closes #123`
+# sample was still returned as a genuine closing reference to every
+# default-mode consumer -- the same false-positive --all was fixed for, left
+# behind on the sibling path.
+BODY="$(printf '%s\n' "$BODY" | _strip_fenced_blocks)"
+
 # --- extract issue number(s) ---
 if [[ "$ALL_MODE" -eq 1 ]]; then
-  # Examples inside fenced blocks are not closing references (see above).
-  BODY="$(printf '%s\n' "$BODY" | _strip_fenced_blocks)"
   # --all mode: collect every closing reference that targets the current repository.
   #
   # Pass 1: bare `#N` form. The leading `(^|[^[:alnum:]_])` is a left word-boundary.

--- a/.github/workflows/ac-gate.yml
+++ b/.github/workflows/ac-gate.yml
@@ -1,5 +1,14 @@
 on:
-  pull_request: {}
+  # `edited` is load-bearing, not decorative. The gate reads the PR *body*, and
+  # the documented way to clear a failure is to tick the boxes or add a tracking
+  # issue — both body-only edits. Under the default activity types
+  # (opened/synchronize/reopened) such an edit never re-runs the check, so a
+  # failed required gate would stay red until an unrelated push happened to
+  # arrive. `ready_for_review` covers a draft whose body was written before it
+  # was marked ready. Listing `types` overrides the defaults, so the three
+  # default events must be named explicitly here too.
+  pull_request:
+    types: [opened, synchronize, reopened, edited, ready_for_review]
 
 permissions:
   contents: read

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -216,15 +216,19 @@ final class AppViewModel {
         } catch let apiError as APIError where apiError.status == 401 && apiError.code == "TOKEN_EXPIRED" {
             currentView = .auth
             authStatusMessage = apiError.message
-            syncWidgetData()
+            syncWidgetData(signedOutCause: .unauthorized)
         } catch let apiError as APIError {
             currentView = .auth
             authStatusMessage = apiError.message
-            syncWidgetData()
+            // #671: only a 401 proves we're signed out. A 500 (or any other server
+            // error) must not wipe the widget's stored week.
+            syncWidgetData(signedOutCause: apiError.status == 401 ? .unauthorized : .serverError)
         } catch {
             currentView = .auth
             authStatusMessage = "Connection failed. Please try again."
-            syncWidgetData()
+            // #671: an unreachable server is not a sign-out — keep the last known
+            // history so a cold start with no network still renders the real week.
+            syncWidgetData(signedOutCause: .unreachable)
         }
         // #526: clear per-account unlock state on any unauthenticated redirect so the
         // next sign-in always re-qualifies (mirrors clearOnLogout called by didLogout).
@@ -674,7 +678,11 @@ final class AppViewModel {
 
     /// Persist a widget snapshot to the App Group container and reload timelines.
     /// Called from auth + session-completion flows; no extra API calls.
-    private func syncWidgetData() {
+    ///
+    /// `signedOutCause` distinguishes a real sign-out (wipe the shared blob) from
+    /// merely failing to reach the server at cold start — see #671 and
+    /// `WidgetDataStore.shouldClearStoredSnapshot(on:)`.
+    private func syncWidgetData(signedOutCause: WidgetDataStore.SignedOutCause = .signedOut) {
         let snapshot = WidgetDataStore.makeSnapshot(
             user: currentUser,
             primaryDoneToday: primaryDoneToday,
@@ -686,8 +694,12 @@ final class AppViewModel {
         )
         if snapshot.isLoggedIn {
             WidgetDataStore.save(snapshot)
-        } else {
+        } else if WidgetDataStore.shouldClearStoredSnapshot(on: signedOutCause) {
             WidgetDataStore.clear()
+            // #671: the next sign-in must re-backfill the week. Without this the
+            // once-per-account-per-day throttle below would suppress the fetch for
+            // the rest of the day, leaving the row blank on a sign-out/sign-in.
+            widgetHistoryRefreshKey = nil
         }
         WidgetTimelineReloader.reloadHabitWidget()
     }
@@ -709,7 +721,9 @@ final class AppViewModel {
         guard ProcessInfo.processInfo.environment["SP_UI_TEST_MODE"] != "1",
               let user = currentUser else { return }
         // Throttle: `/api/sessions` returns the full history, so skip the re-fetch
-        // when we've already backfilled for this account today.
+        // when we've already backfilled for this account today. `syncWidgetData`
+        // resets the key whenever it clears the stored snapshot (#671), so a
+        // sign-out/sign-in always re-backfills rather than showing a blank row.
         let refreshKey = "\(user.id)|\(WidgetDataStore.localDayString(Date()))"
         guard widgetHistoryRefreshKey != refreshKey else { return }
         widgetHistoryRefreshKey = refreshKey
@@ -733,6 +747,11 @@ final class AppViewModel {
             let today = WidgetDataStore.localDayString(now)
             let doneToday = completed.primary.contains(today)
             let secondDone = completed.second.contains(today)
+            // #671: keep the server-computed streak (the same number the app and
+            // web history show) instead of discarding it — it's the only source
+            // that knows about days older than the widget's trailing-7 row. It is
+            // anchored onto a day, so it can only ever extend a run both rows
+            // already corroborate (#684 day-credit rule: either track keeps a day).
             let snapshot = WidgetDataStore.makeSnapshot(
                 user: current,
                 primaryDoneToday: primaryDoneToday,
@@ -740,7 +759,9 @@ final class AppViewModel {
                 practiceDoneToday: doneToday,
                 now: now,
                 completedPracticeDates: completed.primary,
-                secondCompletedPracticeDates: completed.second
+                secondCompletedPracticeDates: completed.second,
+                serverStreak: result.stats.streak,
+                serverStreakDate: WidgetDataStore.serverStreakAnchorDate(from: result.sessions)
             )
             WidgetDataStore.save(snapshot)
             WidgetTimelineReloader.reloadHabitWidget()

--- a/ios/StillPointShared/Sources/StillPointShared/WidgetData.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/WidgetData.swift
@@ -51,6 +51,11 @@ public struct WidgetData: Codable, Sendable, Equatable {
     /// Track Two's equivalent is `secondDoneToday`; day continuity uses the union
     /// of both (see `isDayKeptToday(at:)`).
     public var practiceDoneToday: Bool
+    /// Streak the widget renders. Always derived from the completion history the
+    /// rows are drawn from (`completedDates` ∪ `secondCompletedDates`, plus the
+    /// extensions below) by `WidgetDataStore.reconciledStreak` — never
+    /// accumulated from snapshot-to-snapshot flag transitions (#671), so it can
+    /// never contradict the weekday row(s) rendered beside it.
     public var streak: Int
     /// #84 follow-up: ISO local-day strings (`yyyy-MM-dd`) within the trailing
     /// 7-day window on which **Track One** practice was completed. Drives the
@@ -64,6 +69,15 @@ public struct WidgetData: Codable, Sendable, Equatable {
     /// to a two-a-day schedule carry no second-track sit, so they render on the
     /// Track One row only. Legacy snapshots decode this as empty.
     public var secondCompletedDates: [String]
+    /// #671: server-computed `stats.streak` from `/api/sessions`, the only source
+    /// that knows about days older than the trailing-7 window the rows render.
+    /// Used solely to *extend* a run the rows already corroborate — never to
+    /// contradict them. Nil when no authoritative fetch has landed yet.
+    public var serverStreak: Int?
+    /// #671: the ISO local day `serverStreak` counts through (the most recent
+    /// completed standard sit at fetch time). Anchors the server total onto the
+    /// row so later days can extend it without a second fetch.
+    public var serverStreakDate: String?
     public var lastUpdated: Date
 
     public init(
@@ -81,6 +95,8 @@ public struct WidgetData: Codable, Sendable, Equatable {
         streak: Int,
         completedDates: [String] = [],
         secondCompletedDates: [String] = [],
+        serverStreak: Int? = nil,
+        serverStreakDate: String? = nil,
         lastUpdated: Date
     ) {
         self.isLoggedIn = isLoggedIn
@@ -97,6 +113,8 @@ public struct WidgetData: Codable, Sendable, Equatable {
         self.streak = streak
         self.completedDates = completedDates
         self.secondCompletedDates = secondCompletedDates
+        self.serverStreak = serverStreak
+        self.serverStreakDate = serverStreakDate
         self.lastUpdated = lastUpdated
     }
 
@@ -104,7 +122,8 @@ public struct WidgetData: Codable, Sendable, Equatable {
         case isLoggedIn, userId, currentDay, secondTrackDay, dualTrackEnabled
         case recoveryTargetDay, recoveryCurrentStep, recoveryTotalSteps
         case primaryDoneToday, secondDoneToday, practiceDoneToday, streak
-        case completedDates, secondCompletedDates, lastUpdated
+        case completedDates, secondCompletedDates
+        case serverStreak, serverStreakDate, lastUpdated
     }
 
     /// Custom decoder so blobs persisted before `completedDates` /
@@ -129,6 +148,8 @@ public struct WidgetData: Codable, Sendable, Equatable {
         // Pre-#684 snapshots have no Track Two history: their `completedDates`
         // stay Track One and Track Two starts empty (no back-fill, no migration).
         secondCompletedDates = try c.decodeIfPresent([String].self, forKey: .secondCompletedDates) ?? []
+        serverStreak = try c.decodeIfPresent(Int.self, forKey: .serverStreak)
+        serverStreakDate = try c.decodeIfPresent(String.self, forKey: .serverStreakDate)
         lastUpdated = try c.decode(Date.self, forKey: .lastUpdated)
     }
 
@@ -161,7 +182,8 @@ public struct WidgetData: Codable, Sendable, Equatable {
     }
 
     /// Local days in the trailing window on which **either** track recorded a
-    /// completed sit — the set day continuity and the streak walk over (#684).
+    /// completed sit — the set day continuity and the streak walk over (#684),
+    /// and therefore the evidence the displayed streak must agree with (#671).
     public var completedDayUnion: Set<String> {
         Set(completedDates).union(secondCompletedDates)
     }
@@ -202,6 +224,10 @@ public struct WidgetData: Codable, Sendable, Equatable {
     /// is checked when **either** track completed a sit, matching the day-credit
     /// rule in `isDayKeptToday(at:)`. Single-track users have no Track Two
     /// history, so this is identical to their Track One row.
+    ///
+    /// #671 reads the streak off exactly this row: on a two-a-day schedule the
+    /// two rendered rows show, between them, precisely the days this union row
+    /// marks, so "the run the row draws" is well-defined for both layouts.
     public func weekMarks(now: Date = Date(), calendar: Calendar = .current) -> [WidgetDayMark] {
         weekMarks(
             completed: completedDayUnion,
@@ -248,7 +274,7 @@ public struct WidgetData: Codable, Sendable, Equatable {
         let start = calendar.startOfDay(for: now)
         let letters = WidgetData.narrowWeekdaySymbols(calendar: calendar)
         let names = WidgetData.fullWeekdaySymbols(calendar: calendar)
-        return (0..<7).reversed().compactMap { offset -> WidgetDayMark? in
+        return (0..<WidgetDataStore.historyWindowDays).reversed().compactMap { offset -> WidgetDayMark? in
             guard let date = calendar.date(byAdding: .day, value: -offset, to: start) else { return nil }
             let iso = WidgetDataStore.localDayString(date, calendar: calendar)
             let isToday = offset == 0
@@ -258,6 +284,53 @@ public struct WidgetData: Codable, Sendable, Equatable {
             let name = names.isEmpty ? "" : names[(weekday - 1) % names.count]
             return WidgetDayMark(iso: iso, letter: letter, weekdayName: name, done: done, isToday: isToday)
         }
+    }
+
+    /// Whether the weekday row's trailing column (today) renders as completed.
+    /// Mirrors exactly what `weekMarks(now:)` decides — the union of both tracks
+    /// under the #684 day-credit rule — so streak derivation and the rendered
+    /// row(s) can never disagree about today (#671).
+    public func isTodayMarkedDone(now: Date = Date(), calendar: Calendar = .current) -> Bool {
+        completedDayUnion.contains(WidgetDataStore.localDayString(now, calendar: calendar))
+            || isDayKeptToday(at: now)
+    }
+
+    /// #671: the run of consecutive kept days the weekday row *itself* shows,
+    /// ending on today — or on yesterday when today is still pending. Read
+    /// straight off `weekMarks(now:)` so it is, by construction, the number a
+    /// person counts off the row with their finger. On a two-a-day schedule that
+    /// row is the union of the two rendered rows, matching the day-credit rule.
+    /// Bounded by the 7-day window; `streak` may legitimately exceed it (see
+    /// `serverStreak`), but can never fall below it.
+    public func weekRowStreak(now: Date = Date(), calendar: Calendar = .current) -> Int {
+        WidgetData.rowRun(in: weekMarks(now: now, calendar: calendar))
+    }
+
+    /// True when `weekRowStreak` runs off the oldest column of the row, i.e. the
+    /// row cannot see where the streak actually began. Only then may a larger
+    /// `streak` be shown without contradicting the row.
+    public func weekRowStreakReachesWindowEdge(now: Date = Date(), calendar: Calendar = .current) -> Bool {
+        let marks = weekMarks(now: now, calendar: calendar)
+        let run = WidgetData.rowRun(in: marks)
+        guard run > 0 else { return false }
+        let pendingToday = marks.last.map { !$0.done } ?? false
+        return run + (pendingToday ? 1 : 0) >= marks.count
+    }
+
+    /// Walk the rendered marks newest → oldest, counting completed days until a
+    /// missed one. A pending *today* is skipped rather than treated as a break.
+    private static func rowRun(in marks: [WidgetDayMark]) -> Int {
+        var run = 0
+        for mark in marks.reversed() {
+            if mark.done {
+                run += 1
+            } else if mark.isToday {
+                continue
+            } else {
+                break
+            }
+        }
+        return run
     }
 
     /// Narrow standalone weekday initials indexed by `weekday - 1` (1 = Sunday).
@@ -296,11 +369,15 @@ public struct WidgetData: Codable, Sendable, Equatable {
         streak: 12,
         completedDates: WidgetDataStore.previewCompletedDates(),
         secondCompletedDates: [],
+        // Anchored on yesterday so the 12 stays compatible with the 6-day row.
+        serverStreak: 12,
+        serverStreakDate: WidgetDataStore.previewCompletedDates().last,
         lastUpdated: Date()
     )
 
     /// #684: two-a-day gallery / Xcode preview fixture — Track Two has a shorter
-    /// history than Track One, the way a mid-week switch actually looks.
+    /// history than Track One, the way a mid-week switch actually looks. The
+    /// union of the two rows is still the unbroken run `streak` claims (#671).
     public static let previewDualTrack = WidgetData(
         isLoggedIn: true,
         userId: "preview-dual",
@@ -313,11 +390,16 @@ public struct WidgetData: Codable, Sendable, Equatable {
         streak: 12,
         completedDates: WidgetDataStore.previewCompletedDates(),
         secondCompletedDates: WidgetDataStore.previewSecondCompletedDates(),
+        serverStreak: 12,
+        serverStreakDate: WidgetDataStore.previewCompletedDates().last,
         lastUpdated: Date()
     )
 }
 
 public enum WidgetDataStore {
+    /// Length of the trailing history window the widget keeps and renders.
+    public static let historyWindowDays = 7
+
     public static var sharedDefaults: UserDefaults? {
         UserDefaults(suiteName: WidgetAppGroup.id)
     }
@@ -344,6 +426,34 @@ public enum WidgetDataStore {
         sharedDefaults?.removeObject(forKey: WidgetAppGroup.dataKey)
     }
 
+    /// Why the app is about to render a signed-out widget snapshot.
+    public enum SignedOutCause: Sendable, Equatable {
+        /// The user signed out, or the server authoritatively reported no session.
+        case signedOut
+        /// Credentials were rejected (HTTP 401) — the session is genuinely over.
+        case unauthorized
+        /// The server answered, but with an error that says nothing about auth.
+        case serverError
+        /// The server could not be reached at all (offline cold start).
+        case unreachable
+    }
+
+    /// #671 (symptom 2 — "the week resets"): only an authoritative sign-out may
+    /// wipe the shared snapshot. A launch that simply can't reach the server is
+    /// not a sign-out, and clearing there destroys the widget's only copy of the
+    /// week: the rows go blank, and once history is refetched the streak has
+    /// already restarted from 1 because there is no longer a prior snapshot to
+    /// build on. Keeping the blob costs nothing — `normalizedForDisplay` bounds
+    /// and re-derives it on every read.
+    public static func shouldClearStoredSnapshot(on cause: SignedOutCause) -> Bool {
+        switch cause {
+        case .signedOut, .unauthorized:
+            return true
+        case .serverError, .unreachable:
+            return false
+        }
+    }
+
     /// Build a widget snapshot from in-memory app state, adjusting streak without
     /// extra network calls by comparing against the last persisted snapshot.
     ///
@@ -354,6 +464,13 @@ public enum WidgetDataStore {
     /// sync path never wipes history it can't recompute. Today is folded into a
     /// track only when that track's own "done today" flag is set, so completing
     /// either sit checks that row's box immediately (#684).
+    ///
+    /// #671: the streak is then *derived* from the union of those sets — the
+    /// same evidence the rows draw — rather than accumulated from flag
+    /// transitions, so a day the app never observed can no longer be silently
+    /// dropped. It is extended past the window edge only by the server anchor or
+    /// the previous snapshot's carried value, and only while the rows corroborate
+    /// an unbroken run all the way back to that edge.
     public static func makeSnapshot(
         user: UserDTO?,
         primaryDoneToday: Bool,
@@ -362,28 +479,29 @@ public enum WidgetDataStore {
         now: Date = Date(),
         previous: WidgetData? = nil,
         completedPracticeDates: Set<String>? = nil,
-        secondCompletedPracticeDates: Set<String>? = nil
+        secondCompletedPracticeDates: Set<String>? = nil,
+        serverStreak: Int? = nil,
+        serverStreakDate: String? = nil
     ) -> WidgetData {
         guard let user else {
             return .loggedOut
         }
 
-        let prior = previous ?? load()
-        // Carry forward what we already knew; drop the other account's history.
-        let sameAccount: Bool = {
-            guard let prior, prior.isLoggedIn else { return false }
-            return prior.userId == user.id
-        }()
+        // Nil unless the stored snapshot belongs to this same signed-in account —
+        // another account's history and streak must never carry over.
+        let prior = (previous ?? load()).flatMap { snapshot in
+            snapshot.isLoggedIn && snapshot.userId == user.id ? snapshot : nil
+        }
 
-        let window = Set(localDayStrings(lastN: 7, endingAt: now))
+        let window = Set(localDayStrings(lastN: historyWindowDays, endingAt: now))
         var dates = windowedDates(
             authoritative: completedPracticeDates,
-            carriedForward: sameAccount ? prior?.completedDates : nil,
+            carriedForward: prior?.completedDates,
             window: window
         )
         var secondDates = windowedDates(
             authoritative: secondCompletedPracticeDates,
-            carriedForward: sameAccount ? prior?.secondCompletedDates : nil,
+            carriedForward: prior?.secondCompletedDates,
             window: window
         )
         // Fold today in only on the synchronous fast path (no session set), where
@@ -399,16 +517,36 @@ public enum WidgetDataStore {
             secondDates.insert(today)
         }
 
+        // The authoritative fetch supplies a fresh (streak, anchor) pair; the fast,
+        // network-free path reuses the one already stored for this same account so
+        // a sit today still extends a streak older than the 7-day rows.
+        let resolvedServerStreak: Int?
+        let resolvedServerStreakDate: String?
+        if serverStreak != nil || serverStreakDate != nil {
+            resolvedServerStreak = serverStreak
+            resolvedServerStreakDate = serverStreakDate
+        } else if let prior {
+            resolvedServerStreak = prior.serverStreak
+            resolvedServerStreakDate = prior.serverStreakDate
+        } else {
+            resolvedServerStreak = nil
+            resolvedServerStreakDate = nil
+        }
+
         // Day-credit rule (#684; cross-surface policy tracked in #679): the day is
         // kept when AT LEAST ONE track finished a sit. On a two-a-day schedule
-        // either session alone preserves continuity — only a zero-sit day breaks it.
-        let dayKeptToday = practiceDoneToday || secondDoneToday
+        // either session alone preserves continuity — only a zero-sit day breaks
+        // it. This matches exactly what `weekMarks(now:)` renders for today.
+        let union = dates.union(secondDates)
+        let dayKeptToday = union.contains(today) || practiceDoneToday || secondDoneToday
         let streak = resolvedStreak(
             userId: user.id,
             dayKeptToday: dayKeptToday,
             previous: prior,
             now: now,
-            completedDays: dates.union(secondDates)
+            completedDays: union,
+            serverStreak: resolvedServerStreak,
+            serverStreakDate: resolvedServerStreakDate
         )
 
         return WidgetData(
@@ -426,12 +564,14 @@ public enum WidgetDataStore {
             streak: streak,
             completedDates: dates.sorted(),
             secondCompletedDates: secondDates.sorted(),
+            serverStreak: resolvedServerStreak,
+            serverStreakDate: resolvedServerStreakDate,
             lastUpdated: now
         )
     }
 
     /// Authoritative set when supplied, else the carried-forward one, always
-    /// clipped to the trailing window the row can render.
+    /// clipped to the trailing window the rows can render.
     private static func windowedDates(
         authoritative: Set<String>?,
         carriedForward: [String]?,
@@ -482,7 +622,7 @@ public enum WidgetDataStore {
         now: Date = Date(),
         calendar: Calendar = .current
     ) -> (primary: Set<String>, second: Set<String>) {
-        let window = Set(localDayStrings(lastN: 7, endingAt: now, calendar: calendar))
+        let window = Set(localDayStrings(lastN: historyWindowDays, endingAt: now, calendar: calendar))
         var primary = Set<String>()
         var second = Set<String>()
         for session in sessions where window.contains(session.sessionDate) {
@@ -496,114 +636,175 @@ public enum WidgetDataStore {
         return (primary: primary, second: second)
     }
 
-    /// Normalize persisted data for widget display, clearing stale "done today"
-    /// flags and re-resolving streak after local midnight without an app sync.
+    /// Normalize persisted data for widget display: clear stale "done today"
+    /// flags after local midnight, prune both tracks' history to the renderable
+    /// window, and re-derive the streak from that history.
+    ///
+    /// #671: the streak is recomputed on *every* display (not only on a day
+    /// rollover) so the number beside the rows is always the number they imply.
+    /// The old rollover branch zeroed the streak whenever the previous snapshot's
+    /// `practiceDoneToday` was false, wiping an intact streak the history plainly
+    /// showed.
     public static func normalizedForDisplay(_ data: WidgetData, now: Date = Date()) -> WidgetData {
         guard data.isLoggedIn else { return data }
-        guard !isSameLocalDay(data.lastUpdated, now) else { return data }
 
         var copy = data
-        copy.primaryDoneToday = false
-        copy.secondDoneToday = false
-        copy.practiceDoneToday = false
-        // Keep completion history bounded to the window the rows can render.
-        let window = Set(localDayStrings(lastN: 7, endingAt: now))
-        copy.completedDates = data.completedDates.filter { window.contains($0) }
-        copy.secondCompletedDates = data.secondCompletedDates.filter { window.contains($0) }
-        if let userId = data.userId {
-            // Re-resolve under the same day-credit rule the app uses, so a widget
-            // left untouched across several days drops a genuinely broken streak.
-            copy.streak = resolvedStreak(
-                userId: userId,
-                dayKeptToday: false,
-                previous: data,
-                now: now,
-                completedDays: Set(copy.completedDates).union(copy.secondCompletedDates)
-            )
-        } else {
-            copy.streak = data.anyTrackDoneToday ? max(data.streak, 0) : 0
+        if !isSameLocalDay(data.lastUpdated, now) {
+            copy.primaryDoneToday = false
+            copy.secondDoneToday = false
+            copy.practiceDoneToday = false
+            // Keep completion history bounded to the window the rows can render.
+            let window = Set(localDayStrings(lastN: historyWindowDays, endingAt: now))
+            copy.completedDates = data.completedDates.filter { window.contains($0) }
+            copy.secondCompletedDates = data.secondCompletedDates.filter { window.contains($0) }
         }
+        // The snapshot is its own "previous": its stored streak is the only record
+        // of days older than the window until the next authoritative fetch. A nil
+        // `userId` fails the same-account check inside `resolvedStreak`, so an
+        // unattributed blob carries nothing forward.
+        copy.streak = resolvedStreak(
+            userId: data.userId ?? "",
+            dayKeptToday: copy.isTodayMarkedDone(now: now),
+            previous: data,
+            now: now,
+            completedDays: copy.completedDayUnion,
+            serverStreak: copy.serverStreak,
+            serverStreakDate: copy.serverStreakDate
+        )
         return copy
     }
 
-    /// Resolve the widget streak under the #684 day-credit rule: a local day
-    /// counts when **at least one** track completed a sit that day.
+    /// The run of consecutive kept days ending today — or ending yesterday when
+    /// today is still pending — implied by `completedDates`. This is the same run
+    /// the weekday row draws, so the two can never disagree (#671).
+    public static func historyStreak(
+        completedDates: [String],
+        practiceDoneToday: Bool = false,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> Int {
+        historyRun(
+            days: windowDays(now: now, calendar: calendar),
+            completedDates: completedDates,
+            practiceDoneToday: practiceDoneToday
+        ).length
+    }
+
+    /// The streak the widget displays: the run its own row shows, extended past
+    /// the oldest column by history the row cannot see — and only when the row
+    /// corroborates an unbroken run all the way back to that column.
     ///
-    /// Two independent estimates are combined:
+    /// Two extension sources, both bounded by that same guard:
     ///
-    /// 1. A backward walk over `completedDays` (the union of both tracks) from
-    ///    today — or yesterday when today is still open. This is real evidence,
-    ///    and it is what catches a multi-day gap the carried-forward value used
-    ///    to paper over. It is only a **lower** bound, because the set is pruned
-    ///    to the trailing 7-day window the rows render.
-    /// 2. The carried-forward streak from the previous snapshot, which knows
-    ///    about history older than that window.
+    /// 1. `serverStreak` anchored on `serverStreakDate` (#671) — the
+    ///    server-computed `stats.streak`, anchored onto a day inside the
+    ///    corroborated run so later days extend it without a second fetch.
+    /// 2. `carriedStreak` (#684) — the previous snapshot's own value, which knows
+    ///    about days older than the window when no anchor has been stored yet.
     ///
-    /// The larger wins: the walk can only *raise* a stale carried value, and a
-    /// real gap zeroes both.
+    /// Recomputing locally keeps the number correct offline and after a day
+    /// rollover; both extensions are reconciliation inputs, never overrides. A
+    /// visible gap in the row therefore always wins: `/api/sessions` reports the
+    /// run ending at the *latest recorded* day, which stays non-zero long after a
+    /// streak has actually lapsed, and a carried value knows nothing about the
+    /// days it skipped.
+    public static func reconciledStreak(
+        completedDates: [String],
+        practiceDoneToday: Bool = false,
+        serverStreak: Int?,
+        serverStreakDate: String?,
+        carriedStreak: Int? = nil,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> Int {
+        let days = windowDays(now: now, calendar: calendar)
+        let run = historyRun(
+            days: days,
+            completedDates: completedDates,
+            practiceDoneToday: practiceDoneToday
+        )
+        guard run.length > 0 else { return 0 }
+        // The row itself shows where the streak broke — nothing may extend it.
+        guard run.startOffset + run.length >= days.count else { return run.length }
+
+        var extended = run.length
+        if let serverStreak, serverStreak > 0, let serverStreakDate,
+           let anchorOffset = days.firstIndex(of: serverStreakDate),
+           anchorOffset >= run.startOffset,
+           anchorOffset < run.startOffset + run.length {
+            // Days completed since the server counted, all inside the corroborated run.
+            let daysSinceAnchor = anchorOffset - run.startOffset
+            extended = max(extended, serverStreak + daysSinceAnchor)
+        }
+        if let carriedStreak, carriedStreak > 0 {
+            extended = max(extended, carriedStreak)
+        }
+        return extended
+    }
+
+    /// Resolve the widget streak under the #684 day-credit rule — a local day
+    /// counts when **at least one** track completed a sit that day — subject to
+    /// the #671 invariant that the number may never contradict the rendered rows.
+    ///
+    /// `completedDays` is the union of both tracks' history: exactly what
+    /// `WidgetData.weekMarks(now:)` renders. The previous snapshot's streak is
+    /// offered as an extension candidate only; `reconciledStreak` admits it just
+    /// when the run reaches the oldest column, i.e. when the rows cannot see
+    /// where the streak began.
     public static func resolvedStreak(
         userId: String,
         dayKeptToday: Bool,
         previous: WidgetData?,
         now: Date = Date(),
         completedDays: Set<String> = [],
+        serverStreak: Int? = nil,
+        serverStreakDate: String? = nil,
         calendar: Calendar = .current
     ) -> Int {
-        let today = localDayString(now, calendar: calendar)
-        var days = completedDays
-        if dayKeptToday {
-            days.insert(today)
+        // Another account's history and streak must never carry over.
+        let sameAccount = previous.flatMap { snapshot in
+            snapshot.isLoggedIn && snapshot.userId == userId ? snapshot : nil
         }
-        let walked = consecutiveKeptDays(endingAt: today, in: days)
-        let carried = carriedStreak(
-            userId: userId,
-            dayKeptToday: dayKeptToday,
-            previous: previous,
+        return reconciledStreak(
+            completedDates: Array(completedDays),
+            practiceDoneToday: dayKeptToday,
+            serverStreak: serverStreak,
+            serverStreakDate: serverStreakDate,
+            carriedStreak: carriedStreak(
+                dayKeptToday: dayKeptToday,
+                previous: sameAccount,
+                now: now,
+                calendar: calendar
+            ),
             now: now,
             calendar: calendar
         )
-        return max(walked, carried)
-    }
-
-    /// Consecutive kept days ending at `today`, or at yesterday when today has no
-    /// sit yet (today is still open, so it can't break the streak). Modeled on
-    /// `SessionStatistics.calculateStats`'s backward walk.
-    private static func consecutiveKeptDays(endingAt today: String, in days: Set<String>) -> Int {
-        var cursor: String
-        if days.contains(today) {
-            cursor = today
-        } else {
-            let yesterday = SessionCalendar.addDays(toIsoDate: today, deltaDays: -1)
-            guard yesterday != today, days.contains(yesterday) else { return 0 }
-            cursor = yesterday
-        }
-
-        var count = 0
-        while days.contains(cursor) {
-            count += 1
-            let previousDay = SessionCalendar.addDays(toIsoDate: cursor, deltaDays: -1)
-            if previousDay == cursor { break }
-            cursor = previousDay
-        }
-        return count
     }
 
     /// Carry the previous snapshot's streak forward across local days, so a
-    /// streak longer than the 7-day history window survives. Resets on account
-    /// switch, and on any gap of two or more days with no recorded sit.
+    /// streak longer than the 7-day history window survives (#684). Resets on any
+    /// gap of two or more days with no recorded sit. Callers must have already
+    /// confirmed the snapshot belongs to the same account.
+    ///
+    /// This is a *candidate*, not the answer: `reconciledStreak` discards it the
+    /// moment the rendered row shows where the run actually broke (#671).
     private static func carriedStreak(
-        userId: String,
         dayKeptToday: Bool,
         previous: WidgetData?,
         now: Date,
         calendar: Calendar
     ) -> Int {
-        guard let previous, previous.isLoggedIn, previous.userId == userId else {
+        guard let previous, previous.isLoggedIn else {
             return dayKeptToday ? 1 : 0
         }
 
         let priorStreak = max(previous.streak, 0)
-        let priorDayKept = previous.anyTrackDoneToday
+        // Was the previous snapshot's *own* local day already counted? The flags
+        // alone are not enough: the authoritative fetch path records the day in
+        // history while leaving a track's flag false, and reading only the flag
+        // there would count that day a second time on the next display.
+        let priorDay = localDayString(previous.lastUpdated, calendar: calendar)
+        let priorDayKept = previous.anyTrackDoneToday || previous.completedDayUnion.contains(priorDay)
         let elapsed = SessionCalendar.daysBetweenInclusive(
             fromIso: localDayString(previous.lastUpdated, calendar: calendar),
             toIso: localDayString(now, calendar: calendar)
@@ -621,6 +822,56 @@ public enum WidgetDataStore {
             return dayKeptToday ? 1 : 0
         }
         return dayKeptToday ? priorStreak + 1 : priorStreak
+    }
+
+    /// The local day the server-computed `stats.streak` counts through: the most
+    /// recent completed **standard** sit, matching the web's `calculateSessionStats`
+    /// (which counts standard sessions only). Nil when there is no such sit.
+    ///
+    /// Deliberately track-agnostic: under the #684 day-credit rule a second-track
+    /// standard sit keeps its day and is drawn on the Track Two row, so an anchor
+    /// landing there is corroborated by the rendered rows. The remaining
+    /// cross-surface gap — the server counts standard sits only, while the rows
+    /// also count quick and breath — is tracked in #679.
+    public static func serverStreakAnchorDate(from sessions: [SessionDTO]) -> String? {
+        var latest: String?
+        for session in sessions where session.completed && session.sessionType == .standard {
+            if let current = latest, session.sessionDate <= current { continue }
+            latest = session.sessionDate
+        }
+        return latest
+    }
+
+    /// Offsets are counted back from today: `startOffset` 0 means the run ends
+    /// today, 1 means it ends yesterday (today still pending).
+    private struct HistoryRun {
+        let length: Int
+        let startOffset: Int
+    }
+
+    /// The renderable window newest → oldest, so an array index *is* the day's
+    /// offset back from today.
+    private static func windowDays(now: Date, calendar: Calendar) -> [String] {
+        Array(localDayStrings(lastN: historyWindowDays, endingAt: now, calendar: calendar).reversed())
+    }
+
+    private static func historyRun(
+        days: [String],
+        completedDates: [String],
+        practiceDoneToday: Bool
+    ) -> HistoryRun {
+        guard let today = days.first else { return HistoryRun(length: 0, startOffset: 0) }
+        var completed = Set(completedDates)
+        if practiceDoneToday { completed.insert(today) }
+
+        let startOffset = completed.contains(today) ? 0 : 1
+        var length = 0
+        var offset = startOffset
+        while offset < days.count, completed.contains(days[offset]) {
+            length += 1
+            offset += 1
+        }
+        return HistoryRun(length: length, startOffset: startOffset)
     }
 
     public static func isSameLocalDay(_ lhs: Date, _ rhs: Date) -> Bool {
@@ -652,14 +903,15 @@ public enum WidgetDataStore {
         }
     }
 
-    /// Four of the six prior days marked complete, for gallery/Xcode previews.
+    /// The six prior days marked complete, for gallery/Xcode previews. An
+    /// unbroken trailing run so the preview streak can't contradict the row.
     public static func previewCompletedDates(now: Date = Date()) -> [String] {
-        let recent = localDayStrings(lastN: 7, endingAt: now)
-        return Array(recent.dropLast().suffix(4))
+        Array(localDayStrings(lastN: historyWindowDays, endingAt: now).dropLast())
     }
 
-    /// Two of the four prior days marked complete on Track Two, so the dual-track
-    /// preview shows a shorter second-track history than Track One (#684).
+    /// The two most recent of those days on Track Two, so the dual-track preview
+    /// shows a shorter second-track history than Track One (#684) while the union
+    /// of the two rows stays the unbroken run the preview streak claims.
     public static func previewSecondCompletedDates(now: Date = Date()) -> [String] {
         Array(previewCompletedDates(now: now).suffix(2))
     }

--- a/ios/StillPointShared/Sources/StillPointShared/WidgetData.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/WidgetData.swift
@@ -79,6 +79,21 @@ public struct WidgetData: Codable, Sendable, Equatable {
     /// row so later days can extend it without a second fetch.
     public var serverStreakDate: String?
     public var lastUpdated: Date
+    /// True only for a blob persisted *before* #671 shipped: one whose
+    /// `completedDates` and `serverStreak` keys are both absent, so it records a
+    /// `streak` with no evidence behind it. Distinguishes **unknown** history
+    /// ("this writer never stored any") from **known-empty** history ("this
+    /// writer stored history and it is empty" — a genuine lapse). Both decode to
+    /// `completedDates == []`, so `isEmpty` alone cannot tell them apart, and
+    /// conflating them either zeroes every upgrading user's streak or lets a
+    /// real lapse keep a stale one.
+    ///
+    /// Provenance, not content: set only by `init(from:)`, absent from
+    /// `CodingKeys` so it is never written back, and always `false` for a
+    /// snapshot this version constructs — including every `makeSnapshot` result.
+    /// A legacy blob therefore self-heals to `false` the first time the app
+    /// writes real history.
+    public private(set) var historyIsUnknown: Bool = false
 
     public init(
         isLoggedIn: Bool,
@@ -151,6 +166,14 @@ public struct WidgetData: Codable, Sendable, Equatable {
         serverStreak = try c.decodeIfPresent(Int.self, forKey: .serverStreak)
         serverStreakDate = try c.decodeIfPresent(String.self, forKey: .serverStreakDate)
         lastUpdated = try c.decode(Date.self, forKey: .lastUpdated)
+        // Key *absence* — not an empty value — is what marks a pre-#671 writer.
+        // `contains` is the only signal that survives `decodeIfPresent`'s
+        // `?? []`, so it is captured here rather than inferred later. Any history
+        // key at all, either track's, means the writer recorded history: a #684
+        // snapshot always writes both, so it is never mistaken for a legacy blob.
+        historyIsUnknown = !c.contains(.completedDates)
+            && !c.contains(.secondCompletedDates)
+            && !c.contains(.serverStreak)
     }
 
     public static let loggedOut = WidgetData(
@@ -659,25 +682,29 @@ public enum WidgetDataStore {
             copy.secondCompletedDates = data.secondCompletedDates.filter { window.contains($0) }
         }
         // A snapshot written before #671 carries a historical `streak` but no
-        // `completedDates` and no server anchor: both decode to their absent
-        // defaults ([] and nil). Recomputing from that would return 0 -- not
-        // because the streak lapsed, but because the evidence was never stored --
-        // so every existing user's widget would read zero from the moment they
-        // upgraded until the app next foregrounded and refetched. The widget is
-        // exactly the surface that renders *without* the app opening, so that is
-        // a visible regression, and in a change whose whole purpose is to stop
-        // the streak being wrong.
+        // stored evidence for it: its `completedDates` and `serverStreak` keys
+        // are both absent, so they decode to `[]` and `nil`. Recomputing from
+        // that reads 0 -- not because the streak lapsed, but because the
+        // evidence was never recorded -- which would zero every existing user's
+        // widget the moment they upgraded, before the app next foregrounded.
+        // The widget is exactly the surface that renders *without* the app
+        // opening, so that is a visible regression in a change whose whole
+        // purpose is to stop the streak being wrong.
         //
-        // "No history and no anchor" is therefore treated as unknown history
-        // rather than empty history, and the stored value is kept until an
-        // authoritative fetch stores real completion dates. This does not weaken
-        // the #671 invariant: that invariant governs a streak displayed *beside a
-        // row*, and a snapshot with no completion history draws no marks to
-        // contradict. Any snapshot written by this version records
-        // `completedDates`, so a genuine lapse still recomputes to 0 through the
-        // normal path below.
-        let hasHistoryToRecomputeFrom = !copy.completedDayUnion.isEmpty || copy.serverStreak != nil
-        guard hasHistoryToRecomputeFrom else { return copy }
+        // The distinction has to come from `historyIsUnknown`, which records
+        // whether those keys were *present* at decode time. An `isEmpty` test
+        // cannot make it: a snapshot written by this version also prunes to an
+        // empty history once the user lapses past the window, and treating that
+        // as "unknown" would keep a stale streak beside a blank row -- bug #671
+        // itself. Provenance separates them; emptiness does not.
+        //
+        // Belt and braces: even for a legacy blob, skip recomputation only while
+        // there is genuinely nothing to recompute from. Any evidence at all,
+        // from either track or from the anchor, goes down the normal path.
+        let historyIsUnrecorded = copy.historyIsUnknown
+            && copy.completedDayUnion.isEmpty
+            && copy.serverStreak == nil
+        guard !historyIsUnrecorded else { return copy }
 
         // The snapshot is its own "previous": its stored streak is the only record
         // of days older than the window until the next authoritative fetch. A nil

--- a/ios/StillPointShared/Sources/StillPointShared/WidgetData.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/WidgetData.swift
@@ -658,6 +658,27 @@ public enum WidgetDataStore {
             copy.completedDates = data.completedDates.filter { window.contains($0) }
             copy.secondCompletedDates = data.secondCompletedDates.filter { window.contains($0) }
         }
+        // A snapshot written before #671 carries a historical `streak` but no
+        // `completedDates` and no server anchor: both decode to their absent
+        // defaults ([] and nil). Recomputing from that would return 0 -- not
+        // because the streak lapsed, but because the evidence was never stored --
+        // so every existing user's widget would read zero from the moment they
+        // upgraded until the app next foregrounded and refetched. The widget is
+        // exactly the surface that renders *without* the app opening, so that is
+        // a visible regression, and in a change whose whole purpose is to stop
+        // the streak being wrong.
+        //
+        // "No history and no anchor" is therefore treated as unknown history
+        // rather than empty history, and the stored value is kept until an
+        // authoritative fetch stores real completion dates. This does not weaken
+        // the #671 invariant: that invariant governs a streak displayed *beside a
+        // row*, and a snapshot with no completion history draws no marks to
+        // contradict. Any snapshot written by this version records
+        // `completedDates`, so a genuine lapse still recomputes to 0 through the
+        // normal path below.
+        let hasHistoryToRecomputeFrom = !copy.completedDayUnion.isEmpty || copy.serverStreak != nil
+        guard hasHistoryToRecomputeFrom else { return copy }
+
         // The snapshot is its own "previous": its stored streak is the only record
         // of days older than the window until the next authoritative fetch. A nil
         // `userId` fails the same-account check inside `resolvedStreak`, so an

--- a/ios/StillPointShared/Tests/StillPointSharedTests/WidgetDataTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/WidgetDataTests.swift
@@ -458,6 +458,77 @@ final class WidgetDataTests: XCTestCase {
         XCTAssertEqual(shown.streak, 0, "a lapsed run with no corroborating history reads zero")
     }
 
+    /// The legacy carry-forward must key off *provenance*, not emptiness. A
+    /// snapshot written by this version that has lapsed past the window prunes
+    /// to exactly the shape of a legacy blob — no history, no anchor — and must
+    /// still recompute to 0, or #671 is back: a stale streak beside a blank row.
+    /// This is the case the 640-case property sweep caught; pinned by name here
+    /// so the distinction cannot regress silently.
+    func testEmptyHistoryWithoutAnchorRecomputesToZeroWhenHistoryWasRecorded() {
+        let now = Date()
+        let lapsed = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 10,
+            secondTrackDay: 2,
+            dualTrackEnabled: false,
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            practiceDoneToday: false,
+            streak: 42,
+            completedDates: [],
+            serverStreak: nil,
+            serverStreakDate: nil,
+            lastUpdated: now
+        )
+        XCTAssertFalse(lapsed.historyIsUnknown, "precondition: this version records history")
+
+        let shown = WidgetDataStore.normalizedForDisplay(lapsed, now: now)
+        XCTAssertEqual(shown.weekMarks(now: now).filter(\.done).count, 0, "precondition: the row is blank")
+        XCTAssertEqual(shown.streak, 0, "a blank row may never carry a streak")
+    }
+
+    /// The two shapes are indistinguishable by content, so assert directly that
+    /// decoding is what separates them: keys absent means unknown, keys present
+    /// (even empty) means recorded.
+    func testHistoryIsUnknownTracksKeyPresenceNotEmptiness() throws {
+        let ref = Date(timeIntervalSince1970: 1_700_000_000)
+        var blob: [String: Any] = [
+            "isLoggedIn": true,
+            "userId": "u1",
+            "currentDay": 10,
+            "secondTrackDay": 2,
+            "dualTrackEnabled": false,
+            "primaryDoneToday": false,
+            "secondDoneToday": false,
+            "streak": 42,
+            "lastUpdated": ref.timeIntervalSinceReferenceDate
+        ]
+
+        let legacy = try JSONDecoder().decode(
+            WidgetData.self,
+            from: try JSONSerialization.data(withJSONObject: blob)
+        )
+        XCTAssertTrue(legacy.historyIsUnknown, "no history keys at all means unknown history")
+
+        // Same empty history, but explicitly recorded by the writer.
+        blob["completedDates"] = [String]()
+        let recorded = try JSONDecoder().decode(
+            WidgetData.self,
+            from: try JSONSerialization.data(withJSONObject: blob)
+        )
+        XCTAssertFalse(recorded.historyIsUnknown, "an explicitly empty history is known, not unknown")
+        XCTAssertEqual(
+            WidgetDataStore.normalizedForDisplay(recorded, now: Date()).streak,
+            0,
+            "a recorded empty history is a lapse and must recompute to zero"
+        )
+
+        // Provenance is never written back: re-encoding clears it.
+        let roundTripped = try JSONDecoder().decode(WidgetData.self, from: try JSONEncoder().encode(legacy))
+        XCTAssertFalse(roundTripped.historyIsUnknown, "saving a snapshot records its history")
+    }
+
     func testRecentCompletedPracticeDatesFiltersTypeTrackAndWindow() {
         let now = Date()
         let today = localDay(0, from: now)

--- a/ios/StillPointShared/Tests/StillPointSharedTests/WidgetDataTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/WidgetDataTests.swift
@@ -59,127 +59,208 @@ final class WidgetDataTests: XCTestCase {
         XCTAssertEqual(snapshot.currentDay, 1)
     }
 
-    func testResolvedStreakIncrementsWhenPracticeDoneFlips() {
-        let now = Date(timeIntervalSince1970: 1_700_000_000)
-        let previous = WidgetData(
-            isLoggedIn: true,
-            userId: "u1",
-            currentDay: 4,
-            secondTrackDay: 1,
-            dualTrackEnabled: false,
-            primaryDoneToday: false,
-            secondDoneToday: false,
-            practiceDoneToday: false,
-            streak: 3,
-            lastUpdated: now
-        )
+    // MARK: - #671: streak derived from history, never from flag transitions
 
-        let streak = WidgetDataStore.resolvedStreak(
-            userId: "u1",
-            dayKeptToday: true,
-            previous: previous,
-            now: now
-        )
-        XCTAssertEqual(streak, 4)
+    func testHistoryStreakCountsRunEndingToday() {
+        let now = Date()
+        let dates = (0...3).map { localDay(-$0, from: now) }
+        XCTAssertEqual(WidgetDataStore.historyStreak(completedDates: dates, now: now), 4)
     }
 
-    func testResolvedStreakResetsOnAccountSwitch() {
-        let previous = WidgetData(
-            isLoggedIn: true,
-            userId: "old-user",
-            currentDay: 10,
-            secondTrackDay: 1,
-            dualTrackEnabled: false,
-            primaryDoneToday: true,
-            secondDoneToday: false,
-            practiceDoneToday: true,
-            streak: 8,
-            lastUpdated: Date()
-        )
-
-        let streak = WidgetDataStore.resolvedStreak(
-            userId: "new-user",
-            dayKeptToday: false,
-            previous: previous
-        )
-        XCTAssertEqual(streak, 0)
+    func testHistoryStreakCountsRunEndingYesterdayWhenTodayPending() {
+        let now = Date()
+        let dates = (1...3).map { localDay(-$0, from: now) }
+        XCTAssertEqual(WidgetDataStore.historyStreak(completedDates: dates, now: now), 3)
     }
 
-    func testResolvedStreakResetsOnNewLocalDayWithoutCompletion() {
-        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
-        let previous = WidgetData(
-            isLoggedIn: true,
-            userId: "u1",
-            currentDay: 4,
-            secondTrackDay: 1,
-            dualTrackEnabled: false,
-            primaryDoneToday: false,
-            secondDoneToday: false,
-            practiceDoneToday: false,
-            streak: 6,
-            lastUpdated: yesterday
-        )
-
-        let streak = WidgetDataStore.resolvedStreak(
-            userId: "u1",
-            dayKeptToday: false,
-            previous: previous,
-            now: Date()
-        )
-        XCTAssertEqual(streak, 0)
+    func testHistoryStreakIsZeroWhenYesterdayMissedAndTodayPending() {
+        let now = Date()
+        let dates = (2...4).map { localDay(-$0, from: now) }
+        XCTAssertEqual(WidgetDataStore.historyStreak(completedDates: dates, now: now), 0)
     }
 
-    func testResolvedStreakPreservesOnNewDayAfterYesterdayComplete() {
-        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
-        let previous = WidgetData(
-            isLoggedIn: true,
-            userId: "u1",
-            currentDay: 4,
-            secondTrackDay: 1,
-            dualTrackEnabled: false,
-            primaryDoneToday: true,
-            secondDoneToday: false,
-            practiceDoneToday: true,
-            streak: 6,
-            lastUpdated: yesterday
-        )
-
-        let streak = WidgetDataStore.resolvedStreak(
-            userId: "u1",
-            dayKeptToday: false,
-            previous: previous,
-            now: Date()
-        )
-        XCTAssertEqual(streak, 6)
+    func testHistoryStreakStopsAtFirstGap() {
+        let now = Date()
+        // Today, yesterday complete; two days ago missed; older days complete.
+        let dates = [localDay(0, from: now), localDay(-1, from: now), localDay(-3, from: now)]
+        XCTAssertEqual(WidgetDataStore.historyStreak(completedDates: dates, now: now), 2)
     }
 
-    func testResolvedStreakIncrementsOnNewDayWhenAlreadyDone() {
-        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+    func testHistoryStreakUsesPracticeFlagForTodayWithoutCompletedDate() {
+        let now = Date()
+        let dates = (1...2).map { localDay(-$0, from: now) }
+        XCTAssertEqual(
+            WidgetDataStore.historyStreak(completedDates: dates, practiceDoneToday: true, now: now),
+            3
+        )
+    }
+
+    /// The exact case in the #671 screenshot: six consecutive completed days
+    /// ending yesterday with today still pending must read 6, not the 2 the old
+    /// flag-transition counter accumulated.
+    func testSixCompletedDaysWithTodayPendingYieldsStreakSix() {
         let now = Date()
         let previous = WidgetData(
             isLoggedIn: true,
             userId: "u1",
-            currentDay: 4,
+            currentDay: 30,
             secondTrackDay: 1,
             dualTrackEnabled: false,
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            practiceDoneToday: false,
+            streak: 2, // the wrong number the widget used to carry
+            completedDates: (1...6).map { localDay(-$0, from: now) },
+            lastUpdated: now
+        )
+        let snapshot = WidgetDataStore.makeSnapshot(
+            user: makeUser(id: "u1"),
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            practiceDoneToday: false,
+            now: now,
+            previous: previous
+        )
+        XCTAssertEqual(snapshot.streak, 6)
+        XCTAssertEqual(snapshot.weekRowStreak(now: now), 6)
+    }
+
+    func testServerStreakExtendsRunPastTheWindowEdge() {
+        let now = Date()
+        let snapshot = WidgetDataStore.makeSnapshot(
+            user: makeUser(id: "u1"),
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            practiceDoneToday: false,
+            now: now,
+            previous: nil,
+            completedPracticeDates: Set((1...6).map { localDay(-$0, from: now) }),
+            serverStreak: 20,
+            serverStreakDate: localDay(-1, from: now)
+        )
+        XCTAssertEqual(snapshot.streak, 20)
+    }
+
+    /// A gap the row can see always wins: `/api/sessions` reports the run ending
+    /// at the latest recorded day, which stays non-zero long after a lapse.
+    func testServerStreakCannotOverrideAVisibleGap() {
+        let now = Date()
+        let snapshot = WidgetDataStore.makeSnapshot(
+            user: makeUser(id: "u1"),
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            practiceDoneToday: false,
+            now: now,
+            previous: nil,
+            completedPracticeDates: Set((1...3).map { localDay(-$0, from: now) }),
+            serverStreak: 20,
+            serverStreakDate: localDay(-1, from: now)
+        )
+        XCTAssertEqual(snapshot.streak, 3)
+    }
+
+    func testServerStreakIgnoredWhenAnchorPredatesTheRun() {
+        let now = Date()
+        let snapshot = WidgetDataStore.makeSnapshot(
+            user: makeUser(id: "u1"),
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            practiceDoneToday: false,
+            now: now,
+            previous: nil,
+            completedPracticeDates: Set((1...6).map { localDay(-$0, from: now) }),
+            serverStreak: 20,
+            serverStreakDate: localDay(-30, from: now) // stale; outside the row
+        )
+        XCTAssertEqual(snapshot.streak, 6)
+    }
+
+    /// Sitting today must move the flame even when the streak is older than the
+    /// row — the carried-forward anchor supplies the days the row can't show.
+    func testSitTodayExtendsCarriedForwardServerStreak() {
+        let now = Date()
+        let previous = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 30,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            practiceDoneToday: false,
+            streak: 20,
+            completedDates: (1...6).map { localDay(-$0, from: now) },
+            serverStreak: 20,
+            serverStreakDate: localDay(-1, from: now),
+            lastUpdated: now
+        )
+        let snapshot = WidgetDataStore.makeSnapshot(
+            user: makeUser(id: "u1"),
             primaryDoneToday: true,
             secondDoneToday: false,
             practiceDoneToday: true,
-            streak: 5,
-            lastUpdated: yesterday
+            now: now,
+            previous: previous
         )
-
-        let streak = WidgetDataStore.resolvedStreak(
-            userId: "u1",
-            dayKeptToday: true,
-            previous: previous,
-            now: now
-        )
-        XCTAssertEqual(streak, 6)
+        XCTAssertEqual(snapshot.streak, 21)
+        XCTAssertEqual(snapshot.serverStreak, 20, "anchor carries forward for the next sit")
     }
 
+    func testMakeSnapshotDropsServerAnchorOnAccountSwitch() {
+        let now = Date()
+        let previous = WidgetData(
+            isLoggedIn: true,
+            userId: "old-user",
+            currentDay: 30,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            practiceDoneToday: false,
+            streak: 20,
+            completedDates: (1...6).map { localDay(-$0, from: now) },
+            serverStreak: 20,
+            serverStreakDate: localDay(-1, from: now),
+            lastUpdated: now
+        )
+        let snapshot = WidgetDataStore.makeSnapshot(
+            user: makeUser(id: "new-user"),
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            practiceDoneToday: false,
+            now: now,
+            previous: previous
+        )
+        XCTAssertEqual(snapshot.streak, 0)
+        XCTAssertNil(snapshot.serverStreak)
+        XCTAssertNil(snapshot.serverStreakDate)
+    }
+
+    func testServerStreakAnchorDateIsLatestCompletedStandardSit() {
+        let now = Date()
+        let sessions = [
+            session(date: localDay(-4, from: now), type: .standard, completed: true),
+            session(date: localDay(-2, from: now), type: .standard, completed: true),
+            session(date: localDay(-1, from: now), type: .standard, completed: false),
+            session(date: localDay(0, from: now), type: .quick, completed: true)
+        ]
+        XCTAssertEqual(
+            WidgetDataStore.serverStreakAnchorDate(from: sessions),
+            localDay(-2, from: now)
+        )
+    }
+
+    func testServerStreakAnchorDateIsNilWithoutCompletedStandardSit() {
+        let now = Date()
+        let sessions = [session(date: localDay(0, from: now), type: .breath, completed: true)]
+        XCTAssertNil(WidgetDataStore.serverStreakAnchorDate(from: sessions))
+    }
+
+    // MARK: - #671: day rollover
+
     func testNormalizedForDisplayClearsStaleDoneToday() {
-        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        let now = Date()
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: now)!
         let stale = WidgetData(
             isLoggedIn: true,
             userId: "u1",
@@ -190,12 +271,60 @@ final class WidgetDataTests: XCTestCase {
             secondDoneToday: false,
             practiceDoneToday: true,
             streak: 6,
+            completedDates: (1...6).map { localDay(-$0, from: now) },
             lastUpdated: yesterday
         )
 
-        let normalized = WidgetDataStore.normalizedForDisplay(stale, now: Date())
-        XCTAssertFalse(normalized.isPracticeCompleteForToday(at: Date()))
-        XCTAssertEqual(normalized.streak, 6)
+        let normalized = WidgetDataStore.normalizedForDisplay(stale, now: now)
+        XCTAssertFalse(normalized.isPracticeCompleteForToday(at: now))
+        XCTAssertFalse(normalized.primaryDoneToday)
+        XCTAssertFalse(normalized.secondDoneToday)
+        XCTAssertEqual(normalized.streak, 6, "an intact streak survives the rollover")
+    }
+
+    /// The regression #671 AC3 names: the rollover branch zeroed the streak
+    /// whenever the previous snapshot's `practiceDoneToday` was false, even when
+    /// history plainly showed the streak was intact.
+    func testNormalizedForDisplayKeepsStreakWhenPriorSnapshotHadNotSatYet() {
+        let now = Date()
+        let yesterdayMorning = Calendar.current.date(byAdding: .day, value: -1, to: now)!
+        let data = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 30,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            practiceDoneToday: false, // snapshot written before yesterday's sit
+            streak: 5,
+            completedDates: (1...5).map { localDay(-$0, from: now) },
+            lastUpdated: yesterdayMorning
+        )
+        XCTAssertEqual(WidgetDataStore.normalizedForDisplay(data, now: now).streak, 5)
+    }
+
+    func testNormalizedForDisplayZeroesStreakWhenRowShowsALapse() {
+        let now = Date()
+        let threeDaysAgo = Calendar.current.date(byAdding: .day, value: -3, to: now)!
+        let data = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 30,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: true,
+            secondDoneToday: false,
+            practiceDoneToday: true,
+            streak: 12,
+            completedDates: (3...5).map { localDay(-$0, from: now) },
+            serverStreak: 12,
+            serverStreakDate: localDay(-3, from: now),
+            lastUpdated: threeDaysAgo
+        )
+        let normalized = WidgetDataStore.normalizedForDisplay(data, now: now)
+        XCTAssertEqual(normalized.streak, 0)
+        XCTAssertEqual(normalized.weekRowStreak(now: now), 0)
     }
 
     func testMakeSnapshotPreservesStreakSameDay() {
@@ -210,7 +339,8 @@ final class WidgetDataTests: XCTestCase {
             primaryDoneToday: true,
             secondDoneToday: false,
             practiceDoneToday: true,
-            streak: 9,
+            streak: 7,
+            completedDates: (0...6).map { localDay(-$0, from: now) },
             lastUpdated: now
         )
 
@@ -222,7 +352,7 @@ final class WidgetDataTests: XCTestCase {
             now: now,
             previous: previous
         )
-        XCTAssertEqual(snapshot.streak, 9)
+        XCTAssertEqual(snapshot.streak, 7)
     }
 
     // MARK: - #84 follow-up: weekday checkmark row
@@ -271,7 +401,6 @@ final class WidgetDataTests: XCTestCase {
         let data = try JSONSerialization.data(withJSONObject: legacy)
         let decoded = try JSONDecoder().decode(WidgetData.self, from: data)
         XCTAssertEqual(decoded.completedDates, [])
-        XCTAssertEqual(decoded.secondCompletedDates, [])
         XCTAssertEqual(decoded.streak, 7)
         XCTAssertTrue(decoded.primaryDoneToday)
         XCTAssertTrue(decoded.practiceDoneToday, "legacy blobs fall back to primaryDoneToday")
@@ -290,13 +419,12 @@ final class WidgetDataTests: XCTestCase {
             session(date: today, type: .quick, completed: true, track: .primary), // quick counts (#589)
             session(date: twoDaysAgo, type: .breath, completed: true, track: nil), // breath counts (#589)
             session(date: today, type: .standard, completed: false, track: .primary), // incomplete excluded
-            session(date: today, type: .standard, completed: true, track: .second) // Track Two only (#684)
+            session(date: today, type: .standard, completed: true, track: .second) // second track excluded
         ]
 
         let result = WidgetDataStore.recentCompletedPracticeDates(from: sessions, now: now)
         XCTAssertEqual(result.primary, [today, twoDaysAgo])
-        // #684: the second-track standard sit lands on Track Two, never Track One.
-        XCTAssertEqual(result.second, [today])
+        XCTAssertEqual(result.second, [today], "the second-track standard sit lands on Track Two (#684)")
     }
 
     func testWeekMarksHasSevenDaysEndingToday() {
@@ -489,6 +617,7 @@ final class WidgetDataTests: XCTestCase {
             secondDoneToday: false,
             practiceDoneToday: false,
             streak: 2,
+            completedDates: (1...2).map { localDay(-$0, from: now) },
             lastUpdated: now
         )
         let snapshot = WidgetDataStore.makeSnapshot(
@@ -512,6 +641,254 @@ final class WidgetDataTests: XCTestCase {
         let iso = WidgetDataStore.localDayString(date, calendar: buddhist)
         XCTAssertEqual(iso.count, 10)
         XCTAssertTrue(iso.hasPrefix("20"), "expected Gregorian year, got \(iso)")
+    }
+
+    // MARK: - #671 symptom 2: the stored week must survive a failed launch
+
+    /// Root cause of "the week resets": `syncWidgetData()` wiped the shared blob
+    /// on *any* signed-out render, including a launch that merely couldn't reach
+    /// the server. Only an authoritative sign-out may clear it.
+    func testOnlyAuthoritativeSignOutClearsTheStoredSnapshot() {
+        XCTAssertTrue(WidgetDataStore.shouldClearStoredSnapshot(on: .signedOut))
+        XCTAssertTrue(WidgetDataStore.shouldClearStoredSnapshot(on: .unauthorized))
+        XCTAssertFalse(
+            WidgetDataStore.shouldClearStoredSnapshot(on: .unreachable),
+            "an offline cold start is not a sign-out"
+        )
+        XCTAssertFalse(
+            WidgetDataStore.shouldClearStoredSnapshot(on: .serverError),
+            "a 500 says nothing about the session"
+        )
+    }
+
+    /// The damage a wipe does, and why it looks like the row "reset": with no
+    /// prior snapshot to carry forward, the network-free sync path has nothing to
+    /// build a week from, so both the row and the streak start over.
+    func testWipedSnapshotLeavesTheRowBlankAndTheStreakAtZero() {
+        let now = Date()
+        let snapshot = WidgetDataStore.makeSnapshot(
+            user: makeUser(id: "u1"),
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            practiceDoneToday: false,
+            now: now,
+            previous: nil // the blob a failed launch had already cleared
+        )
+        XCTAssertEqual(snapshot.completedDates, [])
+        XCTAssertEqual(snapshot.streak, 0)
+        XCTAssertEqual(snapshot.weekMarks(now: now).filter(\.done).count, 0)
+    }
+
+    // MARK: - #671 symptom 2: the week must not reset at a calendar boundary
+
+    /// Fixed `now` on a Monday with completions the preceding Wed–Sun: those days
+    /// belong to the *previous* calendar week but are inside the trailing seven,
+    /// so they must stay marked.
+    func testWeekBoundaryKeepsPriorCalendarWeekMarked() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        // 2026-03-16 is a Monday.
+        let monday = ISO8601DateFormatter().date(from: "2026-03-16T12:00:00Z")!
+        XCTAssertEqual(calendar.component(.weekday, from: monday), 2, "fixture must be a Monday")
+
+        let priorWeek = ["2026-03-11", "2026-03-12", "2026-03-13", "2026-03-14", "2026-03-15"] // Wed–Sun
+        let data = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 30,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            practiceDoneToday: false,
+            streak: 5,
+            completedDates: priorWeek,
+            lastUpdated: monday
+        )
+
+        let marks = data.weekMarks(now: monday, calendar: calendar)
+        let done = Set(marks.filter(\.done).map(\.iso))
+        XCTAssertEqual(done, Set(priorWeek), "prior-week completions must survive the boundary")
+        XCTAssertEqual(marks.last?.iso, "2026-03-16")
+        XCTAssertEqual(marks.last?.done, false, "Monday is still pending")
+        XCTAssertEqual(
+            WidgetDataStore.reconciledStreak(
+                completedDates: priorWeek,
+                serverStreak: nil,
+                serverStreakDate: nil,
+                now: monday,
+                calendar: calendar
+            ),
+            5
+        )
+    }
+
+    /// A snapshot written last week must still carry its history forward through
+    /// the network-free sync path once the calendar week rolls over.
+    func testMakeSnapshotCarriesHistoryAcrossAWeekBoundary() {
+        let now = Date()
+        let priorDays = (1...5).map { localDay(-$0, from: now) }
+        let previous = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 30,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            practiceDoneToday: false,
+            streak: 5,
+            completedDates: priorDays,
+            lastUpdated: Calendar.current.date(byAdding: .day, value: -1, to: now)!
+        )
+        let snapshot = WidgetDataStore.makeSnapshot(
+            user: makeUser(id: "u1"),
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            practiceDoneToday: false,
+            now: now,
+            previous: previous
+        )
+        XCTAssertEqual(Set(snapshot.completedDates), Set(priorDays))
+        XCTAssertEqual(snapshot.streak, 5)
+    }
+
+    /// #671 AC6: a cold start with no network keeps the last known history —
+    /// `normalizedForDisplay` is the widget's only read path, and it must never
+    /// blank the row or zero an intact streak.
+    func testColdStartWithoutNetworkKeepsLastKnownHistory() {
+        let now = Date()
+        let lastSeen = Calendar.current.date(byAdding: .day, value: -1, to: now)!
+        let stored = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 30,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: true,
+            secondDoneToday: false,
+            practiceDoneToday: true,
+            streak: 4,
+            completedDates: (1...4).map { localDay(-$0, from: now) },
+            lastUpdated: lastSeen
+        )
+        let displayed = WidgetDataStore.normalizedForDisplay(stored, now: now)
+        XCTAssertEqual(displayed.completedDates.count, 4)
+        XCTAssertEqual(displayed.weekMarks(now: now).filter(\.done).count, 4)
+        XCTAssertEqual(displayed.streak, 4)
+    }
+
+    // MARK: - #671 AC2 × #684: streak and the rendered rows cannot disagree
+
+    /// Property check over generated completion sets, ported to the two-a-day row
+    /// model (#684): whatever the widget shows as `streak`, it can never
+    /// contradict the run its own rows draw.
+    ///
+    /// Under the day-credit rule a day is *shown* as kept when **either** row
+    /// marks it, so the union row `weekMarks(now:)` is exactly the run a person
+    /// counts off the widget with their finger — one row on a single-session
+    /// setup, the two rows read together on a two-a-day one. The sweep therefore
+    /// asserts both halves: that the rendered rows really do partition the kept
+    /// days between them, and that the number beside them never exceeds what
+    /// they show unless the run leaves the window.
+    func testStreakNeverContradictsTheRenderedRow() {
+        let now = Date()
+        let serverCases: [(Int?, String?)] = [
+            (nil, nil),
+            (20, localDay(-1, from: now)),
+            (20, localDay(0, from: now)),
+            (20, localDay(-30, from: now)),
+            (3, localDay(-2, from: now))
+        ]
+
+        // Every subset of the trailing seven days, against every server anchor.
+        for mask in 0..<(1 << 7) {
+            let offsets = (0..<7).filter { mask & (1 << $0) != 0 }
+            // Split the kept days across the tracks so all three shapes occur in
+            // every mask: Track One only, Track Two only, and both. The union is
+            // unchanged by the split — which is the point, since day credit does
+            // not care which of the two sits landed.
+            let primaryDates = offsets.filter { $0 % 3 != 1 }.map { localDay(-$0, from: now) }
+            let secondDates = offsets.filter { $0 % 3 != 0 }.map { localDay(-$0, from: now) }
+            let keptDays = Set(offsets.map { localDay(-$0, from: now) })
+
+            func snapshot(serverStreak: Int?, serverStreakDate: String?) -> WidgetData {
+                WidgetDataStore.normalizedForDisplay(
+                    WidgetData(
+                        isLoggedIn: true,
+                        userId: "u1",
+                        currentDay: 30,
+                        secondTrackDay: 4,
+                        dualTrackEnabled: true,
+                        primaryDoneToday: false,
+                        secondDoneToday: false,
+                        practiceDoneToday: false,
+                        streak: 999, // deliberately wrong; display must re-derive it
+                        completedDates: primaryDates,
+                        secondCompletedDates: secondDates,
+                        serverStreak: serverStreak,
+                        serverStreakDate: serverStreakDate,
+                        lastUpdated: now
+                    ),
+                    now: now
+                )
+            }
+
+            // The rendered rows, between them, show exactly the kept days — and
+            // neither row ever marks a day its own track did not sit. None of
+            // this depends on the server anchor, so it is asserted once per mask.
+            let rendered = snapshot(serverStreak: nil, serverStreakDate: nil)
+            let rowOne = Set(rendered.weekMarks(for: .primary, now: now).filter(\.done).map(\.iso))
+            let rowTwo = Set(rendered.weekMarks(for: .second, now: now).filter(\.done).map(\.iso))
+            let unionRow = Set(rendered.weekMarks(now: now).filter(\.done).map(\.iso))
+            XCTAssertEqual(unionRow, rowOne.union(rowTwo), "union row is not what the rows show (mask=\(mask))")
+            XCTAssertEqual(unionRow, keptDays, "the rendered rows lost a kept day (mask=\(mask))")
+            XCTAssertTrue(
+                rowOne.isSubset(of: Set(primaryDates)),
+                "Track One marked a day it did not sit (mask=\(mask))"
+            )
+            XCTAssertTrue(
+                rowTwo.isSubset(of: Set(secondDates)),
+                "Track Two marked a day it did not sit (mask=\(mask))"
+            )
+
+            for (serverStreak, serverStreakDate) in serverCases {
+                let shown = snapshot(serverStreak: serverStreak, serverStreakDate: serverStreakDate)
+                let context = "mask=\(mask) server=\(String(describing: serverStreak))"
+                let rowRun = shown.weekRowStreak(now: now)
+                // Rows with no run mean no streak — nothing may inflate it.
+                if rowRun == 0 {
+                    XCTAssertEqual(shown.streak, 0, "streak must be 0 when the rows show none (\(context))")
+                    continue
+                }
+                // The streak may never undercount days the rows visibly show.
+                XCTAssertGreaterThanOrEqual(shown.streak, rowRun, "streak below the rows (\(context))")
+                // When the rows can see where the run began, the streak must match
+                // exactly — only a run that leaves the window may exceed it.
+                if !shown.weekRowStreakReachesWindowEdge(now: now) {
+                    XCTAssertEqual(shown.streak, rowRun, "streak exceeds a visibly broken row (\(context))")
+                }
+            }
+        }
+    }
+
+    func testWeekRowStreakReadsTheRenderedMarks() {
+        let now = Date()
+        let data = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 30,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            practiceDoneToday: false,
+            streak: 0,
+            completedDates: [localDay(-1, from: now), localDay(-2, from: now), localDay(-4, from: now)],
+            lastUpdated: now
+        )
+        XCTAssertEqual(data.weekRowStreak(now: now), 2)
+        XCTAssertFalse(data.weekRowStreakReachesWindowEdge(now: now))
     }
 
     func testWeekMarksPopulateWeekdayName() {
@@ -745,9 +1122,18 @@ final class WidgetDataTests: XCTestCase {
     // MARK: - #684 day-credit rule: at least one session keeps the day
 
     /// Finishing only the shorter (second) sit keeps the streak moving.
+    ///
+    /// #671 note: the previous snapshot carries the four days the run is built
+    /// from. A carried number with no history behind it is exactly what this PR
+    /// stops the widget displaying, so the fixture supplies the evidence the row
+    /// would be drawing.
     func testStreakKeptWhenOnlySecondSessionCompleted() {
         let now = Date()
-        let previous = dualTrackData(now: now, streak: 4)
+        let previous = dualTrackData(
+            now: now,
+            completedDates: (1...4).map { localDay(-$0, from: now) },
+            streak: 4
+        )
         let snapshot = WidgetDataStore.makeSnapshot(
             user: makeUser(id: "u1"),
             primaryDoneToday: false,
@@ -842,11 +1228,205 @@ final class WidgetDataTests: XCTestCase {
         XCTAssertEqual(snapshot.streak, 30)
     }
 
+    /// …and it keeps counting: a sit today on a week the rows show unbroken
+    /// advances the carried total rather than collapsing to the window length.
+    func testCarriedStreakLongerThanWindowIncrementsAcrossADay() {
+        let now = Date()
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: now)!
+        var previous = dualTrackData(
+            now: now,
+            completedDates: (1...7).map { localDay(-$0, from: now) },
+            primaryDoneToday: true,
+            practiceDoneToday: true,
+            streak: 30
+        )
+        previous.lastUpdated = yesterday
+
+        let snapshot = WidgetDataStore.makeSnapshot(
+            user: makeUser(id: "u1"),
+            primaryDoneToday: false,
+            secondDoneToday: true, // only the second sit today — still a kept day
+            practiceDoneToday: false,
+            now: now,
+            previous: previous
+        )
+        XCTAssertEqual(snapshot.streak, 31)
+    }
+
+    /// #671 × #684: the carried total is a *candidate*, never an override. When
+    /// the rows show where the run actually broke, the number beside them is the
+    /// run they draw — no matter what the previous snapshot claimed.
+    func testCarriedStreakIsIgnoredWhenTheRowsShowABreak() {
+        let now = Date()
+        let previous = dualTrackData(
+            now: now,
+            completedDates: [localDay(-1, from: now)],
+            secondCompletedDates: [localDay(-4, from: now)],
+            primaryDoneToday: true,
+            practiceDoneToday: true,
+            streak: 30
+        )
+        let snapshot = WidgetDataStore.makeSnapshot(
+            user: makeUser(id: "u1"),
+            primaryDoneToday: true,
+            secondDoneToday: false,
+            practiceDoneToday: true,
+            now: now,
+            previous: previous
+        )
+        // Today and yesterday are kept; -2 and -3 are blank, and the rows say so.
+        XCTAssertEqual(snapshot.streak, 2)
+        XCTAssertEqual(snapshot.weekRowStreak(now: now), 2)
+    }
+
     func testIsDayKeptTodayHonorsEitherTrack() {
         let now = Date()
         XCTAssertTrue(dualTrackData(now: now, secondDoneToday: true).isDayKeptToday(at: now))
         XCTAssertTrue(dualTrackData(now: now, practiceDoneToday: true).isDayKeptToday(at: now))
         XCTAssertFalse(dualTrackData(now: now).isDayKeptToday(at: now))
+    }
+
+    // MARK: - #684 carry-forward, bounded by the #671 row invariant
+
+    /// Every case below feeds `resolvedStreak` the history the rows would be
+    /// drawing, because the carried value is only admissible while the rows
+    /// corroborate an unbroken run back to the oldest column. With no history at
+    /// all the rows are blank, and a blank row may never carry a streak.
+
+    func testResolvedStreakIncrementsWhenPracticeDoneFlips() {
+        let now = Date()
+        let previous = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 4,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            practiceDoneToday: false,
+            streak: 30,
+            completedDates: (1...6).map { localDay(-$0, from: now) },
+            lastUpdated: now
+        )
+
+        let streak = WidgetDataStore.resolvedStreak(
+            userId: "u1",
+            dayKeptToday: true,
+            previous: previous,
+            now: now,
+            completedDays: Set((0...6).map { localDay(-$0, from: now) })
+        )
+        XCTAssertEqual(streak, 31)
+    }
+
+    func testResolvedStreakResetsOnAccountSwitch() {
+        let now = Date()
+        let previous = WidgetData(
+            isLoggedIn: true,
+            userId: "old-user",
+            currentDay: 10,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: true,
+            secondDoneToday: false,
+            practiceDoneToday: true,
+            streak: 8,
+            completedDates: (0...6).map { localDay(-$0, from: now) },
+            lastUpdated: now
+        )
+
+        // The other account's history never reaches this call either, so the rows
+        // the new account renders are blank and the streak is zero.
+        let streak = WidgetDataStore.resolvedStreak(
+            userId: "new-user",
+            dayKeptToday: false,
+            previous: previous,
+            now: now
+        )
+        XCTAssertEqual(streak, 0)
+    }
+
+    func testResolvedStreakResetsOnNewLocalDayWithoutCompletion() {
+        let now = Date()
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: now)!
+        let previous = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 4,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            practiceDoneToday: false,
+            streak: 6,
+            completedDates: [],
+            lastUpdated: yesterday
+        )
+
+        let streak = WidgetDataStore.resolvedStreak(
+            userId: "u1",
+            dayKeptToday: false,
+            previous: previous,
+            now: now
+        )
+        XCTAssertEqual(streak, 0)
+    }
+
+    func testResolvedStreakPreservesOnNewDayAfterYesterdayComplete() {
+        let now = Date()
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: now)!
+        let history = (1...7).map { localDay(-$0, from: now) }
+        let previous = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 4,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: true,
+            secondDoneToday: false,
+            practiceDoneToday: true,
+            streak: 20,
+            completedDates: history,
+            lastUpdated: yesterday
+        )
+
+        // Today is still pending, so the run ends yesterday and reaches the oldest
+        // column — the rows cannot see where it began, so the carried 20 stands.
+        let streak = WidgetDataStore.resolvedStreak(
+            userId: "u1",
+            dayKeptToday: false,
+            previous: previous,
+            now: now,
+            completedDays: Set(history)
+        )
+        XCTAssertEqual(streak, 20)
+    }
+
+    func testResolvedStreakIncrementsOnNewDayWhenAlreadyDone() {
+        let now = Date()
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: now)!
+        let previous = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 4,
+            secondTrackDay: 1,
+            dualTrackEnabled: false,
+            primaryDoneToday: true,
+            secondDoneToday: false,
+            practiceDoneToday: true,
+            streak: 20,
+            completedDates: (1...7).map { localDay(-$0, from: now) },
+            lastUpdated: yesterday
+        )
+
+        let streak = WidgetDataStore.resolvedStreak(
+            userId: "u1",
+            dayKeptToday: true,
+            previous: previous,
+            now: now,
+            completedDays: Set((0...6).map { localDay(-$0, from: now) })
+        )
+        XCTAssertEqual(streak, 21)
     }
 
     // MARK: - #684 per-track weekday rows

--- a/ios/StillPointShared/Tests/StillPointSharedTests/WidgetDataTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/WidgetDataTests.swift
@@ -406,6 +406,58 @@ final class WidgetDataTests: XCTestCase {
         XCTAssertTrue(decoded.practiceDoneToday, "legacy blobs fall back to primaryDoneToday")
     }
 
+    /// A pre-#671 snapshot has a real `streak` but no stored history to justify
+    /// it. Recomputing would read 0 -- not a lapse, just missing evidence -- and
+    /// zero every existing user's widget the moment they upgraded, before the
+    /// app next foregrounded. Unknown history must not be read as empty history.
+    func testLegacySnapshotKeepsItsStreakUntilHistoryIsStored() throws {
+        let ref = Date(timeIntervalSince1970: 1_700_000_000)
+        let legacy: [String: Any] = [
+            "isLoggedIn": true,
+            "userId": "u1",
+            "currentDay": 10,
+            "secondTrackDay": 2,
+            "dualTrackEnabled": false,
+            "primaryDoneToday": false,
+            "secondDoneToday": false,
+            "streak": 42,
+            "lastUpdated": ref.timeIntervalSinceReferenceDate
+        ]
+        let data = try JSONSerialization.data(withJSONObject: legacy)
+        let decoded = try JSONDecoder().decode(WidgetData.self, from: data)
+        XCTAssertEqual(decoded.completedDates, [], "precondition: legacy blob stores no history")
+        XCTAssertNil(decoded.serverStreak, "precondition: legacy blob stores no anchor")
+
+        // `now` is far past lastUpdated, so the rollover branch also runs.
+        let shown = WidgetDataStore.normalizedForDisplay(decoded, now: Date())
+        XCTAssertEqual(shown.streak, 42, "legacy streak must survive until real history is stored")
+        XCTAssertFalse(shown.practiceDoneToday, "stale done-today flags are still cleared")
+    }
+
+    /// The guard above must not become a way for a genuine lapse to persist: a
+    /// snapshot written by *this* version always records `completedDates`, so an
+    /// empty-but-present history alongside a server anchor still recomputes.
+    func testEmptyHistoryWithAnchorStillRecomputesToZero() {
+        let now = Date()
+        let data = WidgetData(
+            isLoggedIn: true,
+            userId: "u1",
+            currentDay: 10,
+            secondTrackDay: 2,
+            dualTrackEnabled: false,
+            primaryDoneToday: false,
+            secondDoneToday: false,
+            practiceDoneToday: false,
+            streak: 42,
+            completedDates: [],
+            serverStreak: 3,
+            serverStreakDate: localDay(-30, from: now),
+            lastUpdated: now
+        )
+        let shown = WidgetDataStore.normalizedForDisplay(data, now: now)
+        XCTAssertEqual(shown.streak, 0, "a lapsed run with no corroborating history reads zero")
+    }
+
     func testRecentCompletedPracticeDatesFiltersTypeTrackAndWindow() {
         let now = Date()
         let today = localDay(0, from: now)


### PR DESCRIPTION
## **User description**
Closes #671

> **Rebased onto `main` after PR #686 (2026-08-27).** #686 ("one widget row per sit on a two-a-day schedule", for issue #684) merged four minutes into this PR's last review round and rewrote all six files this PR touches, including `normalizedForDisplay` itself. #686's two-a-day row model is canon; this PR's invariant has been **re-derived inside it**, not layered against it. See "What the rebase changed" below.

## What was wrong

The widget's streak and its weekday row were two views of the same fact computed from **different sources**, so they contradicted each other.

- The **row** was backfilled from real session history (`/api/sessions`).
- The **streak** was accumulated from snapshot-to-snapshot `practiceDoneToday` flag transitions (`resolvedStreak`), incrementing only on a false→true flip the app happened to observe. A day the app never opened on was silently dropped forever. That is how six checked days ended up beside a flame of 2.

`refreshWidgetWeekHistory()` already fetched the server-computed `stats.streak` — the same number the app and web history show — and threw it away.

## Root cause of symptom 2 ("the week resets")

Both symptoms trace to one line. `syncWidgetData()` wiped the shared App Group blob on **any** signed-out render:

```swift
if snapshot.isLoggedIn { WidgetDataStore.save(snapshot) } else { WidgetDataStore.clear() }
```

`checkAuth()` reaches that `else` on a plain network failure — the "Connection failed. Please try again." branch — so **an offline cold start deleted the widget's only copy of the week.** The row goes blank, and because `makeSnapshot`'s carry-forward path needs a prior snapshot (`prior == nil` → `dates = []`), the flag-transition counter then restarts from 1 and climbs to 2, 3… while the row independently heals from the server. That is exactly the screenshot: a healed row next to a restarted flame.

The issue listed both the `prior == nil` path and the refresh throttle as candidates. The `prior == nil` path is the *mechanism*; the unconditional `clear()` is what puts it there. The throttle is a real secondary path (sign-out then sign-in keeps the same `userId|day` key, suppressing the re-backfill for the rest of the day) and is fixed too.

## What changed

**`WidgetData.swift`**
- `reconciledStreak(...)` derives the streak from `completedDates` — the same set the row draws — and uses the server's `stats.streak` **only to extend a run the row already corroborates**, anchored on `serverStreakDate` (the day that total counts through). A gap the row can see always wins: `/api/sessions` reports the run ending at the *latest recorded* day, which stays non-zero long after a streak has lapsed, so it can never be trusted outright.
- Two new persisted fields, `serverStreak` / `serverStreakDate`, decoded permissively (legacy blobs still load). The anchor is what lets a sit today extend a streak older than the seven-day row without a second fetch.
- `normalizedForDisplay` recomputes the streak on **every** display, not only on a day rollover, and no longer zeroes it when the prior snapshot's `practiceDoneToday` was false.
- `shouldClearStoredSnapshot(on:)` names the wipe policy: `signedOut` / `unauthorized` clear; `serverError` / `unreachable` do not.
- `resolvedStreak` no longer accumulates from flag transitions. It survives as the **day-credit entry point** (#684's rule: a day is kept when at least one track sat) and delegates to `reconciledStreak`, offering the previous snapshot's value only as an extension *candidate*.

**`AppViewModel.swift`** (kept minimal for the #665 rebase)
- Passes `result.stats.streak` and the derived anchor into `makeSnapshot` instead of discarding them.
- `syncWidgetData(signedOutCause:)` distinguishes a real sign-out from a failed launch.
- Clearing the snapshot resets `widgetHistoryRefreshKey`, so a sign-out/sign-in re-backfills.

## What the rebase changed (re-deriving the invariant inside #686's model)

#686 redefined what a *row* is: on a two-a-day schedule the widget draws **two** rows, and a day is kept when **either** track sat. #671's thesis — "never display a streak the rows cannot corroborate" — had to be restated against that, not merely re-applied.

- **The corroborating row is the union.** `weekMarks(now:)` (#686's single-row layout) marks exactly the days at least one track sat, which is precisely the day-credit rule. So the run a person counts off the widget is well-defined for both layouts, and `isTodayMarkedDone` / `weekRowStreak` now read the union rather than Track One alone.
- **The streak derives from the union history.** `makeSnapshot` and `normalizedForDisplay` both feed `completedDates ∪ secondCompletedDates` into `reconciledStreak`.
- **#686's carry-forward survives, bounded.** #686 combined a backward walk with a carried value as `max(walked, carried)`. The carried half never consulted the row, so a snapshot claiming 30 could still be shown beside a row with a visible two-day hole — #671 in a new guise, narrowed by #686's gap reset but not closed. The carried value is now a *candidate* admitted by the same guard the server anchor passes through: the run must reach the oldest column, i.e. the rows must not be able to see where it began. `testStreakLongerThanWindowSurvives` and the multi-day-gap regression stay green; `testCarriedStreakIsIgnoredWhenTheRowsShowABreak` pins the new bound.
- **`carriedStreak` reads "was the prior day kept?" from history, not only the flag.** The authoritative fetch path records a day in history while leaving a track's flag false, so a flag-only test double-counted that day on the next display.
- **The property test was ported, not deleted.** Same 128 subsets × 5 server anchors, but each mask now splits its kept days three ways (Track One only / Track Two only / both), and the sweep additionally asserts that the two rendered rows partition the kept days between them and that neither marks a day its own track did not sit. Dropping Track Two from day credit fails it in 193 places; removing the window-edge guard fails it in 472.
- **The five `testResolvedStreak*` cases from #686 were kept and given evidence.** Each previously asserted a carried number against an *empty* history — the exact shape this PR stops the widget rendering. Their intent (flip increments, account switch resets, new-day reset, new-day preserve, new-day increment) is unchanged; each fixture now supplies the history the rows would be drawing, and the two that could not distinguish carried from walked use a >window streak so they actually exercise the carry.
- **`serverStreakAnchorDate` got more accurate for free.** Its track-agnostic filter used to be half of #679: a second-track standard sit anchored the server total on a day the row would not mark. #686 gives those sits their own row, so that axis is now corroborated. The type axis (server counts standard only; the rows also count quick and breath) remains open in #679.

## Acceptance criteria

- [x] Widget streak derived from actual completed-practice history, not flag transitions
- [x] Streak and row consistent by construction, with a test asserting they cannot disagree
- [x] `normalizedForDisplay` no longer zeroes the streak on a rollover when history says the streak is intact
- [x] Symptom 2 root cause identified and stated above, with tests
- [x] After a week boundary, the row still shows completed days from the prior calendar week
- [x] Widget values survive a cold start with no network
- [x] Both widget families correct — small and medium both render `entry.data.streak` and `weekMarks`, and `HabitWidget` routes both through `normalizedForDisplay`
- [x] The invariant holds inside #686's two-a-day row model: the streak agrees with the union of the two rendered rows, and neither row marks a day its own track did not sit

## Test plan

- [x] Unit: six consecutive completed days ending yesterday, today pending → streak 6, not 2 (`testSixCompletedDaysWithTodayPendingYieldsStreakSix`)
- [x] Unit: week boundary — fixed `now` on Monday 2026-03-16, completions the preceding Wed–Sun stay marked (`testWeekBoundaryKeepsPriorCalendarWeekMarked`)
- [x] Unit: streak/row consistency property, ported to the two-a-day model — all 128 subsets of the trailing seven, each split three ways across the tracks, × 5 server-anchor cases (`testStreakNeverContradictsTheRenderedRow`)
- [x] Unit: `normalizedForDisplay` across a midnight rollover preserves an intact streak and clears only the done-today flags (`testNormalizedForDisplayClearsStaleDoneToday`, `testNormalizedForDisplayKeepsStreakWhenPriorSnapshotHadNotSatYet`)
- [x] Unit: cold start with no network keeps the last known history (`testColdStartWithoutNetworkKeepsLastKnownHistory`)
- [x] Unit: only an authoritative sign-out clears the stored snapshot (`testOnlyAuthoritativeSignOutClearsTheStoredSnapshot`)
- [x] Unit (#684 preserved): day credit walks the union, a zero-sit day breaks it, a multi-day gap resets it, and a streak longer than the window survives and keeps counting (`testStreakWalksUnionOfBothTracks`, `testStreakBreaksOnDayWithNoSitOnEitherTrack`, `testStreakResetsAfterMultiDayGap`, `testStreakLongerThanWindowSurvives`, `testCarriedStreakLongerThanWindowIncrementsAcrossADay`)
- [x] Unit (new bound): a carried streak is ignored once the rows show where the run broke (`testCarriedStreakIsIgnoredWhenTheRowsShowABreak`)
- [x] Regression: logged-out state and account switching still clear history and the server anchor (`testMakeSnapshotDropsHistoryOnAccountSwitch`, `testMakeSnapshotDropsBothTrackHistoriesOnAccountSwitch`, `testMakeSnapshotDropsServerAnchorOnAccountSwitch`)
- [x] Regression: legacy snapshots without the new fields still decode, on both the pre-#671 and pre-#684 shapes (`testDecodesLegacyBlobWithoutCompletedDates`, `testDecodesPreDualTrackBlobIntoTrackOneOnly`, `testCodableRoundTrip`, `testCodableRoundTripPreservesBothTrackHistories`)

## Post-merge verification

Tracking issue: #693

- [ ] **Manual (device, not runnable in session):** complete sits on consecutive days — including a two-a-day setup where only one of the two sits lands — and confirm the flame increments in step with the rows; force-quit and cold-launch offline to confirm no reset; check the widget on a Monday morning.

### Why the manual box is unchecked

This machine has **no full Xcode — only CommandLineTools** (`xcode-select -p` → `/Library/Developer/CommandLineTools`, no `/Applications/Xcode.app`). That blocks the iOS Simulator and blocks `swift test` locally in two ways: the SwiftData macro plugins are absent (`@Model` in `Models/{User,Session,Thought}.swift` fails to expand) and `XCTest` ships no module. CI's macOS runner has both, so the `StillPointShared swift test` check is the real gate.

To avoid pushing unverified logic, every new assertion was executed locally another way:

1. A scratch SwiftPM copy of the package minus the three SwiftData-only model files — **builds clean**.
2. A standalone executable harness running all the new assertions (including the full 640-case consistency property) against the real `WidgetDataStore` — **all checks passed**.
3. `WidgetDataTests.swift` type-checked against the built module via a minimal XCTest shim — **no errors**; the whole test directory type-checks with no errors outside the shim's own missing `accuracy:` overload.

Behavioural claims that need a real home screen (timeline reload cadence, widget rendering) remain genuinely manual.

**Local review coverage:** none

Both local CLIs failed twice and were dropped for the session, per `cr-local-review.md`:

- **CodeRabbit CLI** — `rate_limit: Rate limit exceeded` on both attempts (`verified_run: false`, `failure_mode: error_record`).
- **CodeAnt CLI** — `403 Access denied` on both attempts (`failure_mode: stderr_error`). Not re-authenticated, per the rule that a CodeAnt 403 is the undocumented daily cap, not an auth problem.

Neither produced findings before dropping, so nothing is waived. A self-review ran instead and changed four things: a throttle bypass that would have refetched full history on every return-home for users with an empty week (replaced with a precise reset at the clear site); a redundant `sameAccount` double-binding; a duplicated day-window computation between `reconciledStreak` and `historyRun`; and a doubled `weekMarks` call in `weekRowStreakReachesWindowEdge`. A self-review does not satisfy the merge gate — the GitHub reviewers still do.

## Bootstrap files

`repo-bootstrap.sh --apply` installed three missing provisioned files, riding along with this feature PR per `repo-bootstrap.md` (never a bootstrap-only PR): `.github/workflows/ac-gate.yml`, `.claude/scripts/ac-gate.sh`, `.claude/scripts/pr-issue-ref.sh`. Branch protection was not touched — it already reports `[OK]`.

## Notes

- **On #663** (a web-completed sit not reaching the phone's streak widget): this likely shrinks it but should not be assumed to close it. The widget now reads the server's streak, so a web sit is reflected as soon as the app foregrounds and refetches — but nothing here makes that happen *without* the app opening. Worth re-testing against #663 before closing either.
- **Decision on the open question** (prefer the server value outright, or recompute locally?): recompute locally, reconcile with the server. Local keeps the number right offline and across a rollover; the server value alone is wrong for this purpose because it counts the run ending at the latest *recorded* day, not today. Hence "extend, never override".
- **Known limitation:** `serverStreak` can understate if the app has not fetched for days while sits are recorded elsewhere — `max()` keeps it non-contradictory, and it self-heals on the next fetch. Documented at the call site. *(The companion limitation — a second-track-only standard sit counting for the server's streak but not the widget's row — no longer applies: #686 gives those sits their own row, so the anchor now lands on a day the rows mark. See "What the rebase changed".)*

## CI status

> **Superseded by the rebase.** Everything in this section describes the pre-rebase history and is kept for the record. The rebase moved HEAD to a new SHA, which retires the CI run and the CodeAnt approval earned on `472121d`; **a fresh CI + reviewer round is required.** How the rebase was validated locally is in "Verifying the rebase without Xcode" below.

### Historical: all five required contexts green on `497a948`

**A GitHub Actions outage delayed this PR's checks** (incident opened 2026-08-26 15:11Z; repo-wide, zero new workflow runs created after 15:41Z, earlier runs landing as `startup_failure` or stuck `queued`). The incident cleared at ~17:59Z and the workflows were re-triggered.

**All five branch-protection required contexts have run on HEAD `497a948` and passed:**

| Required context | Conclusion |
| --- | --- |
| `typecheck` | success |
| `StillPointShared swift test` | success |
| `build` | success |
| `unit-tests` | success |
| `Info.plist in sync with project.yml` | success |

**The new `WidgetDataTests` have now been executed by a real test runner** — the main open risk while CI was dark. On `bb7d4e2` ([run 32997270032](https://github.com/auerbachb/still-point/actions/runs/32997270032)) the suite executed **40 tests with 0 failures** inside a 307-test package run that was green end to end, and again on `3df6f81` ([run 32998835556](https://github.com/auerbachb/still-point/actions/runs/32998835556)).

### The property test earned its keep on `00d48ff`

`00d48ff` set out to distinguish *unknown* history (a pre-#671 blob, keys absent) from *known-empty* history (this version, a genuine lapse), so that upgrading users would not see their streak drop to zero before the app next foregrounded. The guard it shipped tested `completedDates.isEmpty || serverStreak != nil` — which is that conflation, not a fix for it. CI caught it immediately:

```
testStreakNeverContradictsTheRenderedRow
XCTAssertEqual failed: ("999") is not equal to ("0")
- streak must be 0 when the row shows none (mask=0 server=nil)
```

The two shapes are indistinguishable by content: a snapshot written by *this* version also prunes to an empty history once the user lapses past the 7-day window, and the guard then kept a stale streak beside a blank row — bug #671 itself, reintroduced by the commit meant to harden against it. This is exactly what AC2's consistency property exists to catch, and it caught it on the first real run.

`497a948` keys the carry-forward off **provenance** instead. `WidgetData` records `historyIsUnknown` at decode time from key *presence* (`contains`) — the one signal `decodeIfPresent`'s `?? []` destroys. It is absent from `CodingKeys` so it is never written back, and always false for a snapshot this version constructs, so a legacy blob self-heals the first time real history is stored. Recomputation is skipped only when the snapshot both predates history tracking and carries no evidence from either source. Both concerns now hold at once: the legacy carry-forward survives (`testLegacySnapshotKeepsItsStreakUntilHistoryIsStored` reads 42) and a recorded empty history recomputes to 0. Two named regression tests were added so the distinction cannot regress silently.

This mattered because the dev machine has CommandLineTools only: `XCTest` has no module and the SwiftData macro plugins are absent, so `swift test` and `swift build` both fail locally. To avoid spending another CI round on an unverified guard, `497a948` was verified before pushing by typechecking all 40 non-SwiftData sources clean and then compiling them against a standalone harness replicating the XCTest cases — **1128 checks pass**, including the full 640-case sweep, the legacy test, the Codable round trip and `makeSnapshot` equality. The same harness built against `00d48ff` reproduces CI's failure verbatim (got 999, expected 0, same case), so the harness is faithful and the fix is what closes it. CI has since confirmed it: `StillPointShared swift test` is green on `497a948`.

*(Historical: `mergeStateStatus` read `BEHIND` after docs-only PR #677 merged, with zero file overlap. That window closed when PR #686 merged and turned the state `CONFLICTING`/`DIRTY` across all six files, which is what forced the rebase. `UNSTABLE` before that was driven entirely by **non-required, non-blocking** `neutral` check-runs — `Cursor Bugbot` (usage limit reached), `Vercel Agent Review` (insufficient credit) and `e2e coverage nudge (advisory)` — none a required context, and none able to turn green on its own, each being a paid-service capability failure rather than anything about this code.)*

**Standing caveat on `merge-gate.sh`, unchanged:** its `ci_status` block summarises only the check-runs that happen to exist and never compares them against the required-contexts list, so an outage that suppresses every required check still reads as "CI clean". That false green is what made the earlier dark-CI state look mergeable. Verify the five contexts by name, as above, rather than trusting the summary.

## Verifying the rebase without Xcode

Same constraint as before — CommandLineTools only, so `swift test` cannot run and `swift build` fails on the SwiftData macro plugins. CI's `StillPointShared swift test` remains **the authoritative gate**; what follows is what was done to avoid pushing an unverified semantic merge.

1. **`diff-survival-check.sh`** (issue #757) snapshotted the branch's substantive files before the rebase and verified after: `verdict: intact`, all 6 files still carry changes against `origin/main`, `lost_files: []`. This is the guard against a conflict resolution that is marker-free and green while containing none of the change the PR exists to deliver.
2. **`swiftc -typecheck`** over all 43 non-SwiftData shared sources — clean (one pre-existing `FileManager`-Sendable warning in `OfflineSessionQueue.swift`, untouched here). `AppViewModel.swift` parses clean.
3. **The standalone harness was rebuilt against the new model** and runs the *real* `WidgetDataTests.swift` source through a minimal XCTest shim, so there is no transcription drift: **70 tests, 1772 checks, 0 failures**, including the full ported sweep. The pre-rebase suite on `472121d` scores 1192 checks in 12.9 s; the ported suite does 1772 in 9.0 s, so the added coverage costs no CI time.
4. **Three mutation checks prove the harness discriminates**, rather than merely passing:
   - reverting `497a948`'s provenance guard to the emptiness test reproduces CI's original failure verbatim — `("999") is not equal to ("0") - streak must be 0 when the rows show none (mask=0 server=nil)` — plus both named regression tests (3 failures);
   - removing the window-edge guard from `reconciledStreak` fails 472 checks;
   - dropping Track Two from `completedDayUnion` (i.e. regressing #686's model) fails 193.
5. **The three rider files are byte-identical to their `472121d` content** (`git diff 472121d HEAD -- .claude/scripts .github/workflows/ac-gate.yml` is empty apart from restoring `ac-gate.sh`'s executable bit). All five `fix(ac-gate)` commits and the `fix(pr-issue-ref)` commit survived the rebase intact; `main`'s copy of `ac-gate.sh` (installed by #686) is a strict subset of this branch's.

### `ac-gate` now evaluates this PR for real

`.claude/scripts/ac-gate.sh` reached `main` with #686, so the workflow — which deliberately checks out the **base** commit, keeping the gate implementation trusted code the PR cannot modify — no longer takes the bootstrap-skip path. It previously reported `success` without evaluating anything.

Run against the pre-rebase body it **failed**, because the deliberately unchecked manual box sat under `## Test plan`. That box now lives under `## Post-merge verification` with `Tracking issue: #693`, which is the documented pattern (`.claude/reference/ac-gate.md`), and #693 is an open issue this PR does not close.

## Review coverage (pre-rebase SHAs)

> All of the below predates the rebase. Every finding was dispositioned and every thread resolved, but none of it attests to the current HEAD — a fresh round is required.

- **CodeRabbit** — reviewed `bb7d4e2` once the rate-limit window cleared and returned `COMMENTED` with **2 Minor findings**, both verified against the code and both fixed in `3df6f81`. See the disposition below. Earlier in the PR it was rate limited on both pushes (account at 1 review/hour; the banner also reported the organisation at its usage spending cap).
- **CodeAnt** — reviewed `2dc7194`, `a5670b7`, `bb7d4e2`, `3df6f81`, `440ded9` and `2ac8055`, raising eight findings in total (disposition below). The last two, on `2ac8055`, were fixed in `00d48ff` and their threads are resolved. CodeAnt then **skipped `00d48ff` entirely** — it posted its usual auto-`APPROVED` stub but never ran — and was re-nudged onto `497a948`. Its `APPROVED` reviews are **not** evidence of a pass; see the reviewer caution at the end.
- **Cursor BugBot** — refused with "couldn't run — usage limit reached" on every SHA, most recently at 20:32:13Z, which postdates HEAD; not re-nudged, per the spend-refusal rule.
- **Graphite** — ran, 0 comments.
- **Vercel Agent Review** — skipped, insufficient credit.

### Disposition of the two CodeRabbit findings (`bb7d4e2`)

Both were valid, both fixed in `3df6f81`, and both concern the `ac-gate` rider rather than the widget code.

1. **`ac-gate.sh` — level-1 headings did not end a section.** The detection regex required two `#`, so a body with `## Test plan` followed by `# Notes` stayed in the `testplan` state and failed unchecked boxes under Notes as in-scope items — a false FAIL. Now matches `#{1,2}`, which also lets a level-1 `# Acceptance criteria` open a section. Level 3+ still keeps the current state, because `#{1,2}[[:space:]]` cannot match `### Foo`: after two hashes the third `#` must satisfy `[[:space:]]` and does not.
2. **`ac-gate.yml` — the gate could not be cleared by its own documented fix.** The workflow ran only on the default `pull_request` activity types (`opened`/`synchronize`/`reopened`). The gate reads the PR *body*, and every remedy it prints — tick the boxes, or add a `Tracking issue: #N` — is a body-only edit, which never re-triggered the required check. A red required gate would have stayed red until an unrelated push arrived. Now `types: [opened, synchronize, reopened, edited, ready_for_review]`.

Verification: 16/16 parser unit cases against the extracted state machine, covering both new behaviours plus regressions for the earlier ATX-closing-sequence and `[-*+]` bullet fixes. A negative control against the pre-fix script fails exactly the 5 level-1 cases and passes the other 11, so the tests discriminate. End to end, merged PR #659 still passes. The workflow YAML parses, resolves to the five intended types, and — checked explicitly, because the file warns that renaming it silently drops the check from branch protection — still carries the job id `ac-gate`.

### Disposition of the six CodeAnt findings

Across three review passes (`2dc7194`, `a5670b7`, `bb7d4e2`): **2 fixed, 1 declined on the merits, 3 deferred to tracked issues.**

**Fixed** — both in `.claude/scripts/ac-gate.sh`, both unit-verified locally:

1. The heading parser ignored ATX closing sequences, so `## Test Plan ##` normalised to `Test Plan ##`, fell through to the `other` state, and its unchecked boxes bypassed the gate. Fixed in `a5670b7`; 12/12 unit cases including the `## C#` negatives that must *not* be treated as closing sequences.
2. The unchecked-box scan matched only `- [ ]`, so `* [ ]` and `+ [ ]` — both valid GitHub task items — bypassed the gate. Fixed in `bb7d4e2`; 14/14 unit cases. Integration-checked end to end: a merged PR with every box ticked still passes, in-flight PRs with unchecked boxes still fail.

**Declined** — `reconciledStreak` collapsing a long streak once `serverStreakDate` ages out of the seven-day window. That guard *is* #671's invariant: the widget never displays a streak its own row cannot corroborate. Extending past a pruned anchor would assert an unbroken run whose evidence normalisation has already discarded — the original bug, reintroduced. It fails toward under-reporting, stays consistent with the row, and self-heals on the next successful fetch.

**Deferred** — real, but neither introduced by this PR nor verifiable while CI is dark:

- **#678** — pre-existing `AppViewModel` race where a `/api/sessions` backfill landing after a local completion can uncheck today and drop the streak by one. The racing lines are unchanged context here; only the `serverStreak` arguments are new.
- **#679** — the anchor and the row disagree about which sessions count. This was filed against **two** axes; **the track axis is now closed by #686**, which gives second-track standard sits their own rendered row, so an anchor landing there is corroborated. What remains is the session-type axis: `serverStreakAnchorDate` is standard-only while the rows are practice-inclusive (quick and breath also keep a day). Same rule, same fix — the days used to extend `serverStreak` must be exactly the days that contributed to it. Still a *cross-surface* mismatch with app/web, nearer #663; #671's widget-internal streak-vs-rows consistency holds either way. **#679 should be re-scoped to the type axis alone.**

### Reviewer caution for whoever merges this

`codeant-ai[bot]` posts an `APPROVED` within ~50–90 seconds of every push, **before its own review run starts**. This is structural, not a one-off, and it has now been observed on three separate SHAs:

- On `a5670b7` the approval landed at 16:06:07; the run started at 16:08:52.
- On `bb7d4e2` the approvals landed at 16:16:12 and 16:16:13 — **24 seconds before the `@codeant-ai review` comment that requested the review at all**, and 28 seconds before the run started at 16:16:40. The run that followed posted a real finding.
- On `3df6f81` the approval landed at 18:16:56, at which point CodeAnt's status comment carried no run entry for that SHA whatsoever.

So a CodeAnt `APPROVED` records that a push happened, not that the code was read. **Do not treat one as coverage until the status comment shows `done: true` for the exact HEAD SHA**, and check whether the run that followed posted findings — on `bb7d4e2` it did.

`merge-gate.sh` does not currently catch this. It scored `bb7d4e2` as `met: true` with `review_evidence.codeant-ai[bot].run_start_marker_at` **empty** — it never parses the `started` timestamp out of the `<!-- codeant-review-status:[…] -->` payload, so the `temporal_inversion` discriminator (the most decisive of the issue #875 substance checks) silently evaluates `false` and the stub scores as genuine coverage. The gap is being tracked separately; until it is fixed, verify CodeAnt's run markers by hand.

**The working remedy, for the round this rebase requires.** CodeAnt is idempotent per SHA: with an approval already standing it runs, finds nothing, and posts nothing — which is what stalled round 3. Dismiss the hollow stub (`PUT /repos/{owner}/{repo}/pulls/676/reviews/{id}/dismissals`, with a message recording why), then comment `@codeant-ai review`. With no approval standing, the genuine post-run approval fires ~3 s after the run completes. Confirmed on `472121d` (run finished 15:50:27.712 → `APPROVED` 15:50:30Z) and independently on PRs #673 and #677. Also note CodeRabbit has **never** posted an `APPROVED` in this repo across the last 14 merged PRs — CodeAnt is this repo's approver — and CodeRabbit's limit is a rolling 7-day allowance, not a daily reset, so do not assume an overnight clear.

The substantive review coverage on this PR is CodeAnt's six findings across three completed runs and CodeRabbit's two findings on `bb7d4e2` — all eight dispositioned above, with every thread replied to and resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Widget streaks now more accurately reflect completion history across seven-day views.
  * Server-provided streak information is preserved when supported by recorded activity.
  * Widget history is retained during temporary server errors or offline conditions.
  * Stored widget data is cleared only after confirmed sign-out or authorization failure.
  * Account switching and calendar transitions now handle widget history more reliably.

* **Quality**
  * Added automated pull request checks for acceptance criteria, test plans, and issue references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Keep the iOS widget’s streak and weekly history consistent, including offline launches

### What Changed
- The streak is now calculated from completed practice history, so it matches the consecutive days shown in the weekday row instead of relying on observed flag changes.
- Server streak data extends runs beyond the seven-day widget view without overriding visible gaps or lapses.
- The widget preserves its saved week when the server is unavailable or returns an error; only a confirmed sign-out clears it.
- Sign-out and sign-in trigger a fresh history refresh, and saved history remains intact across day and calendar-week boundaries.
- Added coverage for streak reconciliation, legacy snapshots, offline display, account changes, week boundaries, and consistency between the streak and row.

### Impact
`✅ Matching streak counts and weekday checkmarks`
`✅ No blank widget week after offline launches`
`✅ Accurate streaks across missed days and week boundaries`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

