### PR TITLE
feat(ios): stay signed in when the network drops (#665)

### DIFF
--- a/ios/StillPointApp/Components/OfflineIndicatorView.swift
+++ b/ios/StillPointApp/Components/OfflineIndicatorView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// #665: the unobtrusive strip shown while the app is running from its local copy
+/// of identity and state.
+///
+/// Deliberately not an error. There is nothing to act on and nothing to dismiss —
+/// the sit still runs, the day number is still right, and the completion still
+/// saves. It replaces what a lost connection used to produce: a sign-in screen
+/// nobody asked for, with "Connection failed. Please try again." on it. Amber, not
+/// red, for the same reason.
+struct OfflineIndicatorView: View {
+    var body: some View {
+        HStack(spacing: SPSpacing.s1) {
+            Image(systemName: "wifi.slash")
+                .font(.system(size: 10, weight: .medium))
+            Text("OFFLINE · SAVED PROGRESS")
+                .font(SPFont.mono(10, weight: .medium))
+                .tracking(2)
+        }
+        .foregroundStyle(SPColor.amberText)
+        .padding(.vertical, SPSpacing.s1)
+        .frame(maxWidth: .infinity)
+        .background(SPColor.amberBgFaint)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(SPColor.amberBorderSubtle)
+                .frame(height: 1)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityIdentifier("app.offlineIndicator")
+        .accessibilityLabel("Offline. Showing your saved progress; sits are saved and upload when you reconnect.")
+    }
+}

--- a/ios/StillPointApp/Navigation/MainTabView.swift
+++ b/ios/StillPointApp/Navigation/MainTabView.swift
@@ -41,6 +41,16 @@ struct MainTabView: View {
                 .tag(4)
         }
         .tint(SPColor.green)
+        // #665: shown across every tab while the app runs from cached identity and
+        // state; it clears the moment a `me()` succeeds. Scoped to the tabbed
+        // shell on purpose — an active sit stays free of chrome.
+        .safeAreaInset(edge: .top, spacing: 0) {
+            if appVM.isOfflineMode {
+                OfflineIndicatorView()
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: appVM.isOfflineMode)
         .onAppear {
             Self.configureTabBarAppearance()
         }

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -719,8 +719,16 @@ final class AppViewModel {
             // lowers them; the failure path must not be the one exception.
             // Midnight rollover is already handled at the top of this method.
             guard generation == authGeneration else { return }
-            primaryDoneToday = false
-            secondDoneToday = false
+            // Failing closed is right at rest, but not mid-sit. `enterOfflineMode`
+            // deliberately keeps the badges when a session is running, and it
+            // schedules this catch-up moments later against the same dead network
+            // — so clearing here would undo that preservation for the very sit it
+            // was meant to protect. Outside a session the reset stands, and the
+            // next successful refresh restores the truth either way.
+            if !isInSession {
+                primaryDoneToday = false
+                secondDoneToday = false
+            }
         }
         // Both branches above return early on a generation change, so reaching
         // here means the session that started this request is still the live one.

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -378,6 +378,13 @@ final class AppViewModel {
             PushNotificationCoordinator.shared.registerIfAlreadyAuthorized()
             hydrateNotificationSuppressionPreference()
             await refreshTracksDoneToday()
+            // Re-checked again here: `refreshTracksDoneToday()` is itself a
+            // suspension point, so the session can end between the check above and
+            // this line. Consuming the invite is not idempotent — it burns the
+            // token and joins a session — so it must not run for a session that has
+            // since been replaced. (`consumePendingBuddyInviteIfNeeded`'s own
+            // `currentUser != nil` test cannot tell a new account from the old one.)
+            guard generation == authGeneration else { return }
             await consumePendingBuddyInviteIfNeeded()
         } catch let apiError as APIError where apiError.status == 401 {
             // The cached identity outlived the server session — the accepted cost
@@ -788,6 +795,12 @@ final class AppViewModel {
     func returnHome() async {
         currentView = .home
         selectedTab = 0
+        // Same hazard as `refreshAfterReconnect` (#665): the queue flush and the
+        // `me()` request below are both suspension points, so a sign-out or account
+        // switch can land mid-flight and a late response would otherwise restore the
+        // previous `currentUser` and re-save its cached identity after the session
+        // was invalidated.
+        let generation = authGeneration
         if let ownerUserId = currentUser?.id {
             do {
                 _ = try await SessionSyncCoordinator.shared.flushPending(ownerUserId: ownerUserId)
@@ -797,9 +810,14 @@ final class AppViewModel {
             }
         }
         if let user = try? await APIClient.shared.me(today: SessionCalendar.localTodayIsoDate()) {
+            guard generation == authGeneration else { return }
             applyAuthenticatedUser(user)
         }
         await refreshTracksDoneToday()
+        // As in `refreshAfterReconnect`: re-checked because the refresh above is a
+        // suspension point, and consuming the invite burns a token against whatever
+        // session is live when it runs.
+        guard generation == authGeneration else { return }
         await consumePendingBuddyInviteIfNeeded()
         await consumePendingLogReasonIfNeeded()
     }

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -213,6 +213,12 @@ final class AppViewModel {
             if let user = try await APIClient.shared.me(today: SessionCalendar.localTodayIsoDate()) {
                 guard generation == authGeneration else { return }
                 applyAuthenticatedUser(user)
+                // Re-captured deliberately. Adopting the user is itself an expected
+                // transition on a cold start (nil -> user), so the entry generation
+                // is stale from here on *by design* and reusing it below would skip
+                // the side effects on every launch. The entry capture protects the
+                // decision to adopt; this one protects everything after it.
+                let adopted = authGeneration
                 resetTrackCompletionBadges()
                 currentView = Self.initialAuthenticatedView(from: ProcessInfo.processInfo.environment)
                 authStatusMessage = nil
@@ -225,7 +231,7 @@ final class AppViewModel {
                 // identity-scoped side effect — the widget snapshot and three
                 // non-idempotent deep-link/invite consumptions — so none of it may
                 // run for a session that has since been replaced.
-                guard generation == authGeneration else { return }
+                guard adopted == authGeneration else { return }
                 syncWidgetData()
                 await consumePendingBuddyInviteIfNeeded()
                 await consumePendingSessionDeepLinkIfNeeded()
@@ -424,6 +430,10 @@ final class AppViewModel {
             }
             guard generation == authGeneration else { return }
             applyAuthenticatedUser(user)
+            // Re-captured after adoption, as in `checkAuth()`: if the reconnect ever
+            // returns a different account, that adoption is a legitimate transition
+            // and the work below belongs to the account we just adopted.
+            let adopted = authGeneration
             PushNotificationCoordinator.shared.registerIfAlreadyAuthorized()
             hydrateNotificationSuppressionPreference()
             await refreshTracksDoneToday()
@@ -433,7 +443,7 @@ final class AppViewModel {
             // token and joins a session — so it must not run for a session that has
             // since been replaced. (`consumePendingBuddyInviteIfNeeded`'s own
             // `currentUser != nil` test cannot tell a new account from the old one.)
-            guard generation == authGeneration else { return }
+            guard adopted == authGeneration else { return }
             await consumePendingBuddyInviteIfNeeded()
         } catch let apiError as APIError where apiError.status == 401 {
             // The cached identity outlived the server session — the accepted cost
@@ -540,18 +550,23 @@ final class AppViewModel {
     /// - Parameter generation: `identityGeneration` as it was when the request
     ///   started. Required rather than defaulted so a new call site cannot forget
     ///   it and silently reintroduce the stale-write bug.
-    func applySettingsUser(_ user: UserDTO, startedAtGeneration generation: Int) {
+    /// - Returns: whether the response was adopted. Callers that show success UI
+    ///   must branch on this — a silently discarded response would otherwise be
+    ///   reported to the user as a saved change.
+    @discardableResult
+    func applySettingsUser(_ user: UserDTO, startedAtGeneration generation: Int) -> Bool {
         // The id check below cannot tell "same account throughout" from "signed out
         // and signed back in as the same account" — and in the second case a
         // response from the previous session would overwrite newer local fields,
         // clear offline mode, and persist stale data to the cache. That is the case
         // this generation check exists for (#665).
-        guard generation == authGeneration else { return }
-        guard currentView != .auth, let existing = currentUser, existing.id == user.id else { return }
+        guard generation == authGeneration else { return false }
+        guard currentView != .auth, let existing = currentUser, existing.id == user.id else { return false }
         // Server-confirmed (a settings PATCH round-tripped), so the local copy is
         // refreshed too — otherwise a rename or track opt-in would vanish on the
         // next offline launch (#665).
         applyAuthenticatedUser(user)
+        return true
     }
 
     func didLogout() {
@@ -888,15 +903,19 @@ final class AppViewModel {
                 print("Failed to flush offline session queue: \(error)")
             }
         }
+        // Starts equal to the entry capture and is refreshed if we adopt a user, so
+        // an expected adoption is never mistaken for the session being replaced.
+        var adopted = generation
         if let user = try? await APIClient.shared.me(today: SessionCalendar.localTodayIsoDate()) {
             guard generation == authGeneration else { return }
             applyAuthenticatedUser(user)
+            adopted = authGeneration
         }
         await refreshTracksDoneToday()
         // As in `refreshAfterReconnect`: re-checked because the refresh above is a
         // suspension point, and consuming the invite burns a token against whatever
         // session is live when it runs.
-        guard generation == authGeneration else { return }
+        guard adopted == authGeneration else { return }
         await consumePendingBuddyInviteIfNeeded()
         await consumePendingLogReasonIfNeeded()
     }

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -183,6 +183,12 @@ final class AppViewModel {
 
     func checkAuth() async {
         let startedAt = Date()
+        // Not only the cold-start path: `RootView` also runs this on every
+        // `scenePhase == .active`, so it re-validates an *existing* session as
+        // often as it establishes a new one. A sign-out landing while `me()` is
+        // suspended would otherwise let the late response re-adopt the old account
+        // and route back into the authenticated UI (#665).
+        let generation = authGeneration
         isLoading = true
         defer {
             isLoading = false
@@ -199,6 +205,7 @@ final class AppViewModel {
 
         do {
             if let user = try await APIClient.shared.me(today: SessionCalendar.localTodayIsoDate()) {
+                guard generation == authGeneration else { return }
                 applyAuthenticatedUser(user)
                 resetTrackCompletionBadges()
                 currentView = Self.initialAuthenticatedView(from: ProcessInfo.processInfo.environment)
@@ -470,10 +477,16 @@ final class AppViewModel {
     /// `PushNotificationCoordinator.willPresent` reflects current server truth
     /// even before the Notifications screen is opened this launch (#431).
     private func hydrateNotificationSuppressionPreference() {
-        Task {
-            if let prefs = try? await APIClient.shared.getNotificationPreferences() {
-                SessionNotificationSuppressionController.setSuppressPreferenceEnabled(prefs.suppressDuringSession)
-            }
+        // Same class as the flagged sites, guarded pre-emptively: this reads a
+        // per-account server preference and applies it to a device-global
+        // controller, so a response arriving after a sign-out would push the old
+        // account's setting onto whoever is signed in next (#665).
+        let generation = authGeneration
+        Task { [weak self] in
+            guard let self else { return }
+            guard let prefs = try? await APIClient.shared.getNotificationPreferences() else { return }
+            guard generation == self.authGeneration else { return }
+            SessionNotificationSuppressionController.setSuppressPreferenceEnabled(prefs.suppressDuringSession)
         }
     }
 
@@ -530,8 +543,13 @@ final class AppViewModel {
 
     /// #240: opt into the dual-track fork, then refresh local user + badges.
     func enableDualTrack() async {
+        // Same identity-lifetime guard as the other sites that adopt a server
+        // response: without it, a sign-out mid-request lets the old account's
+        // returned UserDTO replace the active account and be persisted (#665).
+        let generation = authGeneration
         do {
             let updated = try await APIClient.shared.enableDualTrack()
+            guard generation == authGeneration else { return }
             applyAuthenticatedUser(updated)
             await refreshTracksDoneToday()
         } catch {
@@ -804,6 +822,12 @@ final class AppViewModel {
         if let ownerUserId = currentUser?.id {
             do {
                 _ = try await SessionSyncCoordinator.shared.flushPending(ownerUserId: ownerUserId)
+                // The flush is a suspension point; don't follow it with a prune for
+                // a session that has since been replaced. Both calls are explicitly
+                // scoped to the `ownerUserId` captured before the await, so neither
+                // can touch another account's rows — this only stops us doing more
+                // work on behalf of a session that is over.
+                guard generation == authGeneration else { return }
                 try await SessionSyncCoordinator.shared.pruneCompletedEntries(ownerUserId: ownerUserId)
             } catch {
                 print("Failed to flush offline session queue: \(error)")

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -515,7 +515,21 @@ final class AppViewModel {
         }
     }
 
-    func applySettingsUser(_ user: UserDTO) {
+    /// Snapshot of the live identity, taken by a caller that will apply a response
+    /// later. Capture this *before* an `await`, hand it back to
+    /// `applySettingsUser(_:startedAtGeneration:)`.
+    var identityGeneration: Int { authGeneration }
+
+    /// - Parameter generation: `identityGeneration` as it was when the request
+    ///   started. Required rather than defaulted so a new call site cannot forget
+    ///   it and silently reintroduce the stale-write bug.
+    func applySettingsUser(_ user: UserDTO, startedAtGeneration generation: Int) {
+        // The id check below cannot tell "same account throughout" from "signed out
+        // and signed back in as the same account" — and in the second case a
+        // response from the previous session would overwrite newer local fields,
+        // clear offline mode, and persist stale data to the cache. That is the case
+        // this generation check exists for (#665).
+        guard generation == authGeneration else { return }
         guard currentView != .auth, let existing = currentUser, existing.id == user.id else { return }
         // Server-confirmed (a settings PATCH round-tripped), so the local copy is
         // refreshed too — otherwise a rename or track opt-in would vanish on the

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -77,6 +77,10 @@ final class AppViewModel {
     /// app-gate pill) can navigate to a tab. 0 = Home … 4 = Settings.
     var selectedTab: Int = AppViewModel.defaultSelectedTab()
     var currentUser: UserDTO?
+    /// #665: true while the app is running from its local copy of identity and
+    /// state because the server could not be reached. Drives the offline
+    /// indicator; any successful `me()` clears it.
+    var isOfflineMode = false
     var isLoading = true
     var authStatusMessage: String?
     var lastColdStartAuthCheckMs: Int?
@@ -195,7 +199,7 @@ final class AppViewModel {
 
         do {
             if let user = try await APIClient.shared.me(today: SessionCalendar.localTodayIsoDate()) {
-                currentUser = user
+                applyAuthenticatedUser(user)
                 resetTrackCompletionBadges()
                 currentView = Self.initialAuthenticatedView(from: ProcessInfo.processInfo.environment)
                 authStatusMessage = nil
@@ -208,33 +212,130 @@ final class AppViewModel {
                 await consumePendingSessionDeepLinkIfNeeded()
                 await consumePendingLogReasonIfNeeded()
                 return
-            } else {
-                currentView = .auth
-                authStatusMessage = nil
-                syncWidgetData()
             }
-        } catch let apiError as APIError where apiError.status == 401 && apiError.code == "TOKEN_EXPIRED" {
-            currentView = .auth
-            authStatusMessage = apiError.message
-            syncWidgetData(signedOutCause: .unauthorized)
-        } catch let apiError as APIError {
-            currentView = .auth
-            authStatusMessage = apiError.message
-            // #671: only a 401 proves we're signed out. A 500 (or any other server
-            // error) must not wipe the widget's stored week.
-            syncWidgetData(signedOutCause: apiError.status == 401 ? .unauthorized : .serverError)
+            // `me()` swallows a 401 that is *not* `TOKEN_EXPIRED` and returns nil:
+            // the server answered, and the answer was "no session". Authoritative.
+            applySignedOut(cause: .signedOut, message: nil)
         } catch {
-            currentView = .auth
-            authStatusMessage = "Connection failed. Please try again."
-            // #671: an unreachable server is not a sign-out — keep the last known
-            // history so a cold start with no network still renders the real week.
-            syncWidgetData(signedOutCause: .unreachable)
+            // #665: a failed request is not a sign-out. `OfflineAuth` makes that
+            // call once, in the taxonomy #676 gave the widget, so the app and the
+            // widget can never disagree about what "signed out" means.
+            let cachedUser = CachedIdentityStore.load()
+            let outcome = OfflineAuth.outcome(for: error, hasCachedIdentity: cachedUser != nil)
+            // Matching on the pair keeps the cached user's presence and the
+            // outcome from drifting apart: without an identity to render there is
+            // nothing to fall back to, whatever the outcome says.
+            switch (outcome, cachedUser) {
+            case let (.offline(cause), .some(user)):
+                await enterOfflineMode(user: user, cause: cause)
+                lastColdStartAuthCheckMs = Int(Date().timeIntervalSince(startedAt) * 1_000)
+                return
+            case (.offline, .none), (.signedOut, _):
+                applySignedOut(cause: outcome.cause, message: Self.authStatusMessage(for: error))
+            }
         }
-        // #526: clear per-account unlock state on any unauthenticated redirect so the
-        // next sign-in always re-qualifies (mirrors clearOnLogout called by didLogout).
-        // The success path returns early above; only auth-redirect branches reach here.
-        trackingControlPrefsManager.clearOnLogout()
         lastColdStartAuthCheckMs = Int(Date().timeIntervalSince(startedAt) * 1_000)
+    }
+
+    /// Status line for a route to sign-in. Unchanged from the pre-#665 behavior:
+    /// whatever the server said, else the generic connection copy.
+    private static func authStatusMessage(for error: Error) -> String? {
+        (error as? APIError)?.message ?? "Connection failed. Please try again."
+    }
+
+    /// Single place a server-confirmed user is adopted — in memory *and* in the
+    /// local copy that survives a launch with no network (#665).
+    private func applyAuthenticatedUser(_ user: UserDTO) {
+        currentUser = user
+        CachedIdentityStore.save(user)
+        isOfflineMode = false
+    }
+
+    /// Route to sign-in.
+    ///
+    /// Local state — the cached identity and the per-account tracking unlock — is
+    /// torn down only for a cause authoritative enough to prove the session is
+    /// over, which is the same predicate guarding the widget's stored week (#676).
+    /// Before #665 every failure path ran this teardown, so a dropped connection
+    /// wiped state the server never contradicted.
+    private func applySignedOut(cause: WidgetDataStore.SignedOutCause, message: String?) {
+        currentUser = nil
+        isOfflineMode = false
+        currentView = .auth
+        authStatusMessage = message
+        if CachedIdentityStore.clearIfAuthoritative(on: cause) {
+            // #526: reset account-scoped unlock so the next sign-in re-qualifies
+            // (mirrors the clearOnLogout called by didLogout).
+            trackingControlPrefsManager.clearOnLogout()
+        }
+        syncWidgetData(signedOutCause: cause)
+    }
+
+    /// #665: run the app from what the device already knows.
+    ///
+    /// Mirrors the success path minus the parts that need the server to be
+    /// believed. `refreshTracksDoneToday()` is still called: it fails closed on its
+    /// own, and it is what pushes a fresh widget snapshot. Push registration and
+    /// the buddy-invite handoff are deliberately skipped — both are doomed without
+    /// a network, and consuming a pending invite here would burn the token on a
+    /// request that cannot succeed. `refreshAfterReconnect()` picks both up.
+    private func enterOfflineMode(user: UserDTO, cause: WidgetDataStore.SignedOutCause) async {
+        currentUser = user
+        isOfflineMode = true
+        resetTrackCompletionBadges()
+        currentView = Self.initialAuthenticatedView(from: ProcessInfo.processInfo.environment)
+        // Not an error the user must act on — the offline indicator says it instead.
+        authStatusMessage = nil
+        // Paint from local state immediately. Nothing here may `await` a request we
+        // already know is failing: `checkAuth`'s `defer` only drops the cold-start
+        // overlay once this returns, so on flaky wifi (as opposed to Airplane Mode,
+        // which fails instantly) a blocking call would hold the launch for a full
+        // URLSession timeout — the offline launch has to be fast, not just correct.
+        //
+        // We are signed in, so this saves rather than clears — but the real cause is
+        // passed rather than the `.signedOut` default so that if the snapshot ever
+        // did come back logged-out, it could not wipe the widget's week on a failure
+        // the server never confirmed (#676).
+        syncWidgetData(signedOutCause: cause)
+        // Local-only deep links still route; the buddy invite is network-bound.
+        await consumePendingSessionDeepLinkIfNeeded()
+        await consumePendingLogReasonIfNeeded()
+        // Fire-and-forget: if connectivity is actually back by the time this runs,
+        // the Home badges and widget history catch up on their own; if not, it fails
+        // closed on its own without having delayed anything.
+        Task { await refreshTracksDoneToday() }
+    }
+
+    /// #665: reconcile with the server once connectivity returns.
+    ///
+    /// Deliberately narrow. It refreshes identity and today's state *in place* and
+    /// never re-routes on success — re-running `checkAuth()` here would flash the
+    /// cold-start overlay and send the user back to Home, which is exactly the
+    /// user-visible reset offline-first exists to avoid (and would eject someone
+    /// mid-sit). Only an authoritative rejection moves anyone to sign-in.
+    ///
+    /// The queued-sit upload is the other half and already exists (#557):
+    /// `NetworkReachabilityMonitor` flushes the write queue on the same transition.
+    func refreshAfterReconnect() async {
+        guard currentUser != nil, currentView != .auth else { return }
+        do {
+            guard let user = try await APIClient.shared.me(today: SessionCalendar.localTodayIsoDate()) else {
+                applySignedOut(cause: .signedOut, message: nil)
+                return
+            }
+            applyAuthenticatedUser(user)
+            PushNotificationCoordinator.shared.registerIfAlreadyAuthorized()
+            hydrateNotificationSuppressionPreference()
+            await refreshTracksDoneToday()
+            await consumePendingBuddyInviteIfNeeded()
+        } catch let apiError as APIError where apiError.status == 401 {
+            // The cached identity outlived the server session — the accepted cost
+            // of sitting offline on a stale copy. Sign in again, now, rather than
+            // having been signed out back when the network dropped.
+            applySignedOut(cause: .unauthorized, message: apiError.message)
+        } catch {
+            // Still no usable answer: stay on local state, say nothing.
+        }
     }
 
     private func viewSlug(_ view: AppView) -> String {
@@ -286,7 +387,7 @@ final class AppViewModel {
     }
 
     func didLogin(user: UserDTO) {
-        currentUser = user
+        applyAuthenticatedUser(user)
         resetTrackCompletionBadges()
         currentView = .home
         // Reset to Home so a prior session's tab (e.g. Settings) doesn't leak
@@ -317,7 +418,10 @@ final class AppViewModel {
 
     func applySettingsUser(_ user: UserDTO) {
         guard currentView != .auth, let existing = currentUser, existing.id == user.id else { return }
-        currentUser = user
+        // Server-confirmed (a settings PATCH round-tripped), so the local copy is
+        // refreshed too — otherwise a rename or track opt-in would vanish on the
+        // next offline launch (#665).
+        applyAuthenticatedUser(user)
     }
 
     func didLogout() {
@@ -326,6 +430,12 @@ final class AppViewModel {
         Task { @MainActor in
             try? await SessionSyncCoordinator.shared.clearQueue()
             currentUser = nil
+            isOfflineMode = false
+            // #665: a real sign-out is the one thing that must take the local copy
+            // of identity with it. `APIClient.logout()` also clears it (in a
+            // `defer`, so an offline sign-out still does), but didLogout is reachable
+            // on its own — belt and braces rather than a single fragile path.
+            CachedIdentityStore.clear()
             pendingBuddyInviteToken = nil
             pendingSessionDeepLink = nil
             pendingLogReasonDate = nil
@@ -356,7 +466,7 @@ final class AppViewModel {
     func enableDualTrack() async {
         do {
             let updated = try await APIClient.shared.enableDualTrack()
-            currentUser = updated
+            applyAuthenticatedUser(updated)
             await refreshTracksDoneToday()
         } catch {
             print("Failed to enable dual track: \(error)")
@@ -618,7 +728,7 @@ final class AppViewModel {
             }
         }
         if let user = try? await APIClient.shared.me(today: SessionCalendar.localTodayIsoDate()) {
-            currentUser = user
+            applyAuthenticatedUser(user)
         }
         await refreshTracksDoneToday()
         await consumePendingBuddyInviteIfNeeded()

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -221,12 +221,20 @@ final class AppViewModel {
                 return
             }
             // `me()` swallows a 401 that is *not* `TOKEN_EXPIRED` and returns nil:
-            // the server answered, and the answer was "no session". Authoritative.
+            // the server answered, and the answer was "no session". Authoritative —
+            // but only for the session that asked. `checkAuth()` runs on every scene
+            // activation, so an older overlapping call must not sign out the account
+            // that has signed in since.
+            guard generation == authGeneration else { return }
             applySignedOut(cause: .signedOut, message: nil)
         } catch {
             // #665: a failed request is not a sign-out. `OfflineAuth` makes that
             // call once, in the taxonomy #676 gave the widget, so the app and the
             // widget can never disagree about what "signed out" means.
+            // Same reasoning as the nil branch: a transport failure belonging to a
+            // superseded call must not drag the current session into offline mode
+            // or sign it out.
+            guard generation == authGeneration else { return }
             let cachedUser = CachedIdentityStore.load()
             let outcome = OfflineAuth.outcome(for: error, hasCachedIdentity: cachedUser != nil)
             // Matching on the pair keeps the cached user's presence and the
@@ -262,7 +270,14 @@ final class AppViewModel {
     /// Single place a server-confirmed user is adopted — in memory *and* in the
     /// local copy that survives a launch with no network (#665).
     private func applyAuthenticatedUser(_ user: UserDTO) {
-        authGeneration &+= 1
+        // Only an actual *transition* invalidates in-flight work. Re-confirming the
+        // same account (a reconnect refresh, a settings PATCH round-trip) is not a
+        // transition, and bumping for it was wrong twice over: it made every
+        // post-adoption `generation == authGeneration` check unsatisfiable, and it
+        // let an unrelated settings save cancel identity work that was still valid.
+        // A sign-out sets `currentUser = nil` and bumps, so a sign-out/sign-in cycle
+        // on the *same* account still bumps twice and stale work is still rejected.
+        if currentUser?.id != user.id { authGeneration &+= 1 }
         currentUser = user
         CachedIdentityStore.save(user)
         isOfflineMode = false
@@ -299,7 +314,8 @@ final class AppViewModel {
     /// a network, and consuming a pending invite here would burn the token on a
     /// request that cannot succeed. `refreshAfterReconnect()` picks both up.
     private func enterOfflineMode(user: UserDTO, cause: WidgetDataStore.SignedOutCause) async {
-        authGeneration &+= 1
+        // Transition-only, matching `applyAuthenticatedUser`.
+        if currentUser?.id != user.id { authGeneration &+= 1 }
         currentUser = user
         isOfflineMode = true
         resetTrackCompletionBadges()
@@ -344,6 +360,15 @@ final class AppViewModel {
         offlineCatchUpTask = nil
         reconnectTask?.cancel()
         reconnectTask = nil
+        // The widget history backfill is identity-scoped too. Its own key check is
+        // `"userId|localDay"`, which a sign-out and sign-in on the *same* account
+        // within the same day would satisfy — so a late response could land in the
+        // freshly rebuilt snapshot. Clearing the key also forces a re-backfill
+        // rather than leaving the row blank. `didLogout` cancelled this already;
+        // `applySignedOut` did not, which is the gap this closes.
+        widgetHistoryTask?.cancel()
+        widgetHistoryTask = nil
+        widgetHistoryRefreshKey = nil
     }
 
     /// #665: non-`async` entry point for the reconnect refresh so the view layer
@@ -503,9 +528,8 @@ final class AppViewModel {
         // `clearQueue()` await below — the moment sign-out is known is the moment a
         // response for the old session stops being allowed to write anything (#665).
         authGeneration &+= 1
+        // Cancels the widget history backfill and clears its key too.
         cancelIdentityScopedTasks()
-        widgetHistoryTask?.cancel()
-        widgetHistoryRefreshKey = nil
         Task { @MainActor in
             try? await SessionSyncCoordinator.shared.clearQueue()
             currentUser = nil

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -233,7 +233,7 @@ final class AppViewModel {
                 // run for a session that has since been replaced.
                 guard adopted == authGeneration else { return }
                 syncWidgetData()
-                await consumePendingBuddyInviteIfNeeded()
+                await consumePendingBuddyInviteIfNeeded(startedAtGeneration: adopted)
                 await consumePendingSessionDeepLinkIfNeeded()
                 await consumePendingLogReasonIfNeeded()
                 return
@@ -243,16 +243,26 @@ final class AppViewModel {
             // but only for the session that asked. `checkAuth()` runs on every scene
             // activation, so an older overlapping call must not sign out the account
             // that has signed in since.
-            guard generation == authGeneration else { return }
+            //
+            // The generation alone cannot express that. Re-confirming the *same*
+            // account is deliberately not a transition (`applyAuthenticatedUser`),
+            // so once a newer check has confirmed this user the generation is
+            // unchanged and an older check's "no session" would still pass this
+            // guard. `activeAuthCheckID` is the value that distinguishes newest
+            // from superseded — the same reason it gates the overlay above — so a
+            // stale answer can no longer sign the live account out.
+            guard generation == authGeneration, checkID == activeAuthCheckID else { return }
             applySignedOut(cause: .signedOut, message: nil)
         } catch {
             // #665: a failed request is not a sign-out. `OfflineAuth` makes that
             // call once, in the taxonomy #676 gave the widget, so the app and the
             // widget can never disagree about what "signed out" means.
-            // Same reasoning as the nil branch: a transport failure belonging to a
-            // superseded call must not drag the current session into offline mode
-            // or sign it out.
-            guard generation == authGeneration else { return }
+            // Same reasoning as the nil branch, including the check-ID half: a
+            // transport failure belonging to a superseded call must not drag the
+            // current session into offline mode or sign it out, and after a newer
+            // check has re-confirmed the same account the generation no longer
+            // moves to say so.
+            guard generation == authGeneration, checkID == activeAuthCheckID else { return }
             let cachedUser = CachedIdentityStore.load()
             let outcome = OfflineAuth.outcome(for: error, hasCachedIdentity: cachedUser != nil)
             // Matching on the pair keeps the cached user's presence and the
@@ -452,7 +462,7 @@ final class AppViewModel {
             // since been replaced. (`consumePendingBuddyInviteIfNeeded`'s own
             // `currentUser != nil` test cannot tell a new account from the old one.)
             guard adopted == authGeneration else { return }
-            await consumePendingBuddyInviteIfNeeded()
+            await consumePendingBuddyInviteIfNeeded(startedAtGeneration: adopted)
         } catch let apiError as APIError where apiError.status == 401 {
             // The cached identity outlived the server session — the accepted cost
             // of sitting offline on a stale copy. Sign in again, now, rather than
@@ -539,7 +549,7 @@ final class AppViewModel {
             await self.refreshTracksDoneToday()
             guard adopted == self.authGeneration else { return }
             self.syncWidgetData()
-            await self.consumePendingBuddyInviteIfNeeded()
+            await self.consumePendingBuddyInviteIfNeeded(startedAtGeneration: adopted)
             await self.consumePendingSessionDeepLinkIfNeeded()
             await self.consumePendingLogReasonIfNeeded()
         }
@@ -790,7 +800,7 @@ final class AppViewModel {
         buddyInviteTask = Task { [weak self] in
             guard let self else { return }
             guard adopted == self.authGeneration else { return }
-            await self.consumePendingBuddyInviteIfNeeded()
+            await self.consumePendingBuddyInviteIfNeeded(startedAtGeneration: adopted)
         }
     }
 
@@ -819,7 +829,7 @@ final class AppViewModel {
         buddyInviteTask = Task { [weak self] in
             guard let self else { return }
             guard adopted == self.authGeneration else { return }
-            await self.joinBuddySession(token: token)
+            await self.joinBuddySession(token: token, startedAtGeneration: adopted)
         }
     }
 
@@ -954,25 +964,45 @@ final class AppViewModel {
         // suspension point, and consuming the invite burns a token against whatever
         // session is live when it runs.
         guard adopted == authGeneration else { return }
-        await consumePendingBuddyInviteIfNeeded()
+        await consumePendingBuddyInviteIfNeeded(startedAtGeneration: adopted)
         await consumePendingLogReasonIfNeeded()
     }
 
-    private func consumePendingBuddyInviteIfNeeded() async {
+    /// - Parameter generation: `authGeneration` as it was when the caller decided
+    ///   to consume the invite, threaded through to the join so the network result
+    ///   is checked against the identity that asked for it.
+    private func consumePendingBuddyInviteIfNeeded(startedAtGeneration generation: Int) async {
         guard currentUser != nil, let token = pendingBuddyInviteToken else { return }
         pendingBuddyInviteToken = nil
-        await joinBuddySession(token: token)
+        await joinBuddySession(token: token, startedAtGeneration: generation)
     }
 
-    private func joinBuddySession(token: String) async {
+    /// - Parameter generation: `authGeneration` at the point the join was decided.
+    ///   Required rather than defaulted, matching `applySettingsUser`, so a new
+    ///   call site cannot forget it and silently reintroduce the stale-write bug.
+    private func joinBuddySession(token: String, startedAtGeneration generation: Int) async {
         do {
             let sessionId = try await APIClient.shared.joinBuddySession(token: token)
+            // The request is a suspension point like every other identity-scoped
+            // network call here. The pre-task guards only decided whether to
+            // *start* the join; a sign-out or account switch landing while it was
+            // in flight must not route the replacement account into this session
+            // (#665).
+            guard generation == authGeneration else { return }
             buddyInviteError = nil
             currentView = .buddySession(sessionId: sessionId)
-        } catch let error as APIError {
-            buddyInviteError = error.message
         } catch {
-            buddyInviteError = "Could not open buddy invite."
+            // The failure path needs the same guard — including for the
+            // cancellation error that a sign-out's own `cancelIdentityScopedTasks`
+            // produces. Cancellation is cooperative and does not by itself stop the
+            // post-await mutation, so without this the previous session's failure
+            // would surface as an invite error on whoever is signed in next.
+            guard generation == authGeneration else { return }
+            if let apiError = error as? APIError {
+                buddyInviteError = apiError.message
+            } else {
+                buddyInviteError = "Could not open buddy invite."
+            }
         }
     }
 

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -623,27 +623,36 @@ final class AppViewModel {
         authGeneration &+= 1
         // Cancels the widget history backfill and clears its key too.
         cancelIdentityScopedTasks()
+        // The teardown is synchronous for the same reason. Deferring it until after
+        // the `clearQueue()` await left `currentUser` set across a suspension point,
+        // so a `checkAuth()` starting inside that window (scene activation) could
+        // re-adopt the account and route back into the authenticated UI — and the
+        // deferred teardown would then wipe *that* session's state. A generation
+        // guard inside the task would not have closed it: re-adopting the same
+        // account is deliberately not a transition, so the generation would not have
+        // moved. Signing out is local truth and needs nothing from the queue flush,
+        // so it lands now and the flush follows on its own.
+        currentUser = nil
+        isOfflineMode = false
+        // #665: a real sign-out is the one thing that must take the local copy
+        // of identity with it. `APIClient.logout()` also clears it (in a
+        // `defer`, so an offline sign-out still does), but didLogout is reachable
+        // on its own — belt and braces rather than a single fragile path.
+        CachedIdentityStore.clear()
+        pendingBuddyInviteToken = nil
+        pendingSessionDeepLink = nil
+        pendingLogReasonDate = nil
+        buddyInviteError = nil
+        authStatusMessage = nil
+        resetTrackCompletionBadges()
+        LastAuthProvider.resetPersisted()
+        currentView = .auth
+        SessionNotificationSuppressionController.clearSuppressPreference()
+        // #526: reset account-scoped tracking unlock so the next sign-in re-qualifies.
+        trackingControlPrefsManager.clearOnLogout()
+        syncWidgetData()
         Task { @MainActor in
             try? await SessionSyncCoordinator.shared.clearQueue()
-            currentUser = nil
-            isOfflineMode = false
-            // #665: a real sign-out is the one thing that must take the local copy
-            // of identity with it. `APIClient.logout()` also clears it (in a
-            // `defer`, so an offline sign-out still does), but didLogout is reachable
-            // on its own — belt and braces rather than a single fragile path.
-            CachedIdentityStore.clear()
-            pendingBuddyInviteToken = nil
-            pendingSessionDeepLink = nil
-            pendingLogReasonDate = nil
-            buddyInviteError = nil
-            authStatusMessage = nil
-            resetTrackCompletionBadges()
-            LastAuthProvider.resetPersisted()
-            currentView = .auth
-            SessionNotificationSuppressionController.clearSuppressPreference()
-            // #526: reset account-scoped tracking unlock so the next sign-in re-qualifies.
-            trackingControlPrefsManager.clearOnLogout()
-            syncWidgetData()
         }
     }
 

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -623,6 +623,12 @@ final class AppViewModel {
         authGeneration &+= 1
         // Cancels the widget history backfill and clears its key too.
         cancelIdentityScopedTasks()
+        // Captured before the teardown clears it. The queue cleanup below is scoped
+        // to this account *and* to this moment: once `currentUser` is nil there is
+        // nothing left to scope it by, and signing back in as the same account would
+        // otherwise let the deferred delete take the new session's sits with it.
+        let signedOutUserId = currentUser?.id
+        let logoutBoundary = Date()
         // The teardown is synchronous for the same reason. Deferring it until after
         // the `clearQueue()` await left `currentUser` set across a suspension point,
         // so a `checkAuth()` starting inside that window (scene activation) could
@@ -651,8 +657,13 @@ final class AppViewModel {
         // #526: reset account-scoped tracking unlock so the next sign-in re-qualifies.
         trackingControlPrefsManager.clearOnLogout()
         syncWidgetData()
-        Task { @MainActor in
-            try? await SessionSyncCoordinator.shared.clearQueue()
+        if let signedOutUserId {
+            Task { @MainActor in
+                try? await SessionSyncCoordinator.shared.clearQueue(
+                    ownerUserId: signedOutUserId,
+                    enqueuedBefore: logoutBoundary
+                )
+            }
         }
     }
 

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -211,7 +211,14 @@ final class AppViewModel {
 
         do {
             if let user = try await APIClient.shared.me(today: SessionCalendar.localTodayIsoDate()) {
-                guard generation == authGeneration else { return }
+                // Paired with the check ID for the same reason as the terminal
+                // branches below. Adopting the user is idempotent, but the route
+                // reset and the badge reset under it are not: `RootView` starts a
+                // check from both `.task` and `scenePhase == .active`, and since
+                // re-confirming the same account does not move the generation, an
+                // older call landing after the newest one finished would send a
+                // user who has since navigated back to the initial view.
+                guard generation == authGeneration, checkID == activeAuthCheckID else { return }
                 applyAuthenticatedUser(user)
                 // Re-captured deliberately. Adopting the user is itself an expected
                 // transition on a cold start (nil -> user), so the entry generation
@@ -351,8 +358,18 @@ final class AppViewModel {
         if currentUser?.id != user.id { authGeneration &+= 1 }
         currentUser = user
         isOfflineMode = true
-        resetTrackCompletionBadges()
-        currentView = Self.initialAuthenticatedView(from: ProcessInfo.processInfo.environment)
+        // `checkAuth()` runs on every scene activation, so this path is reached
+        // mid-sit whenever the app is foregrounded on a bad connection. Routing to
+        // the initial authenticated view there would eject the user from a session
+        // in progress, so the route — and the badge reset that goes with it — is
+        // preserved while one is running. Matches `refreshAfterReconnect()`, which
+        // never touches the route, and the `isInSession` checks the deep-link entry
+        // points already make. Going offline is still recorded either way: the
+        // identity, the offline flag, and the status line below are unconditional.
+        if !isInSession {
+            resetTrackCompletionBadges()
+            currentView = Self.initialAuthenticatedView(from: ProcessInfo.processInfo.environment)
+        }
         // Not an error the user must act on — the offline indicator says it instead.
         authStatusMessage = nil
         // Paint from local state immediately. Nothing here may `await` a request we

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -377,12 +377,20 @@ final class AppViewModel {
     /// late result harmless; cancelling is how we stop paying for it at all.
     private var offlineCatchUpTask: Task<Void, Never>?
     private var reconnectTask: Task<Void, Never>?
+    private var loginCatchUpTask: Task<Void, Never>?
+    /// Buddy invite join/consume. One property: these are alternative routes into
+    /// the same invite flow and never need to run concurrently.
+    private var buddyInviteTask: Task<Void, Never>?
 
     private func cancelIdentityScopedTasks() {
         offlineCatchUpTask?.cancel()
         offlineCatchUpTask = nil
         reconnectTask?.cancel()
         reconnectTask = nil
+        loginCatchUpTask?.cancel()
+        loginCatchUpTask = nil
+        buddyInviteTask?.cancel()
+        buddyInviteTask = nil
         // The widget history backfill is identity-scoped too. Its own key check is
         // `"userId|localDay"`, which a sign-out and sign-in on the *same* account
         // within the same day would satisfy — so a late response could land in the
@@ -508,6 +516,10 @@ final class AppViewModel {
 
     func didLogin(user: UserDTO) {
         applyAuthenticatedUser(user)
+        // Re-captured after adoption, same rule as `checkAuth()`: signing in is
+        // itself the transition, so the generation to defend is the one that exists
+        // once this user is adopted.
+        let adopted = authGeneration
         resetTrackCompletionBadges()
         currentView = .home
         // Reset to Home so a prior session's tab (e.g. Settings) doesn't leak
@@ -516,12 +528,20 @@ final class AppViewModel {
         authStatusMessage = nil
         PushNotificationCoordinator.shared.registerIfAlreadyAuthorized()
         hydrateNotificationSuppressionPreference()
-        Task {
-            await refreshTracksDoneToday()
-            syncWidgetData()
-            await consumePendingBuddyInviteIfNeeded()
-            await consumePendingSessionDeepLinkIfNeeded()
-            await consumePendingLogReasonIfNeeded()
+        // Retained and generation-guarded like the other identity-scoped catch-ups.
+        // `refreshTracksDoneToday()` self-guards, but it returns silently either
+        // way, so the caller cannot infer from it whether the session survived —
+        // hence the explicit re-check before the widget sync and the three
+        // non-idempotent consumptions.
+        loginCatchUpTask?.cancel()
+        loginCatchUpTask = Task { [weak self] in
+            guard let self else { return }
+            await self.refreshTracksDoneToday()
+            guard adopted == self.authGeneration else { return }
+            self.syncWidgetData()
+            await self.consumePendingBuddyInviteIfNeeded()
+            await self.consumePendingSessionDeepLinkIfNeeded()
+            await self.consumePendingLogReasonIfNeeded()
         }
     }
 
@@ -761,7 +781,17 @@ final class AppViewModel {
 
     func leaveBuddySession() {
         currentView = .home
-        Task { await consumePendingBuddyInviteIfNeeded() }
+        // Retained and guarded like the other identity-scoped work: the task body
+        // runs on a later main-actor turn, and consuming an invite is not
+        // idempotent, so a sign-out in between must not let it burn the token
+        // against whoever is signed in next (#665).
+        let adopted = authGeneration
+        buddyInviteTask?.cancel()
+        buddyInviteTask = Task { [weak self] in
+            guard let self else { return }
+            guard adopted == self.authGeneration else { return }
+            await self.consumePendingBuddyInviteIfNeeded()
+        }
     }
 
     func handleIncomingURL(_ url: URL) {
@@ -782,7 +812,15 @@ final class AppViewModel {
             pendingBuddyInviteToken = token
             return
         }
-        Task { await joinBuddySession(token: token) }
+        // Same reasoning as `leaveBuddySession()`: joining is a non-idempotent
+        // network action, so it must not run for a session that replaced this one.
+        let adopted = authGeneration
+        buddyInviteTask?.cancel()
+        buddyInviteTask = Task { [weak self] in
+            guard let self else { return }
+            guard adopted == self.authGeneration else { return }
+            await self.joinBuddySession(token: token)
+        }
     }
 
     func handlePushDeepLink(_ url: URL) {

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -243,9 +243,19 @@ final class AppViewModel {
         (error as? APIError)?.message ?? "Connection failed. Please try again."
     }
 
+    /// Bumped on every identity transition — adopt, offline-adopt, sign-out,
+    /// logout. `@MainActor` serializes these mutations but an `await` is still a
+    /// suspension point, so a request that started under one identity can land
+    /// after another has taken over. Anything that applies a network result to
+    /// identity-scoped state captures this before its `await` and re-checks after,
+    /// rather than re-reading `currentUser` (which cannot distinguish "same user
+    /// throughout" from "signed out and back in").
+    private var authGeneration: Int = 0
+
     /// Single place a server-confirmed user is adopted — in memory *and* in the
     /// local copy that survives a launch with no network (#665).
     private func applyAuthenticatedUser(_ user: UserDTO) {
+        authGeneration &+= 1
         currentUser = user
         CachedIdentityStore.save(user)
         isOfflineMode = false
@@ -259,6 +269,8 @@ final class AppViewModel {
     /// Before #665 every failure path ran this teardown, so a dropped connection
     /// wiped state the server never contradicted.
     private func applySignedOut(cause: WidgetDataStore.SignedOutCause, message: String?) {
+        authGeneration &+= 1
+        cancelIdentityScopedTasks()
         currentUser = nil
         isOfflineMode = false
         currentView = .auth
@@ -280,6 +292,7 @@ final class AppViewModel {
     /// a network, and consuming a pending invite here would burn the token on a
     /// request that cannot succeed. `refreshAfterReconnect()` picks both up.
     private func enterOfflineMode(user: UserDTO, cause: WidgetDataStore.SignedOutCause) async {
+        authGeneration &+= 1
         currentUser = user
         isOfflineMode = true
         resetTrackCompletionBadges()
@@ -300,10 +313,41 @@ final class AppViewModel {
         // Local-only deep links still route; the buddy invite is network-bound.
         await consumePendingSessionDeepLinkIfNeeded()
         await consumePendingLogReasonIfNeeded()
-        // Fire-and-forget: if connectivity is actually back by the time this runs,
-        // the Home badges and widget history catch up on their own; if not, it fails
-        // closed on its own without having delayed anything.
-        Task { await refreshTracksDoneToday() }
+        // Detached from the launch path: if connectivity is actually back by the
+        // time this runs, the Home badges and widget history catch up on their own;
+        // if not, it fails closed without having delayed anything. Retained (not
+        // fire-and-forget) so sign-out can cancel it, and `refreshTracksDoneToday()`
+        // re-checks `authGeneration` after its await so a late response can never
+        // write another account's badges or widget snapshot.
+        offlineCatchUpTask?.cancel()
+        offlineCatchUpTask = Task { [weak self] in
+            guard let self else { return }
+            await self.refreshTracksDoneToday()
+        }
+    }
+
+    /// In-flight identity-scoped background work, cancelled the moment the session
+    /// they were started for ends. The `authGeneration` re-checks are what make a
+    /// late result harmless; cancelling is how we stop paying for it at all.
+    private var offlineCatchUpTask: Task<Void, Never>?
+    private var reconnectTask: Task<Void, Never>?
+
+    private func cancelIdentityScopedTasks() {
+        offlineCatchUpTask?.cancel()
+        offlineCatchUpTask = nil
+        reconnectTask?.cancel()
+        reconnectTask = nil
+    }
+
+    /// #665: non-`async` entry point for the reconnect refresh so the view layer
+    /// hands ownership of the task to the view model instead of spawning an
+    /// unstructured one it cannot cancel.
+    func refreshAfterReconnectInBackground() {
+        reconnectTask?.cancel()
+        reconnectTask = Task { [weak self] in
+            guard let self else { return }
+            await self.refreshAfterReconnect()
+        }
     }
 
     /// #665: reconcile with the server once connectivity returns.
@@ -318,11 +362,18 @@ final class AppViewModel {
     /// `NetworkReachabilityMonitor` flushes the write queue on the same transition.
     func refreshAfterReconnect() async {
         guard currentUser != nil, currentView != .auth else { return }
+        // Captured before the await: signing out (or switching accounts) while
+        // `me()` is in flight must not let the response reinstate the old session.
+        // Applying it would resurrect a signed-out account *and* re-save the cached
+        // identity `applySignedOut` just tore down via `clearIfAuthoritative` (#676).
+        let generation = authGeneration
         do {
             guard let user = try await APIClient.shared.me(today: SessionCalendar.localTodayIsoDate()) else {
+                guard generation == authGeneration else { return }
                 applySignedOut(cause: .signedOut, message: nil)
                 return
             }
+            guard generation == authGeneration else { return }
             applyAuthenticatedUser(user)
             PushNotificationCoordinator.shared.registerIfAlreadyAuthorized()
             hydrateNotificationSuppressionPreference()
@@ -331,7 +382,10 @@ final class AppViewModel {
         } catch let apiError as APIError where apiError.status == 401 {
             // The cached identity outlived the server session — the accepted cost
             // of sitting offline on a stale copy. Sign in again, now, rather than
-            // having been signed out back when the network dropped.
+            // having been signed out back when the network dropped. Generation-
+            // guarded like the success path: a 401 for the *previous* session must
+            // not sign out an account that has since signed in.
+            guard generation == authGeneration else { return }
             applySignedOut(cause: .unauthorized, message: apiError.message)
         } catch {
             // Still no usable answer: stay on local state, say nothing.
@@ -425,6 +479,11 @@ final class AppViewModel {
     }
 
     func didLogout() {
+        // Invalidate in-flight identity-scoped work synchronously, before the
+        // `clearQueue()` await below — the moment sign-out is known is the moment a
+        // response for the old session stops being allowed to write anything (#665).
+        authGeneration &+= 1
+        cancelIdentityScopedTasks()
         widgetHistoryTask?.cancel()
         widgetHistoryRefreshKey = nil
         Task { @MainActor in
@@ -477,6 +536,12 @@ final class AppViewModel {
     /// server-side filtered query.
     func refreshTracksDoneToday() async {
         guard currentUser != nil else { return }
+        // Captured before the request: the `currentUser` check above only holds at
+        // entry, and everything below the await writes identity-scoped state
+        // (Home badges, the widget snapshot, the week history). Re-checked after,
+        // so a response that outlived its session cannot repaint badges or persist
+        // a widget snapshot for an account that has signed out or been switched.
+        let generation = authGeneration
         let now = Date()
         let prior = WidgetDataStore.load()
         if let prior, prior.isLoggedIn, !WidgetDataStore.isSameLocalDay(prior.lastUpdated, now) {
@@ -490,6 +555,7 @@ final class AppViewModel {
         let today = dateFormatter.string(from: Date())
         do {
             let tracksDoneToday = try await APIClient.shared.getTracksDoneToday(date: today)
+            guard generation == authGeneration else { return }
             primaryDoneToday = tracksDoneToday.primary
             secondDoneToday = tracksDoneToday.second
             if primaryDoneToday {
@@ -510,9 +576,12 @@ final class AppViewModel {
             // Note the success path above only ever raises these flags, never
             // lowers them; the failure path must not be the one exception.
             // Midnight rollover is already handled at the top of this method.
+            guard generation == authGeneration else { return }
             primaryDoneToday = false
             secondDoneToday = false
         }
+        // Both branches above return early on a generation change, so reaching
+        // here means the session that started this request is still the live one.
         syncWidgetData()
         refreshWidgetWeekHistory()
     }

--- a/ios/StillPointApp/ViewModels/AppViewModel.swift
+++ b/ios/StillPointApp/ViewModels/AppViewModel.swift
@@ -189,9 +189,15 @@ final class AppViewModel {
         // suspended would otherwise let the late response re-adopt the old account
         // and route back into the authenticated UI (#665).
         let generation = authGeneration
+        // Overlapping checks are possible (cold start immediately followed by a
+        // scene activation). Only the newest may drop the overlay: an older check
+        // finishing first would otherwise clear it while the newest is still
+        // awaiting `me()`, briefly exposing an intermediate or stale route.
+        activeAuthCheckID &+= 1
+        let checkID = activeAuthCheckID
         isLoading = true
         defer {
-            isLoading = false
+            if checkID == activeAuthCheckID { isLoading = false }
             // Diagnostic for issue #266 / #276. Gated on UI-test mode so we
             // don't leak PII in production logs. Switched to os_log
             // (Logger.notice) because `print()` from the app process is not
@@ -214,6 +220,12 @@ final class AppViewModel {
                 PushNotificationCoordinator.shared.registerIfAlreadyAuthorized()
                 hydrateNotificationSuppressionPreference()
                 await refreshTracksDoneToday()
+                // The guard above only covered adopting the response. The refresh is
+                // another suspension point, and everything below it is an
+                // identity-scoped side effect — the widget snapshot and three
+                // non-idempotent deep-link/invite consumptions — so none of it may
+                // run for a session that has since been replaced.
+                guard generation == authGeneration else { return }
                 syncWidgetData()
                 await consumePendingBuddyInviteIfNeeded()
                 await consumePendingSessionDeepLinkIfNeeded()
@@ -266,6 +278,11 @@ final class AppViewModel {
     /// rather than re-reading `currentUser` (which cannot distinguish "same user
     /// throughout" from "signed out and back in").
     private var authGeneration: Int = 0
+
+    /// Identifies the newest in-flight `checkAuth()`. Separate from
+    /// `authGeneration`: this tracks *which check is latest* (so only it may drop
+    /// the loading overlay), not *which identity is live*.
+    private var activeAuthCheckID: Int = 0
 
     /// Single place a server-confirmed user is adopted — in memory *and* in the
     /// local copy that survives a launch with no network (#665).

--- a/ios/StillPointApp/Views/RootView.swift
+++ b/ios/StillPointApp/Views/RootView.swift
@@ -139,9 +139,11 @@ struct RootView: View {
         // #665: connectivity returning is the read/identity half of the reconnect.
         // The monitor already flushes the queued sits itself (#557); this refreshes
         // who we are and today's state, in place, with no user-visible reset.
+        // The view model owns the task so signing out can cancel it, rather than the
+        // view spawning an unstructured one that outlives the session it started in.
         .onChange(of: reachability.isConnected) { wasConnected, isConnected in
             guard !wasConnected, isConnected else { return }
-            Task { await appVM.refreshAfterReconnect() }
+            appVM.refreshAfterReconnectInBackground()
         }
         .onChange(of: scenePhase) { _, phase in
             SessionIdleTimerController.syncSceneForegroundActive(

--- a/ios/StillPointApp/Views/RootView.swift
+++ b/ios/StillPointApp/Views/RootView.swift
@@ -136,6 +136,13 @@ struct RootView: View {
             await appVM.checkAuth()
             await reachability.flushOfflineQueue(ownerUserId: appVM.currentUser?.id)
         }
+        // #665: connectivity returning is the read/identity half of the reconnect.
+        // The monitor already flushes the queued sits itself (#557); this refreshes
+        // who we are and today's state, in place, with no user-visible reset.
+        .onChange(of: reachability.isConnected) { wasConnected, isConnected in
+            guard !wasConnected, isConnected else { return }
+            Task { await appVM.refreshAfterReconnect() }
+        }
         .onChange(of: scenePhase) { _, phase in
             SessionIdleTimerController.syncSceneForegroundActive(
                 appVM: appVM,

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -148,13 +148,16 @@ struct SettingsView: View {
                         guard !isUpdatingAttentionTracking else { return }
                         guard appVM.currentUser?.attentionTrackingEnabled != newValue else { return }
                         isUpdatingAttentionTracking = true
+                        // Captured synchronously with the user's action rather than
+                        // inside the task: the body runs on a later main-actor turn,
+                        // so reading the generation there could pick up an account
+                        // that replaced this one in the gap and apply this toggle's
+                        // intent to them. Binding it here binds it to the identity
+                        // that was live when the toggle was flipped, and still covers
+                        // every later await — including the permission prompt (#665).
+                        let identityAtStart = appVM.identityGeneration
                         Task {
                             defer { isUpdatingAttentionTracking = false }
-                            // Captured at the very top, before any await —
-                            // including a permission prompt. A sign-out during that
-                            // prompt must not let this toggle's intent be applied to
-                            // the replacement account (#665).
-                            let identityAtStart = appVM.identityGeneration
                             if newValue {
                                 let capability = await AttentionTrackingCapability.requestCameraAccessIfNeeded()
                                 switch capability {
@@ -206,13 +209,16 @@ struct SettingsView: View {
                         guard !isUpdatingAmbientSound else { return }
                         guard appVM.currentUser?.ambientSoundEnabled != newValue else { return }
                         isUpdatingAmbientSound = true
+                        // Captured synchronously with the user's action rather than
+                        // inside the task: the body runs on a later main-actor turn,
+                        // so reading the generation there could pick up an account
+                        // that replaced this one in the gap and apply this toggle's
+                        // intent to them. Binding it here binds it to the identity
+                        // that was live when the toggle was flipped, and still covers
+                        // every later await — including the permission prompt (#665).
+                        let identityAtStart = appVM.identityGeneration
                         Task {
                             defer { isUpdatingAmbientSound = false }
-                            // Captured at the very top, before any await —
-                            // including a permission prompt. A sign-out during that
-                            // prompt must not let this toggle's intent be applied to
-                            // the replacement account (#665).
-                            let identityAtStart = appVM.identityGeneration
                             if newValue {
                                 let granted = await AVAudioApplication.requestRecordPermission()
                                 if !granted {
@@ -270,13 +276,15 @@ struct SettingsView: View {
                         guard !isSavingSettings else { return }
                         guard appVM.currentUser?.isPublic != newValue else { return }
                         isUpdating = true
+                        // Captured synchronously with the user's action rather than
+                        // inside the task: the body runs on a later main-actor turn,
+                        // so reading the generation there could pick up an account
+                        // that replaced this one in the gap and apply this toggle's
+                        // intent to them. Binding it here binds it to the identity
+                        // that was live when the toggle was flipped (#665).
+                        let identityAtStart = appVM.identityGeneration
                         Task {
                             defer { isUpdating = false }
-                            // Captured at the very top, before any await —
-                            // including a permission prompt. A sign-out during that
-                            // prompt must not let this toggle's intent be applied to
-                            // the replacement account (#665).
-                            let identityAtStart = appVM.identityGeneration
                             do {
                                 // Re-checked before issuing the write: sending this would
                                 // otherwise apply the previous user's intent to the
@@ -323,13 +331,15 @@ struct SettingsView: View {
                         guard !isUpdatingAphorisms else { return }
                         guard appVM.currentUser?.aphorismsEnabled != newValue else { return }
                         isUpdatingAphorisms = true
+                        // Captured synchronously with the user's action rather than
+                        // inside the task: the body runs on a later main-actor turn,
+                        // so reading the generation there could pick up an account
+                        // that replaced this one in the gap and apply this toggle's
+                        // intent to them. Binding it here binds it to the identity
+                        // that was live when the toggle was flipped (#665).
+                        let identityAtStart = appVM.identityGeneration
                         Task {
                             defer { isUpdatingAphorisms = false }
-                            // Captured at the very top, before any await —
-                            // including a permission prompt. A sign-out during that
-                            // prompt must not let this toggle's intent be applied to
-                            // the replacement account (#665).
-                            let identityAtStart = appVM.identityGeneration
                             do {
                                 // Re-checked before issuing the write: sending this would
                                 // otherwise apply the previous user's intent to the

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -166,8 +166,11 @@ struct SettingsView: View {
                                 }
                             }
                             do {
+                                // Captured before the await: a response that outlived a
+                                // sign-out must not be applied to the next session (#665).
+                                let identityAtStart = appVM.identityGeneration
                                 let updated = try await APIClient.shared.updateSettings(attentionTrackingEnabled: newValue)
-                                appVM.applySettingsUser(updated)
+                                appVM.applySettingsUser(updated, startedAtGeneration: identityAtStart)
                             } catch {
                                 attentionTrackingEnabled = !newValue
                             }
@@ -203,8 +206,11 @@ struct SettingsView: View {
                                 }
                             }
                             do {
+                                // Captured before the await: a response that outlived a
+                                // sign-out must not be applied to the next session (#665).
+                                let identityAtStart = appVM.identityGeneration
                                 let updated = try await APIClient.shared.updateSettings(ambientSoundEnabled: newValue)
-                                appVM.applySettingsUser(updated)
+                                appVM.applySettingsUser(updated, startedAtGeneration: identityAtStart)
                             } catch {
                                 ambientSoundEnabled = !newValue
                             }
@@ -245,8 +251,11 @@ struct SettingsView: View {
                         Task {
                             defer { isUpdating = false }
                             do {
+                                // Captured before the await: a response that outlived a
+                                // sign-out must not be applied to the next session (#665).
+                                let identityAtStart = appVM.identityGeneration
                                 let updated = try await APIClient.shared.updateSettings(isPublic: newValue)
-                                appVM.applySettingsUser(updated)
+                                appVM.applySettingsUser(updated, startedAtGeneration: identityAtStart)
                             } catch {
                                 // Revert on failure
                                 isPublic = !newValue
@@ -284,8 +293,11 @@ struct SettingsView: View {
                         Task {
                             defer { isUpdatingAphorisms = false }
                             do {
+                                // Captured before the await: a response that outlived a
+                                // sign-out must not be applied to the next session (#665).
+                                let identityAtStart = appVM.identityGeneration
                                 let updated = try await APIClient.shared.updateSettings(aphorismsEnabled: newValue)
-                                appVM.applySettingsUser(updated)
+                                appVM.applySettingsUser(updated, startedAtGeneration: identityAtStart)
                             } catch {
                                 // Revert on failure
                                 aphorismsEnabled = !newValue

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -150,6 +150,11 @@ struct SettingsView: View {
                         isUpdatingAttentionTracking = true
                         Task {
                             defer { isUpdatingAttentionTracking = false }
+                            // Captured at the very top, before any await —
+                            // including a permission prompt. A sign-out during that
+                            // prompt must not let this toggle's intent be applied to
+                            // the replacement account (#665).
+                            let identityAtStart = appVM.identityGeneration
                             if newValue {
                                 let capability = await AttentionTrackingCapability.requestCameraAccessIfNeeded()
                                 switch capability {
@@ -166,9 +171,10 @@ struct SettingsView: View {
                                 }
                             }
                             do {
-                                // Captured before the await: a response that outlived a
-                                // sign-out must not be applied to the next session (#665).
-                                let identityAtStart = appVM.identityGeneration
+                                // Re-checked before issuing the write: sending this would
+                                // otherwise apply the previous user's intent to the
+                                // account that replaced them.
+                                guard identityAtStart == appVM.identityGeneration else { return }
                                 let updated = try await APIClient.shared.updateSettings(attentionTrackingEnabled: newValue)
                                 appVM.applySettingsUser(updated, startedAtGeneration: identityAtStart)
                             } catch {
@@ -197,6 +203,11 @@ struct SettingsView: View {
                         isUpdatingAmbientSound = true
                         Task {
                             defer { isUpdatingAmbientSound = false }
+                            // Captured at the very top, before any await —
+                            // including a permission prompt. A sign-out during that
+                            // prompt must not let this toggle's intent be applied to
+                            // the replacement account (#665).
+                            let identityAtStart = appVM.identityGeneration
                             if newValue {
                                 let granted = await AVAudioApplication.requestRecordPermission()
                                 if !granted {
@@ -206,9 +217,10 @@ struct SettingsView: View {
                                 }
                             }
                             do {
-                                // Captured before the await: a response that outlived a
-                                // sign-out must not be applied to the next session (#665).
-                                let identityAtStart = appVM.identityGeneration
+                                // Re-checked before issuing the write: sending this would
+                                // otherwise apply the previous user's intent to the
+                                // account that replaced them.
+                                guard identityAtStart == appVM.identityGeneration else { return }
                                 let updated = try await APIClient.shared.updateSettings(ambientSoundEnabled: newValue)
                                 appVM.applySettingsUser(updated, startedAtGeneration: identityAtStart)
                             } catch {
@@ -250,10 +262,16 @@ struct SettingsView: View {
                         isUpdating = true
                         Task {
                             defer { isUpdating = false }
+                            // Captured at the very top, before any await —
+                            // including a permission prompt. A sign-out during that
+                            // prompt must not let this toggle's intent be applied to
+                            // the replacement account (#665).
+                            let identityAtStart = appVM.identityGeneration
                             do {
-                                // Captured before the await: a response that outlived a
-                                // sign-out must not be applied to the next session (#665).
-                                let identityAtStart = appVM.identityGeneration
+                                // Re-checked before issuing the write: sending this would
+                                // otherwise apply the previous user's intent to the
+                                // account that replaced them.
+                                guard identityAtStart == appVM.identityGeneration else { return }
                                 let updated = try await APIClient.shared.updateSettings(isPublic: newValue)
                                 appVM.applySettingsUser(updated, startedAtGeneration: identityAtStart)
                             } catch {
@@ -292,10 +310,16 @@ struct SettingsView: View {
                         isUpdatingAphorisms = true
                         Task {
                             defer { isUpdatingAphorisms = false }
+                            // Captured at the very top, before any await —
+                            // including a permission prompt. A sign-out during that
+                            // prompt must not let this toggle's intent be applied to
+                            // the replacement account (#665).
+                            let identityAtStart = appVM.identityGeneration
                             do {
-                                // Captured before the await: a response that outlived a
-                                // sign-out must not be applied to the next session (#665).
-                                let identityAtStart = appVM.identityGeneration
+                                // Re-checked before issuing the write: sending this would
+                                // otherwise apply the previous user's intent to the
+                                // account that replaced them.
+                                guard identityAtStart == appVM.identityGeneration else { return }
                                 let updated = try await APIClient.shared.updateSettings(aphorismsEnabled: newValue)
                                 appVM.applySettingsUser(updated, startedAtGeneration: identityAtStart)
                             } catch {

--- a/ios/StillPointApp/Views/SettingsView.swift
+++ b/ios/StillPointApp/Views/SettingsView.swift
@@ -176,7 +176,12 @@ struct SettingsView: View {
                                 // account that replaced them.
                                 guard identityAtStart == appVM.identityGeneration else { return }
                                 let updated = try await APIClient.shared.updateSettings(attentionTrackingEnabled: newValue)
-                                appVM.applySettingsUser(updated, startedAtGeneration: identityAtStart)
+                                // A discarded response means the session changed; put the
+                                // toggle back rather than leaving it showing an intent that
+                                // was never applied (mirrors the catch below).
+                                if !appVM.applySettingsUser(updated, startedAtGeneration: identityAtStart) {
+                                    attentionTrackingEnabled = !newValue
+                                }
                             } catch {
                                 attentionTrackingEnabled = !newValue
                             }
@@ -222,7 +227,12 @@ struct SettingsView: View {
                                 // account that replaced them.
                                 guard identityAtStart == appVM.identityGeneration else { return }
                                 let updated = try await APIClient.shared.updateSettings(ambientSoundEnabled: newValue)
-                                appVM.applySettingsUser(updated, startedAtGeneration: identityAtStart)
+                                // A discarded response means the session changed; put the
+                                // toggle back rather than leaving it showing an intent that
+                                // was never applied (mirrors the catch below).
+                                if !appVM.applySettingsUser(updated, startedAtGeneration: identityAtStart) {
+                                    ambientSoundEnabled = !newValue
+                                }
                             } catch {
                                 ambientSoundEnabled = !newValue
                             }
@@ -273,7 +283,12 @@ struct SettingsView: View {
                                 // account that replaced them.
                                 guard identityAtStart == appVM.identityGeneration else { return }
                                 let updated = try await APIClient.shared.updateSettings(isPublic: newValue)
-                                appVM.applySettingsUser(updated, startedAtGeneration: identityAtStart)
+                                // A discarded response means the session changed; put the
+                                // toggle back rather than leaving it showing an intent that
+                                // was never applied (mirrors the catch below).
+                                if !appVM.applySettingsUser(updated, startedAtGeneration: identityAtStart) {
+                                    isPublic = !newValue
+                                }
                             } catch {
                                 // Revert on failure
                                 isPublic = !newValue
@@ -321,7 +336,12 @@ struct SettingsView: View {
                                 // account that replaced them.
                                 guard identityAtStart == appVM.identityGeneration else { return }
                                 let updated = try await APIClient.shared.updateSettings(aphorismsEnabled: newValue)
-                                appVM.applySettingsUser(updated, startedAtGeneration: identityAtStart)
+                                // A discarded response means the session changed; put the
+                                // toggle back rather than leaving it showing an intent that
+                                // was never applied (mirrors the catch below).
+                                if !appVM.applySettingsUser(updated, startedAtGeneration: identityAtStart) {
+                                    aphorismsEnabled = !newValue
+                                }
                             } catch {
                                 // Revert on failure
                                 aphorismsEnabled = !newValue

--- a/ios/StillPointApp/Views/UsernameEditView.swift
+++ b/ios/StillPointApp/Views/UsernameEditView.swift
@@ -150,8 +150,11 @@ struct UsernameEditView: View {
         defer { savingUsername = false }
 
         do {
+            // Captured before the await: a response that outlived a sign-out must
+            // not be applied to the next session (#665).
+            let identityAtStart = appVM.identityGeneration
             let updated = try await APIClient.shared.updateSettings(username: trimmed)
-            appVM.applySettingsUser(updated)
+            appVM.applySettingsUser(updated, startedAtGeneration: identityAtStart)
             usernameDraft = updated.username
             editingUsername = false
             usernameSuccessMessage = "Username updated"

--- a/ios/StillPointApp/Views/UsernameEditView.swift
+++ b/ios/StillPointApp/Views/UsernameEditView.swift
@@ -154,7 +154,9 @@ struct UsernameEditView: View {
             // not be applied to the next session (#665).
             let identityAtStart = appVM.identityGeneration
             let updated = try await APIClient.shared.updateSettings(username: trimmed)
-            appVM.applySettingsUser(updated, startedAtGeneration: identityAtStart)
+            // If the view model discarded the response because the session changed
+            // under us, do not tell the user their username was updated (#665).
+            guard appVM.applySettingsUser(updated, startedAtGeneration: identityAtStart) else { return }
             usernameDraft = updated.username
             editingUsername = false
             usernameSuccessMessage = "Username updated"

--- a/ios/StillPointAppUITests/StillPointAppUITests.swift
+++ b/ios/StillPointAppUITests/StillPointAppUITests.swift
@@ -354,6 +354,14 @@ final class StillPointAppUITests: XCTestCase {
         XCTAssertTrue(submitButton.isHittable, "Submit should remain reachable with keyboard visible")
     }
 
+    /// Offline launch with *nothing cached locally* — a first run in a dead zone.
+    ///
+    /// #665 made a dropped connection stop signing the user out, but only where
+    /// there is a local identity to fall back on. `resetStore: true` wipes the
+    /// session artifacts, and since #665 that includes the cached `UserDTO`, so
+    /// this launch genuinely has no idea who the user is: sign-in with a
+    /// connection message stays the only honest destination. The cached-identity
+    /// counterpart is device-manual (Airplane Mode matrix).
     @MainActor
     func testLaunchOfflineShowsUserVisibleMessage() throws {
         let app = makeApp(

--- a/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/APIClient.swift
@@ -50,6 +50,12 @@ public actor APIClient {
     /// when the actor's instance methods are not yet available.
     private static func clearPersistedSessionArtifacts(session: URLSession) {
         _ = AuthTokenStore.clear()
+        // #665: the offline identity cache is a session artifact too. Clearing it
+        // here covers every authoritative teardown at once — sign-out (including a
+        // sign-out performed while offline, since `logout()` clears in a `defer`),
+        // account deletion, and a UI-test reset launch — so no path can leave a
+        // cached identity behind for the next launch to resurrect.
+        CachedIdentityStore.clear()
 
         let cookieStorage = session.configuration.httpCookieStorage ?? .shared
         for cookie in cookieStorage.cookies ?? [] {

--- a/ios/StillPointShared/Sources/StillPointShared/CachedIdentityStore.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/CachedIdentityStore.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// #665 — the last authenticated `UserDTO`, kept on the device so a launch with no
+/// network still knows who you are, what day you're on, and which tracks you run.
+///
+/// **Where it lives.** The App Group container the widget already reads
+/// (`WidgetAppGroup.id`), not a private app container. The widget's snapshot is
+/// this codebase's existing precedent for "trust local state, reconcile later"
+/// (#671/#676), and putting identity beside it keeps one local source of truth
+/// instead of two that can drift. The session *token* stays in the Keychain
+/// (`AuthTokenStore`) where it belongs — only the non-secret identity payload
+/// (id, username, day counters, feature flags) is stored here.
+///
+/// **Staleness is accepted, deliberately.** A cached identity older than the
+/// server's session means the user sits happily offline and then hits a 401 on
+/// reconnect, at which point `clearIfAuthoritative(on:)` wipes it and they sign in
+/// again. That is strictly better than the alternative it replaces — being logged
+/// out at the moment of *losing* the network rather than the moment of regaining it.
+public enum CachedIdentityStore {
+    /// App Group key. Versioned like `WidgetAppGroup.dataKey` so a future shape
+    /// change can be introduced without misreading an old payload.
+    public static let key = "identity.cachedUser.v1"
+
+    public static func load(from defaults: UserDefaults? = WidgetDataStore.sharedDefaults) -> UserDTO? {
+        guard let defaults, let data = defaults.data(forKey: key) else { return nil }
+        return try? JSONDecoder().decode(UserDTO.self, from: data)
+    }
+
+    /// Persist the authenticated user. Call on every successful `me()` so the
+    /// local copy tracks the server (day number, recovery ramp, track opt-ins).
+    @discardableResult
+    public static func save(
+        _ user: UserDTO,
+        into defaults: UserDefaults? = WidgetDataStore.sharedDefaults
+    ) -> Bool {
+        guard let defaults, let data = try? JSONEncoder().encode(user) else { return false }
+        defaults.set(data, forKey: key)
+        return true
+    }
+
+    public static func clear(from defaults: UserDefaults? = WidgetDataStore.sharedDefaults) {
+        defaults?.removeObject(forKey: key)
+    }
+
+    /// Clear the cached identity only for a cause authoritative enough to prove the
+    /// session is over — the same predicate that guards the widget's stored week
+    /// (#676). A dropped connection or a 5xx is never one of them.
+    ///
+    /// Returns whether it actually cleared, so callers can gate the rest of their
+    /// sign-out teardown (`trackingControlPrefsManager.clearOnLogout()`, the
+    /// per-account unlock reset) on the same single answer.
+    @discardableResult
+    public static func clearIfAuthoritative(
+        on cause: WidgetDataStore.SignedOutCause,
+        from defaults: UserDefaults? = WidgetDataStore.sharedDefaults
+    ) -> Bool {
+        guard WidgetDataStore.shouldClearStoredSnapshot(on: cause) else { return false }
+        clear(from: defaults)
+        return true
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/OfflineAuth.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/OfflineAuth.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// #665 — offline-first identity: what a failed `/api/auth/me` means for routing
+/// and for the local state the app already holds.
+///
+/// The practice itself needs nothing from the server: starting a sit, watching
+/// the timer, tapping thoughts, finishing. Internet is required for exactly one
+/// thing — *syncing*. Knowing who you are is not syncing, so a request that never
+/// reached the server must not be read as a sign-out. Before this, any failed
+/// `me()` dropped the user on the sign-in screen, which is precisely what happens
+/// on a plane, on the subway, or in a dead zone: the one place a meditation app is
+/// most useful is where it stopped working.
+///
+/// The decision lives here, once, and is expressed in the taxonomy #676 already
+/// introduced for the widget (`WidgetDataStore.SignedOutCause`) rather than a
+/// second parallel one — so the app and the widget can never disagree about what
+/// "signed out" means. `WidgetDataStore.shouldClearStoredSnapshot(on:)` remains
+/// the single predicate for "is this cause authoritative enough to destroy local
+/// state?"; this type only applies that same predicate to the app's own two
+/// pieces of local state: the cached identity and the route.
+///
+/// **Pattern notes for #666 (web PWA).** Everything here is pure and has no
+/// platform dependencies. A TypeScript mirror needs the same three moving parts:
+/// (1) a classifier that treats only an HTTP 401 as proof the session is over,
+/// (2) one shared predicate deciding whether a cause may destroy local state, and
+/// (3) an outcome that keeps the user signed in from a cached identity whenever
+/// that predicate says no and a cached identity exists.
+public enum OfflineAuth {
+
+    /// What the app should do after an attempt to load the current user failed.
+    public enum Outcome: Sendable, Equatable {
+        /// Authoritative: there is no usable session, or there is nothing local
+        /// to fall back to. Route to sign-in; `cause` decides whether local state
+        /// is cleared on the way.
+        case signedOut(WidgetDataStore.SignedOutCause)
+        /// No trustworthy answer — but a cached identity exists. Stay signed in
+        /// and render from local state until the server can be reached again.
+        case offline(WidgetDataStore.SignedOutCause)
+
+        public var cause: WidgetDataStore.SignedOutCause {
+            switch self {
+            case let .signedOut(cause), let .offline(cause):
+                return cause
+            }
+        }
+
+        /// Whether the app is about to run from its local copy of identity/state.
+        /// Drives the unobtrusive offline indicator.
+        public var usesCachedIdentity: Bool {
+            if case .offline = self { return true }
+            return false
+        }
+    }
+
+    /// Map a thrown `me()` error onto the shared sign-out taxonomy.
+    ///
+    /// Only an HTTP 401 counts as proof the session is over: it is the one answer
+    /// that came *from the server* and was *about auth*. A response-less failure
+    /// is `.unreachable` — that covers a real `URLError` and `APIError(status: 0)`,
+    /// which is how `UITestAPIStore` models a dead network. Anything else the
+    /// server said, and any answer we could not parse, is `.serverError`.
+    ///
+    /// The asymmetry is deliberate. Wrongly deciding "offline" costs a 401 on the
+    /// next request and a trip to sign-in then; wrongly deciding "signed out"
+    /// destroys local state and is the bug this exists to prevent. Only an
+    /// authoritative signal gets to be destructive.
+    public static func cause(for error: Error) -> WidgetDataStore.SignedOutCause {
+        if let apiError = error as? APIError {
+            if apiError.status == 401 { return .unauthorized }
+            return apiError.status <= 0 ? .unreachable : .serverError
+        }
+        if error is URLError { return .unreachable }
+        return .serverError
+    }
+
+    /// Resolve a failed `me()` into a route.
+    ///
+    /// `hasCachedIdentity` is the caller's answer for `CachedIdentityStore.load()`;
+    /// without a local copy there is nothing to render, so even a transport failure
+    /// has to land on sign-in (a first launch with no network, say).
+    public static func outcome(for error: Error, hasCachedIdentity: Bool) -> Outcome {
+        let cause = cause(for: error)
+        // Deliberately the widget's predicate: a cause that may wipe the widget's
+        // stored week is exactly a cause that may sign you out of the app.
+        guard !WidgetDataStore.shouldClearStoredSnapshot(on: cause), hasCachedIdentity else {
+            return .signedOut(cause)
+        }
+        return .offline(cause)
+    }
+}

--- a/ios/StillPointShared/Sources/StillPointShared/OfflineSessionQueue.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/OfflineSessionQueue.swift
@@ -59,7 +59,13 @@ public struct PendingSessionEntry: Codable, Sendable, Identifiable {
         thoughts = try container.decode([PendingSessionThought].self, forKey: .thoughts)
         serverSessionId = try container.decodeIfPresent(String.self, forKey: .serverSessionId)
         sessionSynced = try container.decode(Bool.self, forKey: .sessionSynced)
-        enqueuedAt = try container.decodeIfPresent(Date.self, forKey: .enqueuedAt) ?? Date()
+        // `.distantPast`, not `Date()`: a row persisted before this field existed is
+        // by definition *older* than anything carrying a timestamp. Defaulting to
+        // "now" made such a row look newer than any later logout boundary, so
+        // `clearQueue(ownerUserId:enqueuedBefore:)` would preserve it on every
+        // sign-out — and because the decoded value is only persisted when some other
+        // operation happens to save the queue, it could survive indefinitely.
+        enqueuedAt = try container.decodeIfPresent(Date.self, forKey: .enqueuedAt) ?? .distantPast
     }
 
     public func encode(to encoder: Encoder) throws {

--- a/ios/StillPointShared/Sources/StillPointShared/SessionSyncCoordinator.swift
+++ b/ios/StillPointShared/Sources/StillPointShared/SessionSyncCoordinator.swift
@@ -168,9 +168,41 @@ public actor SessionSyncCoordinator {
         }
     }
 
-    /// Remove all queued entries (logout / account switch).
-    public func clearQueue() async throws {
-        try queueStore.saveEntries([])
+    /// Remove the signed-out account's queued entries (logout / account switch).
+    ///
+    /// Owner-scoped rather than a blanket wipe. `didLogout()` schedules this after
+    /// tearing the session down and routing to `.auth`, so the user can sign in —
+    /// and the next account can save a sit — while this is still pending. A
+    /// `saveEntries([])` here would delete entries that the *new* login had just
+    /// enqueued; scoping the delete to the account that signed out makes the
+    /// ordering irrelevant instead of merely unlikely. Mirrors
+    /// `flushPending(ownerUserId:)` and `pruneCompletedEntries(ownerUserId:)`.
+    ///
+    /// Scoping by owner alone is not enough, because signing back in as the *same*
+    /// account reuses the same owner id — so a sit saved after the new sign-in would
+    /// still match. This coordinator is an actor, so a cleanup scheduled at logout
+    /// can sit waiting on actor isolation while an in-flight `flushPending` blocks
+    /// on a slow network, which is what makes that window wide enough to matter. The
+    /// boundary confines the delete to rows that already existed when logout began.
+    ///
+    /// - Parameters:
+    ///   - ownerUserId: the account that signed out. Required rather than defaulted
+    ///     so a new call site cannot fall back to erasing the whole queue. Empty is
+    ///     a no-op: legacy entries decoded without an owner cannot be attributed to
+    ///     the account signing out, and deleting unattributable rows is the hazard
+    ///     this scoping exists to prevent.
+    ///   - boundary: the moment logout began. Only entries enqueued strictly before
+    ///     it are removed, so anything the next sign-in saves survives regardless of
+    ///     when this cleanup actually runs.
+    public func clearQueue(ownerUserId: String, enqueuedBefore boundary: Date) async throws {
+        guard !ownerUserId.isEmpty else { return }
+
+        var entries = try queueStore.loadEntries()
+        let before = entries.count
+        entries.removeAll { $0.ownerUserId == ownerUserId && $0.enqueuedAt < boundary }
+        if entries.count != before {
+            try queueStore.saveEntries(entries)
+        }
     }
 
     // MARK: - Private

--- a/ios/StillPointShared/Tests/StillPointSharedTests/CachedIdentityStoreTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/CachedIdentityStoreTests.swift
@@ -1,0 +1,159 @@
+import XCTest
+import StillPointShared
+
+/// #665 — the identity half of offline-first: the local copy of `UserDTO` that
+/// lets a cold launch with no network still know who you are.
+final class CachedIdentityStoreTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        suiteName = "still-point.cached-identity.tests.\(UUID().uuidString)"
+        defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    }
+
+    override func tearDownWithError() throws {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        try super.tearDownWithError()
+    }
+
+    private func makeUser(
+        id: String = "user-1",
+        currentDay: Int = 24,
+        dualTrackEnabled: Bool = true,
+        secondTrackDay: Int = 8
+    ) -> UserDTO {
+        UserDTO(
+            id: id,
+            email: "sitter@example.com",
+            username: "sitter",
+            isPublic: true,
+            currentDay: currentDay,
+            aphorismsEnabled: true,
+            attentionTrackingEnabled: true,
+            dualTrackEnabled: dualTrackEnabled,
+            secondTrackDay: secondTrackDay,
+            recoveryTargetDay: 30,
+            recoveryCurrentStep: 2,
+            recoveryTotalSteps: 4,
+            ambientSoundEnabled: true
+        )
+    }
+
+    // MARK: - Round trip
+
+    /// Everything the offline Home screen reads has to survive the round trip —
+    /// the day number, the dual-track fork, and the recovery ramp especially,
+    /// since those drive what a sit is *for* today.
+    func testSaveThenLoadRestoresEveryField() throws {
+        let user = makeUser()
+
+        XCTAssertTrue(CachedIdentityStore.save(user, into: defaults))
+        let restored = try XCTUnwrap(CachedIdentityStore.load(from: defaults))
+
+        XCTAssertEqual(restored.id, user.id)
+        XCTAssertEqual(restored.email, user.email)
+        XCTAssertEqual(restored.username, user.username)
+        XCTAssertEqual(restored.isPublic, user.isPublic)
+        XCTAssertEqual(restored.currentDay, user.currentDay)
+        XCTAssertEqual(restored.aphorismsEnabled, user.aphorismsEnabled)
+        XCTAssertEqual(restored.attentionTrackingEnabled, user.attentionTrackingEnabled)
+        XCTAssertEqual(restored.dualTrackEnabled, user.dualTrackEnabled)
+        XCTAssertEqual(restored.secondTrackDay, user.secondTrackDay)
+        XCTAssertEqual(restored.recoveryTargetDay, user.recoveryTargetDay)
+        XCTAssertEqual(restored.recoveryCurrentStep, user.recoveryCurrentStep)
+        XCTAssertEqual(restored.recoveryTotalSteps, user.recoveryTotalSteps)
+        XCTAssertEqual(restored.ambientSoundEnabled, user.ambientSoundEnabled)
+    }
+
+    func testLoadReturnsNilWhenNothingCached() {
+        XCTAssertNil(CachedIdentityStore.load(from: defaults))
+    }
+
+    /// A later `me()` must replace the local copy rather than accumulate — the day
+    /// number moves, and an account switch must not leave the old identity behind.
+    func testSaveOverwritesPriorIdentity() throws {
+        CachedIdentityStore.save(makeUser(id: "user-1", currentDay: 24), into: defaults)
+        CachedIdentityStore.save(makeUser(id: "user-2", currentDay: 3), into: defaults)
+
+        let restored = try XCTUnwrap(CachedIdentityStore.load(from: defaults))
+        XCTAssertEqual(restored.id, "user-2")
+        XCTAssertEqual(restored.currentDay, 3)
+    }
+
+    func testClearRemovesIdentity() {
+        CachedIdentityStore.save(makeUser(), into: defaults)
+        CachedIdentityStore.clear(from: defaults)
+
+        XCTAssertNil(CachedIdentityStore.load(from: defaults))
+    }
+
+    func testCorruptPayloadLoadsAsNilRatherThanThrowing() {
+        defaults.set(Data("not json".utf8), forKey: CachedIdentityStore.key)
+
+        XCTAssertNil(CachedIdentityStore.load(from: defaults))
+    }
+
+    // MARK: - Only an authoritative cause may clear
+
+    /// AC: a 401 clears the cached identity.
+    func testUnauthorizedClearsCachedIdentity() {
+        CachedIdentityStore.save(makeUser(), into: defaults)
+
+        XCTAssertTrue(CachedIdentityStore.clearIfAuthoritative(on: .unauthorized, from: defaults))
+        XCTAssertNil(CachedIdentityStore.load(from: defaults))
+    }
+
+    /// An explicit sign-out, or the server reporting no session at all.
+    func testSignedOutClearsCachedIdentity() {
+        CachedIdentityStore.save(makeUser(), into: defaults)
+
+        XCTAssertTrue(CachedIdentityStore.clearIfAuthoritative(on: .signedOut, from: defaults))
+        XCTAssertNil(CachedIdentityStore.load(from: defaults))
+    }
+
+    /// AC: a transport failure must not trigger the sign-out teardown. Callers gate
+    /// `trackingControlPrefsManager.clearOnLogout()` and the per-account unlock reset
+    /// on this same `false`.
+    func testUnreachableKeepsCachedIdentity() throws {
+        CachedIdentityStore.save(makeUser(), into: defaults)
+
+        XCTAssertFalse(CachedIdentityStore.clearIfAuthoritative(on: .unreachable, from: defaults))
+        XCTAssertEqual(try XCTUnwrap(CachedIdentityStore.load(from: defaults)).id, "user-1")
+    }
+
+    func testServerErrorKeepsCachedIdentity() throws {
+        CachedIdentityStore.save(makeUser(), into: defaults)
+
+        XCTAssertFalse(CachedIdentityStore.clearIfAuthoritative(on: .serverError, from: defaults))
+        XCTAssertEqual(try XCTUnwrap(CachedIdentityStore.load(from: defaults)).id, "user-1")
+    }
+
+    /// The clearing rule is not a second copy of the widget's — it is the widget's.
+    func testClearingMatchesWidgetSnapshotPredicate() {
+        for cause in [WidgetDataStore.SignedOutCause.signedOut, .unauthorized, .serverError, .unreachable] {
+            CachedIdentityStore.save(makeUser(), into: defaults)
+            XCTAssertEqual(
+                CachedIdentityStore.clearIfAuthoritative(on: cause, from: defaults),
+                WidgetDataStore.shouldClearStoredSnapshot(on: cause),
+                "Cached identity and widget snapshot disagreed on \(cause)"
+            )
+            CachedIdentityStore.clear(from: defaults)
+        }
+    }
+
+    /// The identity payload is stored under its own key, so clearing it never
+    /// disturbs the widget's snapshot living in the same App Group container.
+    func testClearingIdentityLeavesWidgetSnapshotKeyUntouched() {
+        defaults.set(Data("widget-blob".utf8), forKey: WidgetAppGroup.dataKey)
+        CachedIdentityStore.save(makeUser(), into: defaults)
+
+        CachedIdentityStore.clear(from: defaults)
+
+        XCTAssertNotNil(defaults.data(forKey: WidgetAppGroup.dataKey))
+        XCTAssertNotEqual(CachedIdentityStore.key, WidgetAppGroup.dataKey)
+    }
+}

--- a/ios/StillPointShared/Tests/StillPointSharedTests/OfflineAuthTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/OfflineAuthTests.swift
@@ -1,0 +1,155 @@
+import XCTest
+import StillPointShared
+
+/// #665 — the routing half of offline-first. These cover the decision
+/// `AppViewModel.checkAuth()` makes on a failed `me()`; the view model is a thin
+/// switch over `OfflineAuth.outcome(for:hasCachedIdentity:)`, which lives in the
+/// package so it is reachable from `swift test` (the app target is Xcode-only).
+final class OfflineAuthTests: XCTestCase {
+
+    // MARK: - Transport failure keeps the user signed in
+
+    /// AC: a connection error hydrates from the local copy and does NOT route to
+    /// `.auth`.
+    func testTransportErrorWithCachedIdentityStaysSignedIn() {
+        let outcome = OfflineAuth.outcome(
+            for: URLError(.notConnectedToInternet),
+            hasCachedIdentity: true
+        )
+
+        XCTAssertEqual(outcome, .offline(.unreachable))
+        XCTAssertTrue(outcome.usesCachedIdentity)
+    }
+
+    func testTimeoutWithCachedIdentityStaysSignedIn() {
+        XCTAssertEqual(
+            OfflineAuth.outcome(for: URLError(.timedOut), hasCachedIdentity: true),
+            .offline(.unreachable)
+        )
+    }
+
+    func testNetworkConnectionLostWithCachedIdentityStaysSignedIn() {
+        XCTAssertEqual(
+            OfflineAuth.outcome(for: URLError(.networkConnectionLost), hasCachedIdentity: true),
+            .offline(.unreachable)
+        )
+    }
+
+    /// `UITestAPIStore` models a dead network as `APIError(status: 0)`, so the
+    /// classifier has to read a response-less `APIError` as transport, not as
+    /// something the server said.
+    func testResponselessAPIErrorIsTransportNotServerError() {
+        let offline = APIError(status: 0, message: "No internet connection")
+
+        XCTAssertEqual(OfflineAuth.cause(for: offline), .unreachable)
+        XCTAssertEqual(OfflineAuth.outcome(for: offline, hasCachedIdentity: true), .offline(.unreachable))
+    }
+
+    /// A 5xx is the server answering with something that says nothing about auth —
+    /// same treatment as unreachable, consistent with #676 refusing to wipe the
+    /// widget's week on one.
+    func testServerErrorWithCachedIdentityStaysSignedIn() {
+        let outcome = OfflineAuth.outcome(
+            for: APIError(status: 500, message: "Internal Server Error"),
+            hasCachedIdentity: true
+        )
+
+        XCTAssertEqual(outcome, .offline(.serverError))
+        XCTAssertTrue(outcome.usesCachedIdentity)
+    }
+
+    /// A response we cannot parse is still an answer from a reachable server, so it
+    /// classifies as `.serverError` — but it is just as non-authoritative, and the
+    /// user stays signed in.
+    func testUnparseableResponseIsNonAuthoritative() {
+        struct Undecodable: Error {}
+
+        XCTAssertEqual(OfflineAuth.cause(for: Undecodable()), .serverError)
+        XCTAssertEqual(
+            OfflineAuth.outcome(for: Undecodable(), hasCachedIdentity: true),
+            .offline(.serverError)
+        )
+    }
+
+    // MARK: - Authoritative rejection still signs out
+
+    /// AC: a 401 `TOKEN_EXPIRED` still routes to `.auth` and clears cached identity
+    /// (the clearing predicate is asserted in `CachedIdentityStoreTests`).
+    func testTokenExpiredRoutesToAuthEvenWithCachedIdentity() {
+        let expired = APIError(status: 401, message: "Session expired. Please log in again.", code: "TOKEN_EXPIRED")
+        let outcome = OfflineAuth.outcome(for: expired, hasCachedIdentity: true)
+
+        XCTAssertEqual(outcome, .signedOut(.unauthorized))
+        XCTAssertFalse(outcome.usesCachedIdentity)
+        XCTAssertTrue(WidgetDataStore.shouldClearStoredSnapshot(on: outcome.cause))
+    }
+
+    /// A 401 without the `TOKEN_EXPIRED` code is just as authoritative.
+    func testUncodedUnauthorizedRoutesToAuth() {
+        XCTAssertEqual(
+            OfflineAuth.outcome(for: APIError(status: 401, message: "Unauthorized"), hasCachedIdentity: true),
+            .signedOut(.unauthorized)
+        )
+    }
+
+    // MARK: - Nothing cached to fall back on
+
+    /// First launch with no network: there is no local copy to render, so sign-in
+    /// (with the connection message) remains the only honest destination.
+    func testTransportErrorWithoutCachedIdentityRoutesToAuth() {
+        let outcome = OfflineAuth.outcome(
+            for: URLError(.notConnectedToInternet),
+            hasCachedIdentity: false
+        )
+
+        XCTAssertEqual(outcome, .signedOut(.unreachable))
+        XCTAssertFalse(outcome.usesCachedIdentity)
+        // …but it is still not an authoritative sign-out, so nothing local is wiped.
+        XCTAssertFalse(WidgetDataStore.shouldClearStoredSnapshot(on: outcome.cause))
+    }
+
+    func testServerErrorWithoutCachedIdentityRoutesToAuth() {
+        XCTAssertEqual(
+            OfflineAuth.outcome(for: APIError(status: 503, message: "Unavailable"), hasCachedIdentity: false),
+            .signedOut(.serverError)
+        )
+    }
+
+    // MARK: - One taxonomy, shared with the widget (#676)
+
+    /// The app must never sign the user out on a cause that #676 already decided is
+    /// too weak to wipe the widget's snapshot. Locking the two together here is what
+    /// stops a second convention from appearing later.
+    func testRoutingAgreesWithWidgetSnapshotClearing() {
+        let causes: [WidgetDataStore.SignedOutCause] = [.signedOut, .unauthorized, .serverError, .unreachable]
+        let errors: [Error] = [
+            APIError(status: 401, message: "Unauthorized"),
+            APIError(status: 500, message: "Boom"),
+            APIError(status: 0, message: "No internet connection"),
+            URLError(.notConnectedToInternet),
+        ]
+
+        for error in errors {
+            let outcome = OfflineAuth.outcome(for: error, hasCachedIdentity: true)
+            XCTAssertEqual(
+                outcome.usesCachedIdentity,
+                !WidgetDataStore.shouldClearStoredSnapshot(on: outcome.cause),
+                "Routing and snapshot-clearing disagreed for \(error)"
+            )
+        }
+
+        // The `.signedOut` cause has no error to classify (it is `me()` returning
+        // nil), but it must remain destructive.
+        XCTAssertTrue(WidgetDataStore.shouldClearStoredSnapshot(on: .signedOut))
+        XCTAssertEqual(causes.count, 4, "A new cause needs a routing decision here")
+    }
+
+    func testCauseMapping() {
+        XCTAssertEqual(OfflineAuth.cause(for: APIError(status: 401, message: "x")), .unauthorized)
+        XCTAssertEqual(OfflineAuth.cause(for: APIError(status: 403, message: "x")), .serverError)
+        XCTAssertEqual(OfflineAuth.cause(for: APIError(status: 500, message: "x")), .serverError)
+        XCTAssertEqual(OfflineAuth.cause(for: APIError(status: 0, message: "x")), .unreachable)
+        XCTAssertEqual(OfflineAuth.cause(for: URLError(.cannotFindHost)), .unreachable)
+        XCTAssertEqual(OfflineAuth.cause(for: URLError(.dnsLookupFailed)), .unreachable)
+    }
+}

--- a/ios/StillPointShared/Tests/StillPointSharedTests/SessionSyncCoordinatorClearQueueTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/SessionSyncCoordinatorClearQueueTests.swift
@@ -8,7 +8,9 @@ import XCTest
 /// before that cleanup runs, and because the coordinator is an actor the cleanup
 /// can be stuck waiting on an in-flight `flushPending` the whole time. These cover
 /// that ordering for both the next-account and same-account cases.
-final class SessionSyncCoordinatorTests: XCTestCase {
+/// Named for the method under test: `SessionSyncCoordinatorTests` already exists in
+/// `OfflineSessionQueueTests.swift` and a second declaration breaks the test target.
+final class SessionSyncCoordinatorClearQueueTests: XCTestCase {
     private func makeEntry(owner: String, enqueuedAt: Date = Date()) -> PendingSessionEntry {
         let clientSessionId = UUID()
         return PendingSessionEntry(
@@ -93,6 +95,28 @@ final class SessionSyncCoordinatorTests: XCTestCase {
         try await coordinator.clearQueue(ownerUserId: "", enqueuedBefore: logoutBoundary)
 
         XCTAssertEqual(try store.loadEntries().count, 1)
+    }
+
+    /// A row persisted before `enqueuedAt` existed decodes to `.distantPast`, so it
+    /// counts as pre-existing and its owner's sign-out can actually remove it.
+    /// Defaulting that decode to `Date()` would make it outlive every logout.
+    func testLegacyEntryWithoutEnqueuedAtIsTreatedAsPreExisting() async throws {
+        // Round-trips the real encoder with the key removed, rather than a
+        // hand-written fixture, so this cannot drift from the entry's coding shape.
+        // The source entry is deliberately stamped *after* the boundary: absent the
+        // key the decoded value must still come back as pre-existing.
+        let encoded = try JSONEncoder().encode([makeEntry(owner: "user-a", enqueuedAt: afterLogout)])
+        var objects = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [[String: Any]])
+        objects[0].removeValue(forKey: "enqueuedAt")
+        let stripped = try JSONSerialization.data(withJSONObject: objects)
+
+        let decoded = try JSONDecoder().decode([PendingSessionEntry].self, from: stripped)
+        XCTAssertEqual(decoded.first?.enqueuedAt, .distantPast)
+
+        let (coordinator, store) = makeCoordinator(decoded)
+        try await coordinator.clearQueue(ownerUserId: "user-a", enqueuedBefore: logoutBoundary)
+
+        XCTAssertTrue(try store.loadEntries().isEmpty)
     }
 
     /// Legacy rows decoded without an owner are left alone rather than swept up by

--- a/ios/StillPointShared/Tests/StillPointSharedTests/SessionSyncCoordinatorTests.swift
+++ b/ios/StillPointShared/Tests/StillPointSharedTests/SessionSyncCoordinatorTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+@testable import StillPointShared
+
+/// #665: logout's queue cleanup must not take a later sign-in's sits with it.
+///
+/// `didLogout()` tears the session down and routes to `.auth` synchronously, then
+/// schedules the queue cleanup. The user can therefore sign in — and save a sit —
+/// before that cleanup runs, and because the coordinator is an actor the cleanup
+/// can be stuck waiting on an in-flight `flushPending` the whole time. These cover
+/// that ordering for both the next-account and same-account cases.
+final class SessionSyncCoordinatorTests: XCTestCase {
+    private func makeEntry(owner: String, enqueuedAt: Date = Date()) -> PendingSessionEntry {
+        let clientSessionId = UUID()
+        return PendingSessionEntry(
+            clientSessionId: clientSessionId,
+            ownerUserId: owner,
+            request: CreateSessionRequest(
+                dayNumber: 1,
+                duration: 60,
+                completed: true,
+                actualTime: 60,
+                clearPercent: 50,
+                thoughtCount: 0,
+                mindStateLog: [],
+                sessionDate: "2026-08-27",
+                clientSessionId: clientSessionId
+            ),
+            thoughts: [],
+            enqueuedAt: enqueuedAt
+        )
+    }
+
+    private func makeCoordinator(
+        _ entries: [PendingSessionEntry]
+    ) -> (SessionSyncCoordinator, InMemoryOfflineSessionQueueStore) {
+        let store = InMemoryOfflineSessionQueueStore(entries: entries)
+        return (SessionSyncCoordinator(queueStore: store, transport: .alwaysFailing), store)
+    }
+
+    private let logoutBoundary = Date()
+    private var beforeLogout: Date { logoutBoundary.addingTimeInterval(-60) }
+    private var afterLogout: Date { logoutBoundary.addingTimeInterval(60) }
+
+    /// Sign out as A, sign in as B, B saves a sit, then A's deferred cleanup lands.
+    func testClearQueueKeepsEntriesBelongingToTheNextAccount() async throws {
+        let signedOut = makeEntry(owner: "user-a", enqueuedAt: beforeLogout)
+        let nextLogin = makeEntry(owner: "user-b", enqueuedAt: afterLogout)
+        let (coordinator, store) = makeCoordinator([signedOut, nextLogin])
+
+        try await coordinator.clearQueue(ownerUserId: "user-a", enqueuedBefore: logoutBoundary)
+
+        let remaining = try store.loadEntries()
+        XCTAssertEqual(remaining.count, 1)
+        XCTAssertEqual(remaining.first?.clientSessionId, nextLogin.clientSessionId)
+    }
+
+    /// The same-account ordering: sign out as A, sign back in as A, save a sit, then
+    /// the deferred cleanup lands. Owner scoping alone would delete the new sit
+    /// because the owner id is identical — the logout boundary is what saves it.
+    func testClearQueueKeepsSitsSavedAfterSigningBackInAsTheSameAccount() async throws {
+        let staleSit = makeEntry(owner: "user-a", enqueuedAt: beforeLogout)
+        let sitAfterSigningBackIn = makeEntry(owner: "user-a", enqueuedAt: afterLogout)
+        let (coordinator, store) = makeCoordinator([staleSit, sitAfterSigningBackIn])
+
+        try await coordinator.clearQueue(ownerUserId: "user-a", enqueuedBefore: logoutBoundary)
+
+        let remaining = try store.loadEntries()
+        XCTAssertEqual(remaining.count, 1)
+        XCTAssertEqual(remaining.first?.clientSessionId, sitAfterSigningBackIn.clientSessionId)
+    }
+
+    func testClearQueueRemovesEveryPriorSitForTheSignedOutAccount() async throws {
+        let (coordinator, store) = makeCoordinator([
+            makeEntry(owner: "user-a", enqueuedAt: beforeLogout),
+            makeEntry(owner: "user-a", enqueuedAt: beforeLogout),
+            makeEntry(owner: "user-b", enqueuedAt: beforeLogout)
+        ])
+
+        try await coordinator.clearQueue(ownerUserId: "user-a", enqueuedBefore: logoutBoundary)
+
+        let remaining = try store.loadEntries()
+        XCTAssertEqual(remaining.count, 1)
+        XCTAssertEqual(remaining.first?.ownerUserId, "user-b")
+    }
+
+    /// An unattributable owner id must not degrade into the blanket wipe this
+    /// scoping replaced.
+    func testClearQueueWithEmptyOwnerIsANoOp() async throws {
+        let (coordinator, store) = makeCoordinator([
+            makeEntry(owner: "user-a", enqueuedAt: beforeLogout)
+        ])
+
+        try await coordinator.clearQueue(ownerUserId: "", enqueuedBefore: logoutBoundary)
+
+        XCTAssertEqual(try store.loadEntries().count, 1)
+    }
+
+    /// Legacy rows decoded without an owner are left alone rather than swept up by
+    /// an unrelated account's sign-out.
+    func testClearQueueLeavesLegacyOwnerlessEntriesAlone() async throws {
+        let (coordinator, store) = makeCoordinator([
+            makeEntry(owner: "", enqueuedAt: beforeLogout),
+            makeEntry(owner: "user-a", enqueuedAt: beforeLogout)
+        ])
+
+        try await coordinator.clearQueue(ownerUserId: "user-a", enqueuedBefore: logoutBoundary)
+
+        let remaining = try store.loadEntries()
+        XCTAssertEqual(remaining.count, 1)
+        XCTAssertEqual(remaining.first?.ownerUserId, "")
+    }
+}


### PR DESCRIPTION
## **User description**
Opening Still Point without a network logged you out. The cold-start `me()` call was treated as a precondition for *being signed in*, so any failed request — plane, subway, dead zone, flaky wifi — dropped you on the sign-in screen with "Connection failed. Please try again." Your day count, your streak, your settings, all behind a network call that just failed. The one place a meditation app is most useful is exactly where it stopped working.

Internet is now required for one thing only: syncing. A failed request is no longer read as a sign-out.

## What changed

**One taxonomy, not two.** PR #676 already established the principle on the widget side: only a real sign-out or a 401 may clear the App Group snapshot; a transport failure never does. `OfflineAuth` (new, in `StillPointShared`) applies the same rule to the app, in the same vocabulary — `WidgetDataStore.SignedOutCause` — and reuses `WidgetDataStore.shouldClearStoredSnapshot(on:)` as the single predicate for "is this cause authoritative enough to destroy local state?". A test locks the two together so a second convention can't appear later.

Only an HTTP 401 counts as proof the session is over — it is the one answer that came *from the server* and was *about auth*. A response-less failure is `.unreachable`, which covers both a real `URLError` and the `APIError(status: 0)` that `UITestAPIStore` uses to model a dead network. Anything else the server said, or any answer we couldn't parse, is `.serverError`. The asymmetry is deliberate: wrongly deciding "offline" costs a 401 on the next request; wrongly deciding "signed out" destroys local state, which is the bug being fixed.

**The identity is persisted locally.** `CachedIdentityStore` saves the authenticated `UserDTO` on every successful `me()`. It lives in the **App Group container the widget already reads**, per the issue's decision — the widget snapshot is this codebase's existing "trust local state, reconcile later" precedent, and putting identity beside it keeps one local source of truth rather than two that drift. The session **token** stays in the Keychain (`AuthTokenStore`); only the non-secret identity payload goes to the App Group. It is cleared by `APIClient.clearPersistedSessionArtifacts`, which covers sign-out (including an offline sign-out — `logout()` clears in a `defer`), account deletion, and UI-test reset launches in one place.

**`checkAuth()` is now a thin switch** over that decision. A transport or 5xx failure hydrates `currentUser` from the local copy and routes to the normal authenticated view; a 401 still routes to `.auth` and clears the cached identity. The sign-out teardown (`trackingControlPrefsManager.clearOnLogout()`, the per-account unlock reset) used to run on *every* failure path — it is now gated on the same predicate, so a dropped connection no longer wipes state the server never contradicted.

**Reconnect reconciles in place.** `refreshAfterReconnect()` refreshes identity and today's state without re-routing: re-running `checkAuth()` there would flash the cold-start overlay and send the user back to Home, which is the exact user-visible reset offline-first exists to avoid (and would eject someone mid-sit). Only an authoritative rejection moves anyone to sign-in. The queued-sit upload is the other half and already exists — `NetworkReachabilityMonitor` flushes the write queue on the same transition (#557).

**The indicator is not an error.** An amber `OFFLINE · SAVED PROGRESS` strip sits above the tab content while the app runs from cached state and clears on the next successful `me()`. Scoped to the tabbed shell on purpose: an active sit stays free of chrome.

One performance note worth calling out: the offline launch path never `await`s a request already known to be failing. `checkAuth`'s `defer` only drops the cold-start overlay once it returns, so on flaky wifi (as opposed to Airplane Mode, which fails instantly) a blocking call would have held the launch for a full URLSession timeout. The badge refresh is fire-and-forget.

## Pattern notes for issue #666 (web PWA)

`OfflineAuth` and `CachedIdentityStore` are pure and platform-free by design; a TypeScript mirror needs the same three parts:

1. **A classifier** that treats only an HTTP 401 as proof the session is over, and everything else — network error, timeout, 5xx, unparseable body — as non-authoritative.
2. **One shared predicate** deciding whether a cause may destroy local state, used by *every* consumer (routing, the cached identity, any local snapshot). Not a copy per call site.
3. **An outcome** that keeps the user signed in from a cached identity whenever that predicate says no and a cached identity exists — and falls back to sign-in when there is nothing cached to render.

The routing rule generalizes cleanly: the app's auth bootstrap (`src/app/app/[[...tab]]/page.tsx`) should hydrate from its local copy rather than bouncing to sign-in, and sign-out teardown should be gated on the same predicate rather than on "the request failed".

## Deliberate trade-offs

- **Stale cached identity.** An identity older than the server session means the user sits offline happily and then hits a 401 on reconnect, at which point the cache is cleared and they sign in. Accepted per the issue, and strictly better than the behavior it replaces: being signed out at the moment of *losing* the network rather than the moment of regaining it.
- **A 5xx keeps you signed in too**, not just a transport failure. The AC names connection/timeout, but routing follows the shared predicate exactly — and #676 already decided a 500 must not wipe the widget's week. A server that answers with garbage is no more evidence you're signed out than one that doesn't answer.
- **Push registration and the buddy-invite handoff are skipped on the offline path** — both are network-bound, and consuming a pending invite there would burn the token on a request that cannot succeed. `refreshAfterReconnect()` picks up both.

## Test plan

- [x] Unit: a stubbed transport error (`URLError`) with a cached identity resolves to `.offline(.unreachable)` and does **not** route to `.auth` — `OfflineAuthTests.testTransportErrorWithCachedIdentityStaysSignedIn`, plus timeout and connection-lost variants. `checkAuth()` is a thin switch over this decision; the decision lives in `StillPointShared` because the app target is Xcode-only and unreachable from `swift test`.
- [x] Unit: a stubbed `401 TOKEN_EXPIRED` still resolves to `.signedOut(.unauthorized)` even with a cached identity — `OfflineAuthTests.testTokenExpiredRoutesToAuthEvenWithCachedIdentity`.
- [x] Unit: a 401 clears the cached identity; `.unreachable` and `.serverError` do not — `CachedIdentityStoreTests.testUnauthorizedClearsCachedIdentity`, `testUnreachableKeepsCachedIdentity`, `testServerErrorKeepsCachedIdentity`. This is the same `false` that gates `trackingControlPrefsManager.clearOnLogout()` in `applySignedOut`, so the AC about the logout teardown not firing on a transport failure follows from it.
- [x] Unit: `APIError(status: 0)` — how the UI-test backend models a dead network — classifies as `.unreachable`, not `.serverError` — `OfflineAuthTests.testResponselessAPIErrorIsTransportNotServerError`.
- [x] Unit: with no cached identity, a transport failure still routes to sign-in (first launch in a dead zone) — `OfflineAuthTests.testTransportErrorWithoutCachedIdentityRoutesToAuth`.
- [x] Unit: routing agrees with `WidgetDataStore.shouldClearStoredSnapshot(on:)` for every cause, and cached-identity clearing matches the same predicate — `OfflineAuthTests.testRoutingAgreesWithWidgetSnapshotClearing`, `CachedIdentityStoreTests.testClearingMatchesWidgetSnapshotPredicate`. These are the guards against a second convention.
- [x] Unit: `UserDTO` round-trips through the App Group store with every field intact — day number, dual-track fork and recovery ramp included, since those drive what an offline sit *is* — and a corrupt payload loads as nil rather than throwing — `CachedIdentityStoreTests`.
- [x] Unit: clearing the cached identity leaves the widget's snapshot key untouched, since both live in the same container — `CachedIdentityStoreTests.testClearingIdentityLeavesWidgetSnapshotKeyUntouched`.
- [x] Regression, online launch unchanged: the success path is byte-for-byte the prior sequence with `currentUser = user` replaced by `applyAuthenticatedUser(user)` (same assignment, plus a local write) — no new `await` before `return`, so cold-start latency is unchanged. Every other `currentUser` assignment routes through the same helper, so a real account switch overwrites the cached identity rather than layering on it (`testSaveOverwritesPriorIdentity`).
- [x] Regression, offline launch with nothing cached: `resetStore` now also clears the cached identity, so `testLaunchOfflineShowsUserVisibleMessage` still asserts the correct behavior — sign-in with a connection message — for a launch that genuinely has no idea who the user is.
- [x] CI: `StillPointShared swift test` passes (the required check; this PR touches the package, so the real suite runs, not the no-op).

## Post-merge verification

Tracking issue: #695

The following need a real device with a real radio and cannot be exercised by a test runner or in-session on this machine (CommandLineTools only — no Simulator, no device); the iOS UI-test lane also runs on the TestFlight gate rather than on PRs.

- Cold launch in Airplane Mode lands on Home with the correct day number, and a full sit can be started, completed and saved. — DEVICE-MANUAL
- Re-enabling the network shows the sit in history and on the widget. — DEVICE-MANUAL
- The offline indicator appears while offline and clears on reconnect with no screen reset. — DEVICE-MANUAL
- Explicit sign-out while offline reaches the sign-in screen with the cached identity cleared. — DEVICE-MANUAL
- Reconnecting on an identity whose server session has since expired routes to sign-in at that point. — DEVICE-MANUAL

## Local review coverage

**Local review coverage:** none

- **CodeRabbit CLI** — one verified-successful run, which raised one `major` finding: the offline path awaited `refreshTracksDoneToday()` before returning, holding the cold-start overlay behind a request already known to be failing. Fixed (the badge refresh is now fire-and-forget after the snapshot is written). The follow-up verification pass hit `rate_limit: Rate limit exceeded` twice, so no clean pass was recorded.
- **CodeAnt CLI** — `403 Access denied` on both attempts (the undocumented daily cap; no `logout`/`login` was run). Dropped for the session.
- Substituted a self-review plus a scratch SwiftPM harness: `swift test` cannot run on this machine at all (no Xcode.app, so the SwiftData macro plugin and `XCTest` are both unavailable). The harness compiles the real package minus its three SwiftData model files and runs 56 assertions mirroring the new XCTest cases — all passing — and compile-checks the exact `switch` shape `checkAuth()` uses. CI's `StillPointShared swift test` remains the gate.

Closes #665

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added offline mode support with a clear status banner across the app.
  * Preserved signed-in access using cached identity when connectivity is unavailable.
  * Automatically refreshes account information after reconnecting.

* **Bug Fixes**
  * Prevented delayed account and settings updates from affecting the wrong session after sign-out or account changes.
  * Improved authentication failure handling and offline startup behavior.
  * Limited logout cleanup to the signed-out account’s eligible queued sessions.

* **Tests**
  * Added coverage for cached identity storage, offline authentication, and session cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Keep users signed in and their meditation progress available during network outages

### What Changed
- App launches with saved identity and progress when the network is unavailable instead of sending users to sign-in
- An amber “OFFLINE · SAVED PROGRESS” indicator explains that sessions continue and upload after reconnecting
- Reconnection refreshes identity and today’s progress in place without resetting tabs or interrupting an active session
- Only a confirmed sign-out or HTTP 401 clears cached identity; connection failures and server errors preserve local state
- Settings changes, buddy invites, session updates, and background refreshes no longer apply results to a different account after sign-out or account switching
- Logout cleanup removes only the signed-out account’s older queued sessions, preserving sessions saved after the next login
- Added coverage for cached identity recovery, offline routing, stale responses, and account-safe queue cleanup

### Impact
`✅ Continued meditation access without internet`
`✅ Saved progress preserved through connection failures`
`✅ Fewer accidental sign-outs and stale account updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
