### PR TITLE
feat(session): sound toggles as real buttons on iOS and web (#668)

### DIFF
--- a/ios/StillPointApp/Views/SessionView.swift
+++ b/ios/StillPointApp/Views/SessionView.swift
@@ -7,8 +7,9 @@ struct SessionView: View {
     private static let bottomOverlayReserveWithControls: CGFloat = 300
     /// Minimum vertical hit target for hold-to-track controls (Apple HIG ~44pt+).
     private static let thumbReachHoldMinHeight: CGFloat = 56
-    /// Minimum tap target for sound toggles (Apple HIG 44pt).
-    private static let soundToggleMinSize: CGFloat = 44
+    /// Minimum tap target for sound toggles and the bottom-bar icon buttons
+    /// (Apple HIG 44pt). Shared with web through `SoundToggleAppearance` (#668).
+    private static let minTapTarget = CGFloat(SoundToggleAppearance.minimumTapTarget)
 
     /// #669: long-press duration that opens thought capture from the minimal view.
     private static let minimalViewCapturePressDuration: Double = 0.5
@@ -660,7 +661,7 @@ struct SessionView: View {
                         Image(systemName: "info.circle")
                             .font(.system(size: 16, weight: .medium))
                             .foregroundStyle(Color(SPColor.fg4))
-                            .frame(width: Self.soundToggleMinSize, height: Self.soundToggleMinSize)
+                            .frame(width: Self.minTapTarget, height: Self.minTapTarget)
                             .contentShape(Rectangle())
                     }
                     .accessibilityLabel("Capture intrusive thought help")
@@ -682,7 +683,7 @@ struct SessionView: View {
                         Image(systemName: "arrow.down.right.and.arrow.up.left")
                             .font(.system(size: 16, weight: .medium))
                             .foregroundStyle(Color(SPColor.fg3))
-                            .frame(width: Self.soundToggleMinSize, height: Self.soundToggleMinSize)
+                            .frame(width: Self.minTapTarget, height: Self.minTapTarget)
                             .contentShape(Rectangle())
                     }
                     .accessibilityLabel("Show only the timer")
@@ -887,8 +888,10 @@ struct SessionView: View {
                 .accessibilityIdentifier("session.abandonButton")
             }
 
-            // Sound toggles
-            HStack(spacing: SPSpacing.s3) {
+            // Sound toggles. #668: the pills are wider than the bare words they
+            // replaced, so the row tightens to s1 to keep all four on one line on
+            // the narrowest supported iPhone.
+            HStack(spacing: SPSpacing.s1) {
                 soundToggle("tick", isOn: vm.soundPrefs.tick) {
                     vm.toggleSound(\.tick)
                 }
@@ -913,20 +916,43 @@ struct SessionView: View {
         )
     }
 
+    /// #668: a real pill button rather than a bare word.
+    ///
+    /// On/off is carried by three redundant channels — fill, border, and the
+    /// speaker icon — so the state reads at a glance instead of resting on a
+    /// shift between two muted greys. `SoundToggleAppearance` owns those rules and
+    /// web reads the same ones, so the two clients stay in step. The pill itself
+    /// is 44pt tall, so the visible control *is* the tap target.
     private func soundToggle(_ label: String, isOn: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            HStack(spacing: 4) {
-                Image(systemName: isOn ? "speaker.wave.2.fill" : "speaker.slash.fill")
+        let appearance = SoundToggleAppearance.appearance(isOn: isOn)
+
+        return Button(action: action) {
+            HStack(spacing: 5) {
+                Image(systemName: appearance.systemImageName)
                     .font(.system(size: 12))
                 Text(label)
                     .font(SPFont.mono(11))
                     .lineLimit(1)
+                    .minimumScaleFactor(0.8)
             }
-            .foregroundStyle(isOn ? Color(SPColor.fg3) : Color(SPColor.fg4))
-            .frame(minWidth: Self.soundToggleMinSize, minHeight: Self.soundToggleMinSize)
-            .contentShape(Rectangle())
+            .foregroundStyle(isOn ? Color(SPColor.fg2) : Color(SPColor.fg4))
+            .padding(.horizontal, SPSpacing.s2)
+            .frame(minHeight: Self.minTapTarget)
+            .background(appearance.isFilled ? SPColor.surface3 : Color.clear)
+            .clipShape(Capsule())
+            .overlay(
+                Capsule().stroke(
+                    appearance.hasProminentBorder ? SPColor.border2 : SPColor.border1
+                )
+            )
+            .contentShape(Capsule())
         }
-        .accessibilityIdentifier("session.soundToggle.\(label)")
+        .animation(.easeInOut(duration: 0.2), value: isOn)
+        .accessibilityIdentifier(SoundToggleAppearance.accessibilityIdentifier(label: label))
+        // VoiceOver reads "tick sound, on, button" — the state is announced, not
+        // left to the colour of the pill.
+        .accessibilityLabel(Text(SoundToggleAppearance.accessibilityLabel(label: label)))
+        .accessibilityValue(Text(SoundToggleAppearance.accessibilityValue(isOn: isOn)))
     }
 
     // MARK: - Completion Handler

--- a/ios/StillPointShared/Sources/StillPointShared/SoundToggleAppearance.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/SoundToggleAppearance.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Presentation rules for the mid-session sound toggles (tick / chime / voice / end).
+///
+/// The row used to be four bare lowercase words whose only state cue was a shift
+/// between two muted greys — `fg3` when on, `fg4` when off (#668). Mid-sit, on a
+/// phone, that is neither obviously tappable nor obviously on.
+///
+/// This type owns the *appearance* decision so both clients derive it from one
+/// place: iOS renders it in `SessionView.soundToggle`, web in
+/// `src/components/SessionView.tsx` via the port at
+/// `src/lib/soundToggleAppearance.ts`. Nothing here touches audio — the toggle
+/// side effects still live in `SoundToggleLogic` (#667) and are untouched by the
+/// restyle.
+///
+/// Free of SwiftUI / UIKit so it compiles and runs under `swift test` on macOS.
+public enum SoundToggleAppearance {
+
+    /// Minimum tap target for a sound toggle (Apple HIG 44pt / WCAG 2.5.5 44px).
+    ///
+    /// This is the size of the *visible* pill, not an invisible target wrapped
+    /// around a small glyph: the fill and border are drawn at this height so what
+    /// you see is what you can hit.
+    public static let minimumTapTarget: Double = 44
+
+    /// The visual channels that carry on/off state.
+    ///
+    /// Three redundant cues, deliberately: an off state that only differs in text
+    /// colour is unreadable at a glance and fails "does not rely on a subtle
+    /// two-grey color difference alone". Anything that collapses these back into a
+    /// single channel breaks `SoundToggleAppearanceTests`.
+    public struct Appearance: Equatable {
+        /// Pill is filled (on) rather than transparent (off).
+        public let isFilled: Bool
+        /// Pill border is the stronger tier (on) rather than the faint tier (off).
+        public let hasProminentBorder: Bool
+        /// Icon shows a muted speaker (off) rather than a sounding one (on).
+        public let isIconMuted: Bool
+
+        public init(isFilled: Bool, hasProminentBorder: Bool, isIconMuted: Bool) {
+            self.isFilled = isFilled
+            self.hasProminentBorder = hasProminentBorder
+            self.isIconMuted = isIconMuted
+        }
+
+        /// SF Symbol for the icon half of the control.
+        public var systemImageName: String {
+            isIconMuted ? "speaker.slash.fill" : "speaker.wave.2.fill"
+        }
+    }
+
+    /// Resolves every visual channel from the single on/off input.
+    public static func appearance(isOn: Bool) -> Appearance {
+        Appearance(isFilled: isOn, hasProminentBorder: isOn, isIconMuted: !isOn)
+    }
+
+    /// UI-test hook. Unchanged by the restyle — `StillPointAppUITests` and the web
+    /// e2e suite both address the toggles through this identifier.
+    public static func accessibilityIdentifier(label: String) -> String {
+        "session.soundToggle.\(label)"
+    }
+
+    /// Accessible name. Keeps the visible word first so speech input ("tap tick")
+    /// still matches the label a sighted user reads (WCAG 2.5.3 Label in Name).
+    public static func accessibilityLabel(label: String) -> String {
+        "\(label) sound"
+    }
+
+    /// Accessible value, so VoiceOver announces the state change rather than
+    /// leaving it to colour alone. Read as "tick sound, on, button".
+    public static func accessibilityValue(isOn: Bool) -> String {
+        isOn ? "on" : "off"
+    }
+}

--- a/ios/StillPointShared/Tests/StillPointSharedTests/SoundToggleAppearanceTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/SoundToggleAppearanceTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import StillPointShared
+
+/// #668 — the sound toggles must read as buttons with an unmistakable on/off state.
+///
+/// Ported to `src/lib/soundToggleAppearance.test.ts` so both clients assert the
+/// same rules; keep the two files in step.
+final class SoundToggleAppearanceTests: XCTestCase {
+
+    // MARK: - State is carried by more than colour
+
+    func testOnStateFillsThePillAndUsesTheSoundingIcon() {
+        let appearance = SoundToggleAppearance.appearance(isOn: true)
+
+        XCTAssertTrue(appearance.isFilled)
+        XCTAssertTrue(appearance.hasProminentBorder)
+        XCTAssertFalse(appearance.isIconMuted)
+        XCTAssertEqual(appearance.systemImageName, "speaker.wave.2.fill")
+    }
+
+    func testOffStateDropsTheFillAndUsesTheMutedIcon() {
+        let appearance = SoundToggleAppearance.appearance(isOn: false)
+
+        XCTAssertFalse(appearance.isFilled)
+        XCTAssertFalse(appearance.hasProminentBorder)
+        XCTAssertTrue(appearance.isIconMuted)
+        XCTAssertEqual(appearance.systemImageName, "speaker.slash.fill")
+    }
+
+    /// The acceptance criterion the restyle exists for: on and off must differ in
+    /// fill, border, *and* icon — not in text colour alone. A regression that
+    /// collapses the state onto one channel fails here.
+    func testEveryVisualChannelDistinguishesOnFromOff() {
+        let on = SoundToggleAppearance.appearance(isOn: true)
+        let off = SoundToggleAppearance.appearance(isOn: false)
+
+        XCTAssertNotEqual(on.isFilled, off.isFilled)
+        XCTAssertNotEqual(on.hasProminentBorder, off.hasProminentBorder)
+        XCTAssertNotEqual(on.isIconMuted, off.isIconMuted)
+        XCTAssertNotEqual(on.systemImageName, off.systemImageName)
+    }
+
+    // MARK: - Tap target
+
+    func testMinimumTapTargetMeetsTheHumanInterfaceGuidelines() {
+        XCTAssertGreaterThanOrEqual(SoundToggleAppearance.minimumTapTarget, 44)
+    }
+
+    // MARK: - Accessibility
+
+    /// UI tests address the toggles by this identifier; the restyle must not move it.
+    func testAccessibilityIdentifierKeepsTheExistingFormat() {
+        XCTAssertEqual(
+            SoundToggleAppearance.accessibilityIdentifier(label: "tick"),
+            "session.soundToggle.tick"
+        )
+        XCTAssertEqual(
+            SoundToggleAppearance.accessibilityIdentifier(label: "chime"),
+            "session.soundToggle.chime"
+        )
+        XCTAssertEqual(
+            SoundToggleAppearance.accessibilityIdentifier(label: "voice"),
+            "session.soundToggle.voice"
+        )
+        XCTAssertEqual(
+            SoundToggleAppearance.accessibilityIdentifier(label: "end"),
+            "session.soundToggle.end"
+        )
+    }
+
+    /// WCAG 2.5.3: the accessible name starts with the word shown on the control,
+    /// so voice control matches what a sighted user would say.
+    func testAccessibilityLabelStartsWithTheVisibleWord() {
+        XCTAssertEqual(SoundToggleAppearance.accessibilityLabel(label: "tick"), "tick sound")
+        XCTAssertTrue(
+            SoundToggleAppearance.accessibilityLabel(label: "voice").hasPrefix("voice")
+        )
+    }
+
+    func testAccessibilityValueAnnouncesStateRatherThanRelyingOnColour() {
+        XCTAssertEqual(SoundToggleAppearance.accessibilityValue(isOn: true), "on")
+        XCTAssertEqual(SoundToggleAppearance.accessibilityValue(isOn: false), "off")
+    }
+}

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -28,9 +28,53 @@ import {
   resolveMinimalViewRelease,
   type MinimalViewPress,
 } from "@/lib/minimalSessionGestures";
+import {
+  SOUND_TOGGLE_MIN_TAP_TARGET_PX,
+  soundToggleAccessibilityLabel,
+  soundToggleAppearance,
+  soundToggleStateText,
+  soundToggleTestId,
+} from "@/lib/soundToggleAppearance";
 import { GuidedExerciseOverlay } from "./GuidedExerciseOverlay";
 
 type MindState = "clear" | "thinking" | "hyperfocus";
+
+/**
+ * #668: the speaker glyph inside a sound toggle. Inline SVG rather than a text
+ * glyph so the on/off shapes are the same pair iOS draws with SF Symbols
+ * (`speaker.wave.2.fill` / `speaker.slash.fill`) instead of whatever the device
+ * font happens to have for `♪`.
+ */
+function SoundToggleIcon({ muted }: { muted: boolean }) {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+      style={{ flexShrink: 0 }}
+    >
+      {/* Speaker body, shared by both states. */}
+      <path d="M3 6h2l3-2.5v9L5 10H3z" fill="currentColor" stroke="none" />
+      {muted ? (
+        // Off: a slash through the waves.
+        <path d="M10.5 6l4 4m0-4l-4 4" />
+      ) : (
+        // On: two sound waves, matching speaker.wave.2.fill.
+        <>
+          <path d="M10.5 5.75a3 3 0 010 4.5" />
+          <path d="M12.75 4a5.5 5.5 0 010 8" />
+        </>
+      )}
+    </svg>
+  );
+}
 
 const NO_RECOVERY: RecoveryFields = {
   recoveryTargetDay: null,
@@ -986,15 +1030,24 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
           </div>
         )}
 
+        {/*
+          #668: real pill buttons, not four bare words. On/off is carried by fill,
+          border, and the speaker icon together \u2014 the same three channels iOS uses
+          via `SoundToggleAppearance` \u2014 so the state reads at a glance rather than
+          resting on a shift between two muted greys. `flexWrap` is a safety net:
+          the row is sized to fit four pills at 320px, and an unusually wide font
+          drops to a second line instead of being clipped by `overflow-x: hidden`.
+        */}
         <div
           style={{
             display: "flex",
             justifyContent: "center",
-            gap: "16px",
+            flexWrap: "wrap",
+            gap: "6px",
             marginTop: isMobile ? "8px" : "24px",
             ...mono,
-            fontSize: "11px",
-            letterSpacing: "0.1em",
+            fontSize: "10px",
+            letterSpacing: "0.06em",
           }}
         >
           {(
@@ -1004,34 +1057,59 @@ export function SessionView({ currentDay, recovery = NO_RECOVERY, sessionType = 
               ["voiceCountdown", "voice"],
               ["completion", "end"],
             ] as const
-          ).map(([key, label]) => (
-            <button
-              type="button"
-              key={key}
-              onClick={() => {
-                const next = { ...soundPrefs, [key]: !soundPrefs[key] };
-                setSoundPrefs(next);
-                saveSoundPrefs(next);
-                if (next[key]) {
-                  void unlockAudioContext();
-                }
-              }}
-              style={{
-                background: "none",
-                border: "none",
-                cursor: "pointer",
-                color: soundPrefs[key] ? "var(--fg-3)" : "var(--fg-4)",
-                transition: "color 0.3s",
-                padding: "12px 14px",
-                minHeight: "44px",
-                display: "inline-flex",
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-            >
-              {soundPrefs[key] ? "\u266A" : "\u2022"} {label}
-            </button>
-          ))}
+          ).map(([key, label]) => {
+            const isOn = soundPrefs[key];
+            const appearance = soundToggleAppearance(isOn);
+            return (
+              <button
+                type="button"
+                key={key}
+                // Native button + aria-pressed: assistive tech announces
+                // "tick sound, toggle button, pressed" and re-announces on change,
+                // so the state never depends on seeing the fill.
+                aria-pressed={isOn}
+                aria-label={soundToggleAccessibilityLabel(label)}
+                // Becomes the accessible *description*, not the name. Deliberately
+                // restates the state in words: it is the hover tooltip for mouse
+                // users, and a plain-language fallback on the older
+                // browser/screen-reader pairs that handle `aria-pressed` poorly.
+                title={`${soundToggleAccessibilityLabel(label)} \u2014 ${soundToggleStateText(isOn)}`}
+                data-testid={soundToggleTestId(label)}
+                data-sound-toggle={label}
+                data-state={soundToggleStateText(isOn)}
+                onClick={() => {
+                  const next = { ...soundPrefs, [key]: !soundPrefs[key] };
+                  setSoundPrefs(next);
+                  saveSoundPrefs(next);
+                  if (next[key]) {
+                    void unlockAudioContext();
+                  }
+                }}
+                style={{
+                  background: appearance.isFilled ? "var(--surface-3)" : "transparent",
+                  border: `1px solid ${
+                    appearance.hasProminentBorder ? "var(--border-2)" : "var(--border-1)"
+                  }`,
+                  cursor: "pointer",
+                  color: isOn ? "var(--fg-2)" : "var(--fg-4)",
+                  transition: "background 0.2s, border-color 0.2s, color 0.2s",
+                  // Padding plus this min-height makes the *visible* pill the tap
+                  // target, rather than a small glyph inside an invisible one.
+                  padding: "0 10px",
+                  minHeight: `${SOUND_TOGGLE_MIN_TAP_TARGET_PX}px`,
+                  borderRadius: `${SOUND_TOGGLE_MIN_TAP_TARGET_PX / 2}px`,
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: "5px",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                <SoundToggleIcon muted={appearance.isIconMuted} />
+                {label}
+              </button>
+            );
+          })}
         </div>
       </div>
       )}

--- a/src/lib/soundToggleAppearance.test.ts
+++ b/src/lib/soundToggleAppearance.test.ts
@@ -1,0 +1,72 @@
+/**
+ * #668 — the sound toggles must read as buttons with an unmistakable on/off state.
+ *
+ * Ports ios/StillPointShared/Tests/StillPointSharedTests/SoundToggleAppearanceTests.swift
+ * so both clients assert the same rules; keep the two files in step.
+ */
+import { describe, expect, test } from "vitest";
+import {
+  SOUND_TOGGLE_MIN_TAP_TARGET_PX,
+  soundToggleAccessibilityLabel,
+  soundToggleAppearance,
+  soundToggleStateText,
+  soundToggleTestId,
+} from "@/lib/soundToggleAppearance";
+
+describe("soundToggleAppearance", () => {
+  test("on state fills the pill and uses the sounding icon", () => {
+    expect(soundToggleAppearance(true)).toEqual({
+      isFilled: true,
+      hasProminentBorder: true,
+      isIconMuted: false,
+    });
+  });
+
+  test("off state drops the fill and uses the muted icon", () => {
+    expect(soundToggleAppearance(false)).toEqual({
+      isFilled: false,
+      hasProminentBorder: false,
+      isIconMuted: true,
+    });
+  });
+
+  // The acceptance criterion the restyle exists for: on and off must differ in
+  // fill, border, *and* icon — not in text colour alone. A regression that
+  // collapses the state onto one channel fails here.
+  test("every visual channel distinguishes on from off", () => {
+    const on = soundToggleAppearance(true);
+    const off = soundToggleAppearance(false);
+
+    expect(on.isFilled).not.toBe(off.isFilled);
+    expect(on.hasProminentBorder).not.toBe(off.hasProminentBorder);
+    expect(on.isIconMuted).not.toBe(off.isIconMuted);
+  });
+});
+
+describe("tap target", () => {
+  test("minimum tap target meets WCAG 2.5.5", () => {
+    expect(SOUND_TOGGLE_MIN_TAP_TARGET_PX).toBeGreaterThanOrEqual(44);
+  });
+});
+
+describe("accessibility", () => {
+  // UI tests address the toggles by this identifier; the restyle must not move it.
+  test("test id keeps the existing format", () => {
+    expect(soundToggleTestId("tick")).toBe("session.soundToggle.tick");
+    expect(soundToggleTestId("chime")).toBe("session.soundToggle.chime");
+    expect(soundToggleTestId("voice")).toBe("session.soundToggle.voice");
+    expect(soundToggleTestId("end")).toBe("session.soundToggle.end");
+  });
+
+  // WCAG 2.5.3: the accessible name starts with the word shown on the control,
+  // so voice control matches what a sighted user would say.
+  test("accessible name starts with the visible word", () => {
+    expect(soundToggleAccessibilityLabel("tick")).toBe("tick sound");
+    expect(soundToggleAccessibilityLabel("voice").startsWith("voice")).toBe(true);
+  });
+
+  test("state text announces on/off rather than relying on colour", () => {
+    expect(soundToggleStateText(true)).toBe("on");
+    expect(soundToggleStateText(false)).toBe("off");
+  });
+});

--- a/src/lib/soundToggleAppearance.ts
+++ b/src/lib/soundToggleAppearance.ts
@@ -1,0 +1,64 @@
+/**
+ * #668 — presentation rules for the mid-session sound toggles (tick / chime /
+ * voice / end).
+ *
+ * The row used to be four bare lowercase words whose only state cue was a shift
+ * between two muted greys (`--fg-3` on, `--fg-4` off). Mid-sit, on a phone, that
+ * is neither obviously tappable nor obviously on.
+ *
+ * Port of `ios/StillPointShared/Sources/StillPointShared/SoundToggleAppearance.swift`
+ * so both clients derive the same appearance from one rule set — keep the two in
+ * step. Nothing here touches audio: the toggle side effects stay in the click
+ * handler in `SessionView.tsx` (web) and `SoundToggleLogic` (#667, iOS).
+ */
+
+/** Minimum tap target for a sound toggle (WCAG 2.5.5 44px / Apple HIG 44pt). */
+export const SOUND_TOGGLE_MIN_TAP_TARGET_PX = 44;
+
+/**
+ * The visual channels that carry on/off state.
+ *
+ * Three redundant cues, deliberately: an off state that only differs in text
+ * colour is unreadable at a glance and fails "does not rely on a subtle two-grey
+ * color difference alone". Anything that collapses these into a single channel
+ * breaks `soundToggleAppearance.test.ts`.
+ */
+export type SoundToggleAppearance = {
+  /** Pill is filled (on) rather than transparent (off). */
+  isFilled: boolean;
+  /** Pill border is the stronger tier (on) rather than the faint tier (off). */
+  hasProminentBorder: boolean;
+  /** Icon shows a muted speaker (off) rather than a sounding one (on). */
+  isIconMuted: boolean;
+};
+
+/** Resolves every visual channel from the single on/off input. */
+export function soundToggleAppearance(isOn: boolean): SoundToggleAppearance {
+  return { isFilled: isOn, hasProminentBorder: isOn, isIconMuted: !isOn };
+}
+
+/**
+ * UI-test hook, unchanged by the restyle. iOS `StillPointAppUITests` and the web
+ * e2e suite both address the toggles through this identifier.
+ */
+export function soundToggleTestId(label: string): string {
+  return `session.soundToggle.${label}`;
+}
+
+/**
+ * Accessible name. Keeps the visible word first so speech input ("click tick")
+ * still matches the label a sighted user reads (WCAG 2.5.3 Label in Name).
+ */
+export function soundToggleAccessibilityLabel(label: string): string {
+  return `${label} sound`;
+}
+
+/**
+ * Human-readable state, for the screen-reader announcement. The web control is a
+ * `<button aria-pressed>`, so assistive tech derives "pressed"/"not pressed" on
+ * its own; this string backs the `title` tooltip and keeps the announced wording
+ * identical to iOS's `accessibilityValue`.
+ */
+export function soundToggleStateText(isOn: boolean): string {
+  return isOn ? "on" : "off";
+}


### PR DESCRIPTION
## **User description**
## What this changes

The four mid-sit sound controls (`tick` / `chime` / `voice` / `end`) were bare lowercase words whose only state cue was a shift between `--fg-3` and `--fg-4` — two muted greys. They read as labels, not controls. Mid-sit, eyes half-closed, on a phone, neither "is this tappable" nor "is this on" was answerable at a glance.

They are now pill buttons on both clients.

Closes #668

## Design decisions

**Icons *and* labels.** The issue left this call open. Labels alone can't carry state without leaning on colour; icons alone lose the four sounds' identity ("which one is the chime?"). Keeping both lets the icon carry state while the word carries identity — and the word stays the accessible name, so speech input still works.

**Three redundant state channels, not one.** On/off changes the pill's fill (`--surface-3` → transparent), its border tier (`--border-2` → `--border-1`), and the speaker icon (waves → slashed). Text colour still moves too, but it is no longer load-bearing. `SoundToggleAppearanceTests` / `soundToggleAppearance.test.ts` both assert that on and off differ in *every* channel, so a future change that collapses them back to colour alone fails CI.

**The visible pill is the tap target.** Previously a small glyph sat inside an invisible 44pt frame. Now the pill itself is 44pt/44px tall with the fill and border drawn at that size — you can see what you can hit.

**Shared appearance rules.** `SoundToggleAppearance.swift` (in `StillPointShared`, so it runs under `swift test`) and its port `src/lib/soundToggleAppearance.ts` own the on/off rules and the accessibility strings. Both clients read from them, which is what keeps "the two clients look like the same product" from drifting. This follows the existing `MinimalSessionViewPrefs` / `SoundToggleLogic` convention in this repo.

**Inline SVG on web** rather than the old `♪` / `•` text glyphs, so the on/off shapes are the same pair iOS draws with SF Symbols instead of whatever the device font happens to have.

**Behaviour untouched.** `toggleSound` and `SoundToggleLogic` (#667) are not modified; the web click handler body is byte-identical. This is a visual/a11y change only.

**Subordinate weight.** The pills use a fainter fill and smaller type (10–11px) than the sibling `pause` / `end early` / `abandon` row, which keeps them tertiary to the timer.

## Accessibility

- **iOS:** gains `.accessibilityLabel` + `.accessibilityValue`, so VoiceOver reads "tick sound, on, button" instead of just "tick", and re-announces on toggle.
- **Web:** native `<button aria-pressed>`, announced as a toggle button with pressed state. The `title` is the accessible *description* and restates the state in words as a fallback for browser/SR pairs that handle `aria-pressed` poorly.
- `session.soundToggle.<label>` identifiers are unchanged and now pinned by tests on both clients.

## Verification run locally

| Check | Result |
|---|---|
| `npm run typecheck` | pass |
| `npm run test:unit` | new suite 7/7; 3 pre-existing pglite DB suites time out locally (cold-start, 5s limit) — they import only `@/db/schema` and `@/lib/testing/pgliteTestDb`, neither touched here, and are green on `main` in CI |
| `npm run build` | pass |
| `npm run e2e:policy:design-tokens` | pass (30 shared colors, 6 spacing values) |
| `swift build` (StillPointShared) | pass — new file compiles |
| `swiftc -parse` (SessionView.swift + new Swift files) | pass |
| `swift test` (StillPointShared) | **not runnable locally** — `error: fatalError`, the XCTest limitation under CommandLineTools with no Xcode. **CI's `StillPointShared swift test` is the gate for `SoundToggleAppearanceTests`.** |

**320px width measured, not assumed.** A static probe reproducing the exact pill styles at a 320px viewport reports pill widths `[66.5, 73.1, 73.1, 59.9]`, all heights exactly `44`, total row `290.6px`, `linesUsed: 1`, `overflows: false` — ~29px of headroom before wrapping. `flexWrap` is kept as a safety net so an unusually wide font drops to a second line rather than being clipped by `overflow-x: hidden`.

## Test plan

- [x] `npm run typecheck` passes.
- [x] `npm run test:unit` passes, including the new `src/lib/soundToggleAppearance.test.ts`.
- [x] `npm run build` passes.
- [x] `npm run e2e:policy:design-tokens` passes — the pills use only shared cross-client tokens.
- [x] CI's `StillPointShared swift test` passes, including the new `SoundToggleAppearanceTests`.
- [x] Tests assert on and off differ in fill, border, **and** icon — state is not carried by colour alone.
- [x] Tests assert the minimum tap target is >= 44 on both clients.
- [x] Tests assert `session.soundToggle.<label>` identifier format is unchanged (iOS `accessibilityIdentifier`, web `data-testid`).
- [x] Web control is a native `<button>` with `aria-pressed` reflecting the pref; iOS sets `accessibilityLabel` + `accessibilityValue`.
- [x] `toggleSound` / `SoundToggleLogic.swift` are not modified by this PR (`git diff` shows no change to either).
- [x] The minimal session view (#687) still hides the sound-toggle row entirely; only the full-view row is restyled.

## Post-merge verification

Tracking issue: #688

Device- and browser-only items that CI cannot check — the toggles clearly reading as buttons, on/off obvious at a glance, one-handed comfort mid-sit, VoiceOver/NVDA phrasing, Dynamic Type, real-device 320px rendering, and the installed PWA. Both clients are dark-only today (iOS pins `.preferredColorScheme(.dark)`; web ships one `:root` palette with no `prefers-color-scheme` block), so "light mode" is not a separate state to check until a light theme exists — noted in #688.

## Follow-up filed

**#689** — the buddy session screen has its own copy of these toggles, deliberately out of scope here (#668 named only the solo `SessionView` files, and the buddy row carries different "only you hear this" semantics). Filing it surfaced a real bug: the **web** buddy toggles have no minimum tap target (`padding: "4px 8px"`, no `minHeight`), roughly a 20px target. Left untouched rather than fixed silently as drive-by scope.

## Local review coverage

**Local review coverage:** cr-only — CodeRabbit CLI returned a verified clean pass with 0 findings. CodeAnt CLI failed twice with `403 Access denied` (the known undocumented daily cap) and was dropped for the session per `cr-local-review.md`; no `codeant logout/login` was run.


___

## **CodeAnt-AI Description**
Turn session sound controls into clear, accessible toggle buttons

### What Changed
- Replaced bare sound labels with visible pill buttons for tick, chime, voice, and end sounds on iOS and web
- Shows sound state through the pill fill, border strength, and speaker icon instead of relying on muted text colors
- Keeps the visible control at least 44pt/44px high and allows the row to wrap when needed
- Screen readers announce each sound name and its on/off state; web controls expose their pressed state
- Added shared behavior checks for visual states, tap targets, accessibility text, and existing test identifiers

### Impact
`✅ Clearer sound state at a glance`
`✅ Easier tapping on phones`
`✅ Clearer VoiceOver and screen-reader announcements`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
