### PR TITLE
feat(session): minimal "just the timer" view on iOS and web (#669)

### DIFF
--- a/e2e/session/session-flow.spec.ts
+++ b/e2e/session/session-flow.spec.ts
@@ -121,6 +121,49 @@ test.describe("mobile session flow", () => {
     await expect(page.getByRole("button", { name: /light distraction/i })).toHaveCount(0);
   });
 
+  test("minimal view collapses the sit to the timer and a tap brings it back", async ({
+    page,
+    ensureLoggedIn,
+  }) => {
+    await seedTrackingControlsUnlocked(page);
+    await ensureLoggedIn();
+    await applyTrackingControlsUnlocked(page);
+    await tap(page.getByRole("button", { name: "Begin" }));
+
+    const sessionRoot = page.locator("[data-session-view-mode]");
+    const trackingLayer = page.locator('[data-session-tracking-layer="persistent"]');
+    const secondaryChrome = page.locator('[data-session-chrome="secondary"]');
+    const timerDigits = page.locator("[data-session-timer-digits]");
+    const readStoredPref = () =>
+      page.evaluate(() => localStorage.getItem("stillpoint_minimal_session_view"));
+
+    await expect(sessionRoot).toHaveAttribute("data-session-view-mode", "full");
+    await expect(trackingLayer).toBeVisible();
+
+    await tapWithControlReveal(page, page.getByRole("button", { name: "Show only the timer" }));
+
+    // Everything but the countdown is gone.
+    await expect(sessionRoot).toHaveAttribute("data-session-view-mode", "minimal");
+    await expect(timerDigits).toBeVisible();
+    await expect(trackingLayer).toHaveCount(0);
+    await expect(secondaryChrome).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /light distraction/i })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /^\+1 min$/ })).toHaveCount(0);
+    // Remembered for the next sit.
+    expect(await readStoredPref()).toBe("true");
+
+    // Tap anywhere restores the full screen, sit still running.
+    await page.tap("body");
+    await expect(sessionRoot).toHaveAttribute("data-session-view-mode", "full");
+    await expect(trackingLayer).toBeVisible();
+    await expect(secondaryChrome).toBeVisible();
+    await expect(page.getByRole("button", { name: /light distraction/i })).toBeVisible();
+    expect(await readStoredPref()).toBe("false");
+
+    await tapWithControlReveal(page, page.getByRole("button", { name: /end early/i }));
+    await expect(page.getByRole("button", { name: "Return" })).toBeVisible();
+  });
+
   test("pull-to-refresh style overscroll does not break active session", async ({ page, ensureLoggedIn }) => {
     await seedTrackingControlsUnlocked(page);
     await ensureLoggedIn();

--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -10,8 +10,19 @@ struct SessionView: View {
     /// Minimum tap target for sound toggles (Apple HIG 44pt).
     private static let soundToggleMinSize: CGFloat = 44
 
+    /// #669: long-press duration that opens thought capture from the minimal view.
+    private static let minimalViewCapturePressDuration: Double = 0.5
+    /// #669: no bottom chrome to clear in minimal view, so the capture card sits low.
+    private static let minimalViewCaptureBottomPadding: CGFloat = 80
+
     let appVM: AppViewModel
     @State private var vm: SessionViewModel
+    /// #669 "just the timer": seeded from the persisted preference so the choice
+    /// carries into the next sit, and written back whenever it is toggled.
+    @State private var minimalView: Bool
+    /// Drives the fade-out "tap to come back" hint each time minimal view is entered.
+    @State private var minimalHintVisible = false
+    @State private var minimalHintToken = 0
     @State private var showSaveError = false
     @State private var showCaptureHelper = false
     @State private var showAttentionUnsupportedAlert = false
@@ -35,6 +46,9 @@ struct SessionView: View {
             track: track,
             recovery: recovery
         ))
+        // #669: restore the last-used view mode before the first frame so a sit
+        // that should start minimal never flashes the full screen first.
+        self._minimalView = State(initialValue: MinimalSessionViewPrefs.isMinimalSessionViewEnabled)
     }
 
     var body: some View {
@@ -47,6 +61,10 @@ struct SessionView: View {
                 VStack(spacing: 0) {
                     // Main content — fits in viewport above controls
                     VStack(spacing: SPSpacing.s3) {
+                        if minimalView {
+                            Spacer(minLength: 0)
+                        }
+
                         // Timer display
                         Text(vm.timeString)
                             .font(SPFont.timerDisplay)
@@ -58,32 +76,39 @@ struct SessionView: View {
                             .accessibilityIdentifier("session.timerLabel")
                             .accessibilityLabel("Time remaining \(vm.timeString)")
 
-                        // 60-second progress bar
-                        progressBar
+                        // #669: minimal view is the countdown alone — everything below
+                        // it is chrome and goes away until the user taps to come back.
+                        if minimalView {
+                            minimalViewHint
+                            Spacer(minLength: 0)
+                        } else {
+                            // 60-second progress bar
+                            progressBar
 
-                        // Block grid — dynamic sizing to fill available space
-                        BlockGridView(
-                            blocks: vm.blocks,
-                            elapsed: vm.elapsed,
-                            totalSeconds: vm.totalSeconds,
-                            availableHeight: contentHeight * 0.4,
-                            availableWidth: geo.size.width - SPSpacing.s2 * 2
-                        )
-                        .padding(.horizontal, SPSpacing.s2)
+                            // Block grid — dynamic sizing to fill available space
+                            BlockGridView(
+                                blocks: vm.blocks,
+                                elapsed: vm.elapsed,
+                                totalSeconds: vm.totalSeconds,
+                                availableHeight: contentHeight * 0.4,
+                                availableWidth: geo.size.width - SPSpacing.s2 * 2
+                            )
+                            .padding(.horizontal, SPSpacing.s2)
 
-                        // Mind state bar
-                        MindStateBarView(
-                            elapsed: vm.elapsed,
-                            totalSeconds: vm.totalSeconds,
-                            mindStateLog: vm.mindStateLog,
-                            currentMindState: vm.mindState
-                        )
+                            // Mind state bar
+                            MindStateBarView(
+                                elapsed: vm.elapsed,
+                                totalSeconds: vm.totalSeconds,
+                                mindStateLog: vm.mindStateLog,
+                                currentMindState: vm.mindState
+                            )
 
-                        // Status label
-                        Text(vm.statusLabel.uppercased())
-                            .font(SPFont.mono(14))
-                            .foregroundStyle(Color(SPColor.fg3))
-                            .tracking(2)
+                            // Status label
+                            Text(vm.statusLabel.uppercased())
+                                .font(SPFont.mono(14))
+                                .foregroundStyle(Color(SPColor.fg3))
+                                .tracking(2)
+                        }
                     }
                     .frame(height: contentHeight)
                     .padding(.top, SPSpacing.s1)
@@ -91,31 +116,34 @@ struct SessionView: View {
             }
 
             // Bottom chrome: secondary controls above; primary hold targets pinned to thumb-reach zone.
-            VStack(spacing: 0) {
-                Spacer()
-                if sessionInProgress {
-                    sessionTrackingInfoBar
-                }
-                controlPanel
-                    .opacity(secondaryChromeDimmed ? 0.32 : 1)
-                    .accessibilityValue(secondaryChromeDimmed ? "dimmed" : "visible")
-                if sessionInProgress {
-                    // #526: show hold cluster only when unlocked and not hidden by the user.
-                    if appVM.trackingControlPrefsManager.showDistractionHyperfocusCluster {
-                        thumbReachHoldControls
-                    } else if !appVM.trackingControlPrefsManager.trackingControlsUnlocked {
-                        trackingUnlockExplainer
+            // #669: all of it is hidden in minimal view.
+            if !minimalView {
+                VStack(spacing: 0) {
+                    Spacer()
+                    if sessionInProgress {
+                        sessionTrackingInfoBar
                     }
-                    // else: unlocked but hidden by user preference — show nothing.
+                    controlPanel
+                        .opacity(secondaryChromeDimmed ? 0.32 : 1)
+                        .accessibilityValue(secondaryChromeDimmed ? "dimmed" : "visible")
+                    if sessionInProgress {
+                        // #526: show hold cluster only when unlocked and not hidden by the user.
+                        if appVM.trackingControlPrefsManager.showDistractionHyperfocusCluster {
+                            thumbReachHoldControls
+                        } else if !appVM.trackingControlPrefsManager.trackingControlsUnlocked {
+                            trackingUnlockExplainer
+                        }
+                        // else: unlocked but hidden by user preference — show nothing.
+                    }
+                    Color.clear
+                        .frame(width: 1, height: 1)
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityIdentifier("session.secondaryChromeMarker")
+                        .accessibilityValue(secondaryChromeDimmed ? "dimmed" : "visible")
                 }
-                Color.clear
-                    .frame(width: 1, height: 1)
-                    .accessibilityElement(children: .ignore)
-                    .accessibilityIdentifier("session.secondaryChromeMarker")
-                    .accessibilityValue(secondaryChromeDimmed ? "dimmed" : "visible")
+                .allowsHitTesting(!vm.showIntroOverlay)
+                .animation(.easeInOut(duration: 0.3), value: vm.controlsVisible)
             }
-            .allowsHitTesting(!vm.showIntroOverlay)
-            .animation(.easeInOut(duration: 0.3), value: vm.controlsVisible)
 
             // Thought capture after releasing a distraction hold
             if vm.showPostDistractionCapture {
@@ -156,8 +184,35 @@ struct SessionView: View {
                 .transition(.opacity)
             }
         }
+        // #669: while minimal the whole screen is the affordance — a tap brings the
+        // session screen back, a long press opens thought capture *without* leaving
+        // minimal view. Tap-anywhere is not a capture gesture in the full view
+        // either, so the two never compete for the same tap.
         .onTapGesture {
-            vm.userInteracted()
+            if minimalView, minimalGesturesEnabled {
+                setMinimalView(false)
+            } else {
+                vm.userInteracted()
+            }
+        }
+        // `including: .subviews` makes this recognizer inert outside minimal view, so it
+        // can never compete with the hold-to-track drag gestures in the full screen.
+        .simultaneousGesture(
+            LongPressGesture(minimumDuration: Self.minimalViewCapturePressDuration)
+                .onEnded { _ in
+                    guard minimalView, minimalGesturesEnabled else { return }
+                    vm.openThoughtCapture()
+                },
+            including: minimalView ? .all : .subviews
+        )
+        .task(id: MinimalHintTrigger(token: minimalHintToken, introVisible: vm.showIntroOverlay)) {
+            guard minimalView, !vm.showIntroOverlay else { return }
+            minimalHintVisible = true
+            try? await Task.sleep(for: .seconds(5))
+            guard !Task.isCancelled else { return }
+            withAnimation(.easeInOut(duration: 0.7)) {
+                minimalHintVisible = false
+            }
         }
         .onAppear {
             let skipIntro = ProcessInfo.processInfo.environment["SP_UI_TEST_MODE"] == "1"
@@ -427,15 +482,77 @@ struct SessionView: View {
     }
 
     private var bottomOverlayReserve: CGFloat {
-        Self.bottomOverlayReserveWithControls
+        // #669: minimal view has no bottom chrome, so the timer gets the whole screen.
+        minimalView ? 0 : Self.bottomOverlayReserveWithControls
     }
 
     private var thoughtCaptureBottomPadding: CGFloat {
         // Keep capture card stable while typing even if controls auto-hide.
+        if minimalView {
+            return Self.minimalViewCaptureBottomPadding
+        }
         if vm.showPostDistractionCapture {
             return Self.bottomOverlayReserveWithControls + SPSpacing.s2
         }
         return bottomOverlayReserve + SPSpacing.s2
+    }
+
+    // MARK: - Minimal View (#669)
+
+    /// Identity for the minimal-view hint task. Re-runs on every entry *and* once the
+    /// intro overlay clears, so a sit restored straight into minimal view from the
+    /// persisted preference still gets its "how to come back" hint — the overlay is
+    /// up when the view first appears, and the hint would otherwise never flash.
+    private struct MinimalHintTrigger: Equatable {
+        let token: Int
+        let introVisible: Bool
+    }
+
+    /// Screen-wide tap/long-press only apply while a sit is running with no overlay on top.
+    private var minimalGesturesEnabled: Bool {
+        sessionInProgress
+            && !vm.showPostDistractionCapture
+            && !vm.showGuidedExercise
+            && !vm.showIntroOverlay
+    }
+
+    /// Enters or leaves minimal view and persists the choice for the next sit.
+    private func setMinimalView(_ enabled: Bool) {
+        guard minimalView != enabled else { return }
+        if enabled {
+            // The hold targets are about to be removed from the hierarchy, so their
+            // `DragGesture.onEnded` would never fire for a hold that is active right
+            // now (two-finger: hold with one thumb, tap the toggle with the other) —
+            // the sit would stay stuck in `thinking`/`hyperfocus` and skew
+            // `clearPercent`. Both calls are guarded no-ops when nothing is held.
+            // Mirrors web's `enterMinimalView`, which finalizes the same way.
+            vm.endDistraction()
+            vm.endHyperfocus()
+        }
+        withAnimation(.easeInOut(duration: 0.3)) {
+            minimalView = enabled
+        }
+        MinimalSessionViewPrefs.setMinimalSessionViewEnabled(enabled)
+        if enabled {
+            // Re-flash the "how to get back" hint on every entry.
+            minimalHintVisible = false
+            minimalHintToken += 1
+        } else {
+            minimalHintVisible = false
+            vm.userInteracted()
+        }
+    }
+
+    /// Fades out after a few seconds so the minimal screen really is just the timer.
+    private var minimalViewHint: some View {
+        Text("Tap anywhere to bring the session back · press and hold to capture a note")
+            .font(SPFont.mono(11))
+            .foregroundStyle(Color(SPColor.fg4))
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, SPSpacing.s4)
+            .opacity(minimalHintVisible ? 1 : 0)
+            .accessibilityIdentifier("session.minimalViewHint")
+            .accessibilityHidden(!minimalHintVisible)
     }
 
     private var secondaryChromeDimmed: Bool {
@@ -556,6 +673,20 @@ struct SessionView: View {
                             .frame(maxWidth: 280)
                             .presentationCompactAdaptation(.popover)
                     }
+
+                    // #669: collapse to the countdown alone. Kept as an icon so it
+                    // stays an affordance rather than becoming more chrome.
+                    Button {
+                        setMinimalView(true)
+                    } label: {
+                        Image(systemName: "arrow.down.right.and.arrow.up.left")
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundStyle(Color(SPColor.fg3))
+                            .frame(width: Self.soundToggleMinSize, height: Self.soundToggleMinSize)
+                            .contentShape(Rectangle())
+                    }
+                    .accessibilityLabel("Show only the timer")
+                    .accessibilityIdentifier("session.minimalViewToggle")
                 }
                 .opacity(vm.isActive && !vm.controlsVisible ? 0.48 : 0.88)
                 .animation(.easeInOut(duration: 0.3), value: vm.controlsVisible)

--- a/ios/StillPointShared/Sources/StillPointShared/MinimalSessionViewPrefs.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/MinimalSessionViewPrefs.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Persists the "just the timer" minimal session view preference (#669).
+///
+/// When enabled, the session screen collapses to the numeric countdown alone —
+/// block grid, mind-state bar, tracking info, controls, and sound toggles all go
+/// away — and the choice is restored on the next sit.
+///
+/// Mirrors web's `src/lib/minimalSessionViewPrefs.ts`, which reserves the iOS key
+/// name as `IOS_MINIMAL_SESSION_VIEW_KEY` so both clients agree on it. Follows the
+/// `SessionIntroPrefs` convention: a static enum over `UserDefaults.standard`
+/// with an explicit reset for tests and UI-test reset paths.
+public enum MinimalSessionViewPrefs {
+    /// iOS UserDefaults key (parity with web localStorage naming style).
+    public static let minimalSessionViewKey = "sp_minimalSessionView"
+
+    /// `true` when the user chose to see only the timer during a sit.
+    /// Defaults to `false`, so an untouched install gets the full session screen.
+    public static var isMinimalSessionViewEnabled: Bool {
+        UserDefaults.standard.bool(forKey: minimalSessionViewKey)
+    }
+
+    public static func setMinimalSessionViewEnabled(_ enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: minimalSessionViewKey)
+    }
+
+    /// Wipes the persisted minimal-view preference. Used by tests and UI-test reset paths.
+    public static func resetPersistedPrefs() {
+        UserDefaults.standard.removeObject(forKey: minimalSessionViewKey)
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/UITestAPIStore.swift
@@ -69,6 +69,9 @@ actor UITestAPIStore {
             defaults.removeObject(forKey: defaultsKey)
             AudioEngine.resetPersistedPrefs()
             SessionIntroPrefs.resetPersistedPrefs()
+            // #669: a leftover minimal-view preference would start every subsequent
+            // UI test with the session chrome collapsed to the countdown alone.
+            MinimalSessionViewPrefs.resetPersistedPrefs()
             LastAuthProvider.resetPersisted()
             // Flush the in-memory cache to cfprefsd so the immediately
             // following read sees the cleared state. Issue #266 follow-up.

--- a/ios/StillPointShared/Tests/StillPointSharedTests/MinimalSessionViewPrefsTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/MinimalSessionViewPrefsTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import StillPointShared
+
+/// Issue #669 — the "just the timer" preference must survive into the next sit
+/// and stay easy to reverse.
+final class MinimalSessionViewPrefsTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        MinimalSessionViewPrefs.resetPersistedPrefs()
+    }
+
+    override func tearDown() {
+        MinimalSessionViewPrefs.resetPersistedPrefs()
+        super.tearDown()
+    }
+
+    func testDefaultIsFullSessionScreen() {
+        XCTAssertFalse(MinimalSessionViewPrefs.isMinimalSessionViewEnabled)
+    }
+
+    func testEnablingPersists() {
+        MinimalSessionViewPrefs.setMinimalSessionViewEnabled(true)
+        XCTAssertTrue(MinimalSessionViewPrefs.isMinimalSessionViewEnabled)
+    }
+
+    func testChoiceIsEasyToReverse() {
+        MinimalSessionViewPrefs.setMinimalSessionViewEnabled(true)
+        MinimalSessionViewPrefs.setMinimalSessionViewEnabled(false)
+        XCTAssertFalse(MinimalSessionViewPrefs.isMinimalSessionViewEnabled)
+    }
+
+    func testResetClearsThePreference() {
+        MinimalSessionViewPrefs.setMinimalSessionViewEnabled(true)
+        MinimalSessionViewPrefs.resetPersistedPrefs()
+        XCTAssertFalse(MinimalSessionViewPrefs.isMinimalSessionViewEnabled)
+    }
+
+    /// Web reserves this exact key name in `src/lib/minimalSessionViewPrefs.ts`
+    /// (`IOS_MINIMAL_SESSION_VIEW_KEY`); both clients must keep it aligned.
+    func testStorageKeyMatchesWebParityConstant() {
+        XCTAssertEqual(MinimalSessionViewPrefs.minimalSessionViewKey, "sp_minimalSessionView")
+    }
+
+    func testReadsBackFromUserDefaultsWrittenOutsideTheHelper() {
+        UserDefaults.standard.set(true, forKey: MinimalSessionViewPrefs.minimalSessionViewKey)
+        XCTAssertTrue(MinimalSessionViewPrefs.isMinimalSessionViewEnabled)
+    }
+}

--- a/src/components/BlockTimer.tsx
+++ b/src/components/BlockTimer.tsx
@@ -30,6 +30,13 @@ type BlockTimerProps = {
     serverNow: string;
     durationSeconds: number;
   };
+  /**
+   * #669 "just the timer": render the numeric countdown alone — no mind-state bar,
+   * progress bar, block grid, or show/hide toggle. The clock, sounds, and
+   * completion callback are unaffected, so the sit runs exactly as it does in the
+   * full view.
+   */
+  minimal?: boolean;
 };
 
 type BlockDef = {
@@ -50,6 +57,7 @@ export function BlockTimer({
   soundPrefs,
   controlledElapsed,
   syncClock,
+  minimal = false,
 }: BlockTimerProps) {
   const [elapsed, setElapsed] = useState(0);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -373,6 +381,11 @@ export function BlockTimer({
   const boxesAreaViewportInset = boxesAreaMaxPx > 500 ? 24 : 40;
   const boxesAreaWidth = `min(${boxesAreaMaxPx}px, calc(100vw - ${boxesAreaViewportInset}px))`;
 
+  // #669: minimal view *is* the countdown, so the "hide numerical timer" display
+  // preference is bypassed while minimal — honouring it there would leave a blank
+  // screen with no way to read the sit. The stored preference is left untouched.
+  const digitsVisible = minimal || showTimer;
+
   return (
     <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: isMobile ? "18px" : "32px" }}>
       <div
@@ -385,7 +398,8 @@ export function BlockTimer({
         }}
       >
         <div
-          aria-hidden={!showTimer}
+          data-session-timer-digits
+          aria-hidden={!digitsVisible}
           style={{
             fontFamily: "var(--font-mono)",
             fontSize: isMobile ? "min(72px, 19vw)" : "min(120px, 18vw)",
@@ -394,13 +408,14 @@ export function BlockTimer({
             color: elapsed >= totalSeconds ? "var(--accent-green)" : "var(--fg)",
             textShadow: elapsed >= totalSeconds ? "0 0 40px var(--accent-green-glow)" : "none",
             transition: "color 0.8s, text-shadow 0.8s, opacity 0.25s ease",
-            opacity: showTimer ? 1 : 0,
+            opacity: digitsVisible ? 1 : 0,
             minHeight: "1em",
             userSelect: "none",
           }}
         >
           {minutes}:{seconds.toString().padStart(2, "0")}
         </div>
+        {!minimal && (
         <button
           type="button"
           aria-pressed={showTimer}
@@ -429,8 +444,10 @@ export function BlockTimer({
         >
           {showTimer ? "hide" : "show"}
         </button>
+        )}
       </div>
 
+      {!minimal && (
       <div style={{ width: boxesAreaWidth, margin: "0 auto", display: "flex", flexDirection: "column", gap: "14px" }}>
         <MindStateBar
           elapsed={elapsed}
@@ -457,8 +474,9 @@ export function BlockTimer({
           </div>
         </div>
       </div>
+      )}
 
-      {useMinuteBlocks ? (
+      {minimal ? null : useMinuteBlocks ? (
         <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "16px" }}>
           <div style={{
             display: "flex", flexWrap: "wrap", gap: blockGap,

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -18,6 +18,16 @@ import {
   useTrackingControlsUnlocked,
 } from "@/lib/useTrackingControlPrefs";
 import { useSessionSuppressionRelay } from "@/lib/useSessionSuppression";
+import { saveMinimalSessionViewPref } from "@/lib/minimalSessionViewPrefs";
+import { useMinimalSessionViewPref } from "@/lib/useMinimalSessionView";
+import {
+  MINIMAL_VIEW_LONG_PRESS_MS,
+  beginMinimalViewPress,
+  isPressPointer,
+  pressMovedBeyondTolerance,
+  resolveMinimalViewRelease,
+  type MinimalViewPress,
+} from "@/lib/minimalSessionGestures";
 import { GuidedExerciseOverlay } from "./GuidedExerciseOverlay";
 
 type MindState = "clear" | "thinking" | "hyperfocus";
@@ -97,6 +107,13 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
   const [wasPausedInSession, setWasPausedInSession] = useState(false);
   const [showGuidedExercise, setShowGuidedExercise] = useState(false);
   const guidedExerciseTriggerRef = useRef<HTMLButtonElement>(null);
+  /**
+   * #669: "just the timer". The persisted preference is the live source of truth,
+   * so toggling both restyles this sit and is remembered for the next one.
+   */
+  const minimalView = useMinimalSessionViewPref();
+  /** Keeps the screen-reader/keyboard escape hatch invisible until it is focused. */
+  const [minimalExitFocused, setMinimalExitFocused] = useState(false);
   /** Live opt-in Settings pref; pause/complete/abandon drop `isActive` and toggle-off releases too. */
   const keepScreenAwakePref = useKeepScreenAwakePref();
   const trackingControlsUnlocked = useTrackingControlsUnlocked();
@@ -261,10 +278,112 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
     finalizeActiveHold(elapsedRef.current);
   };
 
-  const handleOpenThoughtCapture = () => {
+  /** Stable so the minimal-view long press can depend on it without re-subscribing. */
+  const handleOpenThoughtCapture = useCallback(() => {
     finalizeActiveHold(elapsedRef.current);
     setShowPostDistractionCapture(true);
-  };
+  }, [finalizeActiveHold]);
+
+  const exitMinimalView = useCallback(() => {
+    // The exit button unmounts with minimal view, so its `onBlur` may never fire.
+    // Left set, the next entry into minimal view would render the button in its
+    // visible state — new chrome on a screen that is meant to be just the timer.
+    setMinimalExitFocused(false);
+    saveMinimalSessionViewPref(false);
+  }, []);
+
+  const enterMinimalView = useCallback(() => {
+    finalizeActiveHold(elapsedRef.current);
+    resetHoldTracking();
+    saveMinimalSessionViewPref(true);
+  }, [finalizeActiveHold, resetHoldTracking]);
+
+  /**
+   * #669: while minimal, the whole screen is the affordance — a tap restores the
+   * full session screen, a long press opens thought capture *without* leaving
+   * minimal view, and a drag (scroll) does neither. Escape also restores, for
+   * keyboard users who cannot long-press.
+   *
+   * The tap and the capture gesture never collide: tap-anywhere is not a capture
+   * gesture in the full view either, so capture keeps its own distinct gesture.
+   */
+  useEffect(() => {
+    if (!minimalView || sessionFinished || showPostDistractionCapture || showGuidedExercise) return;
+
+    let press: MinimalViewPress | null = null;
+    let longPressTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearLongPressTimer = () => {
+      if (longPressTimer) clearTimeout(longPressTimer);
+      longPressTimer = null;
+    };
+
+    const onPointerDown = (e: PointerEvent) => {
+      // Right/middle click opens a context menu — it must not drop the sit out of
+      // minimal view. Touch and pen both report button 0 here.
+      if (e.button !== 0) return;
+      // First finger down owns the gesture; a second one is ignored until it ends.
+      if (press) return;
+      press = beginMinimalViewPress(e.pointerId, e.clientX, e.clientY);
+      clearLongPressTimer();
+      longPressTimer = setTimeout(() => {
+        longPressTimer = null;
+        if (!press || press.consumed) return;
+        press.consumed = true;
+        handleOpenThoughtCapture();
+      }, MINIMAL_VIEW_LONG_PRESS_MS);
+    };
+
+    const onPointerMove = (e: PointerEvent) => {
+      if (!press || press.consumed || !isPressPointer(press, e.pointerId)) return;
+      if (pressMovedBeyondTolerance(press, e.clientX, e.clientY)) {
+        press.consumed = true;
+        clearLongPressTimer();
+      }
+    };
+
+    const onPointerUp = (e: PointerEvent) => {
+      // Same mouse pointer id carries every button; only the one that opened the
+      // press resolves it.
+      if (e.button !== 0) return;
+      if (!isPressPointer(press, e.pointerId)) return;
+      clearLongPressTimer();
+      const action = resolveMinimalViewRelease(press);
+      press = null;
+      if (action === "exit") exitMinimalView();
+    };
+
+    const onPointerCancel = (e: PointerEvent) => {
+      if (!isPressPointer(press, e.pointerId)) return;
+      clearLongPressTimer();
+      press = null;
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") exitMinimalView();
+    };
+
+    window.addEventListener("pointerdown", onPointerDown);
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp);
+    window.addEventListener("pointercancel", onPointerCancel);
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      clearLongPressTimer();
+      window.removeEventListener("pointerdown", onPointerDown);
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
+      window.removeEventListener("pointercancel", onPointerCancel);
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [
+    minimalView,
+    sessionFinished,
+    showPostDistractionCapture,
+    showGuidedExercise,
+    exitMinimalView,
+    handleOpenThoughtCapture,
+  ]);
 
   const handleSaveThought = (text: string) => {
     setSessionThoughts(prev => [...prev, { timeInSession: Math.round(elapsedRef.current), text }]);
@@ -345,7 +464,39 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
     mindState === "thinking" ? "Distracted" : mindState === "hyperfocus" ? "Hyperfocus" : "Aware";
   const capturedCount = sessionThoughts.length;
   const sessionChromeDimmed = isActive && !controlsVisible;
-  const showSessionTrackingLayer = isActive || wasPausedInSession;
+  const showSessionTrackingLayer = (isActive || wasPausedInSession) && !minimalView;
+  /** Off-screen until focused: the keyboard/screen-reader way out of minimal view. */
+  const minimalExitButtonStyle: CSSProperties = minimalExitFocused
+    ? {
+        position: "fixed",
+        top: "12px",
+        left: "50%",
+        transform: "translateX(-50%)",
+        zIndex: 10,
+        background: "var(--surface-1)",
+        border: "1px solid var(--border-2)",
+        color: "var(--fg-3)",
+        ...mono,
+        fontSize: "11px",
+        letterSpacing: "0.15em",
+        textTransform: "uppercase",
+        padding: "14px 24px",
+        minHeight: "44px",
+        borderRadius: "20px",
+        cursor: "pointer",
+      }
+    : {
+        position: "absolute",
+        width: "1px",
+        height: "1px",
+        padding: 0,
+        margin: "-1px",
+        overflow: "hidden",
+        clipPath: "inset(50%)",
+        whiteSpace: "nowrap",
+        border: 0,
+        background: "none",
+      };
   /** Capture stays in the persistent tracking layer while running so it is never hidden with secondary chrome. */
   const captureNoteButtonStyle: CSSProperties = {
     background: "none",
@@ -388,7 +539,17 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
   };
 
   return (
-    <div style={{ animation: "fadeIn 0.8s ease", display: "flex", flexDirection: "column", alignItems: "center" }}>
+    <div
+      data-session-view-mode={minimalView ? "minimal" : "full"}
+      style={{
+        animation: "fadeIn 0.8s ease",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        // Minimal view drops every row below the countdown, so centre what is left.
+        ...(minimalView ? { justifyContent: "center", minHeight: "60vh" } : null),
+      }}
+    >
       <GuidedExerciseOverlay open={showGuidedExercise} onClose={closeGuidedExercise} />
       <BlockTimer
         totalSeconds={totalSeconds}
@@ -398,7 +559,52 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
         mindStateLog={mindStateLog}
         onElapsedChange={handleElapsedChange}
         soundPrefs={soundPrefs}
+        minimal={minimalView}
       />
+
+      {minimalView && (
+        <button
+          type="button"
+          data-minimal-view-exit
+          onClick={exitMinimalView}
+          onFocus={() => setMinimalExitFocused(true)}
+          onBlur={() => setMinimalExitFocused(false)}
+          style={minimalExitButtonStyle}
+        >
+          show session controls
+        </button>
+      )}
+
+      {minimalView && !showPostDistractionCapture && (
+        <FlashHint style={{ marginTop: "24px", width: "100%" }}>
+          <p
+            data-minimal-view-hint
+            style={{
+              margin: 0,
+              textAlign: "center",
+              ...mono,
+              fontSize: "10px",
+              color: "var(--fg-4)",
+              letterSpacing: "0.08em",
+              lineHeight: 1.5,
+              padding: "0 20px",
+            }}
+          >
+            {isMobile
+              ? "Tap anywhere to bring the session back · press and hold to capture a note"
+              : "Tap anywhere or press Esc to bring the session back · press and hold to capture a note"}
+          </p>
+        </FlashHint>
+      )}
+
+      {minimalView && showPostDistractionCapture && (
+        <div
+          data-no-space-distraction
+          style={{ marginTop: "28px", width: "100%", display: "flex", justifyContent: "center" }}
+        >
+          <ThoughtCapture onSave={handleSaveThought} onCancel={handleDismissPostCapture} />
+        </div>
+      )}
 
       {showSessionTrackingLayer && (
         <div
@@ -631,6 +837,20 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
               >
                 capture note
               </button>
+              <button
+                type="button"
+                onClick={enterMinimalView}
+                aria-label="Show only the timer"
+                data-minimal-view-enter
+                style={{
+                  ...captureNoteButtonStyle,
+                  borderColor: "var(--border-2)",
+                  color: "var(--fg-3)",
+                  opacity: sessionChromeDimmed ? 0.48 : 0.88,
+                }}
+              >
+                just the timer
+              </button>
             </div>
           )}
 
@@ -645,7 +865,7 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
         </div>
       )}
 
-      {!sessionFinished && !showPostDistractionCapture && (
+      {!sessionFinished && !showPostDistractionCapture && !minimalView && (
         <div style={{ display: "flex", justifyContent: "center", gap: "10px", marginTop: isMobile ? "12px" : "20px", flexWrap: "wrap" }}>
           <button
             type="button"
@@ -694,6 +914,7 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
         </div>
       )}
 
+      {!minimalView && (
       <div
         data-session-chrome="secondary"
         data-visibility={sessionChromeDimmed ? "dimmed" : "visible"}
@@ -813,6 +1034,7 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
           ))}
         </div>
       </div>
+      )}
     </div>
   );
 }

--- a/src/lib/minimalSessionGestures.test.ts
+++ b/src/lib/minimalSessionGestures.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Issue #669 — gesture rules for the minimal ("just the timer") session view.
+ *
+ * While minimal the whole screen is the affordance, so the tap that restores the
+ * session screen must not swallow thought capture (long press) or fire on a
+ * scroll (drag).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  MINIMAL_VIEW_LONG_PRESS_MS,
+  MINIMAL_VIEW_MOVE_TOLERANCE_PX,
+  beginMinimalViewPress,
+  isPressPointer,
+  pressMovedBeyondTolerance,
+  resolveMinimalViewRelease,
+} from "./minimalSessionGestures";
+
+describe("minimal view gesture constants", () => {
+  it("uses a long-press window long enough to distinguish it from a tap", () => {
+    expect(MINIMAL_VIEW_LONG_PRESS_MS).toBeGreaterThanOrEqual(400);
+    expect(MINIMAL_VIEW_MOVE_TOLERANCE_PX).toBeGreaterThan(0);
+  });
+});
+
+describe("pressMovedBeyondTolerance", () => {
+  it("treats a still finger as a tap", () => {
+    const press = beginMinimalViewPress(1, 100, 200);
+    expect(pressMovedBeyondTolerance(press, 100, 200)).toBe(false);
+  });
+
+  it("tolerates small jitter inside the threshold", () => {
+    const press = beginMinimalViewPress(1, 100, 200);
+    expect(pressMovedBeyondTolerance(press, 105, 203)).toBe(false);
+  });
+
+  it("rejects a press that travels past the threshold in either axis", () => {
+    const press = beginMinimalViewPress(1, 100, 200);
+    expect(pressMovedBeyondTolerance(press, 100, 240)).toBe(true);
+    expect(pressMovedBeyondTolerance(press, 160, 200)).toBe(true);
+  });
+
+  it("measures diagonal travel, not per-axis travel", () => {
+    const press = beginMinimalViewPress(1, 0, 0);
+    // 10px on each axis is under tolerance per-axis but ~14.1px diagonally.
+    expect(pressMovedBeyondTolerance(press, 10, 10)).toBe(true);
+  });
+
+  it("honours a caller-supplied tolerance", () => {
+    const press = beginMinimalViewPress(1, 0, 0);
+    expect(pressMovedBeyondTolerance(press, 30, 0, 40)).toBe(false);
+  });
+});
+
+describe("isPressPointer", () => {
+  it("matches only the pointer that opened the press", () => {
+    const press = beginMinimalViewPress(7, 10, 10);
+    expect(isPressPointer(press, 7)).toBe(true);
+    // A second finger must not resolve the first finger's press.
+    expect(isPressPointer(press, 8)).toBe(false);
+  });
+
+  it("matches nothing when no press is active", () => {
+    expect(isPressPointer(null, 7)).toBe(false);
+  });
+});
+
+describe("resolveMinimalViewRelease", () => {
+  it("restores the full session screen after a plain tap", () => {
+    const press = beginMinimalViewPress(1, 10, 10);
+    expect(resolveMinimalViewRelease(press)).toBe("exit");
+  });
+
+  it("does nothing when the long press already opened thought capture", () => {
+    const press = beginMinimalViewPress(1, 10, 10);
+    press.consumed = true;
+    expect(resolveMinimalViewRelease(press)).toBe("none");
+  });
+
+  it("does nothing when the press was disqualified by movement", () => {
+    const press = beginMinimalViewPress(1, 10, 10);
+    if (pressMovedBeyondTolerance(press, 10, 90)) press.consumed = true;
+    expect(resolveMinimalViewRelease(press)).toBe("none");
+  });
+
+  it("does nothing for a release with no matching press", () => {
+    expect(resolveMinimalViewRelease(null)).toBe("none");
+  });
+});

--- a/src/lib/minimalSessionGestures.ts
+++ b/src/lib/minimalSessionGestures.ts
@@ -1,0 +1,59 @@
+/**
+ * #669: pure gesture rules for the minimal ("just the timer") session view.
+ *
+ * While minimal, the whole screen is the affordance:
+ * - a plain tap/click restores the full session screen;
+ * - a press held past {@link MINIMAL_VIEW_LONG_PRESS_MS} opens thought capture
+ *   without leaving minimal view, so the core interaction is never blocked;
+ * - a press that drags past {@link MINIMAL_VIEW_MOVE_TOLERANCE_PX} is a scroll or
+ *   a stray swipe and does nothing.
+ *
+ * Kept separate from the component so the rules are unit-testable without a DOM.
+ */
+
+/** Hold duration that opens thought capture instead of exiting minimal view. */
+export const MINIMAL_VIEW_LONG_PRESS_MS = 500;
+
+/** Pointer travel (px) past which a press is treated as a drag/scroll, not a tap. */
+export const MINIMAL_VIEW_MOVE_TOLERANCE_PX = 12;
+
+export type MinimalViewPress = {
+  /** The pointer that opened the press; later events from other fingers are ignored. */
+  pointerId: number;
+  x: number;
+  y: number;
+  /** Set once the long-press fired or the press was cancelled by movement. */
+  consumed: boolean;
+};
+
+export function beginMinimalViewPress(pointerId: number, x: number, y: number): MinimalViewPress {
+  return { pointerId, x, y, consumed: false };
+}
+
+/**
+ * True when an event belongs to the pointer that started the press. Without this
+ * a second finger's release would resolve the first finger's press and drop the
+ * user out of minimal view mid-gesture.
+ */
+export function isPressPointer(press: MinimalViewPress | null, pointerId: number): boolean {
+  return press !== null && press.pointerId === pointerId;
+}
+
+/** True when the pointer has travelled far enough to disqualify the press as a tap. */
+export function pressMovedBeyondTolerance(
+  press: MinimalViewPress,
+  x: number,
+  y: number,
+  tolerancePx: number = MINIMAL_VIEW_MOVE_TOLERANCE_PX,
+): boolean {
+  return Math.hypot(x - press.x, y - press.y) > tolerancePx;
+}
+
+/**
+ * What a pointerup should do. `"exit"` restores the full screen; `"none"` means
+ * the press was already handled (long press) or disqualified (drag).
+ */
+export function resolveMinimalViewRelease(press: MinimalViewPress | null): "exit" | "none" {
+  if (!press || press.consumed) return "none";
+  return "exit";
+}

--- a/src/lib/minimalSessionViewPrefs.test.ts
+++ b/src/lib/minimalSessionViewPrefs.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Issue #669 — "just the timer" minimal session view.
+ *
+ * Covers the persisted preference that makes the choice survive into the next
+ * sit, plus the listener contract `useSyncExternalStore` relies on.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  IOS_MINIMAL_SESSION_VIEW_KEY,
+  MINIMAL_SESSION_VIEW_DEFAULT,
+  MINIMAL_SESSION_VIEW_STORAGE_KEY,
+  loadMinimalSessionViewPref,
+  resetMinimalSessionViewPrefFallback,
+  saveMinimalSessionViewPref,
+  subscribeMinimalSessionViewPref,
+} from "./minimalSessionViewPrefs";
+
+type StorageOverrides = {
+  setItem?: (key: string, value: string) => void;
+  getItem?: (key: string) => string | null;
+};
+
+function stubBrowserStorage(
+  initial: Record<string, string> = {},
+  overrides: StorageOverrides = {},
+) {
+  const store = new Map(Object.entries(initial));
+  const localStorageMock = {
+    getItem: overrides.getItem ?? ((key: string) => store.get(key) ?? null),
+    setItem:
+      overrides.setItem
+      ?? ((key: string, value: string) => {
+        store.set(key, value);
+      }),
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+  };
+  vi.stubGlobal("window", {
+    localStorage: localStorageMock,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+  vi.stubGlobal("localStorage", localStorageMock);
+  return store;
+}
+
+afterEach(() => {
+  // Each case swaps in a fresh storage stub, so the fallback recorded by a
+  // refused write must not leak into the next one.
+  resetMinimalSessionViewPrefFallback();
+  vi.unstubAllGlobals();
+});
+
+describe("minimal session view storage keys", () => {
+  it("keeps the web and iOS keys aligned with the documented names", () => {
+    expect(MINIMAL_SESSION_VIEW_STORAGE_KEY).toBe("stillpoint_minimal_session_view");
+    expect(IOS_MINIMAL_SESSION_VIEW_KEY).toBe("sp_minimalSessionView");
+  });
+});
+
+describe("loadMinimalSessionViewPref", () => {
+  it("defaults to the full session screen", () => {
+    expect(MINIMAL_SESSION_VIEW_DEFAULT).toBe(false);
+    stubBrowserStorage();
+    expect(loadMinimalSessionViewPref()).toBe(false);
+  });
+
+  it("returns the default outside the browser", () => {
+    expect(loadMinimalSessionViewPref()).toBe(MINIMAL_SESSION_VIEW_DEFAULT);
+  });
+
+  it("reads both boolean encodings", () => {
+    stubBrowserStorage({ [MINIMAL_SESSION_VIEW_STORAGE_KEY]: "true" });
+    expect(loadMinimalSessionViewPref()).toBe(true);
+
+    stubBrowserStorage({ [MINIMAL_SESSION_VIEW_STORAGE_KEY]: "1" });
+    expect(loadMinimalSessionViewPref()).toBe(true);
+
+    stubBrowserStorage({ [MINIMAL_SESSION_VIEW_STORAGE_KEY]: "false" });
+    expect(loadMinimalSessionViewPref()).toBe(false);
+
+    stubBrowserStorage({ [MINIMAL_SESSION_VIEW_STORAGE_KEY]: "0" });
+    expect(loadMinimalSessionViewPref()).toBe(false);
+  });
+
+  it("falls back to the default for unparseable values", () => {
+    stubBrowserStorage({ [MINIMAL_SESSION_VIEW_STORAGE_KEY]: "{not-a-bool}" });
+    expect(loadMinimalSessionViewPref()).toBe(MINIMAL_SESSION_VIEW_DEFAULT);
+  });
+
+  it("falls back to the default when reading throws", () => {
+    stubBrowserStorage(
+      {},
+      {
+        getItem: () => {
+          throw new Error("storage unavailable");
+        },
+      },
+    );
+    expect(loadMinimalSessionViewPref()).toBe(MINIMAL_SESSION_VIEW_DEFAULT);
+  });
+});
+
+describe("saveMinimalSessionViewPref", () => {
+  it("round-trips the choice so the next sit restores it", () => {
+    const store = stubBrowserStorage();
+
+    saveMinimalSessionViewPref(true);
+    expect(store.get(MINIMAL_SESSION_VIEW_STORAGE_KEY)).toBe("true");
+    expect(loadMinimalSessionViewPref()).toBe(true);
+
+    // Easy to reverse: toggling back clears the minimal view for the next sit.
+    saveMinimalSessionViewPref(false);
+    expect(store.get(MINIMAL_SESSION_VIEW_STORAGE_KEY)).toBe("false");
+    expect(loadMinimalSessionViewPref()).toBe(false);
+  });
+
+  it("is a no-op outside the browser", () => {
+    expect(() => saveMinimalSessionViewPref(true)).not.toThrow();
+  });
+
+  it("still notifies subscribers when the write fails", () => {
+    stubBrowserStorage(
+      {},
+      {
+        setItem: () => {
+          throw new Error("quota exceeded");
+        },
+      },
+    );
+    const listener = vi.fn();
+    const unsubscribe = subscribeMinimalSessionViewPref(listener);
+
+    expect(() => saveMinimalSessionViewPref(true)).not.toThrow();
+    // The live sit must still toggle even when persistence is unavailable.
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+  });
+
+  it("keeps the choice readable after a refused write, so the live sit still toggles", () => {
+    stubBrowserStorage(
+      {},
+      {
+        setItem: () => {
+          throw new Error("quota exceeded");
+        },
+      },
+    );
+
+    saveMinimalSessionViewPref(true);
+    // Notifying listeners is not enough — the hook re-reads through the loader,
+    // which would otherwise still report the (unwritten) stored value.
+    expect(loadMinimalSessionViewPref()).toBe(true);
+
+    saveMinimalSessionViewPref(false);
+    expect(loadMinimalSessionViewPref()).toBe(false);
+  });
+
+  it("hands authority back to storage once a write lands", () => {
+    // Storage that refuses writes until `refuse` is cleared, so one test can walk
+    // the private-browsing path and then the recovery.
+    const backing = new Map<string, string>();
+    let refuse = true;
+    stubBrowserStorage(
+      {},
+      {
+        setItem: (key, value) => {
+          if (refuse) throw new Error("quota exceeded");
+          backing.set(key, value);
+        },
+        getItem: key => backing.get(key) ?? null,
+      },
+    );
+
+    saveMinimalSessionViewPref(true);
+    expect(loadMinimalSessionViewPref()).toBe(true);
+
+    refuse = false;
+    saveMinimalSessionViewPref(false);
+    expect(backing.get(MINIMAL_SESSION_VIEW_STORAGE_KEY)).toBe("false");
+    expect(loadMinimalSessionViewPref()).toBe(false);
+
+    // Storage is authoritative again: a value written behind our back is read back.
+    backing.set(MINIMAL_SESSION_VIEW_STORAGE_KEY, "true");
+    expect(loadMinimalSessionViewPref()).toBe(true);
+  });
+
+  it("lets a cross-tab write take authority back from a refused write", () => {
+    stubBrowserStorage(
+      { [MINIMAL_SESSION_VIEW_STORAGE_KEY]: "false" },
+      {
+        setItem: () => {
+          throw new Error("quota exceeded");
+        },
+      },
+    );
+    const addEventListener = window.addEventListener as unknown as ReturnType<typeof vi.fn>;
+    const unsubscribe = subscribeMinimalSessionViewPref(vi.fn());
+    const onStorage = addEventListener.mock.calls[0][1] as (e: StorageEvent) => void;
+
+    saveMinimalSessionViewPref(true);
+    expect(loadMinimalSessionViewPref()).toBe(true);
+
+    onStorage({ key: MINIMAL_SESSION_VIEW_STORAGE_KEY } as StorageEvent);
+    expect(loadMinimalSessionViewPref()).toBe(false);
+
+    unsubscribe();
+  });
+});
+
+describe("subscribeMinimalSessionViewPref", () => {
+  it("notifies same-tab listeners on every save and stops after unsubscribe", () => {
+    stubBrowserStorage();
+    const listener = vi.fn();
+    const unsubscribe = subscribeMinimalSessionViewPref(listener);
+
+    saveMinimalSessionViewPref(true);
+    saveMinimalSessionViewPref(false);
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    saveMinimalSessionViewPref(true);
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("registers a storage listener for the first subscriber only", () => {
+    stubBrowserStorage();
+    const addEventListener = window.addEventListener as unknown as ReturnType<typeof vi.fn>;
+
+    const first = subscribeMinimalSessionViewPref(vi.fn());
+    const second = subscribeMinimalSessionViewPref(vi.fn());
+    expect(addEventListener).toHaveBeenCalledTimes(1);
+    expect(addEventListener).toHaveBeenCalledWith("storage", expect.any(Function));
+
+    first();
+    second();
+    const removeEventListener = window.removeEventListener as unknown as ReturnType<typeof vi.fn>;
+    expect(removeEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("fans out cross-tab storage events for this key and for a full clear", () => {
+    stubBrowserStorage();
+    const addEventListener = window.addEventListener as unknown as ReturnType<typeof vi.fn>;
+    const listener = vi.fn();
+    const unsubscribe = subscribeMinimalSessionViewPref(listener);
+
+    const onStorage = addEventListener.mock.calls[0][1] as (e: StorageEvent) => void;
+
+    onStorage({ key: MINIMAL_SESSION_VIEW_STORAGE_KEY } as StorageEvent);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    // key === null means the whole storage area was cleared.
+    onStorage({ key: null } as StorageEvent);
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    onStorage({ key: "stillpoint_unrelated_pref" } as StorageEvent);
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+  });
+
+  it("ignores storage events from a different storage area", () => {
+    stubBrowserStorage();
+    const addEventListener = window.addEventListener as unknown as ReturnType<typeof vi.fn>;
+    const listener = vi.fn();
+    const unsubscribe = subscribeMinimalSessionViewPref(listener);
+    const onStorage = addEventListener.mock.calls[0][1] as (e: StorageEvent) => void;
+
+    // `storage` fires for sessionStorage too — same key, different area.
+    const sessionArea = { getItem: () => null } as unknown as Storage;
+    onStorage({ key: MINIMAL_SESSION_VIEW_STORAGE_KEY, storageArea: sessionArea } as StorageEvent);
+    onStorage({ key: null, storageArea: sessionArea } as StorageEvent);
+    expect(listener).not.toHaveBeenCalled();
+
+    onStorage({
+      key: MINIMAL_SESSION_VIEW_STORAGE_KEY,
+      storageArea: window.localStorage,
+    } as StorageEvent);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+  });
+});

--- a/src/lib/minimalSessionViewPrefs.ts
+++ b/src/lib/minimalSessionViewPrefs.ts
@@ -1,0 +1,108 @@
+/**
+ * #669: "just the timer" minimal session view.
+ *
+ * Persists whether the session screen collapses to the numeric countdown alone.
+ * Mirrors `trackingControlPrefs.ts`: one boolean localStorage key plus a listener
+ * set so an already-mounted session re-renders when the value changes — same tab
+ * via `saveMinimalSessionViewPref`, other tabs via the `storage` event.
+ *
+ * iOS persists the same preference in `UserDefaults` under
+ * `IOS_MINIMAL_SESSION_VIEW_KEY` (`MinimalSessionViewPrefs.swift`) so both
+ * clients use identical key naming.
+ */
+
+/** Web localStorage key. */
+export const MINIMAL_SESSION_VIEW_STORAGE_KEY = "stillpoint_minimal_session_view";
+
+/** iOS UserDefaults key (parity with web localStorage). */
+export const IOS_MINIMAL_SESSION_VIEW_KEY = "sp_minimalSessionView";
+
+/** Sits show the full session screen unless the user opts into the minimal view. */
+export const MINIMAL_SESSION_VIEW_DEFAULT = false;
+
+/**
+ * The last value we tried to persist while `localStorage` refused the write
+ * (Safari private browsing, quota exceeded); `null` means storage is
+ * authoritative. Without it a refused write would leave the loader returning the
+ * stale stored value, so `useSyncExternalStore` would re-read the old boolean
+ * and the tap that toggled minimal view would look like it did nothing.
+ */
+let unpersistedPref: boolean | null = null;
+
+export function loadMinimalSessionViewPref(): boolean {
+  if (typeof window === "undefined") return MINIMAL_SESSION_VIEW_DEFAULT;
+  // A choice storage refused wins until storage accepts a write again, so the
+  // running sit follows the user even when persistence is unavailable.
+  if (unpersistedPref !== null) return unpersistedPref;
+  try {
+    const raw = localStorage.getItem(MINIMAL_SESSION_VIEW_STORAGE_KEY);
+    if (raw === "true" || raw === "1") return true;
+    if (raw === "false" || raw === "0") return false;
+    return MINIMAL_SESSION_VIEW_DEFAULT;
+  } catch {
+    return MINIMAL_SESSION_VIEW_DEFAULT;
+  }
+}
+
+export function saveMinimalSessionViewPref(minimal: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(MINIMAL_SESSION_VIEW_STORAGE_KEY, minimal ? "true" : "false");
+    // Storage is authoritative again; drop any earlier refused write.
+    unpersistedPref = null;
+  } catch {
+    // Storage refused the write (private browsing, quota exceeded). Hold the
+    // choice in memory so the live sit still toggles; persistence resumes on the
+    // next write storage accepts.
+    unpersistedPref = minimal;
+  }
+  notifyMinimalSessionViewListeners();
+}
+
+/**
+ * Drops the in-memory value recorded when a `localStorage` write was refused, so
+ * the next read comes from storage again. Exported for tests, which swap the
+ * storage stub between cases.
+ */
+export function resetMinimalSessionViewPrefFallback(): void {
+  unpersistedPref = null;
+}
+
+type MinimalSessionViewListener = () => void;
+
+const listeners = new Set<MinimalSessionViewListener>();
+
+function onStorageEvent(e: StorageEvent): void {
+  // `storage` also fires for sessionStorage. Ignoring those matters most for the
+  // clear-all case below, which would otherwise drop a refused write's in-memory
+  // value and silently revert the sit. Real events always name their area;
+  // synthetic ones (tests, older engines) may not, so only a mismatch is ignored.
+  if (e.storageArea && e.storageArea !== window.localStorage) return;
+  // key === null means the whole storage area was cleared.
+  if (e.key === MINIMAL_SESSION_VIEW_STORAGE_KEY || e.key === null) {
+    // Another tab reached storage, so storage is authoritative again.
+    unpersistedPref = null;
+    notifyMinimalSessionViewListeners();
+  }
+}
+
+function notifyMinimalSessionViewListeners(): void {
+  for (const listener of [...listeners]) listener();
+}
+
+/**
+ * Subscribe to minimal-view preference changes. Returns an unsubscribe function
+ * (`useSyncExternalStore`-compatible).
+ */
+export function subscribeMinimalSessionViewPref(listener: MinimalSessionViewListener): () => void {
+  if (typeof window !== "undefined" && listeners.size === 0) {
+    window.addEventListener("storage", onStorageEvent);
+  }
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+    if (typeof window !== "undefined" && listeners.size === 0) {
+      window.removeEventListener("storage", onStorageEvent);
+    }
+  };
+}

--- a/src/lib/useMinimalSessionView.ts
+++ b/src/lib/useMinimalSessionView.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import {
+  MINIMAL_SESSION_VIEW_DEFAULT,
+  loadMinimalSessionViewPref,
+  subscribeMinimalSessionViewPref,
+} from "@/lib/minimalSessionViewPrefs";
+
+/**
+ * Live view of the persisted "just the timer" preference (#669).
+ *
+ * The stored preference is the single source of truth for the running sit, so
+ * toggling minimal view both updates the screen and is remembered for the next
+ * sit. The server snapshot is the default (full screen) so SSR markup matches
+ * the first client render before localStorage is read.
+ */
+export function useMinimalSessionViewPref(): boolean {
+  return useSyncExternalStore(
+    subscribeMinimalSessionViewPref,
+    loadMinimalSessionViewPref,
+    () => MINIMAL_SESSION_VIEW_DEFAULT,
+  );
+}


### PR DESCRIPTION
## **User description**
Closes #669

## Problem

The session screen carries a lot around the timer — block grid, mind-state bar, status label, tracking info, controls, sound toggles. Useful when you want them, noise when you are trying to settle, and there was no way to strip the screen down in the moment.

## Change

A single control on the session screen collapses everything but the numeric countdown, on both clients. The sit itself is untouched: only presentation is gated, so sounds play per prefs, blocks advance, and completion fires on time. Exiting restores the full screen with elapsed time, thought count, clear percentage, and sound prefs intact, because nothing that holds session state unmounts.

### Scope calls

- **Ships standalone**, not as a slice of #75. A working focus mode today beats a design-complete customization system someday; #75 can generalize this later.
- **"The timer" is the numeric countdown alone.** The block grid hides too — the issue asks for "hide all but the timer", and the grid is chrome around the countdown rather than the countdown itself.
- **The control hides with the chrome**, so minimal view really is just the timer.

### Gesture map (both clients)

While minimal, the whole screen is the affordance:

| Gesture | Result |
|---|---|
| Tap / click anywhere | Restores the full session screen |
| Press and hold (500 ms) | Opens thought capture, **staying in minimal view** |
| Drag past ~12 px | Nothing — that is a scroll, not a tap |
| `Esc` (web) | Restores the full session screen |

**Thought capture wins the collision.** Once the long press fires, the press is marked consumed and the release that follows does not exit minimal view — so the capture gesture can never be swallowed by the restoring tap. This satisfies the AC's "thought capture remains reachable while minimal" without giving capture a second, competing entry point: tap-anywhere is not a capture gesture in the full view either, so capture keeps its own distinct gesture in both views.

Web additionally keeps a **visually-hidden-until-focused "show session controls" button** as the keyboard/screen-reader way out, since a long press is not available to those users. It is off-screen (clipped) until it takes focus, so it is not new chrome.

### Persistence

The choice is remembered for the next sit and reversed by one tap.

- Web: `localStorage` (`stillpoint_minimal_session_view`), read live through `useSyncExternalStore` so the stored preference is the single source of truth for the running sit — one write both restyles this sit and persists it.
- iOS: `UserDefaults` (`sp_minimalSessionView`) via a new `MinimalSessionViewPrefs` helper in `StillPointShared`, following the `SessionIntroPrefs` convention. Seeded in `init` so a sit that should start minimal never flashes the full screen first, and wired into the UI-test reset path so a leftover preference cannot collapse the chrome other UI tests assert on.
- A write `localStorage` refuses (Safari private browsing, quota exceeded) is held in memory, so the live sit still toggles even when the choice cannot be persisted. Storage takes authority back on the next accepted write or a cross-tab `storage` event.

### Notes on specific decisions

- **The web `hide`/`show` numeric-timer preference is bypassed while minimal**, not overwritten. Honouring it there would leave a blank screen with no way to read the sit; the stored preference is untouched and applies again on exit.
- **Entering minimal view finalizes any active hold** on both clients. The hold targets unmount, so their release handler would never fire (two-finger case: hold with one thumb, tap the control with the other) and the sit would stay stuck in `thinking`/`hyperfocus`, skewing `clearPercent`.
- **Sound toggles are untouched.** #668 lands on the same files; the new iOS control sits in the guided-exercise/capture row, not the sound-toggle row, and no toggle styling changed. PR #673's mid-sit warm-up behaviour is on this branch's base and is not disturbed.

## Test plan

- [x] Unit (web): the persisted preference round-trips, reads both boolean encodings, falls back to the default on unparseable/unreadable storage, and is reversible.
- [x] Unit (web): a refused `localStorage` write still flips what the loader reports, so the live sit toggles when persistence is unavailable; storage takes authority back on the next accepted write and on a cross-tab `storage` event.
- [x] Unit (web): `storage` events from a different storage area are ignored.
- [x] Unit (web): gesture rules — a still finger is a tap, jitter inside tolerance is still a tap, diagonal travel past tolerance is a drag, a consumed press (long press fired) resolves to no-op, and only the pointer that opened a press can resolve it.
- [x] Unit (iOS): `MinimalSessionViewPrefs` defaults to the full screen, persists an enable, is reversible, resets, and keeps its key aligned with the web parity constant. Runs in the required `StillPointShared swift test` check.
- [x] `npm run typecheck` clean.
- [x] `npm run test:unit` — all suites pass except `src/db/schema.recovery-constraint.test.ts`, which needs a live database this machine cannot reach (pre-existing; unrelated to this change, and green in CI where the DB is provisioned).
- [x] `npm run build` succeeds.
- [x] Regression (code): the default session screen is unchanged — every hidden region is gated behind `minimalView`, which defaults to `false`, and no existing markup or styling was altered.
- [x] Playwright mobile-web spec added covering collapse (tracking layer, secondary chrome, hold controls, and extend buttons all absent; countdown present), restore by tap-anywhere with the sit still running, and the persisted value in `localStorage` after each toggle. The mobile lane runs in the release pipeline (`e2e-mobile.yml`), not per-PR.

## Verification notes

- `swift test` could not be run locally: this machine has CommandLineTools only, no full Xcode, so the SwiftData `@Model` macro plugin in `Models/User.swift` fails to load. Pre-existing environment limitation. Verified locally instead with `swift build` on the `StillPointShared` package (clean — the only warning is a pre-existing `FileManager` Sendable one in `OfflineSessionQueue.swift`) and `swiftc -parse` on the edited app-target view (clean). CI's `StillPointShared swift test` is the real gate.
- Native iOS UI coverage and the device/browser matrix are deferred to **Post-merge verification** below — `e2e-ios.yml` runs in the release pipeline rather than per-PR.

**Local review coverage:** none — both CLIs are capped for the session. CodeRabbit CLI produced **five** verified-successful runs and every finding it raised was fixed (a refused-write bug that made the toggle silently no-op in private browsing; a stale focus flag that would render the exit button visible on re-entry; multi-touch and non-primary-button pointer handling; a render-phase ref assignment), but it then hit the org review rate limit — "you've used all 5 included reviews currently available", ~32 minute wait — so the sixth round never produced a clean pass. The only change not re-reviewed by the CLI is the last fix itself (replacing the render-phase ref with a stable `useCallback`), which was self-reviewed. CodeAnt CLI failed twice — `noFiles=true` on the uncommitted scope, then `Access denied (403)` on the committed scope, which is its undocumented daily cap rather than an auth fault — and is dropped for the session with zero findings emitted, so nothing is left unresolved or waived. The CodeAnt and CodeRabbit GitHub Apps are unaffected and gate this PR normally.

## Post-merge verification

Tracking issue: #685

- [ ] Manual (iOS + web): start a sit, toggle minimal, confirm only the timer is visible, toggle back, confirm the full screen returns with correct elapsed and thought state.
- [ ] Manual: complete an entire sit in minimal view; confirm it saves with the correct duration, thought count, and clear percentage.
- [ ] Manual: capture thoughts while minimal via press-and-hold; confirm they are recorded and that minimal view is not exited.
- [ ] Manual: relaunch the app / reload the browser and start a new sit; confirm the last-used view mode is restored.
- [ ] Manual (iOS): the "how to come back" hint appears on entry and fades, including on a sit that starts minimal from the restored preference once the intro overlay is dismissed.
- [ ] Manual (web, desktop): `Esc` restores; tabbing to the hidden "show session controls" button reveals and activates it; right-click does not exit minimal view.
- [ ] Manual (web): private browsing — toggling minimal view still works for the live sit even though the preference cannot be persisted.
- [ ] Regression (device): default, non-minimal session screen unchanged on both clients.


___

## **CodeAnt-AI Description**
Add a persisted “just the timer” view for active sessions

### What Changed
- Users can collapse the web or iOS session screen to the countdown alone, hiding tracking details, controls, progress indicators, block grids, and sound toggles while the session continues normally.
- A tap restores the full session screen; pressing and holding opens thought capture without leaving minimal view. Dragging does neither, and web users can also press Escape or use the keyboard-accessible restore control.
- The selected view is remembered for future sessions and remains usable when browser storage is unavailable.
- Added coverage for minimal-view persistence, gesture handling, and the end-to-end web flow.

### Impact
`✅ Fewer session-screen distractions`
`✅ Thought capture remains available in timer-only view`
`✅ Consistent session view across web and iOS`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
