### PR TITLE
chore(ios): bump build number to 27 for TestFlight

### DIFF
--- a/ios/project.yml
+++ b/ios/project.yml
@@ -87,7 +87,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint
         MARKETING_VERSION: "1.0.3"
-        CURRENT_PROJECT_VERSION: 26
+        CURRENT_PROJECT_VERSION: 27
         # Native Google Sign-In client IDs (#344). Empty by default so no real
         # client ID is committed; override per environment / in CI signing config.
         # GID_CLIENT_ID:           iOS OAuth client ID (xxxxx.apps.googleusercontent.com)
@@ -129,7 +129,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint.monitor
         MARKETING_VERSION: "1.0.3"
-        CURRENT_PROJECT_VERSION: 26
+        CURRENT_PROJECT_VERSION: 27
         DEVELOPMENT_TEAM: T5UU4BP6AV
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]: StillPointMonitor/StillPointMonitor.entitlements
@@ -159,7 +159,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.brettonauerbach.stillpoint.widget
         MARKETING_VERSION: "1.0.3"
-        CURRENT_PROJECT_VERSION: 26
+        CURRENT_PROJECT_VERSION: 27
         DEVELOPMENT_TEAM: T5UU4BP6AV
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]: StillPointWidget/StillPointWidget.entitlements


### PR DESCRIPTION
## **User description**
Cut TestFlight build 27 so the batch merged since build 26 (2026-07-24) reaches testers: sound re-enable (#667), pill toggles (#668), minimal timer view (#669), widget streak fix (#671), two-a-day widget model (#684/#686), and offline-first iOS (#665) + web (#666).

Closes #704

## What changed

Three `CURRENT_PROJECT_VERSION` sites in `ios/project.yml` go 26 -> 27 — the app, the `StillPointMonitor` extension, and the `StillPointWidget` extension. All three must move together or the upload is rejected on mismatched build numbers (#446/#451). `MARKETING_VERSION` stays `"1.0.3"`.

Diff shape is identical to the build 25 and 26 precedents (c7cbc6c, ccd4cf7): `ios/project.yml` only, 3 insertions / 3 deletions. The committed `Info.plist` stores `$(CURRENT_PROJECT_VERSION)` as a build-setting placeholder rather than a literal, so nothing else needs regenerating — verified locally by running the sync check's own `xcodegen generate` (2.46.0) and confirming `ios/StillPointApp/Info.plist` came back byte-identical.

## Release mechanism — do not add the `release:ios` label to this PR

The upload does **not** fire on the merge commit. Builds 21–26 were all cut by pushing an `ios-v<marketing>-build<n>` tag, which triggers `ios-testflight.yml` -> `ios-testflight-build.yml`. Tag `ios-v1.0.3-build26` points at ccd4cf7 and was pushed by hand. So after this merges, the release step is:

```
git tag -a ios-v1.0.3-build27 -m "TestFlight release ios-v1.0.3-build27" <merge-sha>
git push origin ios-v1.0.3-build27
```

Labelling this PR `release:ios` instead would be actively wrong: `ios-testflight-auto.yml` *increments* whatever it reads (`NEW=$((CURRENT + 1))`) and commits the bump itself, so it would read the 27 landed here and cut build **28**, skipping 27. The two paths are mutually exclusive; this PR takes the manual/tag path only.

For the record, the reason no build was cut automatically for this batch is not the static build number — it is that none of those six PRs carried the `release:ios` label, so every `ios-testflight-auto.yml` run resolved to `skipped`.

Upload is verified post-merge by the orchestrator; it is not a checkbox here because it cannot run until the tag is pushed.

## Test plan

- [x] `CURRENT_PROJECT_VERSION: 27` at all three sites in `ios/project.yml` (app, monitor, widget), verified in lockstep by the same assertion `ios-testflight-auto.yml` uses
- [x] `MARKETING_VERSION` unchanged at `"1.0.3"`
- [x] No file other than `ios/project.yml` is modified by this PR
- [x] `Info.plist in sync with project.yml` green (runs the real macOS `xcodegen` path, since this PR touches `ios/project.yml`)
- [x] `typecheck` green
- [x] `build` green
- [x] `unit-tests` green
- [x] `StillPointShared swift test` green


___

## **CodeAnt-AI Description**
Prepare the iOS app and extensions for TestFlight build 27

### What Changed
- Updates the iOS app, monitoring extension, and widget extension to build 27
- Keeps all bundled components on the same build number so the TestFlight upload is accepted
- Keeps the marketing version at 1.0.3

### Impact
`✅ TestFlight build 27 available for testers`
`✅ Consistent app and extension versions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
