### PR TITLE
feat(web): stay signed in when the network drops (#666)

### DIFF
--- a/e2e/web/offline-pwa.spec.ts
+++ b/e2e/web/offline-pwa.spec.ts
@@ -1,0 +1,165 @@
+import { test, expect } from "../fixtures/auth.fixture";
+import { OFFLINE_IDB_NAME, OFFLINE_IDB_STORE } from "../../src/lib/offlineSessionQueue/constants";
+import { tap, tapWithControlReveal } from "../utils/mobile-helpers";
+
+/**
+ * #666 — the installed web app has to be usable with no connection: a reload
+ * lands on the normal view from the cached identity, a full sit runs and queues,
+ * and reconnecting syncs it and clears the indicator.
+ *
+ * **How "offline" is simulated.** The auth fixture serves the whole API from
+ * `page.route`, which intercepts *before* the network — so `setOffline(true)`
+ * alone would leave the mocked API answering happily. Offline here is therefore
+ * two things at once: `context.setOffline(true)` (so `navigator.onLine` is false
+ * and the document/asset fetches go through the service worker) and an API
+ * abort switch (so `/api/**` rejects with a genuine transport error, which is
+ * what `resolveAuthBootstrap` classifies as `unreachable`). Both flip back
+ * together on reconnect.
+ */
+
+/** Route-level kill switch for the mocked API, layered over the auth fixture. */
+async function installApiOfflineSwitch(page: import("@playwright/test").Page) {
+  const state = { offline: false };
+  // Registered after the fixture's own handler, so Playwright runs this one
+  // first and can abort before the mock replies.
+  await page.route("**/api/**", async (route) => {
+    if (state.offline) return route.abort("internetdisconnected");
+    return route.fallback();
+  });
+  return {
+    goOffline: async () => {
+      state.offline = true;
+      await page.context().setOffline(true);
+    },
+    goOnline: async () => {
+      state.offline = false;
+      await page.context().setOffline(false);
+    },
+  };
+}
+
+/** Wait until the service worker actually controls the page, so a reload with
+ *  the network off is served from the precached app shell rather than failing. */
+async function waitForServiceWorkerControl(page: import("@playwright/test").Page) {
+  await page.waitForFunction(async () => {
+    if (!("serviceWorker" in navigator)) return false;
+    const registration = await navigator.serviceWorker.getRegistration("/");
+    return Boolean(registration?.active) && Boolean(navigator.serviceWorker.controller);
+  }, undefined, { timeout: 20_000 });
+}
+
+function readQueuedSessions(page: import("@playwright/test").Page, dbName: string, storeName: string) {
+  return page.evaluate(
+    ([name, store]) =>
+      new Promise<Array<Record<string, unknown>>>((resolve, reject) => {
+        const open = indexedDB.open(name);
+        open.onerror = () => reject(open.error ?? new Error("open failed"));
+        open.onsuccess = () => {
+          const db = open.result;
+          if (!db.objectStoreNames.contains(store)) {
+            db.close();
+            resolve([]);
+            return;
+          }
+          const request = db.transaction(store, "readonly").objectStore(store).getAll();
+          request.onsuccess = () => {
+            const rows = request.result as Array<Record<string, unknown>>;
+            db.close();
+            resolve(rows);
+          };
+          request.onerror = () => {
+            db.close();
+            reject(request.error ?? new Error("getAll failed"));
+          };
+        };
+      }),
+    [dbName, storeName] as const,
+  );
+}
+
+test.describe("offline-first web PWA", () => {
+  test("@critical reload with no connection lands on the app, not an auth error", async ({
+    page,
+    ensureLoggedIn,
+    mockApiState,
+  }) => {
+    const network = await installApiOfflineSwitch(page);
+    await ensureLoggedIn();
+    await waitForServiceWorkerControl(page);
+
+    // The signed-in day number the offline view has to reproduce.
+    const expectedDay = mockApiState.user.currentDay;
+    await expect(page.getByText(new RegExp(`Day\\s*${expectedDay}\\b`, "i")).first()).toBeVisible();
+
+    await network.goOffline();
+    await page.reload();
+
+    // The normal app, from cache — no sign-in screen, no "Unable to verify".
+    await expect(page.getByRole("button", { name: "Begin" })).toBeVisible();
+    await expect(page.getByText(new RegExp(`Day\\s*${expectedDay}\\b`, "i")).first()).toBeVisible();
+    await expect(page.getByText(/unable to verify your sign-in/i)).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /sign up/i })).toHaveCount(0);
+
+    // ...with the indicator up while it runs from the local copy.
+    await expect(page.getByTestId("offline-indicator")).toBeVisible();
+    await expect(page.getByTestId("offline-indicator")).toContainText(/offline/i);
+  });
+
+  test("a full sit completes offline, queues, and syncs on reconnect", async ({
+    page,
+    ensureLoggedIn,
+    mockApiState,
+  }) => {
+    const network = await installApiOfflineSwitch(page);
+    await ensureLoggedIn();
+    await waitForServiceWorkerControl(page);
+
+    await network.goOffline();
+    await page.reload();
+    await expect(page.getByTestId("offline-indicator")).toBeVisible();
+
+    // A whole sit, start to saved, with nothing reachable.
+    await tap(page.getByRole("button", { name: "Begin" }));
+    await tapWithControlReveal(page, page.getByRole("button", { name: /end early/i }));
+    await expect(page.getByRole("heading", { name: /Complete/i })).toBeVisible();
+
+    // It went to the offline queue rather than being lost.
+    await expect
+      .poll(async () => (await readQueuedSessions(page, OFFLINE_IDB_NAME, OFFLINE_IDB_STORE)).length)
+      .toBeGreaterThan(0);
+    expect(mockApiState.sessions.length, "nothing reached the server while offline").toBe(0);
+
+    await tap(page.getByRole("button", { name: "Return" }));
+
+    // Back online: the queue drains, and the indicator clears on its own once
+    // the bootstrap re-runs successfully — no reload, no sign-in flash.
+    await network.goOnline();
+    await page.evaluate(() => window.dispatchEvent(new Event("online")));
+
+    await expect
+      .poll(async () => (await readQueuedSessions(page, OFFLINE_IDB_NAME, OFFLINE_IDB_STORE)).length)
+      .toBe(0);
+    expect(mockApiState.sessions.length, "the queued sit reached the server").toBeGreaterThan(0);
+    await expect(page.getByTestId("offline-indicator")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Begin" })).toBeVisible();
+  });
+
+  test("a rejected session still signs you out, unlike a dead network", async ({
+    page,
+    ensureLoggedIn,
+    mockApiState,
+  }) => {
+    await ensureLoggedIn();
+
+    // A real 401 from the server — the one answer that proves the session is over.
+    mockApiState.authenticated = false;
+    await page.reload();
+
+    await expect(page.getByRole("button", { name: /sign up/i })).toBeVisible();
+    await expect(page.getByTestId("offline-indicator")).toHaveCount(0);
+    expect(
+      await page.evaluate(() => localStorage.getItem("stillpoint_cached_user_v1")),
+      "an authoritative rejection clears the cached identity",
+    ).toBeNull();
+  });
+});

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -241,7 +241,15 @@ export default function StillPoint() {
   const [buddyInviteError, setBuddyInviteError] = useState<string | null>(null);
   const [buddyCalendarMessage, setBuddyCalendarMessage] = useState<string | null>(null);
   const buddyInviteInFlight = useRef(false);
-  const loginRefreshCancelled = useRef(false);
+  // #666: monotonic session generation. Every async path that adopts a user
+  // captures the generation it started in and drops its result if a sign-out —
+  // or a *different* sign-in — happened in the meantime. A plain "cancelled"
+  // boolean is not enough here: it resets on the next login, so a callback from
+  // the previous session could still land and be adopted as the new one.
+  // Without this the cache effect below would not merely repopulate React state
+  // after a logout, it would persist the signed-out account as the offline
+  // identity, surviving a reload.
+  const sessionGeneration = useRef(0);
   const isMobile = useIsMobile();
   // #666: running the app from the locally cached identity because the server
   // could not be reached. Only a *successful* `/api/auth/me` clears it, mirroring
@@ -256,19 +264,39 @@ export default function StillPoint() {
     resetTrackingUnlockOnLogout();
   };
 
+  // #666: re-read the user from the server after an action that moves account
+  // state (a completed sit advancing the day number, say). The result is dropped
+  // if the session changed while the request was in flight — see
+  // `sessionGeneration`. One helper rather than three copies of the guard, so a
+  // future call site cannot adopt a user without it.
+  const refreshUserFromServer = useCallback(() => {
+    const generation = sessionGeneration.current;
+    void api
+      .me()
+      .then(({ user: u }) => {
+        if (generation === sessionGeneration.current) setUser(u);
+      })
+      .catch(() => {});
+  }, []);
+
   // #666: the single place a server-confirmed user reaches the local copy that
   // survives a reload with no network — the web analogue of the iOS
   // `applyAuthenticatedUser`. An effect rather than a call at each `setUser`
   // site, so every adoption path (bootstrap, sign-in, settings PATCH, buddy
   // completion) keeps the cache tracking the account without a call site being
   // able to forget. Sign-out paths set `user` to null and clear the cache
-  // explicitly, so this never resurrects a signed-out identity.
+  // explicitly; every *asynchronous* adoption is gated on `sessionGeneration`
+  // above, so a response still in flight when the user signs out cannot reach
+  // this effect and resurrect a signed-out identity.
   useEffect(() => {
     if (user) saveCachedUser(user);
   }, [user]);
 
   useEffect(() => {
     let cancelled = false;
+    // The reconnect path re-runs this effect on a live, signed-in screen, so a
+    // sign-out can land between the request and its response (#666).
+    const generation = sessionGeneration.current;
 
     /** Apply a failed `me()` through the shared offline-auth decision (#666). */
     function applyFailure(failure: MeFailure) {
@@ -317,7 +345,7 @@ export default function StillPoint() {
           const data = await res.json();
           // Re-checked after the second await: an unmount between the response
           // and its body must not adopt a user or write the cache.
-          if (cancelled) return;
+          if (cancelled || generation !== sessionGeneration.current) return;
           const freshUser = data?.user ?? null;
           if (freshUser) {
             setUser(freshUser);
@@ -354,6 +382,28 @@ export default function StillPoint() {
     if (!isOnline || !runningFromCache) return;
     setAuthRetryKey((prev) => prev + 1);
   }, [isOnline, runningFromCache]);
+
+  // #666: `navigator.onLine` reports link state, not reachability, so the
+  // transition above never fires for the failures that leave it pinned at
+  // true — a captive portal, a DNS failure, a 5xx. Those sessions would hold the
+  // offline strip until a manual reload. Re-checking when the user returns to
+  // the tab covers them without polling: it is user-driven so it cannot spin,
+  // and coming back to the app is exactly when a stale day number would show.
+  // Only while running from cache, for the same reason as above. A double fire
+  // (visibility *and* focus) is harmless — the bootstrap effect's cleanup
+  // cancels the superseded request.
+  useEffect(() => {
+    if (!runningFromCache) return;
+    const recheck = () => {
+      if (document.visibilityState === "visible") setAuthRetryKey((prev) => prev + 1);
+    };
+    document.addEventListener("visibilitychange", recheck);
+    window.addEventListener("focus", recheck);
+    return () => {
+      document.removeEventListener("visibilitychange", recheck);
+      window.removeEventListener("focus", recheck);
+    };
+  }, [runningFromCache]);
 
   // Redirect legacy `?view=` deep links and unknown tab slugs to their routes.
   useEffect(() => {
@@ -468,22 +518,26 @@ export default function StillPoint() {
     // Intentionally do not navigate: keep the current URL so deep-link state
     // (e.g. /app?buddy=<token> or a deep-linked tab) survives sign-in and the
     // buddy-invite / ?view= effects below can still consume it.
-    loginRefreshCancelled.current = false;
+    sessionGeneration.current += 1;
+    const generation = sessionGeneration.current;
     setUser(userData);
     setOverlay(null);
     // #238: login returns raw DB fields; missed-day gap detection only runs in
     // GET /api/auth/me. Re-fetch silently so a returning user with a 2+ day gap
     // enters the recovery ramp before their first sit of this session.
-    // Guard with loginRefreshCancelled so a slow response can't repopulate user
+    // Guard on the session generation so a slow response can't repopulate user
     // state after an explicit logout before the /api/auth/me response arrives.
     void fetch(`/api/auth/me?date=${todayLocalIsoDate()}`)
       .then((r) => (r.ok ? r.json() : null))
-      .then((data) => { if (!loginRefreshCancelled.current && data?.user) setUser(data.user); })
+      .then((data) => {
+        if (generation === sessionGeneration.current && data?.user) setUser(data.user);
+      })
       .catch(() => {});
   };
 
   const handleLogout = () => {
-    loginRefreshCancelled.current = true;
+    // Invalidates every user adoption already in flight (#666).
+    sessionGeneration.current += 1;
     buddyInviteInFlight.current = false;
     setBuddySessionId(null);
     setBuddyCalendarMessage(null);
@@ -530,7 +584,9 @@ export default function StillPoint() {
   }, []);
 
   const handleEnableDualTrack = useCallback(async () => {
+    const generation = sessionGeneration.current;
     const { user: updated } = await api.enableDualTrack();
+    if (generation !== sessionGeneration.current) return;
     setUser(updated);
     void refreshTodayTracks();
   }, [refreshTodayTracks]);
@@ -568,12 +624,9 @@ export default function StillPoint() {
       nextDuration: previewNextStandardDuration("standard", true, "primary", user),
     });
     setOverlay("complete");
-    void api
-      .me()
-      .then(({ user: u }) => setUser(u))
-      .catch(() => {});
+    refreshUserFromServer();
     void refreshTodayTracks();
-  }, [user, refreshTodayTracks]);
+  }, [user, refreshTodayTracks, refreshUserFromServer]);
 
   const handleSessionComplete = useCallback(async (data: {
     dayNumber: number;
@@ -617,10 +670,7 @@ export default function StillPoint() {
         isPendingSync = result.isPendingSync;
 
         if (data.completed && data.sessionType === "standard" && !isPendingSync) {
-          void api
-            .me()
-            .then(({ user: u }) => setUser(u))
-            .catch(() => {});
+          refreshUserFromServer();
           void refreshTodayTracks();
         } else if (data.completed && data.sessionType === "standard" && isPendingSync) {
           void refreshTodayTracks();
@@ -647,7 +697,7 @@ export default function StillPoint() {
       nextDuration: previewNextStandardDuration(data.sessionType, data.completed, data.track, user),
     });
     setOverlay("complete");
-  }, [user, refreshTodayTracks]);
+  }, [user, refreshTodayTracks, refreshUserFromServer]);
 
   const handleSessionAbandon = useCallback(async (data: {
     dayNumber: number;
@@ -1003,10 +1053,7 @@ export default function StillPoint() {
           onReturn={() => {
             setOverlay(null);
             router.push(pathForTab(DEFAULT_TAB));
-            void api
-              .me()
-              .then(({ user: u }) => setUser(u))
-              .catch(() => {});
+            refreshUserFromServer();
           }}
           onSaveNote={completionData.clientSessionId && user ? async (text: string) => {
             const coordinator = getWebSessionSyncCoordinator();

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -16,6 +16,10 @@ import { FriendsView } from "@/components/FriendsView";
 import { BuddySessionHub } from "@/components/BuddySessionHub";
 import { BuddySessionRoom, type BuddyPersonalRecordPayload } from "@/components/BuddySessionRoom";
 import { useIsMobile } from "@/lib/useIsMobile";
+import { useOnlineStatus } from "@/lib/useOnlineStatus";
+import { OfflineIndicator } from "@/components/OfflineIndicator";
+import { clearCachedUser, clearCachedUserIfAuthoritative, loadCachedUser, saveCachedUser } from "@/lib/cachedUser";
+import { authErrorMessageFor, resolveAuthBootstrap, type MeFailure } from "@/lib/offlineAuth";
 import { api, ApiError } from "@/lib/api";
 import type { SessionType, Track } from "@/lib/constants";
 import { advanceProgression, advanceSecondTrackDay, isDualTrackEligible, sessionDurationForUser, type RecoveryFields } from "@/lib/duration";
@@ -239,6 +243,12 @@ export default function StillPoint() {
   const buddyInviteInFlight = useRef(false);
   const loginRefreshCancelled = useRef(false);
   const isMobile = useIsMobile();
+  // #666: running the app from the locally cached identity because the server
+  // could not be reached. Only a *successful* `/api/auth/me` clears it, mirroring
+  // the iOS `isOfflineMode` — `navigator.onLine` reports link state, not
+  // reachability, so it prompts a re-check and never concludes one.
+  const [runningFromCache, setRunningFromCache] = useState(false);
+  const isOnline = useOnlineStatus();
 
   const clearAccountScopedLocalState = () => {
     setTracksDoneToday({ primary: false, second: false });
@@ -246,8 +256,57 @@ export default function StillPoint() {
     resetTrackingUnlockOnLogout();
   };
 
+  // #666: the single place a server-confirmed user reaches the local copy that
+  // survives a reload with no network — the web analogue of the iOS
+  // `applyAuthenticatedUser`. An effect rather than a call at each `setUser`
+  // site, so every adoption path (bootstrap, sign-in, settings PATCH, buddy
+  // completion) keeps the cache tracking the account without a call site being
+  // able to forget. Sign-out paths set `user` to null and clear the cache
+  // explicitly, so this never resurrects a signed-out identity.
+  useEffect(() => {
+    if (user) saveCachedUser(user);
+  }, [user]);
+
   useEffect(() => {
     let cancelled = false;
+
+    /** Apply a failed `me()` through the shared offline-auth decision (#666). */
+    function applyFailure(failure: MeFailure) {
+      const cachedUser = loadCachedUser();
+      const outcome = resolveAuthBootstrap(failure, cachedUser !== null);
+
+      // Matching on the pair keeps the cached user's presence and the outcome
+      // from drifting apart: without an identity to render there is nothing to
+      // fall back to, whatever the outcome says.
+      if (outcome.action === "offline" && cachedUser) {
+        setUser(cachedUser);
+        setRunningFromCache(true);
+        setAuthError(null);
+        setAuthChecked(true);
+        return;
+      }
+
+      setRunningFromCache(false);
+
+      if (outcome.action === "signedOut") {
+        setUser(null);
+        // Teardown is gated on the one shared predicate — asked once, through
+        // the cached-identity store, whose answer then gates the rest (the iOS
+        // `clearIfAuthoritative` shape). Not on "the request failed", which is
+        // the bug #665/#666 exist to remove.
+        if (clearCachedUserIfAuthoritative(outcome.cause)) {
+          clearAccountScopedLocalState();
+        }
+        setAuthError(null);
+        setAuthChecked(true);
+        return;
+      }
+
+      // `unavailable`: no trustworthy answer and nothing cached to render.
+      // Deliberately keeps every piece of local state, cache included.
+      setAuthError(authErrorMessageFor(outcome.cause));
+      setAuthChecked(true);
+    }
 
     async function checkAuth() {
       try {
@@ -256,35 +315,26 @@ export default function StillPoint() {
 
         if (res.ok) {
           const data = await res.json();
-          setUser(data?.user ?? null);
-          setAuthError(null);
-          setAuthChecked(true);
+          // Re-checked after the second await: an unmount between the response
+          // and its body must not adopt a user or write the cache.
+          if (cancelled) return;
+          const freshUser = data?.user ?? null;
+          if (freshUser) {
+            setUser(freshUser);
+            setRunningFromCache(false);
+            setAuthError(null);
+            setAuthChecked(true);
+            return;
+          }
+          // A 2xx with no user is the server authoritatively reporting no
+          // account — the same cause as a 404 from this route.
+          applyFailure({ kind: "status", status: 404 });
           return;
         }
 
-        if (res.status === 401 || res.status === 403) {
-          setUser(null);
-          clearAccountScopedLocalState();
-          setAuthError(null);
-          setAuthChecked(true);
-          return;
-        }
-
-        if (res.status >= 500) {
-          setAuthError("Unable to verify your sign-in due to a server issue. Please retry.");
-          setAuthChecked(true);
-          return;
-        }
-
-        setUser(null);
-        clearAccountScopedLocalState();
-        setAuthError(null);
-        setAuthChecked(true);
+        applyFailure({ kind: "status", status: res.status });
       } catch {
-        if (!cancelled) {
-          setAuthError("Unable to verify your sign-in due to a network issue. Please retry.");
-          setAuthChecked(true);
-        }
+        if (!cancelled) applyFailure({ kind: "transport" });
       }
     }
 
@@ -294,6 +344,16 @@ export default function StillPoint() {
       cancelled = true;
     };
   }, [authRetryKey]);
+
+  // #666: coming back online, re-run the bootstrap so the on-screen state
+  // refreshes from the server and the offline indicator clears on its own. Only
+  // while actually running from cache — a normal online session must not re-auth
+  // every time a flaky radio flaps. Queued sits are flushed by the existing
+  // `initWebPwaOffline` "online" listener; nothing is duplicated here.
+  useEffect(() => {
+    if (!isOnline || !runningFromCache) return;
+    setAuthRetryKey((prev) => prev + 1);
+  }, [isOnline, runningFromCache]);
 
   // Redirect legacy `?view=` deep links and unknown tab slugs to their routes.
   useEffect(() => {
@@ -429,7 +489,11 @@ export default function StillPoint() {
     setBuddyCalendarMessage(null);
     setOverlay(null);
     setUser(null);
+    setRunningFromCache(false);
     clearAccountScopedLocalState();
+    // #666: an explicit sign-out is the most authoritative signal there is, so
+    // the local identity goes with it — including while offline.
+    clearCachedUser();
     void getWebSessionSyncCoordinator().clearQueue().catch((error) => {
       console.error("Failed to clear offline session queue on logout:", error);
     });
@@ -757,6 +821,24 @@ export default function StillPoint() {
 
   const userRecovery = recoveryFieldsOf(user);
 
+  // #666: the strip is hidden in immersive flows for the same reason the nav and
+  // header are — nothing competes with a sit.
+  const showOfflineIndicator = runningFromCache && !isImmersive;
+
+  const welcomeHeader = !isImmersive && !(overlay === "complete" && isMobile) ? (
+    <div style={{
+      fontFamily: "var(--font-mono)",
+      fontSize: "12px", color: "var(--fg-3)",
+      letterSpacing: "0.12em",
+      fontWeight: 400,
+      textAlign: "center",
+      paddingTop: isMobile ? "var(--s1)" : "var(--s5)",
+      marginBottom: "var(--s4)",
+    }}>
+      <span style={{ textTransform: "uppercase" }}>Welcome, </span>{user.username}
+    </div>
+  ) : null;
+
   // Logged in
   return (
     <>
@@ -836,19 +918,17 @@ export default function StillPoint() {
       )}
 
       {/* Welcome header — hidden during the completion overlay on mobile to
-          keep the CompletionScreen content above the fixed bottom nav (#479). */}
-      {!isImmersive && !(overlay === "complete" && isMobile) && (
-        <div style={{
-          fontFamily: "var(--font-mono)",
-          fontSize: "12px", color: "var(--fg-3)",
-          letterSpacing: "0.12em",
-          fontWeight: 400,
-          textAlign: "center",
-          paddingTop: isMobile ? "var(--s1)" : "var(--s5)",
-          marginBottom: "var(--s4)",
-        }}>
-          <span style={{ textTransform: "uppercase" }}>Welcome, </span>{user.username}
+          keep the CompletionScreen content above the fixed bottom nav (#479).
+          #666: when the offline strip is up, the two share a single grid item.
+          This container's rows are `auto 1fr auto`, so an extra top-level child
+          would push the tab content out of the `1fr` track and shrink it. */}
+      {showOfflineIndicator ? (
+        <div>
+          <OfflineIndicator />
+          {welcomeHeader}
         </div>
+      ) : (
+        welcomeHeader
       )}
 
       {buddyInviteError && overlay !== "session" && (

--- a/src/app/app/[[...tab]]/page.tsx
+++ b/src/app/app/[[...tab]]/page.tsx
@@ -300,6 +300,11 @@ export default function StillPoint() {
 
     /** Apply a failed `me()` through the shared offline-auth decision (#666). */
     function applyFailure(failure: MeFailure) {
+      // Guarded here rather than at each call site so the *destructive* branch
+      // cannot outlive its session: a 401/403/404 from a bootstrap that was
+      // still in flight across a sign-out would otherwise sign out — and clear
+      // the cached identity of — whichever account replaced it.
+      if (cancelled || generation !== sessionGeneration.current) return;
       const cachedUser = loadCachedUser();
       const outcome = resolveAuthBootstrap(failure, cachedUser !== null);
 
@@ -362,7 +367,7 @@ export default function StillPoint() {
 
         applyFailure({ kind: "status", status: res.status });
       } catch {
-        if (!cancelled) applyFailure({ kind: "transport" });
+        applyFailure({ kind: "transport" });
       }
     }
 
@@ -892,7 +897,7 @@ export default function StillPoint() {
   // Logged in
   return (
     <>
-      <PwaBootstrap ownerUserId={user.id} />
+      <PwaBootstrap ownerUserId={user.id} onSynced={refreshUserFromServer} />
       <div style={{
       minHeight: "100%",
       display: "grid",

--- a/src/components/OfflineIndicator.tsx
+++ b/src/components/OfflineIndicator.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+/**
+ * #666: the unobtrusive strip shown while the app is running from its local copy
+ * of identity and state. The web twin of the iOS `OfflineIndicatorView` (#665),
+ * down to the same three design tokens (`amberText` / `amberBgFaint` /
+ * `amberBorderSubtle`) and the same copy, so the two clients look and read the
+ * same when disconnected.
+ *
+ * Deliberately not an error. There is nothing to act on and nothing to dismiss —
+ * the sit still runs, the day number is still right, and the completion still
+ * queues for upload. It replaces what a lost connection used to produce: an
+ * "Unable to verify your sign-in" screen nobody asked for. Amber, not red, for
+ * the same reason, and `role="status"` rather than `role="alert"` so a screen
+ * reader announces it politely instead of interrupting.
+ */
+export function OfflineIndicator() {
+  return (
+    <div
+      role="status"
+      data-testid="offline-indicator"
+      aria-label="Offline. Showing your saved progress; sits are saved and upload when you reconnect."
+      style={{
+        width: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "var(--s1)",
+        padding: "var(--s1) var(--s2)",
+        marginBottom: "var(--s3)",
+        background: "var(--accent-amber-bg-faint)",
+        borderBottom: "1px solid var(--accent-amber-border-subtle)",
+        color: "var(--accent-amber-text)",
+        fontFamily: "var(--font-mono)",
+        fontSize: "10px",
+        fontWeight: 500,
+        letterSpacing: "0.2em",
+      }}
+    >
+      <span aria-hidden="true">
+        <svg
+          width="11"
+          height="11"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          focusable="false"
+        >
+          <path d="M2 2l20 20" />
+          <path d="M8.5 16.5a5 5 0 0 1 7 0" />
+          <path d="M5 12.9a10 10 0 0 1 5.2-2.7" />
+          <path d="M13.8 10.2a10 10 0 0 1 5.2 2.7" />
+          <path d="M2 8.8a15 15 0 0 1 5.1-3" />
+          <path d="M16.9 5.8A15 15 0 0 1 22 8.8" />
+          <path d="M12 20h.01" />
+        </svg>
+      </span>
+      <span>OFFLINE · SAVED PROGRESS</span>
+    </div>
+  );
+}

--- a/src/components/PwaBootstrap.tsx
+++ b/src/components/PwaBootstrap.tsx
@@ -5,15 +5,27 @@ import { initWebPwaOffline, persistOfflineOwnerUserId } from "@/lib/offlineSessi
 
 type PwaBootstrapProps = {
   ownerUserId: string | null;
+  /**
+   * #666: called after a reconnect flush actually uploaded a queued sit, so the
+   * caller can re-read the user. Held in a ref like `ownerUserId` because the
+   * listeners are registered exactly once — a prop identity change must not tear
+   * down and re-register the service-worker wiring.
+   */
+  onSynced?: () => void;
 };
 
 /** Registers the PWA service worker and reconnect flush hooks (#558). */
-export function PwaBootstrap({ ownerUserId }: PwaBootstrapProps) {
+export function PwaBootstrap({ ownerUserId, onSynced }: PwaBootstrapProps) {
   const ownerUserIdRef = useRef(ownerUserId);
   ownerUserIdRef.current = ownerUserId;
+  const onSyncedRef = useRef(onSynced);
+  onSyncedRef.current = onSynced;
 
   useEffect(() => {
-    return initWebPwaOffline(() => ownerUserIdRef.current);
+    return initWebPwaOffline(
+      () => ownerUserIdRef.current,
+      () => onSyncedRef.current?.(),
+    );
   }, []);
 
   useEffect(() => {

--- a/src/lib/cachedUser.test.ts
+++ b/src/lib/cachedUser.test.ts
@@ -1,0 +1,121 @@
+/** @vitest-environment jsdom */
+import { beforeEach, describe, expect, test } from "vitest";
+import type { User } from "@/lib/api";
+import {
+  clearCachedUser,
+  clearCachedUserIfAuthoritative,
+  loadCachedUser,
+  saveCachedUser,
+} from "./cachedUser";
+
+const STORAGE_KEY = "stillpoint_cached_user_v1";
+
+/**
+ * jsdom 29 under Vitest 4 exposes a `window` with no `localStorage`, so the
+ * suite supplies its own conforming Storage. The module reads the global at
+ * call time (never at import), so installing it per test is enough, and the
+ * production path is unchanged — it still talks to whatever `localStorage` the
+ * browser provides.
+ */
+function installMemoryStorage(): Storage {
+  const entries = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return entries.size;
+    },
+    clear: () => entries.clear(),
+    getItem: (key) => entries.get(key) ?? null,
+    key: (index) => Array.from(entries.keys())[index] ?? null,
+    removeItem: (key) => {
+      entries.delete(key);
+    },
+    setItem: (key, value) => {
+      entries.set(key, String(value));
+    },
+  };
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    writable: true,
+    value: storage,
+  });
+  return storage;
+}
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: "user-1",
+    email: "sitter@stillpoint.test",
+    username: "sitter",
+    isPublic: false,
+    currentDay: 42,
+    aphorismsEnabled: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  installMemoryStorage();
+});
+
+describe("cached identity round trip", () => {
+  test("saves and reloads the full payload", () => {
+    const user = makeUser({ recoveryTargetDay: 7, dualTrackEnabled: true, secondTrackDay: 3 });
+    saveCachedUser(user);
+    expect(loadCachedUser()).toEqual(user);
+  });
+
+  test("an empty store reads as no cache", () => {
+    expect(loadCachedUser()).toBeNull();
+  });
+
+  test("clearing removes the copy", () => {
+    saveCachedUser(makeUser());
+    clearCachedUser();
+    expect(loadCachedUser()).toBeNull();
+  });
+
+  test("unparseable storage reads as no cache rather than throwing", () => {
+    localStorage.setItem(STORAGE_KEY, "{not json");
+    expect(loadCachedUser()).toBeNull();
+  });
+
+  test("a payload missing a required field is rejected, not half-rendered", () => {
+    for (const field of ["id", "email", "username", "isPublic", "currentDay", "aphorismsEnabled"] as const) {
+      const partial: Record<string, unknown> = { ...makeUser() };
+      delete partial[field];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(partial));
+      expect(loadCachedUser()).toBeNull();
+    }
+  });
+
+  test("a wrongly-typed required field is rejected", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...makeUser(), currentDay: "42" }));
+    expect(loadCachedUser()).toBeNull();
+  });
+
+  test("a non-object payload is rejected", () => {
+    for (const raw of ["null", '"sitter"', "7", "[]"]) {
+      localStorage.setItem(STORAGE_KEY, raw);
+      expect(loadCachedUser()).toBeNull();
+    }
+  });
+});
+
+describe("clearCachedUserIfAuthoritative", () => {
+  test("an authoritative cause clears and reports that it did", () => {
+    for (const cause of ["unauthorized", "signedOut"] as const) {
+      saveCachedUser(makeUser());
+      expect(clearCachedUserIfAuthoritative(cause)).toBe(true);
+      expect(loadCachedUser()).toBeNull();
+    }
+  });
+
+  test("a transport or server failure never destroys the cached identity", () => {
+    for (const cause of ["unreachable", "serverError"] as const) {
+      const user = makeUser();
+      saveCachedUser(user);
+      expect(clearCachedUserIfAuthoritative(cause)).toBe(false);
+      expect(loadCachedUser()).toEqual(user);
+    }
+  });
+});

--- a/src/lib/cachedUser.ts
+++ b/src/lib/cachedUser.ts
@@ -1,0 +1,98 @@
+import type { User } from "@/lib/api";
+import { mayClearAccountScopedState, type SignedOutCause } from "@/lib/offlineAuth";
+
+/**
+ * #666 — the last authenticated `User`, kept in the browser so a cold reload of
+ * the installed PWA with no network still knows who you are, what day you're on
+ * and which tracks you run. The web mirror of the iOS `CachedIdentityStore`
+ * (#665).
+ *
+ * **Where it lives.** `localStorage`, following the existing preference-cache
+ * convention (`displayPrefs.ts`, `trackingControlPrefs.ts`) rather than the
+ * IndexedDB the offline session queue uses. The queue is in IndexedDB because
+ * the *service worker* has to read it during a background sync; this payload is
+ * small, is read exactly once per bootstrap by the page, and is needed
+ * synchronously before the first render — three reasons the queue's storage
+ * choice does not carry over. No session token is stored here: the session
+ * cookie stays where the browser keeps it, and only the non-secret identity
+ * payload (id, username, day counters, feature flags) lands in this key.
+ *
+ * **Staleness is accepted, deliberately.** A cached identity older than the
+ * server's session means the user sits happily offline and then hits a 401 on
+ * reconnect, at which point `clearCachedUserIfAuthoritative` wipes it and they
+ * sign in again. That is strictly better than the alternative it replaces —
+ * being logged out at the moment of *losing* the network rather than the moment
+ * of regaining it.
+ */
+
+/** Versioned like the iOS App Group key, so a future shape change can be
+ *  introduced without misreading an old payload. */
+const STORAGE_KEY = "stillpoint_cached_user_v1";
+
+/**
+ * Accept only a payload that can actually render the app. Every non-optional
+ * `User` field must be present and correctly typed; anything else (a truncated
+ * write, a payload from a future shape, hand-edited storage) is treated as no
+ * cache at all rather than rendering a half-built account.
+ */
+function isCachedUser(value: unknown): value is User {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.id === "string"
+    && typeof candidate.email === "string"
+    && typeof candidate.username === "string"
+    && typeof candidate.isPublic === "boolean"
+    && typeof candidate.currentDay === "number"
+    && typeof candidate.aphorismsEnabled === "boolean"
+  );
+}
+
+export function loadCachedUser(): User | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    return isCachedUser(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the authenticated user. Called on every adopted user so the local
+ * copy tracks the server (day number, recovery ramp, track opt-ins).
+ */
+export function saveCachedUser(user: User): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(user));
+  } catch {
+    // Best-effort persistence: a full or blocked quota must not break the app.
+  }
+}
+
+export function clearCachedUser(): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Best-effort: a failed removal leaves a stale copy that the next
+    // authoritative 401 will clear again.
+  }
+}
+
+/**
+ * Clear the cached identity only for a cause authoritative enough to prove the
+ * session is over — the same predicate that guards the widget's stored week
+ * (#676) and the iOS cached identity (#665).
+ *
+ * Returns whether it actually cleared, so callers can gate the rest of their
+ * sign-out teardown on the same single answer.
+ */
+export function clearCachedUserIfAuthoritative(cause: SignedOutCause): boolean {
+  if (!mayClearAccountScopedState(cause)) return false;
+  clearCachedUser();
+  return true;
+}

--- a/src/lib/offlineAuth.test.ts
+++ b/src/lib/offlineAuth.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "vitest";
+import {
+  authErrorMessageFor,
+  mayClearAccountScopedState,
+  resolveAuthBootstrap,
+  signedOutCauseFor,
+  type SignedOutCause,
+} from "./offlineAuth";
+
+/**
+ * #666 — the web half of offline-first identity. These mirror the iOS
+ * `OfflineAuthTests` case for case, so a divergence between the two clients
+ * shows up as a failing test rather than as different behavior in a dead zone.
+ */
+describe("signedOutCauseFor", () => {
+  test("only an auth answer from the server is authoritative", () => {
+    expect(signedOutCauseFor({ kind: "status", status: 401 })).toBe("unauthorized");
+    expect(signedOutCauseFor({ kind: "status", status: 403 })).toBe("unauthorized");
+  });
+
+  test("a missing account row is an authoritative sign-out", () => {
+    expect(signedOutCauseFor({ kind: "status", status: 404 })).toBe("signedOut");
+  });
+
+  test("a response that never arrived is unreachable, never a sign-out", () => {
+    expect(signedOutCauseFor({ kind: "transport" })).toBe("unreachable");
+    expect(signedOutCauseFor({ kind: "status", status: 0 })).toBe("unreachable");
+    expect(signedOutCauseFor({ kind: "status", status: -1 })).toBe("unreachable");
+  });
+
+  test("anything else the server said says nothing about auth", () => {
+    for (const status of [400, 408, 429, 500, 502, 503, 504]) {
+      expect(signedOutCauseFor({ kind: "status", status })).toBe("serverError");
+    }
+  });
+});
+
+describe("mayClearAccountScopedState", () => {
+  test("mirrors the widget predicate exactly", () => {
+    const table: Array<[SignedOutCause, boolean]> = [
+      ["signedOut", true],
+      ["unauthorized", true],
+      ["serverError", false],
+      ["unreachable", false],
+    ];
+    for (const [cause, expected] of table) {
+      expect(mayClearAccountScopedState(cause)).toBe(expected);
+    }
+  });
+});
+
+describe("resolveAuthBootstrap", () => {
+  test("a transport failure with a cached user keeps you signed in, offline", () => {
+    const outcome = resolveAuthBootstrap({ kind: "transport" }, true);
+    expect(outcome).toEqual({
+      action: "offline",
+      cause: "unreachable",
+      clearsLocalState: false,
+      usesCachedIdentity: true,
+    });
+  });
+
+  test("a 5xx with a cached user keeps you signed in too", () => {
+    const outcome = resolveAuthBootstrap({ kind: "status", status: 503 }, true);
+    expect(outcome.action).toBe("offline");
+    expect(outcome.cause).toBe("serverError");
+    expect(outcome.clearsLocalState).toBe(false);
+  });
+
+  test("a 401 signs you out and authorizes the local teardown", () => {
+    const outcome = resolveAuthBootstrap({ kind: "status", status: 401 }, true);
+    expect(outcome).toEqual({
+      action: "signedOut",
+      cause: "unauthorized",
+      clearsLocalState: true,
+      usesCachedIdentity: false,
+    });
+  });
+
+  test("a 403 signs you out the same way", () => {
+    expect(resolveAuthBootstrap({ kind: "status", status: 403 }, true).action).toBe("signedOut");
+  });
+
+  test("a 401 signs you out even with nothing cached", () => {
+    const outcome = resolveAuthBootstrap({ kind: "status", status: 401 }, false);
+    expect(outcome.action).toBe("signedOut");
+    expect(outcome.clearsLocalState).toBe(true);
+  });
+
+  test("a transport failure with nothing cached is retryable, and destroys nothing", () => {
+    const outcome = resolveAuthBootstrap({ kind: "transport" }, false);
+    expect(outcome).toEqual({
+      action: "unavailable",
+      cause: "unreachable",
+      clearsLocalState: false,
+      usesCachedIdentity: false,
+    });
+  });
+
+  test("no transport failure ever authorizes clearing local state", () => {
+    for (const hasCachedUser of [true, false]) {
+      expect(resolveAuthBootstrap({ kind: "transport" }, hasCachedUser).clearsLocalState).toBe(false);
+      expect(resolveAuthBootstrap({ kind: "status", status: 500 }, hasCachedUser).clearsLocalState).toBe(false);
+    }
+  });
+
+  test("only the offline outcome runs from the cached identity", () => {
+    expect(resolveAuthBootstrap({ kind: "transport" }, true).usesCachedIdentity).toBe(true);
+    expect(resolveAuthBootstrap({ kind: "transport" }, false).usesCachedIdentity).toBe(false);
+    expect(resolveAuthBootstrap({ kind: "status", status: 401 }, true).usesCachedIdentity).toBe(false);
+  });
+});
+
+describe("authErrorMessageFor", () => {
+  test("distinguishes a dead network from a server problem", () => {
+    expect(authErrorMessageFor("unreachable")).toContain("network issue");
+    expect(authErrorMessageFor("serverError")).toContain("server issue");
+  });
+});

--- a/src/lib/offlineAuth.ts
+++ b/src/lib/offlineAuth.ts
@@ -1,0 +1,149 @@
+/**
+ * #666 — offline-first identity on the web: what a failed `GET /api/auth/me`
+ * means for routing and for the local state the app already holds.
+ *
+ * The TypeScript mirror of the iOS `OfflineAuth` landed in #665 (PR #696), and
+ * deliberately the *same* three moving parts rather than a second convention:
+ *
+ *   1. one classifier that maps a failed `me()` onto a sign-out taxonomy,
+ *   2. one shared predicate (`mayClearAccountScopedState`) deciding whether a
+ *      cause is authoritative enough to destroy local state — used by every
+ *      consumer (routing, the cached identity, the tracking-unlock reset),
+ *   3. one outcome that keeps the user signed in from a cached identity
+ *      whenever that predicate says no and a cached identity exists.
+ *
+ * The practice needs nothing from the server: starting a sit, watching the
+ * timer, tapping thoughts, finishing. Internet is required for exactly one
+ * thing — *syncing*. Knowing who you are is not syncing, so a request that
+ * never reached the server must not be read as a sign-out. Before this, any
+ * failed `me()` dropped the installed PWA on an auth error, which is precisely
+ * what happens on a plane, on the subway, or in a dead zone.
+ *
+ * The asymmetry is deliberate. Wrongly deciding "offline" costs a 401 on the
+ * next request and a trip to sign-in then; wrongly deciding "signed out"
+ * destroys local state and is the bug this exists to prevent. Only an
+ * authoritative signal gets to be destructive.
+ *
+ * **Two deliberate deviations from a literal port of the Swift classifier**,
+ * both because the web surface produces answers the iOS `APIError` surface does
+ * not, and both preserving the pre-#666 web behavior rather than inventing new:
+ *
+ * - `403` joins `401` as authoritative. iOS only ever sees `401` for a rejected
+ *   session; the web bootstrap has always treated both as a rejection, and the
+ *   #666 acceptance criteria name the pair.
+ * - `404` is authoritative as `signedOut`. It is this route's "the session was
+ *   valid but the account row is gone" answer (`/api/auth/me` returns
+ *   `404 User not found` after a deletion) — the analogue of the iOS
+ *   `applySignedOut(cause: .signedOut)` nil-user branch, not of a transport
+ *   failure.
+ *
+ * Everything else the server said, and every answer that never arrived, stays
+ * non-authoritative exactly as on iOS.
+ */
+
+/**
+ * Why the app believes it may not have a session. Mirrors the iOS
+ * `WidgetDataStore.SignedOutCause` taxonomy #676 introduced for the widget, so
+ * the two clients can never disagree about what "signed out" means.
+ */
+export type SignedOutCause =
+  /** The user signed out, or the server authoritatively reported no account. */
+  | "signedOut"
+  /** Credentials were rejected (HTTP 401/403) — the session is genuinely over. */
+  | "unauthorized"
+  /** The server answered, but with an error that says nothing about auth. */
+  | "serverError"
+  /** The server could not be reached at all (offline cold start). */
+  | "unreachable";
+
+/** A `me()` attempt that did not yield an authenticated user. */
+export type MeFailure =
+  /** The server answered with a non-2xx status. */
+  | { kind: "status"; status: number }
+  /** `fetch` rejected: no response ever arrived (offline, DNS, timeout, abort). */
+  | { kind: "transport" };
+
+/** What the app should do after a failed attempt to load the current user. */
+export type AuthBootstrapOutcome = {
+  /**
+   * - `offline` — stay signed in and render from the cached identity.
+   * - `signedOut` — the session is provably over; render sign-in.
+   * - `unavailable` — no trustworthy answer *and* nothing cached to render;
+   *   render the retryable error. This is the web's rendering of the iOS
+   *   `.signedOut(cause)` "nothing to fall back to" branch: like it, it clears
+   *   nothing, because the cause was never authoritative.
+   */
+  action: "offline" | "signedOut" | "unavailable";
+  cause: SignedOutCause;
+  /**
+   * The single answer to "may this cause destroy account-scoped local state?",
+   * resolved once here so routing, the cached identity and the tracking-unlock
+   * reset cannot drift apart by each asking separately.
+   */
+  clearsLocalState: boolean;
+  /** Whether the app is about to run from its local copy. Drives the indicator. */
+  usesCachedIdentity: boolean;
+};
+
+/**
+ * Map a failed `me()` onto the shared sign-out taxonomy.
+ *
+ * Only an answer that came *from the server* and was *about auth* counts as
+ * proof the session is over. A response-less failure is `unreachable`; a status
+ * the transport never produced (`<= 0`, how some clients model a dead network)
+ * is treated the same way, mirroring the Swift `status <= 0` branch.
+ */
+export function signedOutCauseFor(failure: MeFailure): SignedOutCause {
+  if (failure.kind === "transport") return "unreachable";
+  const { status } = failure;
+  if (status === 401 || status === 403) return "unauthorized";
+  if (status === 404) return "signedOut";
+  if (status <= 0) return "unreachable";
+  return "serverError";
+}
+
+/**
+ * The one predicate for "is this cause authoritative enough to destroy local
+ * state?" — the direct mirror of `WidgetDataStore.shouldClearStoredSnapshot`.
+ * A dropped connection or a 5xx is never one of them.
+ */
+export function mayClearAccountScopedState(cause: SignedOutCause): boolean {
+  return cause === "signedOut" || cause === "unauthorized";
+}
+
+/**
+ * Resolve a failed `me()` into a route.
+ *
+ * `hasCachedUser` is the caller's answer for `loadCachedUser() !== null`;
+ * without a local copy there is nothing to render, so even a transport failure
+ * has to land somewhere else (a first launch with no network, say).
+ */
+export function resolveAuthBootstrap(
+  failure: MeFailure,
+  hasCachedUser: boolean,
+): AuthBootstrapOutcome {
+  const cause = signedOutCauseFor(failure);
+  const clearsLocalState = mayClearAccountScopedState(cause);
+
+  if (clearsLocalState || !hasCachedUser) {
+    return {
+      action: clearsLocalState ? "signedOut" : "unavailable",
+      cause,
+      clearsLocalState,
+      usesCachedIdentity: false,
+    };
+  }
+
+  return { action: "offline", cause, clearsLocalState: false, usesCachedIdentity: true };
+}
+
+/**
+ * Status line for a route away from the app. Unchanged from the pre-#666
+ * copy — a server problem and a dead network read differently to the user, and
+ * both are retryable.
+ */
+export function authErrorMessageFor(cause: SignedOutCause): string {
+  return cause === "unreachable"
+    ? "Unable to verify your sign-in due to a network issue. Please retry."
+    : "Unable to verify your sign-in due to a server issue. Please retry.";
+}

--- a/src/lib/offlineSessionQueue/pwaBootstrap.ts
+++ b/src/lib/offlineSessionQueue/pwaBootstrap.ts
@@ -23,8 +23,19 @@ export async function persistOfflineOwnerUserId(userId: string | null): Promise<
   }
 }
 
-/** Register the PWA service worker and wire reconnect flush (#558). */
-export function initWebPwaOffline(ownerUserIdProvider: () => string | null): () => void {
+/**
+ * Register the PWA service worker and wire reconnect flush (#558).
+ *
+ * `onSynced` fires after a flush that actually uploaded something. #666 needs
+ * it because reconnect starts the auth re-read and this flush independently: a
+ * `GET /api/auth/me` that wins the race returns the *pre-flush* progression, so
+ * without a nudge afterwards the day number stays one behind a sit that synced
+ * successfully — and, now that the identity is cached, stays behind a reload too.
+ */
+export function initWebPwaOffline(
+  ownerUserIdProvider: () => string | null,
+  onSynced?: () => void,
+): () => void {
   if (typeof window === "undefined" || bootstrapStarted) {
     return () => {};
   }
@@ -37,7 +48,12 @@ export function initWebPwaOffline(ownerUserIdProvider: () => string | null): () 
   const flushForCurrentUser = () => {
     const ownerUserId = ownerUserIdProvider();
     if (!ownerUserId) return;
-    void coordinator.flushPending(ownerUserId).catch(() => {});
+    void coordinator
+      .flushPending(ownerUserId)
+      .then((syncedCount) => {
+        if (syncedCount > 0) onSynced?.();
+      })
+      .catch(() => {});
   };
 
   const onOnline = () => flushForCurrentUser();

--- a/src/lib/useOnlineStatus.ts
+++ b/src/lib/useOnlineStatus.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+/**
+ * #666 — whether the browser currently believes it has a connection.
+ *
+ * Used to trigger the reconnect refresh, not to decide what to render: the
+ * offline indicator follows "am I running from the cached identity?" (which
+ * only a successful `me()` clears), exactly as iOS's `isOfflineMode` does.
+ * `navigator.onLine` is a hint — it reports link state, not reachability — so
+ * it is allowed to *prompt* a re-check and never to conclude one.
+ */
+
+function subscribe(callback: () => void) {
+  window.addEventListener("online", callback);
+  window.addEventListener("offline", callback);
+  return () => {
+    window.removeEventListener("online", callback);
+    window.removeEventListener("offline", callback);
+  };
+}
+
+function getSnapshot() {
+  return navigator.onLine;
+}
+
+/** Server renders assume a connection, so hydration never flashes an offline UI. */
+function getServerSnapshot() {
+  return true;
+}
+
+export function useOnlineStatus() {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
## **User description**
Closes #666

Opening the installed web app with no connection used to mean staring at "Unable to verify your sign-in" instead of your timer. The sit needs nothing from the server — the timer runs in the browser and completed sits already queue for upload — but the auth bootstrap gated everything on a live `GET /api/auth/me` and could not tell "you're signed out" from "the network is down".

Now a failed `me()` is classified once, and only an answer that came *from the server* and was *about auth* is allowed to be destructive. Anything else keeps you signed in from a locally cached copy of your account, behind a small `OFFLINE · SAVED PROGRESS` strip that clears on its own when the bootstrap next succeeds.

This is increment 2/2 of the offline-first pair and **ports the decisions #665 landed on iOS (PR #696) rather than inventing a second convention** — same three moving parts, same taxonomy, same accepted trade-offs:

| iOS (#665) | Web (this PR) |
|---|---|
| `OfflineAuth.cause(for:)` | `signedOutCauseFor()` in `src/lib/offlineAuth.ts` |
| `WidgetDataStore.shouldClearStoredSnapshot(on:)` | `mayClearAccountScopedState()` — the one shared predicate |
| `OfflineAuth.outcome(for:hasCachedIdentity:)` | `resolveAuthBootstrap()` |
| `CachedIdentityStore` (App Group) | `cachedUser.ts` (`localStorage`) |
| `OfflineIndicatorView` | `OfflineIndicator.tsx` — same copy, same three design tokens |

Carried over deliberately: a **5xx keeps you signed in** (not just transport failures), and a **cached identity older than the server session surfaces its 401 on reconnect** rather than at the moment the network drops — strictly better than being logged out the moment you *lose* signal.

**Two documented deviations** from a literal port of the Swift classifier, both because the web route produces answers the iOS `APIError` surface does not, and both preserving pre-existing web behavior: `403` joins `401` as authoritative (the web bootstrap has always treated the pair as a rejection, and #666's AC names both), and `404` is authoritative as `signedOut` (this route's "the account row is gone" answer — the analogue of iOS's nil-user branch). Everything else the server says, and every answer that never arrives, stays non-authoritative exactly as on iOS.

**Service worker:** no change needed. `public/sw.js` already precaches the app shell (`/app`, `/app/progress`) and falls back to it on a failed navigation, and the same JS bundle serves every `[[...tab]]` route — reviewed and confirmed rather than added to.

**Layout note:** the strip shares a single grid item with the welcome header. The logged-in container is `gridTemplateRows: auto 1fr auto`, so an extra top-level child would have pushed the tab content out of the `1fr` track.

**Expected reviewer path:** Greptile (see PR #696). CodeAnt on this repo emits only pre-run APPROVED stubs and CodeRabbit has never APPROVED here, so please don't burn cycles polling either.

**Local review coverage:** none — both CLIs were unavailable after one retry each (CodeRabbit CLI `rate_limit: Rate limit exceeded`; CodeAnt CLI `403`, the undocumented daily cap). Self-review ran instead and caught the grid-row bug noted above plus a missing `cancelled` re-check after the response-body await.

## Test plan

- [x] `resolveAuthBootstrap` keeps a user signed in from cache on a transport failure and on a 5xx, and never reports `clearsLocalState` for either (`src/lib/offlineAuth.test.ts`)
- [x] A 401 or 403 returns `signedOut` with `clearsLocalState: true`, with or without a cached user (`src/lib/offlineAuth.test.ts`)
- [x] `signedOutCauseFor` maps 401/403 → `unauthorized`, 404 → `signedOut`, transport and `status <= 0` → `unreachable`, and every other status → `serverError` (`src/lib/offlineAuth.test.ts`)
- [x] `mayClearAccountScopedState` matches the iOS `shouldClearStoredSnapshot` truth table exactly (`src/lib/offlineAuth.test.ts`)
- [x] A transport failure with nothing cached returns `unavailable` — the retryable error — and still destroys nothing (`src/lib/offlineAuth.test.ts`)
- [x] `clearCachedUserIfAuthoritative` clears on `unauthorized`/`signedOut` and leaves the cache intact on `unreachable`/`serverError` (`src/lib/cachedUser.test.ts`)
- [x] The cached payload round-trips, and a malformed, mistyped, non-object or field-missing payload reads as no cache rather than half-rendering the app (`src/lib/cachedUser.test.ts`)
- [x] `clearAccountScopedLocalState()` is invoked only behind `clearCachedUserIfAuthoritative(...)` returning true, so no transport failure can reach it (`src/app/app/[[...tab]]/page.tsx`)
- [x] Explicit logout still clears the cached identity and the account-scoped local state (`handleLogout` in `src/app/app/[[...tab]]/page.tsx`)
- [x] The offline strip renders only while `runningFromCache` and outside immersive flows, and shares one grid item with the welcome header (`src/app/app/[[...tab]]/page.tsx`)
- [x] Reconnect re-runs the bootstrap only while running from cache, and queue flushing is left to the existing `initWebPwaOffline` `online` listener (no duplicate flush path)
- [x] A Playwright spec covers offline reload → app view + day number + indicator, an offline sit landing in the IndexedDB queue, reconnect syncing it and clearing the indicator, and a 401 still signing out (`e2e/web/offline-pwa.spec.ts`)
- [x] `npm run typecheck`, `npm run test:unit` and `npm run build` pass (the only unit failures are the pre-existing DB/migration suites that need a live database: `apply-migrations`, `buddy-one-host-index`, `schema.recovery-constraint`)

## Post-merge verification

Tracking issue: #701

These need a real installed PWA with its radio off — home-screen install, service-worker cold starts and reconnect timing that no unit runner can stand in for. Neither Playwright web lane runs on `pull_request` in this repo, so the spec above ships but does not gate this PR.

- [ ] Install the PWA on iOS Safari and Android Chrome, go offline, cold-launch from the home-screen icon, and confirm the normal app view with the correct day number
- [ ] Complete a full sit offline and confirm it appears in history after reconnecting
- [ ] Confirm the `OFFLINE · SAVED PROGRESS` strip appears and clears on its own, with no reload and no sign-in flash
- [ ] Confirm a desktop DevTools-offline reload degrades identically, served from the service worker's app-shell cache
- [ ] Confirm explicit sign-out while offline, and a genuinely expired session online, both still sign you out and clear the cached identity


___

## **CodeAnt-AI Description**
Keep the web app usable offline and sync progress when reconnected

### What Changed
- Reloading the installed app without a connection keeps users signed in with their saved identity and progress instead of showing an authentication error
- Offline sessions continue to run and completed sits are queued locally for upload
- Reconnecting automatically refreshes authentication, uploads queued sits, and removes the offline indicator
- Only an authoritative server rejection signs the user out and clears saved identity; network failures and server errors preserve it
- Added coverage for offline reloads, queued-session syncing, sign-out behavior, cached identities, and authentication failure handling

### Impact
`✅ Usable meditation timer without a network`
`✅ No lost offline sessions`
`✅ Fewer unnecessary sign-outs during network drops`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
